### PR TITLE
[One Workflow] Add step logs view in workflow execution detail panel

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/nodes_factory.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/nodes_factory.ts
@@ -173,7 +173,7 @@ export class NodesFactory {
           stepExecutionRuntime,
           this.connectorExecutor,
           this.workflowRuntime,
-          this.workflowLogger
+          stepExecutionRuntime.stepLogger
         );
       }
     }

--- a/src/platform/plugins/shared/workflows_extensions/moon.yml
+++ b/src/platform/plugins/shared/workflows_extensions/moon.yml
@@ -34,6 +34,7 @@ dependsOn:
   - '@kbn/logging-mocks'
   - '@kbn/logging'
   - '@kbn/core-http-common'
+  - '@kbn/workflows-ui'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/workflows_extensions/public/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/index.ts
@@ -19,7 +19,12 @@ export type {
   WorkflowsExtensionsPublicPluginStart,
 } from './types';
 
-export type { PublicStepDefinition } from './step_registry/types';
+export type {
+  PublicStepDefinition,
+  StepLogsConfig,
+  StepLogsApi,
+  StepLogEntry,
+} from './step_registry/types';
 export type { StepDocumentation } from '@kbn/workflows';
 
 export { createPublicStepDefinition } from './step_registry/types';

--- a/src/platform/plugins/shared/workflows_extensions/public/step_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/step_registry/types.ts
@@ -28,10 +28,9 @@ export interface StepLogsConfig {
   enabled: boolean;
   /**
    * How to render log entries in the Logs tab.
-   * - `'sections'` (default): stdout and stderr in separate collapsible sections.
-   * - `'terminal'`: all entries interleaved in chronological order, stderr colored.
+   * Currently only `'terminal'` is supported: entries in chronological order, ANSI colors preserved.
    */
-  renderer?: 'sections' | 'terminal';
+  renderer?: 'terminal';
   /**
    * Custom log resolver. When omitted, the Logs tab shows all engine-level log entries
    * for this step via `logsApi.fetchLogs()`. When defined, the step author decides what

--- a/src/platform/plugins/shared/workflows_extensions/public/step_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/step_registry/types.ts
@@ -7,9 +7,41 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { EditorHandlers } from '@kbn/workflows/types/latest';
+import type { EditorHandlers, WorkflowStepExecutionDto } from '@kbn/workflows/types/latest';
+import type { WorkflowExecutionLogEntry } from '@kbn/workflows-ui';
 import type { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../common';
+
+/** Pre-scoped engine logs API handed to a step's `getLogs` function. */
+export interface StepLogsApi {
+  fetchLogs: () => Promise<WorkflowExecutionLogEntry[]>;
+}
+
+/** A single entry rendered in the Logs tab. */
+export interface StepLogEntry {
+  message: string;
+  timestamp?: string;
+  level?: 'info' | 'warn' | 'error';
+}
+
+export interface StepLogsConfig {
+  enabled: boolean;
+  /**
+   * How to render log entries in the Logs tab.
+   * - `'sections'` (default): stdout and stderr in separate collapsible sections.
+   * - `'terminal'`: all entries interleaved in chronological order, stderr colored.
+   */
+  renderer?: 'sections' | 'terminal';
+  /**
+   * Custom log resolver. When omitted, the Logs tab shows all engine-level log entries
+   * for this step via `logsApi.fetchLogs()`. When defined, the step author decides what
+   * to show — extract from `output`, call `logsApi`, or combine both.
+   */
+  getLogs?: (params: {
+    stepExecution: WorkflowStepExecutionDto;
+    logsApi: StepLogsApi;
+  }) => Promise<StepLogEntry[]> | StepLogEntry[];
+}
 
 /**
  * Helper function to create a PublicStepDefinition with automatic type inference.
@@ -48,4 +80,11 @@ export interface PublicStepDefinition<
    * Property handlers for the step.
    */
   editorHandlers?: EditorHandlers<Input, Output, Config>;
+
+  /**
+   * Opt-in logs configuration. When `enabled` is true a Logs tab appears in the
+   * step execution detail panel. Provide `getLogs` to customise what is shown;
+   * omit it to display all engine-level log entries for this step.
+   */
+  logs?: StepLogsConfig;
 }

