### PR TITLE
[CPS] Refresh project picker when the browser tab regains focus

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.test.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.test.tsx
@@ -36,14 +36,19 @@ const mockLinkedProjects: CPSProject[] = [
 ];
 
 describe('ProjectPickerContainer', () => {
-  const renderProjectPicker = async (
-    props: { cpsManager: Partial<ICPSManager> } = { cpsManager: {} }
-  ) => {
+  const renderProjectPicker = async ({
+    cpsManager: cpsManagerOverrides = {},
+    totalProjectCount = 2,
+  }: {
+    cpsManager?: Partial<ICPSManager>;
+    totalProjectCount?: number;
+  } = {}) => {
     const mockProjectRouting$ = new BehaviorSubject<ProjectRouting | undefined>(undefined);
     // Default to EDITABLE access (dashboards app on individual page)
     const mockProjectPickerAccess$ = new BehaviorSubject<ProjectRoutingAccess>(
       ProjectRoutingAccess.EDITABLE
     );
+    const mockTotalProjectCount$ = new BehaviorSubject<number>(totalProjectCount);
     const cpsManager = {
       fetchProjects: jest.fn().mockResolvedValue({
         origin: mockOriginProject,
@@ -55,11 +60,12 @@ describe('ProjectPickerContainer', () => {
       setProjectRouting: jest.fn(),
       getProjectPickerAccess$: jest.fn(() => mockProjectPickerAccess$),
       getDefaultProjectRouting: jest.fn(() => PROJECT_ROUTING.ALL),
-      getTotalProjectCount: jest.fn(() => 2),
+      getTotalProjectCount: jest.fn(() => mockTotalProjectCount$.value),
+      getTotalProjectCount$: jest.fn(() => mockTotalProjectCount$),
       hasLinkedProjects: jest.fn(() => true),
       updateDefaultProjectRouting: jest.fn(),
       registerAppAccess: jest.fn(),
-      ...props.cpsManager,
+      ...cpsManagerOverrides,
     };
     return await act(async () => {
       const component = <ProjectPickerContainer cpsManager={cpsManager} />;
@@ -113,10 +119,27 @@ describe('ProjectPickerContainer', () => {
             origin: mockOriginProject,
             linkedProjects: [],
           }),
-          getTotalProjectCount: jest.fn(() => 1),
+        },
+        totalProjectCount: 1,
+      });
+      expect(screen.queryByTestId('project-picker-button')).not.toBeInTheDocument();
+    });
+
+    it('should render the button when projects are linked after mount', async () => {
+      const totalProjectCount$ = new BehaviorSubject<number>(1);
+      await renderProjectPicker({
+        cpsManager: {
+          getTotalProjectCount: jest.fn(() => totalProjectCount$.value),
+          getTotalProjectCount$: jest.fn(() => totalProjectCount$),
         },
       });
       expect(screen.queryByTestId('project-picker-button')).not.toBeInTheDocument();
+
+      await act(async () => {
+        totalProjectCount$.next(2);
+      });
+
+      expect(screen.getByTestId('project-picker-button')).toBeInTheDocument();
     });
   });
 

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.tsx
@@ -27,14 +27,22 @@ interface ProjectPickerContainerProps {
  */
 export const ProjectPickerContainer: React.FC<ProjectPickerContainerProps> = ({ cpsManager }) => {
   const access = useObservable(cpsManager.getProjectPickerAccess$(), ProjectRoutingAccess.DISABLED);
+  const totalProjectCount = useObservable(
+    cpsManager.getTotalProjectCount$(),
+    cpsManager.getTotalProjectCount()
+  );
 
   if (access === ProjectRoutingAccess.DISABLED) {
-    return <DisabledProjectPicker totalProjectCount={cpsManager.getTotalProjectCount()} />;
+    return <DisabledProjectPicker totalProjectCount={totalProjectCount} />;
   }
 
   return (
     <ActiveProjectPicker
+      // Linking or unlinking invalidates the projects the picker has listed, so start over
+      // instead of showing counts from a mix of the old and new project sets
+      key={totalProjectCount}
       cpsManager={cpsManager}
+      totalProjectCount={totalProjectCount}
       isReadonly={access === ProjectRoutingAccess.READONLY}
     />
   );
@@ -42,10 +50,15 @@ export const ProjectPickerContainer: React.FC<ProjectPickerContainerProps> = ({ 
 
 interface ActiveProjectPickerProps {
   cpsManager: ICPSManager;
+  totalProjectCount: number;
   isReadonly: boolean;
 }
 
-const ActiveProjectPicker: React.FC<ActiveProjectPickerProps> = ({ cpsManager, isReadonly }) => {
+const ActiveProjectPicker: React.FC<ActiveProjectPickerProps> = ({
+  cpsManager,
+  totalProjectCount,
+  isReadonly,
+}) => {
   const { projectRouting, updateProjectRouting } = useProjectRouting(cpsManager);
 
   const fetchProjects = useCallback(
@@ -66,7 +79,7 @@ const ActiveProjectPicker: React.FC<ActiveProjectPickerProps> = ({ cpsManager, i
       projectRouting={projectRouting}
       onProjectRoutingChange={updateProjectRouting}
       projects={projects}
-      totalProjectCount={cpsManager.getTotalProjectCount()}
+      totalProjectCount={totalProjectCount}
       isReadonly={isReadonly}
       settingsComponent={<ProjectPickerSettings onResetToDefaults={resetProjectPicker} />}
     />

--- a/src/platform/packages/shared/kbn-cps-utils/types.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/types.ts
@@ -53,6 +53,8 @@ export interface ICPSManager {
   whenReady(): Promise<void>;
   fetchProjects(projectRouting?: ProjectRouting): Promise<ProjectsData | null>;
   getTotalProjectCount(): number;
+  /** Emits whenever the known set of projects changes. 0 until the initial fetch resolves. */
+  getTotalProjectCount$(): Observable<number>;
   hasLinkedProjects(): boolean;
   getProjectRouting$(): Observable<ProjectRouting | undefined>;
   setProjectRouting(projectRouting: ProjectRouting | undefined): void;

--- a/src/platform/plugins/shared/cps/README.md
+++ b/src/platform/plugins/shared/cps/README.md
@@ -10,7 +10,7 @@ Kibana acts as a **transparent orchestrator**. It does not execute cross-project
 
 - **CPSManager**: The central service for managing CPS state in the browser.
   - **Project Routing**: Manages the `projectRouting$` observable (defaults to searching all projects) and allows applications to set/get the current routing.
-  - **Project Fetching**: Fetches and caches project data using `ProjectFetcher`.
+  - **Project Fetching**: Fetches and caches project data using `ProjectFetcher`. The number of reachable projects is exposed both synchronously (`getTotalProjectCount`) and as an observable (`getTotalProjectCount$`). Because linking projects in Cloud takes time to reach Elasticsearch, the list is refetched whenever the browser tab becomes visible again, so the project picker appears without a page reload once a link lands. Refreshes are throttled by the `ProjectFetcher` cache, and a failed refresh keeps the last known projects.
   - **UI Access Control**: Determines if the project picker should be editable, read-only, or disabled based on the current application and location (via `getProjectPickerAccess$`).
 
 

--- a/src/platform/plugins/shared/cps/public/__mocks__/index.ts
+++ b/src/platform/plugins/shared/cps/public/__mocks__/index.ts
@@ -14,6 +14,7 @@ export const createCpsManagerMock = (): jest.Mocked<ICPSManager> => ({
   whenReady: jest.fn().mockResolvedValue(undefined),
   fetchProjects: jest.fn().mockResolvedValue(null),
   getTotalProjectCount: jest.fn().mockReturnValue(1),
+  getTotalProjectCount$: jest.fn(() => of(1)),
   hasLinkedProjects: jest.fn().mockReturnValue(false),
   getProjectRouting$: jest.fn(() => of(undefined)),
   setProjectRouting: jest.fn(),

--- a/src/platform/plugins/shared/cps/public/plugin.tsx
+++ b/src/platform/plugins/shared/cps/public/plugin.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
-import { type ICPSManager, type CPSAppAccessResolver } from '@kbn/cps-utils';
+import { type CPSAppAccessResolver } from '@kbn/cps-utils';
 import { CPS_TIER_ELIGIBLE_FEATURE_ID } from '@kbn/cps-common';
 import type { CPSPluginSetup, CPSPluginStart, CPSConfigType } from './types';
 import { CPSManager } from './services/cps_manager';
@@ -18,6 +18,7 @@ import { CPSManager } from './services/cps_manager';
 export class CpsPlugin implements Plugin<CPSPluginSetup, CPSPluginStart> {
   private readonly initializerContext: PluginInitializerContext<CPSConfigType>;
   private readonly appAccessResolvers = new Map<string, CPSAppAccessResolver>();
+  private cpsManager?: CPSManager;
 
   constructor(initializerContext: PluginInitializerContext<CPSConfigType>) {
     this.initializerContext = initializerContext;
@@ -36,7 +37,6 @@ export class CpsPlugin implements Plugin<CPSPluginSetup, CPSPluginStart> {
 
   public start(core: CoreStart): CPSPluginStart {
     const { cpsEnabled } = this.initializerContext.config.get();
-    let cpsManager: ICPSManager | undefined;
 
     if (cpsEnabled) {
       const manager = new CPSManager({
@@ -69,16 +69,18 @@ export class CpsPlugin implements Plugin<CPSPluginSetup, CPSPluginStart> {
           });
         })
       );
-      cpsManager = manager;
+      this.cpsManager = manager;
     }
 
     const isTierEligible = core.pricing.isFeatureAvailable(CPS_TIER_ELIGIBLE_FEATURE_ID);
 
     return {
-      cpsManager,
+      cpsManager: this.cpsManager,
       isTierEligible,
     };
   }
 
-  public stop() {}
+  public stop() {
+    this.cpsManager?.stop();
+  }
 }

--- a/src/platform/plugins/shared/cps/public/services/cps_manager.test.ts
+++ b/src/platform/plugins/shared/cps/public/services/cps_manager.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { CPSManager } from './cps_manager';
+import { CACHE_TTL_MS } from './project_fetcher';
 import type { ApplicationStart, HttpSetup } from '@kbn/core/public';
 import { ProjectRoutingAccess } from '@kbn/cps-utils';
 import type { CPSProject, ProjectTagsResponse } from '@kbn/cps-utils';
@@ -86,6 +87,7 @@ describe('CPSManager', () => {
   });
 
   afterEach(() => {
+    cpsManager.stop();
     jest.useRealTimers();
     jest.clearAllMocks();
   });
@@ -110,6 +112,98 @@ describe('CPSManager', () => {
 
       expect(result!.linkedProjects[0]._alias).toBe('A Project');
       expect(result!.linkedProjects[1]._alias).toBe('B Project');
+    });
+  });
+
+  describe('total project count', () => {
+    const createManager = () =>
+      new CPSManager({
+        http: mockHttp,
+        logger: mockLogger,
+        application: mockApplication,
+      });
+
+    /**
+     * Refreshes are served from the project fetcher cache, so let it expire before simulating
+     * the user returning to the tab.
+     */
+    const returnToTab = async () => {
+      jest.useFakeTimers();
+      await jest.advanceTimersByTimeAsync(CACHE_TTL_MS + 1);
+      document.dispatchEvent(new Event('visibilitychange'));
+      await jest.runAllTimersAsync();
+    };
+
+    it('should emit the count once the initial fetch resolves', async () => {
+      const manager = createManager();
+      const emissions: number[] = [];
+      manager.getTotalProjectCount$().subscribe((count) => emissions.push(count));
+
+      expect(emissions).toEqual([0]);
+
+      await manager.whenReady();
+
+      // origin project plus two linked projects
+      expect(emissions).toEqual([0, 3]);
+      expect(manager.getTotalProjectCount()).toBe(3);
+      expect(manager.hasLinkedProjects()).toBe(true);
+      manager.stop();
+    });
+
+    it('should stay at 0 when the initial fetch fails', async () => {
+      mockHttp.post.mockRejectedValue(new Error('Persistent error'));
+      jest.useFakeTimers();
+
+      const manager = createManager();
+      await Promise.all([manager.whenReady(), jest.runAllTimersAsync()]);
+
+      expect(manager.getTotalProjectCount()).toBe(0);
+      expect(manager.hasLinkedProjects()).toBe(false);
+      manager.stop();
+    });
+
+    it('should pick up projects linked after page load when the user returns to the tab', async () => {
+      // nothing was linked yet when the page loaded
+      mockHttp.post.mockResolvedValue({ origin: mockResponse.origin, linked_projects: {} });
+      const manager = createManager();
+      await manager.whenReady();
+
+      const emissions: number[] = [];
+      manager.getTotalProjectCount$().subscribe((count) => emissions.push(count));
+      expect(emissions).toEqual([1]);
+
+      // the link reaches Elasticsearch while the user is away configuring CPS in Cloud UI
+      mockHttp.post.mockResolvedValue(mockResponse);
+      await returnToTab();
+
+      expect(emissions).toEqual([1, 3]);
+      expect(manager.getTotalProjectCount()).toBe(3);
+      manager.stop();
+    });
+
+    it('should keep the last known count when a refresh fails', async () => {
+      const manager = createManager();
+      await manager.whenReady();
+      expect(manager.getTotalProjectCount()).toBe(3);
+
+      mockHttp.post.mockRejectedValue(new Error('Network error'));
+      await returnToTab();
+
+      expect(manager.getTotalProjectCount()).toBe(3);
+      manager.stop();
+    });
+
+    it('should not refresh once stopped', async () => {
+      mockHttp.post.mockResolvedValue({ origin: mockResponse.origin, linked_projects: {} });
+      const manager = createManager();
+      await manager.whenReady();
+      expect(manager.getTotalProjectCount()).toBe(1);
+
+      manager.stop();
+      mockHttp.post.mockResolvedValue(mockResponse);
+      await returnToTab();
+
+      expect(manager.getTotalProjectCount()).toBe(1);
     });
   });
 

--- a/src/platform/plugins/shared/cps/public/services/cps_manager.ts
+++ b/src/platform/plugins/shared/cps/public/services/cps_manager.ts
@@ -10,7 +10,16 @@
 import type { ApplicationStart, HttpSetup } from '@kbn/core/public';
 import type { Logger } from '@kbn/logging';
 import type { ProjectRouting } from '@kbn/es-query';
-import { BehaviorSubject, combineLatest, map } from 'rxjs';
+import {
+  BehaviorSubject,
+  Subscription,
+  combineLatest,
+  distinctUntilChanged,
+  filter,
+  fromEvent,
+  map,
+  type Observable,
+} from 'rxjs';
 import {
   type CPSAppAccessResolver,
   type ICPSManager,
@@ -19,6 +28,9 @@ import {
   PROJECT_ROUTING,
 } from '@kbn/cps-utils';
 import type { ProjectFetcher } from './project_fetcher';
+
+const countProjects = (projects: ProjectsData | null): number =>
+  projects ? (projects.origin ? 1 : 0) + projects.linkedProjects.length : 0;
 
 /**
  * Central service for managing project routing and project data.
@@ -33,7 +45,9 @@ export class CPSManager implements ICPSManager {
   private readonly application: ApplicationStart;
   private projectFetcherPromise: Promise<ProjectFetcher> | null = null;
   private defaultProjectRouting: ProjectRouting = PROJECT_ROUTING.ALL;
-  private allProjects: ProjectsData | null = null;
+  private readonly allProjects$ = new BehaviorSubject<ProjectsData | null>(null);
+  private readonly totalProjectCount$: Observable<number>;
+  private readonly subscriptions = new Subscription();
   private readonly readyPromise: Promise<void>;
   private readonly appAccessResolvers: Map<string, CPSAppAccessResolver>;
   private currentAppId: string = '';
@@ -55,23 +69,43 @@ export class CPSManager implements ICPSManager {
     this.http = deps.http;
     this.logger = deps.logger.get('cps_manager');
     this.application = deps.application;
+    this.totalProjectCount$ = this.allProjects$.pipe(map(countProjects), distinctUntilChanged());
     this.readyPromise = Promise.all([
       this.initializeDefaultProjectRouting(),
       this.fetchAllProjects(),
     ]).then(() => {});
 
     this.appAccessResolvers = deps.appAccessResolvers ?? new Map();
-    combineLatest([this.application.currentAppId$, this.application.currentLocation$])
-      .pipe(
-        map(([appId, location]) => {
-          this.currentAppId = appId ?? '';
-          this.currentLocation = location ?? '';
-          return this.resolveAccess(this.currentAppId, this.currentLocation);
+    this.subscriptions.add(
+      combineLatest([this.application.currentAppId$, this.application.currentLocation$])
+        .pipe(
+          map(([appId, location]) => {
+            this.currentAppId = appId ?? '';
+            this.currentLocation = location ?? '';
+            return this.resolveAccess(this.currentAppId, this.currentLocation);
+          })
+        )
+        .subscribe((access) => {
+          this.applyAccess(access);
         })
-      )
-      .subscribe((access) => {
-        this.applyAccess(access);
-      });
+    );
+    this.subscriptions.add(
+      // Linking projects in Cloud takes a while to reach Elasticsearch, so the count fetched on
+      // page load can already be stale. Refresh whenever the user returns to the tab, which is
+      // what they do after configuring CPS. Throttled by the project fetcher cache.
+      fromEvent(document, 'visibilitychange')
+        .pipe(filter(() => document.visibilityState === 'visible'))
+        .subscribe(() => {
+          void this.fetchAllProjects();
+        })
+    );
+  }
+
+  /**
+   * Releases the manager's subscriptions. Called when the plugin stops.
+   */
+  public stop(): void {
+    this.subscriptions.unsubscribe();
   }
 
   /**
@@ -123,8 +157,9 @@ export class CPSManager implements ICPSManager {
   private async fetchAllProjects(): Promise<void> {
     try {
       const projectsData = await this.fetchProjects(PROJECT_ROUTING.ALL);
-      this.allProjects = projectsData;
+      this.allProjects$.next(projectsData);
     } catch (error) {
+      // Keep the last known projects rather than reporting zero on a transient failure
       this.logger.warn('Failed to fetch total project count', error);
     }
   }
@@ -133,9 +168,15 @@ export class CPSManager implements ICPSManager {
    * Returns the total number of projects (origin + linked) across all project routings.
    */
   public getTotalProjectCount(): number {
-    return this.allProjects
-      ? (this.allProjects?.origin ? 1 : 0) + (this.allProjects?.linkedProjects.length ?? 0)
-      : 0;
+    return countProjects(this.allProjects$.value);
+  }
+
+  /**
+   * Total number of projects as an observable, so consumers update when the projects are
+   * first fetched and whenever they are refreshed. Emits 0 until the initial fetch resolves.
+   */
+  public getTotalProjectCount$(): Observable<number> {
+    return this.totalProjectCount$;
   }
 
   /**
@@ -144,7 +185,7 @@ export class CPSManager implements ICPSManager {
    * `false` until that resolves.
    */
   public hasLinkedProjects(): boolean {
-    return (this.allProjects?.linkedProjects.length ?? 0) > 0;
+    return (this.allProjects$.value?.linkedProjects.length ?? 0) > 0;
   }
 
   /**


### PR DESCRIPTION
## Summary

The cross project search button now appears in the Kibana header on its own once projects are linked in Cloud, instead of staying hidden until the user manually reloads the browser.

Linking projects in Cloud takes a little while to reach Elasticsearch. Kibana only ever asked for the set of reachable projects once, while the page was loading, so a page opened during that window saw a single project, decided cross project search was not available, and hid the button. Nothing rechecked, so the only way out was a full page refresh.

Kibana now rechecks the reachable projects whenever the user returns to the browser tab. The header updates in place when projects appear or disappear, and the picker's contents are refreshed alongside it so the button's counts and the list behind it always describe the same set of projects. Repeat checks are rate limited so switching tabs frequently does not generate extra load, and a check that fails leaves the previously known projects in place rather than making the button vanish.

### How to test

1. In Cloud UI, link one or more serverless projects to another serverless project via CPS configuration.
2. Open that project's Kibana, or switch to a tab where it is already open.
3. Switch to another browser tab and back again.
4. The cross-project search button appears in the global header with no page reload. Unlinking the projects and returning to the tab removes it again.

Automated coverage:

```
node scripts/jest src/platform/plugins/shared/cps
node scripts/jest src/platform/packages/shared/kbn-cps-utils
```

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- The header issues one lightweight request for the project list when the user returns to the tab. It is rate limited, so frequent tab switching does not multiply requests, and the call is already made on every page load today. Low severity.
- A short window remains where a user who returns to the tab within seconds of the previous check is served the rate-limited result and has to switch tabs once more. Low severity, and strictly better than the current behaviour of never recovering.

### Release note

Fixed the cross project search button not appearing in the Kibana header until the page was manually reloaded after configuring cross project search.
