### PR TITLE
[Alerting V2] Episode attachment refresh_episode and get_rule tools

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.test.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { createLoggerService } from '../../lib/services/logger_service/logger_service.mock';
+import { ALERTING_LOG_CODES } from '../../lib/errors/error_codes';
 import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
 import { agentBuilderMocks } from '@kbn/agent-builder-plugin/server/mocks';
 import type {
@@ -21,6 +22,7 @@ import {
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { EpisodesClient } from '../../lib/episodes_client';
 import type { RulesClient } from '../../lib/rules_client';
+import type { PrivilegeChecker } from '../../lib/services/privilege_checker/privilege_checker';
 import { getRuleToolId } from '../tools/get_rule';
 import { refreshEpisodeToolId } from '../tools/refresh_episode';
 import { createEpisodeAttachmentType } from './episode_attachment_type';
@@ -69,21 +71,32 @@ const buildVersionedAttachment = (
 });
 
 describe('createEpisodeAttachmentType', () => {
-  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let loggerService: ReturnType<typeof createLoggerService>['loggerService'];
+  let mockLogger: ReturnType<typeof createLoggerService>['mockLogger'];
   let getEpisode: jest.Mock;
   let getRule: jest.Mock;
+  let canRead: jest.Mock;
   let definition: AttachmentTypeDefinition<typeof EPISODE_ATTACHMENT_TYPE, EpisodeAttachmentData>;
 
+  const createPrivilegeCheckerMock = (canReadResult: boolean = true) => {
+    canRead = jest.fn().mockResolvedValue(canReadResult);
+    return {
+      canRead,
+      canWrite: jest.fn().mockResolvedValue(true),
+    } as unknown as PrivilegeChecker;
+  };
+
   beforeEach(() => {
-    logger = loggingSystemMock.createLogger();
+    ({ loggerService, mockLogger } = createLoggerService());
     getEpisode = jest.fn();
     getRule = jest.fn();
     const episodesClient = { get: getEpisode } as unknown as EpisodesClient;
     const rulesClient = { getRule } as unknown as RulesClient;
     definition = createEpisodeAttachmentType({
-      logger,
+      logger: loggerService,
       getEpisodesClient: () => episodesClient,
       getRulesClient: () => rulesClient,
+      getPrivilegeChecker: () => createPrivilegeCheckerMock(true),
     });
   });
 
@@ -156,9 +169,47 @@ describe('createEpisodeAttachmentType', () => {
       const result = await definition.resolve!('ep-missing', createResolveContext());
 
       expect(result).toBeUndefined();
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to resolve episode attachment for origin "ep-missing"')
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to resolve episode attachment',
+        expect.objectContaining({
+          labels: {
+            episode_id: 'ep-missing',
+            space_id: SPACE_ID,
+            code: ALERTING_LOG_CODES.AGENT_BUILDER_EPISODE_RESOLVE_FAILED,
+          },
+          error: expect.objectContaining({
+            message: 'boom',
+            type: 'Error',
+          }),
+        })
       );
+    });
+
+    it('returns undefined without fetching when user lacks Alerts: Read', async () => {
+      const unauthorizedDefinition = createEpisodeAttachmentType({
+        logger: loggerService,
+        getEpisodesClient: () => ({ get: getEpisode } as unknown as EpisodesClient),
+        getRulesClient: () => ({ getRule } as unknown as RulesClient),
+        getPrivilegeChecker: () => createPrivilegeCheckerMock(false),
+      });
+
+      const result = await unauthorizedDefinition.resolve!('ep-1', createResolveContext());
+
+      expect(result).toBeUndefined();
+      expect(getEpisode).not.toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith('Unauthorized to resolve episode attachment', {
+        labels: { episode_id: 'ep-1', space_id: SPACE_ID },
+      });
+    });
+
+    it('resolves episode data when user has Alerts: Read', async () => {
+      getEpisode.mockResolvedValueOnce(baseEpisodeData);
+
+      const result = await definition.resolve!('ep-1', createResolveContext());
+
+      expect(result).toEqual(expect.objectContaining({ 'episode.id': 'ep-1' }));
+      expect(getEpisode).toHaveBeenCalledWith('ep-1');
+      expect(canRead).toHaveBeenCalledWith('alerts');
     });
   });
 
@@ -243,8 +294,19 @@ describe('createEpisodeAttachmentType', () => {
       const result = await definition.isStale!(buildVersionedAttachment(), createResolveContext());
 
       expect(result).toBe(false);
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to check staleness for episode attachment "ep-1"')
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to check episode attachment staleness',
+        expect.objectContaining({
+          labels: {
+            episode_id: 'ep-1',
+            space_id: SPACE_ID,
+            code: ALERTING_LOG_CODES.AGENT_BUILDER_EPISODE_STALENESS_CHECK_FAILED,
+          },
+          error: expect.objectContaining({
+            message: 'boom',
+            type: 'Error',
+          }),
+        })
       );
     });
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.test.ts
@@ -20,6 +20,9 @@ import {
 } from '@kbn/alerting-v2-schemas';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { EpisodesClient } from '../../lib/episodes_client';
+import type { RulesClient } from '../../lib/rules_client';
+import { getRuleToolId } from '../tools/get_rule';
+import { refreshEpisodeToolId } from '../tools/refresh_episode';
 import { createEpisodeAttachmentType } from './episode_attachment_type';
 
 const SPACE_ID = 'default';