--- a/src/platform/plugins/shared/workflows_extensions/server/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/index.ts
@@ -49,6 +49,7 @@ export type {
   ServerPollStepDefinition,
   StepHandler,
   StepHandlerContext,
+  StepLogMeta,
   StepHandlerResult,
   OnCancelHandler,
   StartWithHandoffHandler,

--- a/src/platform/plugins/shared/workflows_extensions/server/step_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/step_registry/types.ts
@@ -337,6 +337,11 @@ export function createPollServerStepDefinition<
  * Context provided to custom step handlers during execution.
  * This gives access to runtime services needed for step execution.
  */
+
+export interface StepLogMeta {
+  tags?: string[];
+}
+
 export interface StepHandlerContext<TInput = z.ZodType, TConfig = z.ZodObject> {
   /**
    * The validated input provided to the step based on inputSchema
@@ -363,9 +368,9 @@ export interface StepHandlerContext<TInput = z.ZodType, TConfig = z.ZodObject> {
    * Logger scoped to this step execution
    */
   logger: {
-    debug(message: string, meta?: object): void;
-    info(message: string, meta?: object): void;
-    warn(message: string, meta?: object): void;
+    debug(message: string, meta?: StepLogMeta): void;
+    info(message: string, meta?: StepLogMeta): void;
+    warn(message: string, meta?: StepLogMeta): void;
     error(message: string, error?: Error): void;
   };
 

--- a/src/platform/plugins/shared/workflows_extensions/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_extensions/tsconfig.json
@@ -28,7 +28,8 @@
     "@kbn/std",
     "@kbn/logging-mocks",
     "@kbn/logging",
-    "@kbn/core-http-common"
+    "@kbn/core-http-common",
+    "@kbn/workflows-ui"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_logs_view.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_logs_view.tsx
@@ -7,16 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import {
-  EuiAccordion,
-  EuiLoadingSpinner,
-  EuiSpacer,
-  EuiText,
-  useEuiTheme,
-  useGeneratedHtmlId,
-} from '@elastic/eui';
+import { EuiLoadingSpinner, EuiText, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   type ExecutionStatus,
@@ -24,11 +17,6 @@ import {
   type WorkflowStepExecutionDto,
 } from '@kbn/workflows/types/latest';
 import type { StepLogEntry, StepLogsApi, StepLogsConfig } from '@kbn/workflows-extensions/public';
-
-const preWrapCss = css`
-  white-space: pre-wrap;
-  word-break: break-all;
-`;
 
 const terminalContainerCss = css`
   font-family: monospace;
@@ -138,21 +126,6 @@ const ansiToSpans = (text: string): React.ReactNode[] => {
   return result;
 };
 
-interface LogSectionProps {
-  id: string;
-  label: string;
-  content: string;
-}
-
-const LogSection = memo<LogSectionProps>(({ id, label, content }) => (
-  <EuiAccordion id={id} buttonContent={label} paddingSize="s" initialIsOpen>
-    <EuiText size="xs" css={preWrapCss}>
-      <p>{content}</p>
-    </EuiText>
-  </EuiAccordion>
-));
-LogSection.displayName = 'LogSection';
-
 const TerminalLogsView = memo<{ entries: StepLogEntry[] }>(({ entries }) => {
   const { euiTheme } = useEuiTheme();
   return (
@@ -183,8 +156,6 @@ interface StepLogsViewProps {
 
 export const StepLogsView: React.FC<StepLogsViewProps> = ({ stepExecution, config, logsApi }) => {
   const [entries, setEntries] = useState<StepLogEntry[] | null>(null);
-  const outputId = useGeneratedHtmlId({ prefix: 'stepLogsOutput' });
-  const errorId = useGeneratedHtmlId({ prefix: 'stepLogsError' });
 
   // Refs so the poll loop always reads the latest values without restarting on every parent re-render.
   const stepExecutionRef = useRef(stepExecution);
@@ -233,20 +204,6 @@ export const StepLogsView: React.FC<StepLogsViewProps> = ({ stepExecution, confi
     };
   }, [logsApi]); // logsApi is memoized on stepExecution.id — restarts only when the step changes
 
-  const { outputText, errorText } = useMemo(() => {
-    if (!entries) return { outputText: '', errorText: '' };
-    return {
-      outputText: entries
-        .filter((e) => !e.level || e.level === 'info')
-        .map((e) => e.message)
-        .join('\n'),
-      errorText: entries
-        .filter((e) => e.level === 'warn' || e.level === 'error')
-        .map((e) => e.message)
-        .join('\n'),
-    };
-  }, [entries]);
-
   if (entries === null) {
     return <EuiLoadingSpinner size="m" />;
   }
@@ -263,33 +220,5 @@ export const StepLogsView: React.FC<StepLogsViewProps> = ({ stepExecution, confi
     );
   }
 
-  if (config.renderer === 'terminal') {
-    return <TerminalLogsView entries={entries} />;
-  }
-
-  return (
-    <>
-      {errorText && (
-        <>
-          <LogSection
-            id={errorId}
-            label={i18n.translate('workflowsManagement.stepLogsView.errorsLabel', {
-              defaultMessage: 'Errors',
-            })}
-            content={errorText}
-          />
-          <EuiSpacer size="m" />
-        </>
-      )}
-      {outputText && (
-        <LogSection
-          id={outputId}
-          label={i18n.translate('workflowsManagement.stepLogsView.outputLabel', {
-            defaultMessage: 'Output',
-          })}
-          content={outputText}
-        />
-      )}
-    </>
-  );
+  return <TerminalLogsView entries={entries} />;
 };

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_logs_view.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_logs_view.tsx
@@ -63,7 +63,50 @@ interface AnsiState {
   bold: boolean;
 }
 
-// eslint-disable-next-line complexity
+const applyExtendedColor = (
+  codes: number[],
+  i: number,
+  isFg: boolean,
+  state: AnsiState
+): { state: AnsiState; advance: number } | null => {
+  if (codes[i + 1] === 5 && codes[i + 2] !== undefined) {
+    const color = ansi256ToHex(codes[i + 2]);
+    return {
+      state: isFg ? { ...state, fg: color } : { ...state, bg: color },
+      advance: 3,
+    };
+  }
+  if (codes[i + 1] === 2 && codes[i + 4] !== undefined) {
+    const color = `rgb(${codes[i + 2]},${codes[i + 3]},${codes[i + 4]})`;
+    return {
+      state: isFg ? { ...state, fg: color } : { ...state, bg: color },
+      advance: 5,
+    };
+  }
+  return null;
+};
+
+const applyAnsiCode = (
+  codes: number[],
+  i: number,
+  state: AnsiState,
+  rawParam: string
+): { state: AnsiState; advance: number } => {
+  const c = codes[i];
+  if (c === 0 || (rawParam === '' && codes.length === 1))
+    return { state: { bold: false }, advance: 1 };
+  if (c === 1) return { state: { ...state, bold: true }, advance: 1 };
+  if ((c >= 30 && c <= 37) || (c >= 90 && c <= 97))
+    return { state: { ...state, fg: ANSI_FG[c] }, advance: 1 };
+  if ((c >= 40 && c <= 47) || (c >= 100 && c <= 107))
+    return { state: { ...state, bg: ANSI_FG[c - 10] }, advance: 1 };
+  if (c === 38 || c === 48) {
+    const extended = applyExtendedColor(codes, i, c === 38, state);
+    if (extended) return extended;
+  }
+  return { state, advance: 1 };
+};
+
 const ansiToSpans = (text: string): React.ReactNode[] => {
   const result: React.ReactNode[] = [];
   let state: AnsiState = { bold: false };
@@ -92,34 +135,9 @@ const ansiToSpans = (text: string): React.ReactNode[] => {
     const codes = m[1].split(';').map(Number);
     let i = 0;
     while (i < codes.length) {
-      const c = codes[i];
-      if (c === 0 || (m[1] === '' && codes.length === 1)) {
-        state = { bold: false };
-        i++;
-      } else if (c === 1) {
-        state = { ...state, bold: true };
-        i++;
-      } else if ((c >= 30 && c <= 37) || (c >= 90 && c <= 97)) {
-        state = { ...state, fg: ANSI_FG[c] };
-        i++;
-      } else if ((c >= 40 && c <= 47) || (c >= 100 && c <= 107)) {
-        state = { ...state, bg: ANSI_FG[c - 10] };
-        i++;
-      } else if (c === 38 && codes[i + 1] === 5 && codes[i + 2] !== undefined) {
-        state = { ...state, fg: ansi256ToHex(codes[i + 2]) };
-        i += 3;
-      } else if (c === 48 && codes[i + 1] === 5 && codes[i + 2] !== undefined) {
-        state = { ...state, bg: ansi256ToHex(codes[i + 2]) };
-        i += 3;
-      } else if (c === 38 && codes[i + 1] === 2 && codes[i + 4] !== undefined) {
-        state = { ...state, fg: `rgb(${codes[i + 2]},${codes[i + 3]},${codes[i + 4]})` };
-        i += 5;
-      } else if (c === 48 && codes[i + 1] === 2 && codes[i + 4] !== undefined) {
-        state = { ...state, bg: `rgb(${codes[i + 2]},${codes[i + 3]},${codes[i + 4]})` };
-        i += 5;
-      } else {
-        i++;
-      }
+      const { state: next, advance } = applyAnsiCode(codes, i, state, m[1]);
+      state = next;
+      i += advance;
     }
   }
   flush(text.length);

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_logs_view.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/step_logs_view.tsx
@@ -1,0 +1,295 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  EuiAccordion,
+  EuiLoadingSpinner,
+  EuiSpacer,
+  EuiText,
+  useEuiTheme,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import {
+  type ExecutionStatus,
+  TerminalExecutionStatuses,
+  type WorkflowStepExecutionDto,
+} from '@kbn/workflows/types/latest';
+import type { StepLogEntry, StepLogsApi, StepLogsConfig } from '@kbn/workflows-extensions/public';
+
+const preWrapCss = css`
+  white-space: pre-wrap;
+  word-break: break-all;
+`;
+
+const terminalContainerCss = css`
+  font-family: monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+`;
+
+// Standard 4-bit ANSI foreground → CSS hex
+const ANSI_FG: Record<number, string> = {
+  30: '#000000',
+  31: '#cc0000',
+  32: '#4e9a06',
+  33: '#c4a000',
+  34: '#3465a4',
+  35: '#75507b',
+  36: '#06989a',
+  37: '#d3d7cf',
+  90: '#555753',
+  91: '#ef2929',
+  92: '#8ae234',
+  93: '#fce94f',
+  94: '#729fcf',
+  95: '#ad7fa8',
+  96: '#34e2e2',
+  97: '#eeeeec',
+};
+
+const ansi256ToHex = (n: number): string => {
+  if (n < 16) return ANSI_FG[n < 8 ? n + 30 : n + 82] ?? '#ffffff';
+  if (n < 232) {
+    const i = n - 16;
+    const toHex = (v: number) => (v === 0 ? 0 : 55 + 40 * v).toString(16).padStart(2, '0');
+    return `#${toHex(Math.floor(i / 36))}${toHex(Math.floor((i % 36) / 6))}${toHex(i % 6)}`;
+  }
+  const v = (8 + (n - 232) * 10).toString(16).padStart(2, '0');
+  return `#${v}${v}${v}`;
+};
+
+interface AnsiState {
+  fg?: string;
+  bg?: string;
+  bold: boolean;
+}
+
+// eslint-disable-next-line complexity
+const ansiToSpans = (text: string): React.ReactNode[] => {
+  const result: React.ReactNode[] = [];
+  let state: AnsiState = { bold: false };
+  let last = 0;
+  let idx = 0;
+  const re = /\x1b\[([0-9;]*)m/g;
+  let m: RegExpExecArray | null;
+
+  const flush = (end: number) => {
+    if (end <= last) return;
+    const chunk = text.slice(last, end);
+    const style: React.CSSProperties = {};
+    if (state.fg) style.color = state.fg;
+    if (state.bg) style.backgroundColor = state.bg;
+    if (state.bold) style.fontWeight = 'bold';
+    result.push(
+      <span key={idx++} style={style}>
+        {chunk}
+      </span>
+    );
+  };
+
+  while ((m = re.exec(text)) !== null) {
+    flush(m.index);
+    last = m.index + m[0].length;
+    const codes = m[1].split(';').map(Number);
+    let i = 0;
+    while (i < codes.length) {
+      const c = codes[i];
+      if (c === 0 || (m[1] === '' && codes.length === 1)) {
+        state = { bold: false };
+        i++;
+      } else if (c === 1) {
+        state = { ...state, bold: true };
+        i++;
+      } else if ((c >= 30 && c <= 37) || (c >= 90 && c <= 97)) {
+        state = { ...state, fg: ANSI_FG[c] };
+        i++;
+      } else if ((c >= 40 && c <= 47) || (c >= 100 && c <= 107)) {
+        state = { ...state, bg: ANSI_FG[c - 10] };
+        i++;
+      } else if (c === 38 && codes[i + 1] === 5 && codes[i + 2] !== undefined) {
+        state = { ...state, fg: ansi256ToHex(codes[i + 2]) };
+        i += 3;
+      } else if (c === 48 && codes[i + 1] === 5 && codes[i + 2] !== undefined) {
+        state = { ...state, bg: ansi256ToHex(codes[i + 2]) };
+        i += 3;
+      } else if (c === 38 && codes[i + 1] === 2 && codes[i + 4] !== undefined) {
+        state = { ...state, fg: `rgb(${codes[i + 2]},${codes[i + 3]},${codes[i + 4]})` };
+        i += 5;
+      } else if (c === 48 && codes[i + 1] === 2 && codes[i + 4] !== undefined) {
+        state = { ...state, bg: `rgb(${codes[i + 2]},${codes[i + 3]},${codes[i + 4]})` };
+        i += 5;
+      } else {
+        i++;
+      }
+    }
+  }
+  flush(text.length);
+  return result;
+};
+
+interface LogSectionProps {
+  id: string;
+  label: string;
+  content: string;
+}
+
+const LogSection = memo<LogSectionProps>(({ id, label, content }) => (
+  <EuiAccordion id={id} buttonContent={label} paddingSize="s" initialIsOpen>
+    <EuiText size="xs" css={preWrapCss}>
+      <p>{content}</p>
+    </EuiText>
+  </EuiAccordion>
+));
+LogSection.displayName = 'LogSection';
+
+const TerminalLogsView = memo<{ entries: StepLogEntry[] }>(({ entries }) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <div css={terminalContainerCss}>
+      {entries.map((entry, i) => {
+        const color =
+          entry.level === 'error'
+            ? euiTheme.colors.danger
+            : entry.level === 'warn'
+            ? euiTheme.colors.warning
+            : euiTheme.colors.text;
+        return (
+          <div key={i} style={{ color }}>
+            {ansiToSpans(entry.message)}
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+TerminalLogsView.displayName = 'TerminalLogsView';
+
+interface StepLogsViewProps {
+  stepExecution: WorkflowStepExecutionDto;
+  config: StepLogsConfig;
+  logsApi: StepLogsApi;
+}
+
+export const StepLogsView: React.FC<StepLogsViewProps> = ({ stepExecution, config, logsApi }) => {
+  const [entries, setEntries] = useState<StepLogEntry[] | null>(null);
+  const outputId = useGeneratedHtmlId({ prefix: 'stepLogsOutput' });
+  const errorId = useGeneratedHtmlId({ prefix: 'stepLogsError' });
+
+  // Refs so the poll loop always reads the latest values without restarting on every parent re-render.
+  const stepExecutionRef = useRef(stepExecution);
+  stepExecutionRef.current = stepExecution;
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchOnce = (): Promise<StepLogEntry[]> => {
+      const { getLogs } = configRef.current;
+      return getLogs
+        ? Promise.resolve(getLogs({ stepExecution: stepExecutionRef.current, logsApi }))
+        : logsApi.fetchLogs().then((raw) =>
+            raw.map((e) => ({
+              message: e.message,
+              timestamp: e.timestamp,
+              level:
+                e.level === 'info' || e.level === 'warn' || e.level === 'error'
+                  ? e.level
+                  : undefined,
+            }))
+          );
+    };
+
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const result = await fetchOnce();
+        if (!cancelled) setEntries(result);
+      } catch {
+        // keep previous entries on fetch error, keep polling
+      }
+      if (
+        !cancelled &&
+        !TerminalExecutionStatuses.includes(stepExecutionRef.current.status as ExecutionStatus)
+      ) {
+        setTimeout(poll, 500);
+      }
+    };
+
+    poll();
+    return () => {
+      cancelled = true;
+    };
+  }, [logsApi]); // logsApi is memoized on stepExecution.id — restarts only when the step changes
+
+  const { outputText, errorText } = useMemo(() => {
+    if (!entries) return { outputText: '', errorText: '' };
+    return {
+      outputText: entries
+        .filter((e) => !e.level || e.level === 'info')
+        .map((e) => e.message)
+        .join('\n'),
+      errorText: entries
+        .filter((e) => e.level === 'warn' || e.level === 'error')
+        .map((e) => e.message)
+        .join('\n'),
+    };
+  }, [entries]);
+
+  if (entries === null) {
+    return <EuiLoadingSpinner size="m" />;
+  }
+
+  if (entries.length === 0) {
+    return (
+      <EuiText color="subdued" size="s">
+        <p>
+          {i18n.translate('workflowsManagement.stepLogsView.emptyPlaceholder', {
+            defaultMessage: 'No logs.',
+          })}
+        </p>
+      </EuiText>
+    );
+  }
+
+  if (config.renderer === 'terminal') {
+    return <TerminalLogsView entries={entries} />;
+  }
+
+  return (
+    <>
+      {errorText && (
+        <>
+          <LogSection
+            id={errorId}
+            label={i18n.translate('workflowsManagement.stepLogsView.errorsLabel', {
+              defaultMessage: 'Errors',
+            })}
+            content={errorText}
+          />
+          <EuiSpacer size="m" />
+        </>
+      )}
+      {outputText && (
+        <LogSection
+          id={outputId}
+          label={i18n.translate('workflowsManagement.stepLogsView.outputLabel', {
+            defaultMessage: 'Output',
+          })}
+          content={outputText}
+        />
+      )}
+    </>
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
@@ -7,8 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/* eslint-disable complexity */
-
 import {
   EuiCallOut,
   EuiFlexGroup,
@@ -34,7 +32,7 @@ import type {
 } from '@kbn/workflows';
 import { ExecutionStatus, isExecuteSyncStepType, isTerminalStatus } from '@kbn/workflows';
 import type { JsonModelSchemaType } from '@kbn/workflows/spec/schema/common/json_model_schema';
-import type { StepLogsApi } from '@kbn/workflows-extensions/public';
+import type { StepLogsApi, StepLogsConfig } from '@kbn/workflows-extensions/public';
 import { useWorkflowsApi } from '@kbn/workflows-ui';
 import { type ApprovalLabels, ResumeExecutionButton } from './resume_execution_button';
 import { StepExecutionDataView } from './step_execution_data_view';
@@ -44,6 +42,51 @@ import type { WorkflowExecutionLinkInfo } from '../../../hooks/navigation/use_na
 import { useNavigateToExecution } from '../../../hooks/navigation/use_navigate_to_execution';
 import { useKibana } from '../../../hooks/use_kibana';
 import { getExecutionStatusIcon } from '../../../shared/ui/status_badge';
+
+interface StepTab {
+  id: string;
+  name: string;
+}
+
+const buildStepTabs = (
+  isTriggerPseudoStep: boolean,
+  hasError: boolean,
+  hasInput: boolean,
+  hasOutput: boolean,
+  triggerType: string | undefined,
+  logsConfig: StepLogsConfig | undefined
+): StepTab[] => {
+  if (isTriggerPseudoStep) {
+    const pseudoTabs: StepTab[] = [];
+    if (hasError) pseudoTabs.push({ id: 'output', name: 'Error' });
+    if (hasInput) {
+      // For non-manual triggers (alert/document/etc.), rename to "Event" when manual
+      // inputs are also present — the output slot holds those inputs (see workflow_pseudo_step_context.ts)
+      pseudoTabs.push({
+        id: 'input',
+        name: triggerType !== 'manual' && hasOutput ? 'Event' : 'Input',
+      });
+    }
+    if (hasOutput) {
+      // For non-manual triggers, output holds user-supplied manual inputs supplied alongside the event
+      pseudoTabs.push({ id: 'output', name: triggerType !== 'manual' ? 'Input' : 'Output' });
+    }
+    return pseudoTabs;
+  }
+  const baseTabs: StepTab[] = [
+    { id: 'output', name: hasError ? 'Error' : 'Output' },
+    { id: 'input', name: 'Input' },
+  ];
+  if (logsConfig?.enabled) {
+    baseTabs.push({
+      id: 'logs',
+      name: i18n.translate('workflowsManagement.stepExecutionDetails.logsTab', {
+        defaultMessage: 'Logs',
+      }),
+    });
+  }
+  return baseTabs;
+};
 
 interface WorkflowStepExecutionDetailsProps {
   workflowExecutionId: string;
@@ -170,49 +213,11 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
     const hasOutput = Boolean(stepExecution?.output);
     const hasError = Boolean(stepExecution?.error);
 
-    const tabs = useMemo(() => {
-      if (isTriggerPseudoStep) {
-        const pseudoTabs: { id: string; name: string }[] = [];
-        if (hasError) {
-          pseudoTabs.push({
-            id: 'output',
-            name: 'Error',
-          });
-        }
-        if (hasInput) {
-          // For non-manual triggers (alert/document/etc.), rename to "Event" when manual
-          // inputs are also present — the output slot holds those inputs (see workflow_pseudo_step_context.ts)
-          pseudoTabs.push({
-            id: 'input',
-            name: triggerType !== 'manual' && hasOutput ? 'Event' : 'Input',
-          });
-        }
-        if (hasOutput) {
-          // For non-manual triggers, output holds user-supplied manual inputs supplied alongside the event
-          pseudoTabs.push({ id: 'output', name: triggerType !== 'manual' ? 'Input' : 'Output' });
-        }
-        return pseudoTabs;
-      }
-      const baseTabs = [
-        {
-          id: 'output',
-          name: hasError ? 'Error' : 'Output',
-        },
-        {
-          id: 'input',
-          name: 'Input',
-        },
-      ];
-      if (logsConfig?.enabled) {
-        baseTabs.push({
-          id: 'logs',
-          name: i18n.translate('workflowsManagement.stepExecutionDetails.logsTab', {
-            defaultMessage: 'Logs',
-          }),
-        });
-      }
-      return baseTabs;
-    }, [isTriggerPseudoStep, hasError, hasInput, hasOutput, triggerType, logsConfig]);
+    const tabs = useMemo(
+      () =>
+        buildStepTabs(isTriggerPseudoStep, hasError, hasInput, hasOutput, triggerType, logsConfig),
+      [isTriggerPseudoStep, hasError, hasInput, hasOutput, triggerType, logsConfig]
+    );
 
     const defaultTabId = isWaitingForInput ? 'input' : tabs[0]?.id ?? 'input';
     const [selectedTabId, setSelectedTabId] = useState<string>(defaultTabId);

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
@@ -88,7 +88,7 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
       () =>
         stepExecution?.stepType
           ? workflowsExtensions.getStepDefinition(stepExecution.stepType)?.logs ?? {
-              enabled: false,
+              enabled: true,
             }
           : undefined,
       [stepExecution?.stepType, workflowsExtensions]

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+/* eslint-disable complexity */
+
 import {
   EuiCallOut,
   EuiFlexGroup,
@@ -32,11 +34,15 @@ import type {
 } from '@kbn/workflows';
 import { ExecutionStatus, isExecuteSyncStepType, isTerminalStatus } from '@kbn/workflows';
 import type { JsonModelSchemaType } from '@kbn/workflows/spec/schema/common/json_model_schema';
+import type { StepLogsApi } from '@kbn/workflows-extensions/public';
+import { useWorkflowsApi } from '@kbn/workflows-ui';
 import { type ApprovalLabels, ResumeExecutionButton } from './resume_execution_button';
 import { StepExecutionDataView } from './step_execution_data_view';
+import { StepLogsView } from './step_logs_view';
 import { WorkflowExecutionOverview } from './workflow_execution_overview';
 import type { WorkflowExecutionLinkInfo } from '../../../hooks/navigation/use_navigate_to_execution';
 import { useNavigateToExecution } from '../../../hooks/navigation/use_navigate_to_execution';
+import { useKibana } from '../../../hooks/use_kibana';
 import { getExecutionStatusIcon } from '../../../shared/ui/status_badge';
 
 interface WorkflowStepExecutionDetailsProps {
@@ -75,6 +81,33 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
     parentWorkflowExecution,
   }) => {
     const { euiTheme } = useEuiTheme();
+    const { workflowsExtensions } = useKibana().services;
+    const api = useWorkflowsApi();
+
+    const logsConfig = useMemo(
+      () =>
+        stepExecution?.stepType
+          ? workflowsExtensions.getStepDefinition(stepExecution.stepType)?.logs ?? {
+              enabled: false,
+            }
+          : undefined,
+      [stepExecution?.stepType, workflowsExtensions]
+    );
+
+    const logsApi: StepLogsApi = useMemo(
+      () => ({
+        fetchLogs: async () => {
+          if (!stepExecution?.id) return [];
+          const response = await api.getExecutionLogs(workflowExecutionId, {
+            stepExecutionId: stepExecution.id,
+            sortOrder: 'asc',
+          });
+          return response.logs;
+        },
+      }),
+      [api, workflowExecutionId, stepExecution?.id]
+    );
+
     const workflowNav = useNavigateToExecution(
       childWorkflowExecution
         ? {
@@ -160,7 +193,7 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
         }
         return pseudoTabs;
       }
-      return [
+      const baseTabs = [
         {
           id: 'output',
           name: hasError ? 'Error' : 'Output',
@@ -170,7 +203,16 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
           name: 'Input',
         },
       ];
-    }, [isTriggerPseudoStep, hasError, hasInput, hasOutput, triggerType]);
+      if (logsConfig?.enabled) {
+        baseTabs.push({
+          id: 'logs',
+          name: i18n.translate('workflowsManagement.stepExecutionDetails.logsTab', {
+            defaultMessage: 'Logs',
+          }),
+        });
+      }
+      return baseTabs;
+    }, [isTriggerPseudoStep, hasError, hasInput, hasOutput, triggerType, logsConfig]);
 
     const defaultTabId = isWaitingForInput ? 'input' : tabs[0]?.id ?? 'input';
     const [selectedTabId, setSelectedTabId] = useState<string>(defaultTabId);
@@ -275,7 +317,11 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
               ))}
             </EuiTabs>
           </EuiFlexItem>
-          {isFinished ? (
+          {selectedTabId === 'logs' && logsConfig ? (
+            <EuiFlexItem css={{ overflowY: 'auto' }}>
+              <StepLogsView stepExecution={stepExecution} config={logsConfig} logsApi={logsApi} />
+            </EuiFlexItem>
+          ) : isFinished ? (
             <EuiFlexItem css={{ overflowY: 'auto' }}>
               {isLoadingStepData ? (
                 <EuiPanel hasShadow={false} paddingSize="m">

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_step_execution_details.tsx
@@ -88,7 +88,7 @@ export const WorkflowStepExecutionDetails = React.memo<WorkflowStepExecutionDeta
       () =>
         stepExecution?.stepType
           ? workflowsExtensions.getStepDefinition(stepExecution.stepType)?.logs ?? {
-              enabled: true,
+              enabled: false,
             }
           : undefined,
       [stepExecution?.stepType, workflowsExtensions]


### PR DESCRIPTION
## Summary

Adds an opt-in **Logs tab** to the step execution detail panel that step authors enable via a `logs` field on their `PublicStepDefinition`.

### Changes

**New types in `@kbn/workflows-extensions/public`**
- `StepLogsConfig` — opt-in config (`enabled`, optional `renderer`, optional `getLogs`) a step sets on its definition.
- `StepLogsApi` — pre-scoped `fetchLogs()` helper passed into `getLogs` so step authors don't need to wire up the API themselves.
- `StepLogEntry` — the shape rendered in the Logs tab (`message`, `timestamp`, `level`).

**`StepLogsView` component** (`workflows_management`)
- Terminal-style renderer with full ANSI colour support (4-bit, 256-colour, and 24-bit RGB sequences).
- Polls every 500 ms while the step is running; stops automatically when the step reaches a terminal status.
- Reads logs via `getLogs` when provided by the step author, or falls back to `logsApi.fetchLogs()` (engine-level logs scoped to the step execution).

**Logs tab in `WorkflowStepExecutionDetails`**
- Tab is added only when `logsConfig.enabled` is `true` for the step type.
- Tab is resolved through the existing `workflowsExtensions.getStepDefinition()` call, so no new plugin coupling is required.

**`StepLogMeta` interface** (server, `@kbn/workflows-extensions`)
- Narrows the `meta` parameter on `StepHandlerContext.logger` from `object` to `StepLogMeta` (`tags?: string[]`).

**Bug fix**
- `NodesFactory` now passes `stepExecutionRuntime.stepLogger` instead of `this.workflowLogger` to `CustomStepImpl`, ensuring the logger is scoped to the individual step execution rather than the workflow.

** Examples **
The below examples are from WIP `remoteHost.*` steps.

https://github.com/user-attachments/assets/575c6d29-6ed4-46fc-ae05-8307d8bc207e

<img width="1078" height="632" alt="image" src="https://github.com/user-attachments/assets/37b51818-0c8c-4870-b7db-ac0622e31d8e" />