@@ -68,15 +71,19 @@ const buildVersionedAttachment = (
 describe('createEpisodeAttachmentType', () => {
   let logger: ReturnType<typeof loggingSystemMock.createLogger>;
   let getEpisode: jest.Mock;
+  let getRule: jest.Mock;
   let definition: AttachmentTypeDefinition<typeof EPISODE_ATTACHMENT_TYPE, EpisodeAttachmentData>;
 
   beforeEach(() => {
     logger = loggingSystemMock.createLogger();
     getEpisode = jest.fn();
+    getRule = jest.fn();
     const episodesClient = { get: getEpisode } as unknown as EpisodesClient;
+    const rulesClient = { getRule } as unknown as RulesClient;
     definition = createEpisodeAttachmentType({
       logger,
       getEpisodesClient: () => episodesClient,
+      getRulesClient: () => rulesClient,
     });
   });
 
@@ -272,13 +279,46 @@ describe('createEpisodeAttachmentType', () => {
       expect(value).toContain('Severity: high');
       expect(value).toContain('Tags: ops');
     });
+
+    it('mentions the attachment-scoped refresh and get_rule tools', async () => {
+      const value = await formatValue(baseEpisodeData);
+      expect(value).toContain(refreshEpisodeToolId('attach-1'));
+      expect(value).toContain(getRuleToolId('attach-1'));
+      expect(value).toContain('rule-management');
+    });
+
+    it('exposes refresh_episode and get_rule bounded tools unique to the attachment', async () => {
+      const formatted = await definition.format(buildAttachment(baseEpisodeData), {
+        request: {} as KibanaRequest,
+        spaceId: 'default',
+      });
+      expect(formatted.getBoundedTools).toBeDefined();
+      const tools = await formatted.getBoundedTools!();
+      expect(tools).toHaveLength(2);
+      expect(tools[0]).toEqual(
+        expect.objectContaining({
+          id: refreshEpisodeToolId('attach-1'),
+          description: expect.stringContaining('ep-1'),
+        })
+      );
+      expect(tools[1]).toEqual(
+        expect.objectContaining({
+          id: getRuleToolId('attach-1'),
+          description: expect.stringContaining('rule-1'),
+        })
+      );
+      expect(tools[1].description).toContain('rule-management');
+    });
   });
 
   describe('getAgentDescription', () => {
-    it('describes read-only episode context', () => {
+    it('describes read-only episode context, bounded tools, and rule-management skill', () => {
       const description = definition.getAgentDescription!();
       expect(description).toContain('alert episode');
       expect(description).toContain('read-only');
+      expect(description).toContain('refresh_episode');
+      expect(description).toContain('get_rule');
+      expect(description).toContain('rule-management');
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.ts
@@ -30,7 +30,9 @@ interface CreateEpisodeAttachmentTypeOptions {
   logger: LoggerServiceContract;
   getEpisodesClient: (context: AttachmentFormatContext) => EpisodesClient;
   getRulesClient: (context: AttachmentFormatContext) => RulesClient;
-  getPrivilegeChecker: (context: { request: AttachmentResolveContext['request'] }) => PrivilegeChecker;
+  getPrivilegeChecker: (context: {
+    request: AttachmentResolveContext['request'];
+  }) => PrivilegeChecker;
 }
 
 const formatEpisodeDescription = ({

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.ts
@@ -7,9 +7,11 @@
 
 import type {
   AttachmentTypeDefinition,
+  AttachmentFormatContext,
   AttachmentResolveContext,
 } from '@kbn/agent-builder-server/attachments';
 import { getLatestVersion, type VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import { RULE_MANAGEMENT_SKILL_ID } from '@kbn/alerting-v2-constants';
 import {
   EPISODE_ATTACHMENT_TYPE,
   episodeAttachmentDataSchema,
@@ -18,13 +20,27 @@ import {
 import type { Logger } from '@kbn/core/server';
 import { alertEpisodeToEpisodeAttachment } from '../../../common/agent_builder/episode_mappers';
 import type { EpisodesClient } from '../../lib/episodes_client';
+import type { RulesClient } from '../../lib/rules_client';
+import { getRuleTool, getRuleToolId } from '../tools/get_rule';
+import { refreshEpisodeTool, refreshEpisodeToolId } from '../tools/refresh_episode';
 
 interface CreateEpisodeAttachmentTypeOptions {
   logger: Logger;
-  getEpisodesClient: (context: AttachmentResolveContext) => EpisodesClient;
+  getEpisodesClient: (context: AttachmentFormatContext) => EpisodesClient;
+  getRulesClient: (context: AttachmentFormatContext) => RulesClient;
 }
 
-const formatEpisodeDescription = (attachmentId: string, data: EpisodeAttachmentData): string => {
+const formatEpisodeDescription = ({
+  attachmentId,
+  data,
+  refreshToolId,
+  getRuleToolId: ruleToolId,
+}: {
+  attachmentId: string;
+  data: EpisodeAttachmentData;
+  refreshToolId: string;
+  getRuleToolId: string;
+}): string => {
   const lines = [
     `Alert episode "${data['episode.id']}" (episodeAttachment.id: "${attachmentId}")`,
     `Status: ${data['episode.status']}`,
@@ -57,12 +73,20 @@ const formatEpisodeDescription = (attachmentId: string, data: EpisodeAttachmentD
     lines.push(`Tags: ${data.last_tags.join(', ')}`);
   }
 
+  lines.push(
+    `Use the ${refreshToolId} tool to refresh this episode with the latest state from Elasticsearch.`
+  );
+  lines.push(
+    `Use the ${ruleToolId} tool to fetch the rule associated with this episode. To modify that rule, or create a new rule, load the ${RULE_MANAGEMENT_SKILL_ID} skill.`
+  );
+
   return lines.join('\n');
 };
 
 export const createEpisodeAttachmentType = ({
   logger,
   getEpisodesClient,
+  getRulesClient,
 }: CreateEpisodeAttachmentTypeOptions): AttachmentTypeDefinition<
   typeof EPISODE_ATTACHMENT_TYPE,
   EpisodeAttachmentData
@@ -116,15 +140,42 @@ export const createEpisodeAttachmentType = ({
     }
   },
 
-  format: (attachment) => ({
-    getRepresentation: () => ({
-      type: 'text',
-      value: formatEpisodeDescription(attachment.id, attachment.data),
-    }),
-  }),
+  format: (attachment) => {
+    const episodeId = attachment.origin ?? attachment.data['episode.id'];
+    const ruleId = attachment.data['rule.id'];
+    const refreshToolId = refreshEpisodeToolId(attachment.id);
+    const ruleToolId = getRuleToolId(attachment.id);
+
+    return {
+      getRepresentation: () => ({
+        type: 'text',
+        value: formatEpisodeDescription({
+          attachmentId: attachment.id,
+          data: attachment.data,
+          refreshToolId,
+          getRuleToolId: ruleToolId,
+        }),
+      }),
+      getBoundedTools: () => [
+        refreshEpisodeTool({
+          attachmentId: attachment.id,
+          episodeId,
+          logger,
+          getEpisodesClient,
+        }),
+        getRuleTool({
+          attachmentId: attachment.id,
+          episodeId,
+          ruleId,
+          logger,
+          getRulesClient,
+        }),
+      ],
+    };
+  },
 
   getAgentDescription: () =>
-    `An episode attachment represents an alert episode — a stateful lifecycle of related alert events for a rule and group. It is read-only context: use it to reason about status, timing, severity, tags, assignee, and snooze state of the alert episode the user is viewing.`,
+    `An alert episode attachment — a stateful lifecycle of related alert events for a rule and group. It is read-only snapshot context. Use the attachment-scoped refresh_episode tool when you need the latest episode state, and get_rule to fetch the associated rule. To create, explain, or modify that rule, load the ${RULE_MANAGEMENT_SKILL_ID} skill.`,
 
   isReadonly: true,
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/episode_attachment_type.ts
@@ -17,17 +17,20 @@ import {
   episodeAttachmentDataSchema,
   type EpisodeAttachmentData,
 } from '@kbn/alerting-v2-schemas';
-import type { Logger } from '@kbn/core/server';
+import { ALERTING_LOG_CODES } from '../../lib/errors/error_codes';
+import type { LoggerServiceContract } from '../../lib/services/logger_service/logger_service';
 import { alertEpisodeToEpisodeAttachment } from '../../../common/agent_builder/episode_mappers';
 import type { EpisodesClient } from '../../lib/episodes_client';
 import type { RulesClient } from '../../lib/rules_client';
+import type { PrivilegeChecker } from '../../lib/services/privilege_checker/privilege_checker';
 import { getRuleTool, getRuleToolId } from '../tools/get_rule';
 import { refreshEpisodeTool, refreshEpisodeToolId } from '../tools/refresh_episode';
 
 interface CreateEpisodeAttachmentTypeOptions {
-  logger: Logger;
+  logger: LoggerServiceContract;
   getEpisodesClient: (context: AttachmentFormatContext) => EpisodesClient;
   getRulesClient: (context: AttachmentFormatContext) => RulesClient;
+  getPrivilegeChecker: (context: { request: AttachmentResolveContext['request'] }) => PrivilegeChecker;
 }
 
 const formatEpisodeDescription = ({
@@ -87,6 +90,7 @@ export const createEpisodeAttachmentType = ({
   logger,
   getEpisodesClient,
   getRulesClient,
+  getPrivilegeChecker,
 }: CreateEpisodeAttachmentTypeOptions): AttachmentTypeDefinition<
   typeof EPISODE_ATTACHMENT_TYPE,
   EpisodeAttachmentData
@@ -106,13 +110,28 @@ export const createEpisodeAttachmentType = ({
     context: AttachmentResolveContext
   ): Promise<EpisodeAttachmentData | undefined> => {
     try {
+      const privilegeChecker = getPrivilegeChecker({ request: context.request });
+      const canRead = await privilegeChecker.canRead('alerts');
+      if (!canRead) {
+        logger.debug({
+          message: 'Unauthorized to resolve episode attachment',
+          labels: { episode_id: episodeId, space_id: context.spaceId },
+        });
+        return undefined;
+      }
+
       const episode = await getEpisodesClient(context).get(episodeId);
       if (!episode) {
         return undefined;
       }
       return episodeAttachmentDataSchema.parse(alertEpisodeToEpisodeAttachment(episode));
     } catch (error) {
-      logger.warn(`Failed to resolve episode attachment for origin "${episodeId}": ${error}`);
+      logger.warn({
+        message: 'Failed to resolve episode attachment',
+        code: ALERTING_LOG_CODES.AGENT_BUILDER_EPISODE_RESOLVE_FAILED,
+        labels: { episode_id: episodeId, space_id: context.spaceId },
+        error,
+      });
       return undefined;
     }
   },
@@ -133,9 +152,12 @@ export const createEpisodeAttachmentType = ({
       if (!latestVersion) return true;
       return episode.last_timestamp !== latestVersion.data.last_timestamp;
     } catch (error) {
-      logger.warn(
-        `Failed to check staleness for episode attachment "${attachment.origin}": ${error}`
-      );
+      logger.warn({
+        message: 'Failed to check episode attachment staleness',
+        code: ALERTING_LOG_CODES.AGENT_BUILDER_EPISODE_STALENESS_CHECK_FAILED,
+        labels: { episode_id: attachment.origin, space_id: context.spaceId },
+        error,
+      });
       return false;
     }
   },
@@ -162,6 +184,7 @@ export const createEpisodeAttachmentType = ({
           episodeId,
           logger,
           getEpisodesClient,
+          getPrivilegeChecker,
         }),
         getRuleTool({
           attachmentId: attachment.id,
@@ -169,6 +192,7 @@ export const createEpisodeAttachmentType = ({
           ruleId,
           logger,
           getRulesClient,
+          getPrivilegeChecker,
         }),
       ],
     };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { PrivilegeChecker } from '../../lib/services/privilege_checker/privilege_checker';
+import { createUnauthorizedToolResult, ensureToolPrivilege } from './unauthorized_tool_result';
+
+describe('createUnauthorizedToolResult', () => {
+  it('returns a ToolResultType.error with missingPrivileges metadata', () => {
+    expect(
+      createUnauthorizedToolResult({
+        action: 'fetch rule for episode',
+        missingPrivileges: ['Rules: Read'],
+      })
+    ).toEqual({
+      results: [
+        {
+          type: ToolResultType.error,
+          data: {
+            message:
+              'Unauthorized to fetch rule for episode. Missing Kibana privilege: Rules: Read. Ask an administrator to grant this privilege.',
+            metadata: { missingPrivileges: ['Rules: Read'] },
+          },
+        },
+      ],
+    });
+  });
+
+  it('pluralizes the privilege label and supports custom advice', () => {
+    expect(
+      createUnauthorizedToolResult({
+        action: 'compose or modify Alerting V2 rules',
+        missingPrivileges: ['Rules: All', 'Alerts: Read'],
+        advice:
+          'Ask an administrator to grant this privilege, or continue with discovery-only if you only have Rules: Read.',
+      })
+    ).toEqual({
+      results: [
+        {
+          type: ToolResultType.error,
+          data: {
+            message:
+              'Unauthorized to compose or modify Alerting V2 rules. Missing Kibana privileges: Rules: All, Alerts: Read. Ask an administrator to grant this privilege, or continue with discovery-only if you only have Rules: Read.',
+            metadata: { missingPrivileges: ['Rules: All', 'Alerts: Read'] },
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe('ensureToolPrivilege', () => {
+  const createPrivilegeChecker = ({
+    canRead = true,
+    canWrite = true,
+  }: {
+    canRead?: boolean;
+    canWrite?: boolean;
+  } = {}): PrivilegeChecker =>
+    ({
+      canRead: jest.fn().mockResolvedValue(canRead),
+      canWrite: jest.fn().mockResolvedValue(canWrite),
+    }) as unknown as PrivilegeChecker;
+
+  it('returns undefined when the user is authorized', async () => {
+    const privilegeChecker = createPrivilegeChecker({ canRead: true });
+
+    await expect(
+      ensureToolPrivilege({
+        privilegeChecker,
+        feature: 'alerts',
+        level: 'read',
+        action: 'refresh episode',
+      })
+    ).resolves.toBeUndefined();
+
+    expect(privilegeChecker.canRead).toHaveBeenCalledWith('alerts');
+  });
+
+  it('returns an unauthorized tool result when the read check fails', async () => {
+    const privilegeChecker = createPrivilegeChecker({ canRead: false });
+
+    await expect(
+      ensureToolPrivilege({
+        privilegeChecker,
+        feature: 'rules',
+        level: 'read',
+        action: 'fetch rule for episode',
+      })
+    ).resolves.toEqual({
+      results: [
+        {
+          type: ToolResultType.error,
+          data: {
+            message:
+              'Unauthorized to fetch rule for episode. Missing Kibana privilege: Rules: Read. Ask an administrator to grant this privilege.',
+            metadata: { missingPrivileges: ['Rules: Read'] },
+          },
+        },
+      ],
+    });
+  });
+
+  it('checks write privileges for level all', async () => {
+    const privilegeChecker = createPrivilegeChecker({ canWrite: false });
+
+    await expect(
+      ensureToolPrivilege({
+        privilegeChecker,
+        feature: 'rules',
+        level: 'all',
+        action: 'compose or modify Alerting V2 rules',
+        advice:
+          'Ask an administrator to grant this privilege, or continue with discovery-only if you only have Rules: Read.',
+      })
+    ).resolves.toEqual({
+      results: [
+        {
+          type: ToolResultType.error,
+          data: {
+            message:
+              'Unauthorized to compose or modify Alerting V2 rules. Missing Kibana privilege: Rules: All. Ask an administrator to grant this privilege, or continue with discovery-only if you only have Rules: Read.',
+            metadata: { missingPrivileges: ['Rules: All'] },
+          },
+        },
+      ],
+    });
+
+    expect(privilegeChecker.canWrite).toHaveBeenCalledWith('rules');
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.test.ts
@@ -64,7 +64,7 @@ describe('ensureToolPrivilege', () => {
     ({
       canRead: jest.fn().mockResolvedValue(canRead),
       canWrite: jest.fn().mockResolvedValue(canWrite),
-    }) as unknown as PrivilegeChecker;
+    } as unknown as PrivilegeChecker);
 
   it('returns undefined when the user is authorized', async () => {
     const privilegeChecker = createPrivilegeChecker({ canRead: true });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.ts
@@ -15,7 +15,7 @@ import type { PrivilegeChecker } from '../../lib/services/privilege_checker/priv
 
 const DEFAULT_ADVICE = 'Ask an administrator to grant this privilege.';
 
-export type UnauthorizedToolResult = {
+export interface UnauthorizedToolResult {
   results: Array<{
     type: ToolResultType.error;
     data: {
@@ -23,7 +23,7 @@ export type UnauthorizedToolResult = {
       metadata: { missingPrivileges: string[] };
     };
   }>;
-};
+}
 
 type EnsureToolPrivilegeParams = {
   privilegeChecker: PrivilegeChecker;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.ts
@@ -25,13 +25,15 @@ export type UnauthorizedToolResult = {
   }>;
 };
 
-/**
- * Builds a tool handler return value for a Kibana privilege authorization failure.
- *
- * @param action - Short description of the denied action (e.g. "refresh episode")
- * @param missingPrivileges - Human-readable privilege names (e.g. ["Alerts: Read"])
- * @param advice - Optional trailing guidance after the missing-privilege sentence
- */
+type EnsureToolPrivilegeParams = {
+  privilegeChecker: PrivilegeChecker;
+  action: string;
+  advice?: string;
+} & (
+  | { feature: AlertingV2Feature; level: 'read' }
+  | { feature: WritableAlertingV2Feature; level: 'all' }
+);
+
 export const createUnauthorizedToolResult = ({
   action,
   missingPrivileges,
@@ -58,19 +60,6 @@ export const createUnauthorizedToolResult = ({
   };
 };
 
-type EnsureToolPrivilegeParams = {
-  privilegeChecker: PrivilegeChecker;
-  action: string;
-  advice?: string;
-} & (
-  | { feature: AlertingV2Feature; level: 'read' }
-  | { feature: WritableAlertingV2Feature; level: 'all' }
-);
-
-/**
- * Checks the required Alerting v2 privilege and returns an unauthorized tool
- * result when the check fails. Returns `undefined` when authorized.
- */
 export const ensureToolPrivilege = async ({
   privilegeChecker,
   feature,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/common/unauthorized_tool_result.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import {
+  getAlertingPrivilegeDisplayName,
+  type AlertingV2Feature,
+  type WritableAlertingV2Feature,
+} from '../../../common/feature_privileges';
+import type { PrivilegeChecker } from '../../lib/services/privilege_checker/privilege_checker';
+
+const DEFAULT_ADVICE = 'Ask an administrator to grant this privilege.';
+
+export type UnauthorizedToolResult = {
+  results: Array<{
+    type: ToolResultType.error;
+    data: {
+      message: string;
+      metadata: { missingPrivileges: string[] };
+    };
+  }>;
+};
+
+/**
+ * Builds a tool handler return value for a Kibana privilege authorization failure.
+ *
+ * @param action - Short description of the denied action (e.g. "refresh episode")
+ * @param missingPrivileges - Human-readable privilege names (e.g. ["Alerts: Read"])
+ * @param advice - Optional trailing guidance after the missing-privilege sentence
+ */
+export const createUnauthorizedToolResult = ({
+  action,
+  missingPrivileges,
+  advice = DEFAULT_ADVICE,
+}: {
+  action: string;
+  missingPrivileges: string[];
+  advice?: string;
+}): UnauthorizedToolResult => {
+  const privilegeList = missingPrivileges.join(', ');
+  const privilegeLabel =
+    missingPrivileges.length === 1 ? 'Missing Kibana privilege' : 'Missing Kibana privileges';
+
+  return {
+    results: [
+      {
+        type: ToolResultType.error,
+        data: {
+          message: `Unauthorized to ${action}. ${privilegeLabel}: ${privilegeList}. ${advice}`,
+          metadata: { missingPrivileges },
+        },
+      },
+    ],
+  };
+};
+
+type EnsureToolPrivilegeParams = {
+  privilegeChecker: PrivilegeChecker;
+  action: string;
+  advice?: string;
+} & (
+  | { feature: AlertingV2Feature; level: 'read' }
+  | { feature: WritableAlertingV2Feature; level: 'all' }
+);
+
+/**
+ * Checks the required Alerting v2 privilege and returns an unauthorized tool
+ * result when the check fails. Returns `undefined` when authorized.
+ */
+export const ensureToolPrivilege = async ({
+  privilegeChecker,
+  feature,
+  level,
+  action,
+  advice,
+}: EnsureToolPrivilegeParams): Promise<UnauthorizedToolResult | undefined> => {
+  const authorized =
+    level === 'read'
+      ? await privilegeChecker.canRead(feature)
+      : await privilegeChecker.canWrite(feature);
+
+  if (authorized) {
+    return undefined;
+  }
+
+  return createUnauthorizedToolResult({
+    action,
+    missingPrivileges: [getAlertingPrivilegeDisplayName(feature, level)],
+    advice,
+  });
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { agentBuilderMocks } from '@kbn/agent-builder-plugin/server/mocks';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { ToolType } from '@kbn/agent-builder-common';
+import type { RuleAttachmentData } from '@kbn/alerting-v2-schemas';
+import type { RulesClient } from '../../../lib/rules_client';
+import { getRuleTool, getRuleToolId } from './get_rule';
+
+const baseRuleData: RuleAttachmentData = {
+  id: 'rule-1',
+  enabled: true,
+  kind: 'alert',
+  metadata: {
+    name: 'High CPU',
+    description: 'CPU breach detection',
+    tags: ['ops', 'cpu'],
+    owner: 'observability',
+  },
+  time_field: '@timestamp',
+  schedule: { every: '5m', lookback: '15m' },
+  query: {
+    format: 'standalone',
+    breach: { query: 'FROM metrics-* | STATS avg_cpu = AVG(cpu) BY host.name' },
+  },
+  state_transition: null,
+  createdBy: 'elastic',
+  createdAt: '2026-04-01T00:00:00.000Z',
+  updatedBy: 'elastic',
+  updatedAt: '2026-04-10T00:00:00.000Z',
+};
+
+describe('getRuleTool', () => {
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let getRule: jest.Mock;
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    getRule = jest.fn();
+  });
+
+  const createTool = () =>
+    getRuleTool({
+      attachmentId: 'attach-1',
+      episodeId: 'ep-1',
+      ruleId: 'rule-1',
+      logger,
+      getRulesClient: () => ({ getRule } as unknown as RulesClient),
+    });
+
+  describe('id', () => {
+    it('is unique per attachment instance', () => {
+      expect(getRuleToolId('attach-1')).toBe('platform.alerting.get_rule.attach-1');
+      expect(createTool().id).toBe(getRuleToolId('attach-1'));
+    });
+  });
+
+  describe('definition', () => {
+    it('is a builtin read-only tool that points at rule-management', () => {
+      const tool = createTool();
+      expect(tool.type).toBe(ToolType.builtin);
+      expect(tool.description).toContain('rule-1');
+      expect(tool.description).toContain('ep-1');
+      expect(tool.description).toContain('attach-1');
+      expect(tool.description).toContain('read-only');
+      expect(tool.description).toContain('rule-management');
+      expect(tool.schema.safeParse({}).success).toBe(true);
+    });
+  });
+
+  describe('handler', () => {
+    it('returns the associated rule', async () => {
+      getRule.mockResolvedValueOnce(baseRuleData);
+
+      const result = await createTool().handler(
+        {},
+        agentBuilderMocks.tools.createHandlerContext()
+      );
+
+      expect(getRule).toHaveBeenCalledWith({ id: 'rule-1' });
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.other,
+            data: expect.objectContaining({
+              id: 'rule-1',
+              metadata: expect.objectContaining({ name: 'High CPU' }),
+            }),
+          },
+        ],
+      });
+    });
+
+    it('returns an error when getRule throws', async () => {
+      getRule.mockRejectedValueOnce(new Error('not found'));
+
+      const result = await createTool().handler(
+        {},
+        agentBuilderMocks.tools.createHandlerContext()
+      );
+
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: 'Failed to fetch rule "rule-1" for episode "ep-1": not found',
+            },
+          },
+        ],
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch rule "rule-1" for episode "ep-1"')
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.test.ts
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
-import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { createLoggerService } from '../../../lib/services/logger_service/logger_service.mock';
+import { ALERTING_LOG_CODES } from '../../../lib/errors/error_codes';
 import { agentBuilderMocks } from '@kbn/agent-builder-plugin/server/mocks';
+import Boom from '@hapi/boom';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { ToolType } from '@kbn/agent-builder-common';
 import type { RuleAttachmentData } from '@kbn/alerting-v2-schemas';
 import type { RulesClient } from '../../../lib/rules_client';
+import type { PrivilegeChecker } from '../../../lib/services/privilege_checker/privilege_checker';
 import { getRuleTool, getRuleToolId } from './get_rule';
 
 const baseRuleData: RuleAttachmentData = {
@@ -37,21 +40,32 @@ const baseRuleData: RuleAttachmentData = {
 };
 
 describe('getRuleTool', () => {
-  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let loggerService: ReturnType<typeof createLoggerService>['loggerService'];
+  let mockLogger: ReturnType<typeof createLoggerService>['mockLogger'];
   let getRule: jest.Mock;
+  let canRead: jest.Mock;
+
+  const createPrivilegeCheckerMock = (canReadResult: boolean = true) => {
+    canRead = jest.fn().mockResolvedValue(canReadResult);
+    return {
+      canRead,
+      canWrite: jest.fn().mockResolvedValue(true),
+    } as unknown as PrivilegeChecker;
+  };
 
   beforeEach(() => {
-    logger = loggingSystemMock.createLogger();
+    ({ loggerService, mockLogger } = createLoggerService());
     getRule = jest.fn();
   });
 
-  const createTool = () =>
+  const createTool = (canReadResult: boolean = true) =>
     getRuleTool({
       attachmentId: 'attach-1',
       episodeId: 'ep-1',
       ruleId: 'rule-1',
-      logger,
+      logger: loggerService,
       getRulesClient: () => ({ getRule } as unknown as RulesClient),
+      getPrivilegeChecker: () => createPrivilegeCheckerMock(canReadResult),
     });
 
   describe('id', () => {
@@ -97,8 +111,8 @@ describe('getRuleTool', () => {
       });
     });
 
-    it('returns an error when getRule throws', async () => {
-      getRule.mockRejectedValueOnce(new Error('not found'));
+    it('returns an error without logging when getRule returns 404', async () => {
+      getRule.mockRejectedValueOnce(Boom.notFound('Rule not found'));
 
       const result = await createTool().handler(
         {},
@@ -110,14 +124,75 @@ describe('getRuleTool', () => {
           {
             type: ToolResultType.error,
             data: {
-              message: 'Failed to fetch rule "rule-1" for episode "ep-1": not found',
+              message: 'Failed to fetch rule "rule-1" for episode "ep-1": Rule not found',
             },
           },
         ],
       });
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to fetch rule "rule-1" for episode "ep-1"')
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('returns an error and logs a warning when getRule throws unexpectedly', async () => {
+      getRule.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await createTool().handler(
+        {},
+        agentBuilderMocks.tools.createHandlerContext()
       );
+
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: 'Failed to fetch rule "rule-1" for episode "ep-1": boom',
+            },
+          },
+        ],
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to fetch rule for episode',
+        expect.objectContaining({
+          labels: {
+            rule_id: 'rule-1',
+            episode_id: 'ep-1',
+            space_id: 'default',
+            code: ALERTING_LOG_CODES.AGENT_BUILDER_EPISODE_GET_RULE_FAILED,
+          },
+          error: expect.objectContaining({
+            message: 'boom',
+            type: 'Error',
+          }),
+        })
+      );
+    });
+
+    it('returns an unauthorized error when user lacks Rules: Read', async () => {
+      const result = await createTool(false).handler(
+        {},
+        agentBuilderMocks.tools.createHandlerContext()
+      );
+
+      expect(getRule).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: expect.stringContaining('Missing Kibana privilege: Rules: Read'),
+              metadata: { missingPrivileges: ['Rules: Read'] },
+            },
+          },
+        ],
+      });
+    });
+
+    it('checks Rules: Read before fetching', async () => {
+      getRule.mockResolvedValueOnce(baseRuleData);
+
+      await createTool().handler({}, agentBuilderMocks.tools.createHandlerContext());
+
+      expect(canRead).toHaveBeenCalledWith('rules');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.test.ts
@@ -92,10 +92,7 @@ describe('getRuleTool', () => {
     it('returns the associated rule', async () => {
       getRule.mockResolvedValueOnce(baseRuleData);
 
-      const result = await createTool().handler(
-        {},
-        agentBuilderMocks.tools.createHandlerContext()
-      );
+      const result = await createTool().handler({}, agentBuilderMocks.tools.createHandlerContext());
 
       expect(getRule).toHaveBeenCalledWith({ id: 'rule-1' });
       expect(result).toEqual({
@@ -114,10 +111,7 @@ describe('getRuleTool', () => {
     it('returns an error without logging when getRule returns 404', async () => {
       getRule.mockRejectedValueOnce(Boom.notFound('Rule not found'));
 
-      const result = await createTool().handler(
-        {},
-        agentBuilderMocks.tools.createHandlerContext()
-      );
+      const result = await createTool().handler({}, agentBuilderMocks.tools.createHandlerContext());
 
       expect(result).toEqual({
         results: [
@@ -135,10 +129,7 @@ describe('getRuleTool', () => {
     it('returns an error and logs a warning when getRule throws unexpectedly', async () => {
       getRule.mockRejectedValueOnce(new Error('boom'));
 
-      const result = await createTool().handler(
-        {},
-        agentBuilderMocks.tools.createHandlerContext()
-      );
+      const result = await createTool().handler({}, agentBuilderMocks.tools.createHandlerContext());
 
       expect(result).toEqual({
         results: [

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AttachmentFormatContext,
+  BuiltinAttachmentBoundedTool,
+} from '@kbn/agent-builder-server/attachments';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { ALERTING_NAMESPACE, RULE_MANAGEMENT_SKILL_ID } from '@kbn/alerting-v2-constants';
+import { ruleAttachmentDataSchema } from '@kbn/alerting-v2-schemas';
+import type { Logger } from '@kbn/core/server';
+import { z } from '@kbn/zod/v4';
+import type { RulesClient } from '../../../lib/rules_client';
+
+const getRuleSchema = z.object({});
+
+/** Bounded tool id — unique per attachment instance when multiple episodes are present. */
+export const getRuleToolId = (attachmentId: string): string =>
+  `${ALERTING_NAMESPACE}.get_rule.${attachmentId}`;
+
+export interface GetRuleToolParams {
+  attachmentId: string;
+  episodeId: string;
+  ruleId: string;
+  logger: Logger;
+  getRulesClient: (context: AttachmentFormatContext) => RulesClient;
+}
+
+export const getRuleTool = ({
+  attachmentId,
+  episodeId,
+  ruleId,
+  logger,
+  getRulesClient,
+}: GetRuleToolParams): BuiltinAttachmentBoundedTool<typeof getRuleSchema> => ({
+  id: getRuleToolId(attachmentId),
+  type: ToolType.builtin,
+  description: `Fetch rule "${ruleId}" associated with episode "${episodeId}" (attachment "${attachmentId}"), including name, schedule, query, enabled state, and metadata. This tool is read-only. To create, explain, or modify the rule, load the ${RULE_MANAGEMENT_SKILL_ID} skill.`,
+  schema: getRuleSchema,
+  handler: async (_args, toolContext) => {
+    try {
+      const rulesClient = getRulesClient({
+        request: toolContext.request,
+        spaceId: toolContext.spaceId,
+      });
+      const rule = await rulesClient.getRule({ id: ruleId });
+      const data = ruleAttachmentDataSchema.parse(rule);
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data,
+          },
+        ],
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`Failed to fetch rule "${ruleId}" for episode "${episodeId}": ${message}`);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to fetch rule "${ruleId}" for episode "${episodeId}": ${message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.ts
@@ -33,7 +33,9 @@ export interface GetRuleToolParams {
   ruleId: string;
   logger: LoggerServiceContract;
   getRulesClient: (context: AttachmentFormatContext) => RulesClient;
-  getPrivilegeChecker: (context: { request: AttachmentFormatContext['request'] }) => PrivilegeChecker;
+  getPrivilegeChecker: (context: {
+    request: AttachmentFormatContext['request'];
+  }) => PrivilegeChecker;
 }
 
 export const getRuleTool = ({

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/get_rule.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
 import type {
   AttachmentFormatContext,
   BuiltinAttachmentBoundedTool,
@@ -13,9 +14,12 @@ import { ToolType } from '@kbn/agent-builder-common';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { ALERTING_NAMESPACE, RULE_MANAGEMENT_SKILL_ID } from '@kbn/alerting-v2-constants';
 import { ruleAttachmentDataSchema } from '@kbn/alerting-v2-schemas';
-import type { Logger } from '@kbn/core/server';
 import { z } from '@kbn/zod/v4';
+import { ensureToolPrivilege } from '../../common/unauthorized_tool_result';
+import { ALERTING_LOG_CODES } from '../../../lib/errors/error_codes';
 import type { RulesClient } from '../../../lib/rules_client';
+import type { LoggerServiceContract } from '../../../lib/services/logger_service/logger_service';
+import type { PrivilegeChecker } from '../../../lib/services/privilege_checker/privilege_checker';
 
 const getRuleSchema = z.object({});
 
@@ -27,8 +31,9 @@ export interface GetRuleToolParams {
   attachmentId: string;
   episodeId: string;
   ruleId: string;
-  logger: Logger;
+  logger: LoggerServiceContract;
   getRulesClient: (context: AttachmentFormatContext) => RulesClient;
+  getPrivilegeChecker: (context: { request: AttachmentFormatContext['request'] }) => PrivilegeChecker;
 }
 
 export const getRuleTool = ({
@@ -37,12 +42,23 @@ export const getRuleTool = ({
   ruleId,
   logger,
   getRulesClient,
+  getPrivilegeChecker,
 }: GetRuleToolParams): BuiltinAttachmentBoundedTool<typeof getRuleSchema> => ({
   id: getRuleToolId(attachmentId),
   type: ToolType.builtin,
   description: `Fetch rule "${ruleId}" associated with episode "${episodeId}" (attachment "${attachmentId}"), including name, schedule, query, enabled state, and metadata. This tool is read-only. To create, explain, or modify the rule, load the ${RULE_MANAGEMENT_SKILL_ID} skill.`,
   schema: getRuleSchema,
   handler: async (_args, toolContext) => {
+    const unauthorized = await ensureToolPrivilege({
+      privilegeChecker: getPrivilegeChecker({ request: toolContext.request }),
+      feature: 'rules',
+      level: 'read',
+      action: 'fetch rule for episode',
+    });
+    if (unauthorized) {
+      return unauthorized;
+    }
+
     try {
       const rulesClient = getRulesClient({
         request: toolContext.request,
@@ -61,7 +77,19 @@ export const getRuleTool = ({
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      logger.warn(`Failed to fetch rule "${ruleId}" for episode "${episodeId}": ${message}`);
+      const isNotFound = Boom.isBoom(error) && error.output.statusCode === 404;
+      if (!isNotFound) {
+        logger.warn({
+          message: 'Failed to fetch rule for episode',
+          code: ALERTING_LOG_CODES.AGENT_BUILDER_EPISODE_GET_RULE_FAILED,
+          labels: {
+            rule_id: ruleId,
+            episode_id: episodeId,
+            space_id: toolContext.spaceId,
+          },
+          error,
+        });
+      }
       return {
         results: [
           {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/get_rule/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getRuleTool, getRuleToolId } from './get_rule';
+export type { GetRuleToolParams } from './get_rule';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { refreshEpisodeTool, refreshEpisodeToolId } from './refresh_episode';
+export type { RefreshEpisodeToolParams } from './refresh_episode';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.test.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { agentBuilderMocks } from '@kbn/agent-builder-plugin/server/mocks';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { ToolType } from '@kbn/agent-builder-common';
+import {
+  ALERT_EPISODE_STATUS,
+  type AlertEpisode,
+  type EpisodeAttachmentData,
+} from '@kbn/alerting-v2-schemas';
+import type { EpisodesClient } from '../../../lib/episodes_client';
+import { refreshEpisodeTool, refreshEpisodeToolId } from './refresh_episode';
+
+const baseEpisodeData: EpisodeAttachmentData = {
+  '@timestamp': '2026-04-10T12:00:00.000Z',
+  'episode.id': 'ep-1',
+  'episode.status': ALERT_EPISODE_STATUS.ACTIVE,
+  'rule.id': 'rule-1',
+  group_hash: 'gh-1',
+  first_timestamp: '2026-04-10T11:00:00.000Z',
+  last_timestamp: '2026-04-10T12:00:00.000Z',
+  duration: 3600000,
+  severity: 'high',
+  last_tags: ['ops'],
+};
+
+describe('refreshEpisodeTool', () => {
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let get: jest.Mock;
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    get = jest.fn();
+  });
+
+  const createTool = () =>
+    refreshEpisodeTool({
+      attachmentId: 'attach-1',
+      episodeId: 'ep-1',
+      logger,
+      getEpisodesClient: () => ({ get } as unknown as EpisodesClient),
+    });
+
+  describe('id', () => {
+    it('is unique per attachment instance', () => {
+      expect(refreshEpisodeToolId('attach-1')).toBe('platform.alerting.refresh_episode.attach-1');
+      expect(createTool().id).toBe(refreshEpisodeToolId('attach-1'));
+    });
+  });
+
+  describe('definition', () => {
+    it('is a builtin tool with an empty schema', () => {
+      const tool = createTool();
+      expect(tool.type).toBe(ToolType.builtin);
+      expect(tool.description).toContain('ep-1');
+      expect(tool.description).toContain('attach-1');
+      expect(tool.schema.safeParse({}).success).toBe(true);
+    });
+  });
+
+  describe('handler', () => {
+    it('returns the latest episode snapshot', async () => {
+      const refreshed: AlertEpisode = {
+        ...baseEpisodeData,
+        'episode.status': ALERT_EPISODE_STATUS.INACTIVE,
+        last_timestamp: '2026-04-20T12:00:00.000Z',
+        severity: 'low',
+      };
+      get.mockResolvedValueOnce(refreshed);
+
+      const result = await createTool().handler(
+        {},
+        agentBuilderMocks.tools.createHandlerContext()
+      );
+
+      expect(get).toHaveBeenCalledWith('ep-1');
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.other,
+            data: expect.objectContaining({
+              'episode.id': 'ep-1',
+              'episode.status': ALERT_EPISODE_STATUS.INACTIVE,
+              last_timestamp: '2026-04-20T12:00:00.000Z',
+              severity: 'low',
+            }),
+          },
+        ],
+      });
+    });
+
+    it('normalizes null nullable fields', async () => {
+      const episodeWithNulls: AlertEpisode = {
+        ...baseEpisodeData,
+        last_assignee_uid: null,
+        episode_data: null,
+        severity: null,
+      };
+      get.mockResolvedValueOnce(episodeWithNulls);
+
+      const result = await createTool().handler(
+        {},
+        agentBuilderMocks.tools.createHandlerContext()
+      );
+
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.other,
+            data: expect.objectContaining({
+              'episode.id': 'ep-1',
+              last_assignee_uid: undefined,
+              episode_data: undefined,
+              severity: undefined,
+            }),
+          },
+        ],
+      });
+    });
+
+    it('returns an error when the episode is missing', async () => {
+      get.mockResolvedValueOnce(undefined);
+
+      const result = await createTool().handler(
+        {},
+        agentBuilderMocks.tools.createHandlerContext()
+      );
+
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.error,
+            data: { message: 'Episode "ep-1" not found' },
+          },
+        ],
+      });
+    });
+
+    it('returns an error when get throws', async () => {
+      get.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await createTool().handler(
+        {},
+        agentBuilderMocks.tools.createHandlerContext()
+      );
+
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.error,
+            data: { message: 'Failed to refresh episode "ep-1": boom' },
+          },
+        ],
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to refresh episode "ep-1"')
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.test.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { createLoggerService } from '../../../lib/services/logger_service/logger_service.mock';
+import { ALERTING_LOG_CODES } from '../../../lib/errors/error_codes';
 import { agentBuilderMocks } from '@kbn/agent-builder-plugin/server/mocks';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { ToolType } from '@kbn/agent-builder-common';
@@ -15,6 +16,7 @@ import {
   type EpisodeAttachmentData,
 } from '@kbn/alerting-v2-schemas';
 import type { EpisodesClient } from '../../../lib/episodes_client';
+import type { PrivilegeChecker } from '../../../lib/services/privilege_checker/privilege_checker';
 import { refreshEpisodeTool, refreshEpisodeToolId } from './refresh_episode';
 
 const baseEpisodeData: EpisodeAttachmentData = {
@@ -31,20 +33,31 @@ const baseEpisodeData: EpisodeAttachmentData = {
 };
 
 describe('refreshEpisodeTool', () => {
-  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let loggerService: ReturnType<typeof createLoggerService>['loggerService'];
+  let mockLogger: ReturnType<typeof createLoggerService>['mockLogger'];
   let get: jest.Mock;
+  let canRead: jest.Mock;
+
+  const createPrivilegeCheckerMock = (canReadResult: boolean = true) => {
+    canRead = jest.fn().mockResolvedValue(canReadResult);
+    return {
+      canRead,
+      canWrite: jest.fn().mockResolvedValue(true),
+    } as unknown as PrivilegeChecker;
+  };
 
   beforeEach(() => {
-    logger = loggingSystemMock.createLogger();
+    ({ loggerService, mockLogger } = createLoggerService());
     get = jest.fn();
   });
 
-  const createTool = () =>
+  const createTool = (canReadResult: boolean = true) =>
     refreshEpisodeTool({
       attachmentId: 'attach-1',
       episodeId: 'ep-1',
-      logger,
+      logger: loggerService,
       getEpisodesClient: () => ({ get } as unknown as EpisodesClient),
+      getPrivilegeChecker: () => createPrivilegeCheckerMock(canReadResult),
     });
 
   describe('id', () => {
@@ -158,9 +171,48 @@ describe('refreshEpisodeTool', () => {
           },
         ],
       });
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to refresh episode "ep-1"')
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to refresh episode',
+        expect.objectContaining({
+          labels: {
+            episode_id: 'ep-1',
+            space_id: 'default',
+            code: ALERTING_LOG_CODES.AGENT_BUILDER_EPISODE_REFRESH_FAILED,
+          },
+          error: expect.objectContaining({
+            message: 'boom',
+            type: 'Error',
+          }),
+        })
       );
+    });
+
+    it('returns an unauthorized error when user lacks Alerts: Read', async () => {
+      const result = await createTool(false).handler(
+        {},
+        agentBuilderMocks.tools.createHandlerContext()
+      );
+
+      expect(get).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: expect.stringContaining('Missing Kibana privilege: Alerts: Read'),
+              metadata: { missingPrivileges: ['Alerts: Read'] },
+            },
+          },
+        ],
+      });
+    });
+
+    it('checks Alerts: Read before refreshing', async () => {
+      get.mockResolvedValueOnce(baseEpisodeData);
+
+      await createTool().handler({}, agentBuilderMocks.tools.createHandlerContext());
+
+      expect(canRead).toHaveBeenCalledWith('alerts');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.test.ts
@@ -87,10 +87,7 @@ describe('refreshEpisodeTool', () => {
       };
       get.mockResolvedValueOnce(refreshed);
 
-      const result = await createTool().handler(
-        {},
-        agentBuilderMocks.tools.createHandlerContext()
-      );
+      const result = await createTool().handler({}, agentBuilderMocks.tools.createHandlerContext());
 
       expect(get).toHaveBeenCalledWith('ep-1');
       expect(result).toEqual({
@@ -117,10 +114,7 @@ describe('refreshEpisodeTool', () => {
       };
       get.mockResolvedValueOnce(episodeWithNulls);
 
-      const result = await createTool().handler(
-        {},
-        agentBuilderMocks.tools.createHandlerContext()
-      );
+      const result = await createTool().handler({}, agentBuilderMocks.tools.createHandlerContext());
 
       expect(result).toEqual({
         results: [
@@ -140,10 +134,7 @@ describe('refreshEpisodeTool', () => {
     it('returns an error when the episode is missing', async () => {
       get.mockResolvedValueOnce(undefined);
 
-      const result = await createTool().handler(
-        {},
-        agentBuilderMocks.tools.createHandlerContext()
-      );
+      const result = await createTool().handler({}, agentBuilderMocks.tools.createHandlerContext());
 
       expect(result).toEqual({
         results: [
@@ -158,10 +149,7 @@ describe('refreshEpisodeTool', () => {
     it('returns an error when get throws', async () => {
       get.mockRejectedValueOnce(new Error('boom'));
 
-      const result = await createTool().handler(
-        {},
-        agentBuilderMocks.tools.createHandlerContext()
-      );
+      const result = await createTool().handler({}, agentBuilderMocks.tools.createHandlerContext());
 
       expect(result).toEqual({
         results: [

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AttachmentFormatContext,
+  BuiltinAttachmentBoundedTool,
+} from '@kbn/agent-builder-server/attachments';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { ALERTING_NAMESPACE } from '@kbn/alerting-v2-constants';
+import { episodeAttachmentDataSchema } from '@kbn/alerting-v2-schemas';
+import type { Logger } from '@kbn/core/server';
+import { z } from '@kbn/zod/v4';
+import { alertEpisodeToEpisodeAttachment } from '../../../../common/agent_builder/episode_mappers';
+import type { EpisodesClient } from '../../../lib/episodes_client';
+
+const refreshEpisodeSchema = z.object({});
+
+/** Bounded tool id — unique per attachment instance when multiple episodes are present. */
+export const refreshEpisodeToolId = (attachmentId: string): string =>
+  `${ALERTING_NAMESPACE}.refresh_episode.${attachmentId}`;
+
+export interface RefreshEpisodeToolParams {
+  attachmentId: string;
+  episodeId: string;
+  logger: Logger;
+  getEpisodesClient: (context: AttachmentFormatContext) => EpisodesClient;
+}
+
+export const refreshEpisodeTool = ({
+  attachmentId,
+  episodeId,
+  logger,
+  getEpisodesClient,
+}: RefreshEpisodeToolParams): BuiltinAttachmentBoundedTool<typeof refreshEpisodeSchema> => ({
+  id: refreshEpisodeToolId(attachmentId),
+  type: ToolType.builtin,
+  description: `Refresh alert episode "${episodeId}" (attachment "${attachmentId}") with the latest status, timestamps, severity, tags, assignee, and snooze state from Elasticsearch. Call when the snapshot may be outdated or the user asks about current episode state.`,
+  schema: refreshEpisodeSchema,
+  handler: async (_args, toolContext) => {
+    try {
+      const client = getEpisodesClient({
+        request: toolContext.request,
+        spaceId: toolContext.spaceId,
+      });
+      const episode = await client.get(episodeId);
+      if (!episode) {
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Episode "${episodeId}" not found`,
+              },
+            },
+          ],
+        };
+      }
+
+      const data = episodeAttachmentDataSchema.parse(alertEpisodeToEpisodeAttachment(episode));
+
+      return {
+        results: [
+          {
+            type: ToolResultType.other,
+            data,
+          },
+        ],
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`Failed to refresh episode "${episodeId}": ${message}`);
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Failed to refresh episode "${episodeId}": ${message}`,
+            },
+          },
+        ],
+      };
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.ts
@@ -13,10 +13,13 @@ import { ToolType } from '@kbn/agent-builder-common';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { ALERTING_NAMESPACE } from '@kbn/alerting-v2-constants';
 import { episodeAttachmentDataSchema } from '@kbn/alerting-v2-schemas';
-import type { Logger } from '@kbn/core/server';
 import { z } from '@kbn/zod/v4';
 import { alertEpisodeToEpisodeAttachment } from '../../../../common/agent_builder/episode_mappers';
+import { ensureToolPrivilege } from '../../common/unauthorized_tool_result';
+import { ALERTING_LOG_CODES } from '../../../lib/errors/error_codes';
 import type { EpisodesClient } from '../../../lib/episodes_client';
+import type { LoggerServiceContract } from '../../../lib/services/logger_service/logger_service';
+import type { PrivilegeChecker } from '../../../lib/services/privilege_checker/privilege_checker';
 
 const refreshEpisodeSchema = z.object({});
 
@@ -27,8 +30,9 @@ export const refreshEpisodeToolId = (attachmentId: string): string =>
 export interface RefreshEpisodeToolParams {
   attachmentId: string;
   episodeId: string;
-  logger: Logger;
+  logger: LoggerServiceContract;
   getEpisodesClient: (context: AttachmentFormatContext) => EpisodesClient;
+  getPrivilegeChecker: (context: { request: AttachmentFormatContext['request'] }) => PrivilegeChecker;
 }
 
 export const refreshEpisodeTool = ({
@@ -36,12 +40,23 @@ export const refreshEpisodeTool = ({
   episodeId,
   logger,
   getEpisodesClient,
+  getPrivilegeChecker,
 }: RefreshEpisodeToolParams): BuiltinAttachmentBoundedTool<typeof refreshEpisodeSchema> => ({
   id: refreshEpisodeToolId(attachmentId),
   type: ToolType.builtin,
   description: `Refresh alert episode "${episodeId}" (attachment "${attachmentId}") with the latest status, timestamps, severity, tags, assignee, and snooze state from Elasticsearch. Call when the snapshot may be outdated or the user asks about current episode state.`,
   schema: refreshEpisodeSchema,
   handler: async (_args, toolContext) => {
+    const unauthorized = await ensureToolPrivilege({
+      privilegeChecker: getPrivilegeChecker({ request: toolContext.request }),
+      feature: 'alerts',
+      level: 'read',
+      action: 'refresh episode',
+    });
+    if (unauthorized) {
+      return unauthorized;
+    }
+
     try {
       const client = getEpisodesClient({
         request: toolContext.request,
@@ -73,7 +88,15 @@ export const refreshEpisodeTool = ({
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      logger.warn(`Failed to refresh episode "${episodeId}": ${message}`);
+      logger.warn({
+        message: 'Failed to refresh episode',
+        code: ALERTING_LOG_CODES.AGENT_BUILDER_EPISODE_REFRESH_FAILED,
+        labels: {
+          episode_id: episodeId,
+          space_id: toolContext.spaceId,
+        },
+        error,
+      });
       return {
         results: [
           {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/refresh_episode/refresh_episode.ts
@@ -32,7 +32,9 @@ export interface RefreshEpisodeToolParams {
   episodeId: string;
   logger: LoggerServiceContract;
   getEpisodesClient: (context: AttachmentFormatContext) => EpisodesClient;
-  getPrivilegeChecker: (context: { request: AttachmentFormatContext['request'] }) => PrivilegeChecker;
+  getPrivilegeChecker: (context: {
+    request: AttachmentFormatContext['request'];
+  }) => PrivilegeChecker;
 }
 
 export const refreshEpisodeTool = ({

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
@@ -338,6 +338,32 @@ export const ALERTING_LOG_CODES = {
    */
   MAINTENANCE_WINDOW_PIT_CLOSE_FAILED: 'MAINTENANCE_WINDOW_PIT_CLOSE_FAILED',
 
+
+  // ─────────────────────────── Agent Builder ─────────────────────────
+  /**
+   * The episode-attachment `refresh_episode` bounded tool failed while
+   * re-fetching the episode. The tool returns an error result to the agent;
+   * the conversation continues.
+   */
+  AGENT_BUILDER_EPISODE_REFRESH_FAILED: 'AGENT_BUILDER_EPISODE_REFRESH_FAILED',
+  /**
+   * The episode-attachment `get_rule` bounded tool failed while fetching the
+   * associated rule. The tool returns an error result to the agent; the
+   * conversation continues.
+   */
+  AGENT_BUILDER_EPISODE_GET_RULE_FAILED: 'AGENT_BUILDER_EPISODE_GET_RULE_FAILED',
+  /**
+   * Resolving an episode attachment origin failed. The attachment resolve
+   * hook returns undefined so the conversation can continue without the
+   * refreshed snapshot.
+   */
+  AGENT_BUILDER_EPISODE_RESOLVE_FAILED: 'AGENT_BUILDER_EPISODE_RESOLVE_FAILED',
+  /**
+   * Checking whether an episode attachment is stale failed. The isStale hook
+   * returns false so the conversation continues with the existing snapshot.
+   */
+  AGENT_BUILDER_EPISODE_STALENESS_CHECK_FAILED: 'AGENT_BUILDER_EPISODE_STALENESS_CHECK_FAILED',
+
   // ─────────────────────────────── Tasks ─────────────────────────────
   /**
    * A telemetry task run failed. Usage data for the interval is lost; the

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
@@ -340,28 +340,13 @@ export const ALERTING_LOG_CODES = {
 
 
   // ─────────────────────────── Agent Builder ─────────────────────────
-  /**
-   * The episode-attachment `refresh_episode` bounded tool failed while
-   * re-fetching the episode. The tool returns an error result to the agent;
-   * the conversation continues.
-   */
+  /** `refresh_episode` failed; tool returns an error result. */
   AGENT_BUILDER_EPISODE_REFRESH_FAILED: 'AGENT_BUILDER_EPISODE_REFRESH_FAILED',
-  /**
-   * The episode-attachment `get_rule` bounded tool failed while fetching the
-   * associated rule. The tool returns an error result to the agent; the
-   * conversation continues.
-   */
+  /** `get_rule` failed; tool returns an error result. */
   AGENT_BUILDER_EPISODE_GET_RULE_FAILED: 'AGENT_BUILDER_EPISODE_GET_RULE_FAILED',
-  /**
-   * Resolving an episode attachment origin failed. The attachment resolve
-   * hook returns undefined so the conversation can continue without the
-   * refreshed snapshot.
-   */
+  /** Episode attachment resolve failed; returns undefined. */
   AGENT_BUILDER_EPISODE_RESOLVE_FAILED: 'AGENT_BUILDER_EPISODE_RESOLVE_FAILED',
-  /**
-   * Checking whether an episode attachment is stale failed. The isStale hook
-   * returns false so the conversation continues with the existing snapshot.
-   */
+  /** Episode attachment isStale check failed; returns false. */
   AGENT_BUILDER_EPISODE_STALENESS_CHECK_FAILED: 'AGENT_BUILDER_EPISODE_STALENESS_CHECK_FAILED',
 
   // ─────────────────────────────── Tasks ─────────────────────────────

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
@@ -338,7 +338,6 @@ export const ALERTING_LOG_CODES = {
    */
   MAINTENANCE_WINDOW_PIT_CLOSE_FAILED: 'MAINTENANCE_WINDOW_PIT_CLOSE_FAILED',
 
-
   // ─────────────────────────── Agent Builder ─────────────────────────
   /** `refresh_episode` failed; tool returns an error result. */
   AGENT_BUILDER_EPISODE_REFRESH_FAILED: 'AGENT_BUILDER_EPISODE_REFRESH_FAILED',

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -75,6 +75,7 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
         logger,
         getEpisodesClient: (context) =>
           resolveRequestScoped(injection, context.request, EpisodesClient),
+        getRulesClient: (context) => resolveRequestScoped(injection, context.request, RulesClient),
       }) as AttachmentTypeDefinition,
     [Logger, CoreStart('injection')]
   );

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -22,8 +22,13 @@ import { AttachmentTypeToken } from '../agent_builder/tokens';
 import { ActionPolicyClient } from '../lib/action_policy_client';
 import { WorkflowsManagementApiToken } from '../lib/dispatcher/steps/dispatch_step_tokens';
 import { EpisodesClient } from '../lib/episodes_client';
+import { PrivilegeChecker } from '../lib/services/privilege_checker/privilege_checker';
 import { RulesClient } from '../lib/rules_client';
 import { ACTION_POLICY_SAVED_OBJECT_TYPE, RULE_SAVED_OBJECT_TYPE } from '../saved_objects';
+import {
+  LoggerServiceToken,
+  type LoggerServiceContract,
+} from '../lib/services/logger_service/logger_service';
 import { SettingsServiceToken } from '../lib/services/settings_service/tokens';
 import type { AlertingServerSetupDependencies } from '../types';
 
@@ -70,14 +75,16 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
     [Logger, CoreStart('injection')]
   );
   bind(AttachmentTypeToken).toResolvedValue(
-    (logger, injection) =>
+    (loggerService: LoggerServiceContract, injection) =>
       createEpisodeAttachmentType({
-        logger,
+        logger: loggerService.forSubsystem('agentBuilder'),
         getEpisodesClient: (context) =>
           resolveRequestScoped(injection, context.request, EpisodesClient),
         getRulesClient: (context) => resolveRequestScoped(injection, context.request, RulesClient),
+        getPrivilegeChecker: (context) =>
+          resolveRequestScoped(injection, context.request, PrivilegeChecker),
       }) as AttachmentTypeDefinition,
-    [Logger, CoreStart('injection')]
+    [LoggerServiceToken, CoreStart('injection')]
   );
 
   bind(OnSetup).toConstantValue((container) => {


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/rna-program/issues/831

- Adds attachment-scoped Agent Builder tools on `platform.alerting.episode`:
  - `platform.alerting.refresh_episode.<attachmentId>` — re-fetches the episode snapshot via `EpisodesClient`
  - `platform.alerting.get_rule.<attachmentId>` — fetches the associated rule via `RulesClient`
- Soft-routes the agent to load the `rule-management` skill when it needs to create or modify the rule (tools remain read-only)
- Tools live under `server/agent_builder/tools/` with unit tests

## Test plan

- [ ] Unit: `episode_attachment_type.test.ts`
- [ ] Unit: `tools/refresh_episode/refresh_episode.test.ts`
- [ ] Unit: `tools/get_rule/get_rule.test.ts`
- [ ] Manual: open Agent Builder on an episode details page, confirm the agent can call refresh/get_rule for the staged episode attachment
- [ ] Manual: ask the agent to modify the rule and confirm it loads `rule-management` rather than mutating via get_rule


Made with [Cursor](https://cursor.com)