### PR TITLE
[9.5] [Entity Analytics] Maintainers: DSL+ES|QL performance improvements for relationship maintainers (#281804)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.test.ts
@@ -16,6 +16,7 @@ import {
   buildSourcePickerEsql,
   buildDestinationFieldEsql,
   buildOneFieldEvaluationEsql,
+  getHostScopedUserEuidEsql,
 } from './esql';
 import type {
   EuidRankingBranch,
@@ -661,5 +662,91 @@ describe('buildOneFieldEvaluationEsql', () => {
     expect(() => buildOneFieldEvaluationEsql(evaluation)).toThrow(
       'buildOneFieldEvaluationEsql: field evaluation "entity.source" has no sources'
     );
+  });
+});
+
+describe('getHostScopedUserEuidEsql', () => {
+  describe('evalAssignment', () => {
+    it('emits the canonical user:<user.name>@<host.id>@local EUID', () => {
+      const { evalAssignment } = getHostScopedUserEuidEsql();
+
+      expect(evalAssignment).toBe(
+        'CONCAT("user:", TO_STRING(`user.name`), "@", TO_STRING(`host.id`), "@local")'
+      );
+    });
+
+    it('never falls back to user.email — that would reference an IDP EUID', () => {
+      const { evalAssignment } = getHostScopedUserEuidEsql();
+
+      // The host-scoped ranking branch has a single arm gated on user.name being
+      // non-empty, so a fallback could only fire for documents extraction classifies
+      // as IDP users. Emitting `user:alice@corp.com@h1@local` would reference an EUID
+      // that does not exist in the store and 404 on every write.
+      expect(evalAssignment).not.toContain('user.email');
+      expect(evalAssignment).not.toContain('COALESCE');
+    });
+
+    it('keeps host.id and the @local namespace in the canonical positions', () => {
+      const { evalAssignment } = getHostScopedUserEuidEsql();
+
+      expect(evalAssignment.indexOf('`user.name`')).toBeLessThan(
+        evalAssignment.indexOf('`host.id`')
+      );
+      expect(evalAssignment.endsWith('"@local")')).toBe(true);
+    });
+
+    it('emits no entity.namespace derivation chain', () => {
+      const { evalAssignment } = getHostScopedUserEuidEsql();
+
+      // The whole point of this helper: skip the namespace/EUID EVAL chain.
+      expect(evalAssignment).not.toContain('entity.namespace');
+      expect(evalAssignment).not.toContain('CASE(');
+      expect(evalAssignment).not.toContain('MV_FIRST');
+    });
+
+    it('matches the host-scoped branch of the user entity definition euidRanking', () => {
+      // Guards against the definition drifting away from what this helper emits.
+      const { identityField } = userEntityDefinition;
+      if (isSingleFieldIdentity(identityField)) {
+        throw new Error('expected userEntityDefinition to use euidRanking');
+      }
+      const hostScopedBranch = identityField.euidRanking.branches[0];
+
+      // Exactly one arm — this is what makes emitting user.name with no COALESCE
+      // fallback correct. A second arm would mean the EUID has alternatives that
+      // this helper is silently ignoring.
+      expect(hostScopedBranch.ranking).toHaveLength(1);
+      expect(hostScopedBranch.when).toEqual({ field: 'entity.namespace', eq: 'local' });
+
+      const hostScopedBranchFields = hostScopedBranch.ranking[0]
+        .filter((attr): attr is { field: string } => 'field' in attr)
+        .map((attr) => attr.field);
+
+      expect(hostScopedBranchFields).toEqual(['user.name', 'host.id', 'entity.namespace']);
+    });
+  });
+
+  describe('presenceGate', () => {
+    it('requires every field the EUID composes, AND-joined', () => {
+      const { presenceGate } = getHostScopedUserEuidEsql();
+
+      // Both fields are mandatory — a document missing either is an IDP user that
+      // extraction indexed under a different EUID, so admitting it would build an id
+      // the entity store does not hold.
+      expect(presenceGate).toBe(
+        '(`user.name` IS NOT NULL AND `user.name` != "") AND (`host.id` IS NOT NULL AND `host.id` != "")'
+      );
+    });
+
+    it('gates on exactly the fields the EUID reads', () => {
+      const { evalAssignment, presenceGate } = getHostScopedUserEuidEsql();
+
+      for (const field of ['user.name', 'host.id']) {
+        expect(evalAssignment).toContain(`\`${field}\``);
+        expect(presenceGate).toContain(`\`${field}\``);
+      }
+      // user.email belongs to the IDP ranking branch, not this one.
+      expect(presenceGate).not.toContain('user.email');
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/esql.ts
@@ -17,6 +17,7 @@ import type {
 } from '../definitions/entity_schema';
 import { isSingleFieldIdentity } from '../definitions/entity_schema';
 import { getEntityDefinitionWithoutId } from '../definitions/registry';
+import { USER_ENTITY_NAMESPACE } from '../definitions/user_entity_constants';
 import {
   esqlIsNotNullOrEmpty,
   esqlIsNullOrEmpty,
@@ -346,6 +347,36 @@ function buildSourceClauseEsql(evaluation: FieldEvaluation, spec: SourceMatchSpe
 
 export function getFieldEvaluationsEsql(entityType: EntityType): string | undefined {
   return getFieldEvaluationsEsqlFromDefinition(getEntityDefinitionWithoutId(entityType));
+}
+
+/** `field` is present and non-empty, referencing the raw field (no TO_STRING cast). */
+function esqlRawFieldNonEmpty(field: string): string {
+  return `(\`${field}\` IS NOT NULL AND \`${field}\` != "")`;
+}
+
+/** Fields composing the host-scoped user EUID, per the `entity.namespace == 'local'` ranking branch. */
+const HOST_SCOPED_USER_FIELDS = ['user.name', 'host.id'] as const;
+
+/**
+ * ES|QL fragments for the host-scoped (non-IDP) user EUID:
+ * `user:<user.name>@<host.id>@local`.
+ *
+ * Mirrors the `entity.namespace == 'local'` branch of
+ * `userEntityDefinition.identityField.euidRanking`, but hardcodes the namespace
+ * instead of deriving `entity.namespace`.
+ */
+export function getHostScopedUserEuidEsql(): {
+  /** RHS for `| EVAL <col> = …` producing the host-scoped user EUID. */
+  evalAssignment: string;
+  /** `WHERE` gate requiring every field this EUID composes. */
+  presenceGate: string;
+} {
+  const [userField, hostField] = HOST_SCOPED_USER_FIELDS;
+
+  return {
+    evalAssignment: `CONCAT("user:", TO_STRING(\`${userField}\`), "@", TO_STRING(\`${hostField}\`), "@${USER_ENTITY_NAMESPACE.Local}")`,
+    presenceGate: HOST_SCOPED_USER_FIELDS.map(esqlRawFieldNonEmpty).join(' AND '),
+  };
 }
 
 /**

--- a/x-pack/solutions/security/plugins/entity_store/common/domain/euid/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/domain/euid/index.ts
@@ -20,6 +20,7 @@ export {
   getEuidEsqlEvaluation,
   getEuidEsqlFilterBasedOnDocument,
   getFieldEvaluationsEsql,
+  getHostScopedUserEuidEsql,
 } from './esql';
 export {
   applyFieldEvaluations,

--- a/x-pack/solutions/security/plugins/entity_store/common/euid_helpers.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/euid_helpers.ts
@@ -122,6 +122,26 @@ export const euid = {
      */
     getEuidFilterBasedOnDocument: euidModule.getEuidKqlFilterBasedOnDocument,
   },
+
+  /**
+   * Narrow-purpose helpers that trade generality for speed by hardcoding an
+   * assumption the general API derives at query time. **Each is correct only for
+   * callers whose data satisfies its documented precondition** — violate it and you
+   * get plausible-looking EUIDs that no entity-store record matches, so every write
+   * 404s silently.
+   *
+   * Reach for the equivalent under `esql` / `dsl` / `kql` unless you have measured
+   * evidence that the general path is too slow AND can state why the precondition
+   * holds for every document your query reads.
+   */
+  experimental: {
+    /**
+     * Minimal ESQL fragments (`{ evalAssignment, presenceGate }`) for the host-scoped
+     * (non-IDP) user EUID `user:<user.name>@<host.id>@local`, skipping the
+     * `entity.namespace` derivation.
+     */
+    getHostScopedUserEuidEsql: euidModule.getHostScopedUserEuidEsql,
+  },
 };
 
 /** Full EUID API (memory + painless + esql + dsl) — same object for Node and browser lazy chunk. */

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/__snapshots__/configs.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/__snapshots__/configs.test.ts.snap
@@ -124,44 +124,10 @@ FROM logs-system.auth-__namespace__
 | WHERE (MV_CONTAINS(TO_STRING(event.category), \\"authentication\\") OR MV_CONTAINS(TO_STRING(event.category), \\"session\\"))
     AND event.action == \\"ssh_login\\"
     AND event.outcome == \\"success\\"
-    AND ((\`user.email\` IS NOT NULL AND \`user.email\` != \\"\\") OR (\`user.name\` IS NOT NULL AND \`user.name\` != \\"\\"))
-    AND (TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" OR TO_STRING(host.name) IS NOT NULL AND TO_STRING(host.name) != \\"\\" OR TO_STRING(host.hostname) IS NOT NULL AND TO_STRING(host.hostname) != \\"\\")
-| EVAL _src_entity_source0 = MV_FIRST(TO_STRING(event.module)),
- _src_entity_source1 = MV_FIRST(TO_STRING(event.dataset)),
- _src_entity_source2 = MV_FIRST(TO_STRING(data_stream.dataset)),
- _src_entity_source = COALESCE(CASE(_src_entity_source0 IS NOT NULL AND _src_entity_source0 != \\"\\", _src_entity_source0), CASE(_src_entity_source1 IS NOT NULL AND _src_entity_source1 != \\"\\", _src_entity_source1), CASE(_src_entity_source2 IS NOT NULL AND _src_entity_source2 != \\"\\", _src_entity_source2)),
- entity.source = CASE(_src_entity_source IS NULL OR _src_entity_source == \\"\\", NULL, _src_entity_source)
-| EVAL _src_entity_namespace0 = MV_FIRST(TO_STRING(event.module)),
- _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(TO_STRING(data_stream.dataset)), \\".\\")),
- _src_entity_namespace = COALESCE(CASE(_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != \\"\\", _src_entity_namespace0), CASE(_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != \\"\\", _src_entity_namespace1)),
- _eval_entity_namespace_arm0 = (TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\" AND TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" AND NOT (TO_STRING(user.name) IN (\\"root\\", \\"bin\\", \\"daemon\\", \\"sys\\", \\"nobody\\", \\"jenkins\\", \\"ansible\\", \\"deploy\\", \\"terraform\\", \\"gitlab-runner\\", \\"postgres\\", \\"mysql\\", \\"redis\\", \\"elasticsearch\\", \\"kafka\\", \\"admin\\", \\"operator\\", \\"service\\")) AND (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR NOT (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR (TO_STRING(event.kind) != \\"enrichment\\" OR TO_STRING(event.kind) IS NULL) AND MV_CONTAINS(TO_STRING(event.category), \\"iam\\") AND (MV_CONTAINS(TO_STRING(event.type), \\"user\\") OR MV_CONTAINS(TO_STRING(event.type), \\"creation\\") OR MV_CONTAINS(TO_STRING(event.type), \\"deletion\\") OR MV_CONTAINS(TO_STRING(event.type), \\"group\\"))))),
- _eval_entity_namespace_arm1 = (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") AND MV_CONTAINS(TO_STRING(event.module), \\"asset_discovery\\")),
- entity.namespace = COALESCE(CASE(COALESCE(_eval_entity_namespace_arm0, FALSE), \\"local\\"), CASE(COALESCE(_eval_entity_namespace_arm1, FALSE), CASE(MV_FIRST(TO_STRING(cloud.provider)) == \\"aws\\", \\"aws\\", MV_FIRST(TO_STRING(cloud.provider)) == \\"gcp\\", \\"gcp\\", MV_FIRST(TO_STRING(cloud.provider)) == \\"azure\\", \\"entra_id\\")), CASE(COALESCE(_src_entity_namespace IN (\\"okta\\", \\"entityanalytics_okta\\"), FALSE), \\"okta\\"), CASE(COALESCE(_src_entity_namespace IN (\\"azure\\", \\"entityanalytics_entra_id\\"), FALSE), \\"entra_id\\"), CASE(COALESCE(_src_entity_namespace IN (\\"o365\\", \\"o365_metrics\\"), FALSE), \\"microsoft_365\\"), CASE(COALESCE(_src_entity_namespace IN (\\"entityanalytics_ad\\"), FALSE), \\"active_directory\\"), CASE(_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\", \\"unknown\\"), _src_entity_namespace),
- user_name_present = TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\",
- host_id_present = TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\",
- entity_namespace_present = TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\",
- user_email_present = TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\",
- user_id_present = TO_STRING(user.id) IS NOT NULL AND TO_STRING(user.id) != \\"\\",
- user_domain_present = TO_STRING(user.domain) IS NOT NULL AND TO_STRING(user.domain) != \\"\\",
- user_name_present_or_null = CASE(user_name_present, TO_STRING(user.name)),
- host_id_present_or_null = CASE(host_id_present, TO_STRING(host.id)),
- entity_namespace_present_or_null = CASE(entity_namespace_present, TO_STRING(entity.namespace)),
- user_email_present_or_null = CASE(user_email_present, TO_STRING(user.email)),
- user_id_present_or_null = CASE(user_id_present, TO_STRING(user.id)),
- user_domain_present_or_null = CASE(user_domain_present, TO_STRING(user.domain)),
- _euid_branch_0_formula = CONCAT(user_name_present_or_null, \\"@\\", host_id_present_or_null, \\"@\\", entity_namespace_present_or_null),
- _euid_branch_0_cond = (TO_STRING(entity.namespace) == \\"local\\"),
- _euid_branch_1_formula = COALESCE(CONCAT(user_email_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_id_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, \\"@\\", user_domain_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, \\"@\\", entity_namespace_present_or_null)),
- actorUserId = CONCAT(\\"user:\\", CASE(_euid_branch_0_cond, _euid_branch_0_formula,
-TRUE, _euid_branch_1_formula, NULL))
+    AND ((\`user.name\` IS NOT NULL AND \`user.name\` != \\"\\") AND (\`host.id\` IS NOT NULL AND \`host.id\` != \\"\\"))
+| EVAL actorUserId = CONCAT(\\"user:\\", TO_STRING(\`user.name\`), \\"@\\", TO_STRING(\`host.id\`), \\"@local\\")
 | WHERE COALESCE(actorUserId, \\"\\") != \\"\\"
-| EVAL host_id_present = TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\",
- host_name_present = TO_STRING(host.name) IS NOT NULL AND TO_STRING(host.name) != \\"\\",
- host_hostname_present = TO_STRING(host.hostname) IS NOT NULL AND TO_STRING(host.hostname) != \\"\\",
- host_id_present_or_null = CASE(host_id_present, TO_STRING(host.id)),
- host_name_present_or_null = CASE(host_name_present, TO_STRING(host.name)),
- host_hostname_present_or_null = CASE(host_hostname_present, TO_STRING(host.hostname)),
- targetEntityId = CONCAT(\\"host:\\", COALESCE(host_id_present_or_null, host_name_present_or_null, host_hostname_present_or_null))
+| EVAL targetEntityId = CONCAT(\\"host:\\", TO_STRING(\`host.id\`))
 | MV_EXPAND targetEntityId
 | WHERE COALESCE(targetEntityId, \\"\\") != \\"\\"
 | STATS access_count = COUNT(*) BY actorUserId, targetEntityId
@@ -185,44 +151,10 @@ FROM logs-system.security-__namespace__
     AND winlog.logon.type IN (\\"Interactive\\", \\"RemoteInteractive\\", \\"CachedInteractive\\")
     AND event.outcome == \\"success\\"
     AND NOT user.name IN (\\"SYSTEM\\", \\"LOCAL SERVICE\\", \\"NETWORK SERVICE\\", \\"ANONYMOUS LOGON\\")
-    AND ((TO_STRING(event.outcome) IS NULL OR TO_STRING(event.outcome) != \\"failure\\") AND (TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\" OR TO_STRING(user.id) IS NOT NULL AND TO_STRING(user.id) != \\"\\" OR TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\"))
-    AND (TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" OR TO_STRING(host.name) IS NOT NULL AND TO_STRING(host.name) != \\"\\" OR TO_STRING(host.hostname) IS NOT NULL AND TO_STRING(host.hostname) != \\"\\")
-| EVAL _src_entity_source0 = MV_FIRST(TO_STRING(event.module)),
- _src_entity_source1 = MV_FIRST(TO_STRING(event.dataset)),
- _src_entity_source2 = MV_FIRST(TO_STRING(data_stream.dataset)),
- _src_entity_source = COALESCE(CASE(_src_entity_source0 IS NOT NULL AND _src_entity_source0 != \\"\\", _src_entity_source0), CASE(_src_entity_source1 IS NOT NULL AND _src_entity_source1 != \\"\\", _src_entity_source1), CASE(_src_entity_source2 IS NOT NULL AND _src_entity_source2 != \\"\\", _src_entity_source2)),
- entity.source = CASE(_src_entity_source IS NULL OR _src_entity_source == \\"\\", NULL, _src_entity_source)
-| EVAL _src_entity_namespace0 = MV_FIRST(TO_STRING(event.module)),
- _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(TO_STRING(data_stream.dataset)), \\".\\")),
- _src_entity_namespace = COALESCE(CASE(_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != \\"\\", _src_entity_namespace0), CASE(_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != \\"\\", _src_entity_namespace1)),
- _eval_entity_namespace_arm0 = (TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\" AND TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" AND NOT (TO_STRING(user.name) IN (\\"root\\", \\"bin\\", \\"daemon\\", \\"sys\\", \\"nobody\\", \\"jenkins\\", \\"ansible\\", \\"deploy\\", \\"terraform\\", \\"gitlab-runner\\", \\"postgres\\", \\"mysql\\", \\"redis\\", \\"elasticsearch\\", \\"kafka\\", \\"admin\\", \\"operator\\", \\"service\\")) AND (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR NOT (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR (TO_STRING(event.kind) != \\"enrichment\\" OR TO_STRING(event.kind) IS NULL) AND MV_CONTAINS(TO_STRING(event.category), \\"iam\\") AND (MV_CONTAINS(TO_STRING(event.type), \\"user\\") OR MV_CONTAINS(TO_STRING(event.type), \\"creation\\") OR MV_CONTAINS(TO_STRING(event.type), \\"deletion\\") OR MV_CONTAINS(TO_STRING(event.type), \\"group\\"))))),
- _eval_entity_namespace_arm1 = (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") AND MV_CONTAINS(TO_STRING(event.module), \\"asset_discovery\\")),
- entity.namespace = COALESCE(CASE(COALESCE(_eval_entity_namespace_arm0, FALSE), \\"local\\"), CASE(COALESCE(_eval_entity_namespace_arm1, FALSE), CASE(MV_FIRST(TO_STRING(cloud.provider)) == \\"aws\\", \\"aws\\", MV_FIRST(TO_STRING(cloud.provider)) == \\"gcp\\", \\"gcp\\", MV_FIRST(TO_STRING(cloud.provider)) == \\"azure\\", \\"entra_id\\")), CASE(COALESCE(_src_entity_namespace IN (\\"okta\\", \\"entityanalytics_okta\\"), FALSE), \\"okta\\"), CASE(COALESCE(_src_entity_namespace IN (\\"azure\\", \\"entityanalytics_entra_id\\"), FALSE), \\"entra_id\\"), CASE(COALESCE(_src_entity_namespace IN (\\"o365\\", \\"o365_metrics\\"), FALSE), \\"microsoft_365\\"), CASE(COALESCE(_src_entity_namespace IN (\\"entityanalytics_ad\\"), FALSE), \\"active_directory\\"), CASE(_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\", \\"unknown\\"), _src_entity_namespace),
- user_name_present = TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\",
- host_id_present = TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\",
- entity_namespace_present = TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\",
- user_email_present = TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\",
- user_id_present = TO_STRING(user.id) IS NOT NULL AND TO_STRING(user.id) != \\"\\",
- user_domain_present = TO_STRING(user.domain) IS NOT NULL AND TO_STRING(user.domain) != \\"\\",
- user_name_present_or_null = CASE(user_name_present, TO_STRING(user.name)),
- host_id_present_or_null = CASE(host_id_present, TO_STRING(host.id)),
- entity_namespace_present_or_null = CASE(entity_namespace_present, TO_STRING(entity.namespace)),
- user_email_present_or_null = CASE(user_email_present, TO_STRING(user.email)),
- user_id_present_or_null = CASE(user_id_present, TO_STRING(user.id)),
- user_domain_present_or_null = CASE(user_domain_present, TO_STRING(user.domain)),
- _euid_branch_0_formula = CONCAT(user_name_present_or_null, \\"@\\", host_id_present_or_null, \\"@\\", entity_namespace_present_or_null),
- _euid_branch_0_cond = (TO_STRING(entity.namespace) == \\"local\\"),
- _euid_branch_1_formula = COALESCE(CONCAT(user_email_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_id_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, \\"@\\", user_domain_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, \\"@\\", entity_namespace_present_or_null)),
- actorUserId = CONCAT(\\"user:\\", CASE(_euid_branch_0_cond, _euid_branch_0_formula,
-TRUE, _euid_branch_1_formula, NULL))
+    AND ((\`user.name\` IS NOT NULL AND \`user.name\` != \\"\\") AND (\`host.id\` IS NOT NULL AND \`host.id\` != \\"\\"))
+| EVAL actorUserId = CONCAT(\\"user:\\", TO_STRING(\`user.name\`), \\"@\\", TO_STRING(\`host.id\`), \\"@local\\")
 | WHERE COALESCE(actorUserId, \\"\\") != \\"\\"
-| EVAL host_id_present = TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\",
- host_name_present = TO_STRING(host.name) IS NOT NULL AND TO_STRING(host.name) != \\"\\",
- host_hostname_present = TO_STRING(host.hostname) IS NOT NULL AND TO_STRING(host.hostname) != \\"\\",
- host_id_present_or_null = CASE(host_id_present, TO_STRING(host.id)),
- host_name_present_or_null = CASE(host_name_present, TO_STRING(host.name)),
- host_hostname_present_or_null = CASE(host_hostname_present, TO_STRING(host.hostname)),
- targetEntityId = CONCAT(\\"host:\\", COALESCE(host_id_present_or_null, host_name_present_or_null, host_hostname_present_or_null))
+| EVAL targetEntityId = CONCAT(\\"host:\\", TO_STRING(\`host.id\`))
 | MV_EXPAND targetEntityId
 | WHERE COALESCE(targetEntityId, \\"\\") != \\"\\"
 | STATS access_count = COUNT(*) BY actorUserId, targetEntityId

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.test.ts
@@ -129,4 +129,21 @@ describe('ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS', () => {
       }
     );
   });
+
+  describe('hostScopedUsersOnly flag', () => {
+    it('system_auth has hostScopedUsersOnly: true', () => {
+      const cfg = ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS.find((c) => c.id === 'system_auth');
+      expect(cfg?.hostScopedUsersOnly).toBe(true);
+    });
+
+    it('system_security has hostScopedUsersOnly: true', () => {
+      const cfg = ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS.find((c) => c.id === 'system_security');
+      expect(cfg?.hostScopedUsersOnly).toBe(true);
+    });
+
+    it('elastic_defend does NOT have hostScopedUsersOnly', () => {
+      const cfg = ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS.find((c) => c.id === 'elastic_defend');
+      expect(cfg?.hostScopedUsersOnly).toBeUndefined();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/configs.ts
@@ -68,12 +68,13 @@ export const ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipIntegrationC
     targetEntityType: 'host',
     bucketTargetByThreshold: ACCESSES_BUCKETING,
     requireTargetEntityIdExists: true,
-    // SSH auth events use local-namespace EUID: `user.name@host.id@local`.
-    // `user.id` is not part of the EUID for local entities — including it in
-    // the composite agg sources causes bucket explosion (the same username
-    // appears with dozens of distinct Unix UIDs / Windows SIDs across hosts),
-    // multiplying Step 1 pages and Step 2 ES|QL queries for zero benefit.
-    customActor: { fields: ['user.email', 'user.name'] },
+    // Host-scoped EUID is `user:<user.name>@<host.id>@local`, so `user.name` is
+    // the only actor field Step 2 reads. Listing anything else (`user.email`,
+    // `user.id`) only inflates the composite agg: extra sources multiply buckets
+    // — the same username appears with dozens of distinct Unix UIDs / Windows
+    // SIDs across hosts — so Step 1 pages and Step 2 ES|QL queries grow for
+    // actors Step 2 then discards.
+    customActor: { fields: ['user.name'] },
     // `event.category` is multivalued in ECS (Elastic Agent's syslog SSH events
     // emit `["authentication", "session"]`). ES|QL `IN` returns NULL for a
     // multivalued left-hand side, so `event.category IN (...)` silently drops
@@ -86,6 +87,7 @@ export const ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipIntegrationC
       { term: { 'event.action': 'ssh_login' } },
       SUCCESSFUL_OUTCOME_FILTER,
     ],
+    hostScopedUsersOnly: true,
   },
   {
     kind: 'bucketed',
@@ -95,6 +97,12 @@ export const ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipIntegrationC
     targetEntityType: 'host',
     bucketTargetByThreshold: ACCESSES_BUCKETING,
     requireTargetEntityIdExists: true,
+    // Windows logon events carry `user.name`, which is the only actor field the
+    // host-scoped EUID (`user:<user.name>@<host.id>@local`) reads. A doc with
+    // `user.email` but no `user.name` is an IDP user that extraction indexed
+    // under a different EUID, so bucketing on it would surface actors Step 2
+    // cannot build an id for.
+    customActor: { fields: ['user.name'] },
     esqlWhereClause: `event.action IN ("logged-in", "logged-in-explicit")
     AND event.code IN ("4624", "4648")
     AND winlog.logon.type IN ("Interactive", "RemoteInteractive", "CachedInteractive")
@@ -104,5 +112,6 @@ export const ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipIntegrationC
       { terms: { 'event.action': ['logged-in', 'logged-in-explicit'] } },
       SUCCESSFUL_OUTCOME_FILTER,
     ],
+    hostScopedUsersOnly: true,
   },
 ];

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/accesses/index.ts
@@ -44,6 +44,7 @@ export const accessesFrequentlyMaintainer: RegisterEntityMaintainerConfig = {
       crudClient,
       entityMetadataClient,
       integrations: ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS,
+      maintainerName: 'accesses_frequently_and_infrequently',
       abortController,
       telemetryCollector: collector,
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/administers/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/administers/index.ts
@@ -52,6 +52,7 @@ export const administersMaintainer: RegisterEntityMaintainerConfig = {
       crudClient,
       entityMetadataClient,
       integrations: buildAdministersConfigs(lastProcessedTimestamp),
+      maintainerName: 'administers',
       abortController,
       telemetryCollector: collector,
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/__snapshots__/configs.test.ts.snap
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/__snapshots__/configs.test.ts.snap
@@ -147,44 +147,10 @@ FROM logs-system.auth-__namespace__
 | WHERE (MV_CONTAINS(TO_STRING(event.category), \\"authentication\\") OR MV_CONTAINS(TO_STRING(event.category), \\"session\\"))
     AND event.action == \\"ssh_login\\"
     AND event.outcome == \\"success\\"
-    AND ((\`user.email\` IS NOT NULL AND \`user.email\` != \\"\\") OR (\`user.name\` IS NOT NULL AND \`user.name\` != \\"\\"))
-    AND (TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" OR TO_STRING(host.name) IS NOT NULL AND TO_STRING(host.name) != \\"\\" OR TO_STRING(host.hostname) IS NOT NULL AND TO_STRING(host.hostname) != \\"\\")
-| EVAL _src_entity_source0 = MV_FIRST(TO_STRING(event.module)),
- _src_entity_source1 = MV_FIRST(TO_STRING(event.dataset)),
- _src_entity_source2 = MV_FIRST(TO_STRING(data_stream.dataset)),
- _src_entity_source = COALESCE(CASE(_src_entity_source0 IS NOT NULL AND _src_entity_source0 != \\"\\", _src_entity_source0), CASE(_src_entity_source1 IS NOT NULL AND _src_entity_source1 != \\"\\", _src_entity_source1), CASE(_src_entity_source2 IS NOT NULL AND _src_entity_source2 != \\"\\", _src_entity_source2)),
- entity.source = CASE(_src_entity_source IS NULL OR _src_entity_source == \\"\\", NULL, _src_entity_source)
-| EVAL _src_entity_namespace0 = MV_FIRST(TO_STRING(event.module)),
- _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(TO_STRING(data_stream.dataset)), \\".\\")),
- _src_entity_namespace = COALESCE(CASE(_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != \\"\\", _src_entity_namespace0), CASE(_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != \\"\\", _src_entity_namespace1)),
- _eval_entity_namespace_arm0 = (TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\" AND TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" AND NOT (TO_STRING(user.name) IN (\\"root\\", \\"bin\\", \\"daemon\\", \\"sys\\", \\"nobody\\", \\"jenkins\\", \\"ansible\\", \\"deploy\\", \\"terraform\\", \\"gitlab-runner\\", \\"postgres\\", \\"mysql\\", \\"redis\\", \\"elasticsearch\\", \\"kafka\\", \\"admin\\", \\"operator\\", \\"service\\")) AND (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR NOT (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR (TO_STRING(event.kind) != \\"enrichment\\" OR TO_STRING(event.kind) IS NULL) AND MV_CONTAINS(TO_STRING(event.category), \\"iam\\") AND (MV_CONTAINS(TO_STRING(event.type), \\"user\\") OR MV_CONTAINS(TO_STRING(event.type), \\"creation\\") OR MV_CONTAINS(TO_STRING(event.type), \\"deletion\\") OR MV_CONTAINS(TO_STRING(event.type), \\"group\\"))))),
- _eval_entity_namespace_arm1 = (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") AND MV_CONTAINS(TO_STRING(event.module), \\"asset_discovery\\")),
- entity.namespace = COALESCE(CASE(COALESCE(_eval_entity_namespace_arm0, FALSE), \\"local\\"), CASE(COALESCE(_eval_entity_namespace_arm1, FALSE), CASE(MV_FIRST(TO_STRING(cloud.provider)) == \\"aws\\", \\"aws\\", MV_FIRST(TO_STRING(cloud.provider)) == \\"gcp\\", \\"gcp\\", MV_FIRST(TO_STRING(cloud.provider)) == \\"azure\\", \\"entra_id\\")), CASE(COALESCE(_src_entity_namespace IN (\\"okta\\", \\"entityanalytics_okta\\"), FALSE), \\"okta\\"), CASE(COALESCE(_src_entity_namespace IN (\\"azure\\", \\"entityanalytics_entra_id\\"), FALSE), \\"entra_id\\"), CASE(COALESCE(_src_entity_namespace IN (\\"o365\\", \\"o365_metrics\\"), FALSE), \\"microsoft_365\\"), CASE(COALESCE(_src_entity_namespace IN (\\"entityanalytics_ad\\"), FALSE), \\"active_directory\\"), CASE(_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\", \\"unknown\\"), _src_entity_namespace),
- user_name_present = TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\",
- host_id_present = TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\",
- entity_namespace_present = TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\",
- user_email_present = TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\",
- user_id_present = TO_STRING(user.id) IS NOT NULL AND TO_STRING(user.id) != \\"\\",
- user_domain_present = TO_STRING(user.domain) IS NOT NULL AND TO_STRING(user.domain) != \\"\\",
- user_name_present_or_null = CASE(user_name_present, TO_STRING(user.name)),
- host_id_present_or_null = CASE(host_id_present, TO_STRING(host.id)),
- entity_namespace_present_or_null = CASE(entity_namespace_present, TO_STRING(entity.namespace)),
- user_email_present_or_null = CASE(user_email_present, TO_STRING(user.email)),
- user_id_present_or_null = CASE(user_id_present, TO_STRING(user.id)),
- user_domain_present_or_null = CASE(user_domain_present, TO_STRING(user.domain)),
- _euid_branch_0_formula = CONCAT(user_name_present_or_null, \\"@\\", host_id_present_or_null, \\"@\\", entity_namespace_present_or_null),
- _euid_branch_0_cond = (TO_STRING(entity.namespace) == \\"local\\"),
- _euid_branch_1_formula = COALESCE(CONCAT(user_email_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_id_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, \\"@\\", user_domain_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, \\"@\\", entity_namespace_present_or_null)),
- actorUserId = CONCAT(\\"user:\\", CASE(_euid_branch_0_cond, _euid_branch_0_formula,
-TRUE, _euid_branch_1_formula, NULL))
+    AND ((\`user.name\` IS NOT NULL AND \`user.name\` != \\"\\") AND (\`host.id\` IS NOT NULL AND \`host.id\` != \\"\\"))
+| EVAL actorUserId = CONCAT(\\"user:\\", TO_STRING(\`user.name\`), \\"@\\", TO_STRING(\`host.id\`), \\"@local\\")
 | WHERE COALESCE(actorUserId, \\"\\") != \\"\\"
-| EVAL host_id_present = TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\",
- host_name_present = TO_STRING(host.name) IS NOT NULL AND TO_STRING(host.name) != \\"\\",
- host_hostname_present = TO_STRING(host.hostname) IS NOT NULL AND TO_STRING(host.hostname) != \\"\\",
- host_id_present_or_null = CASE(host_id_present, TO_STRING(host.id)),
- host_name_present_or_null = CASE(host_name_present, TO_STRING(host.name)),
- host_hostname_present_or_null = CASE(host_hostname_present, TO_STRING(host.hostname)),
- targetEntityId = CONCAT(\\"host:\\", COALESCE(host_id_present_or_null, host_name_present_or_null, host_hostname_present_or_null))
+| EVAL targetEntityId = CONCAT(\\"host:\\", TO_STRING(\`host.id\`))
 | MV_EXPAND targetEntityId
 | WHERE COALESCE(targetEntityId, \\"\\") != \\"\\"
 | STATS communicates_with = VALUES(targetEntityId) BY actorUserId
@@ -199,44 +165,10 @@ FROM logs-system.security-__namespace__
     AND winlog.logon.type IN (\\"Interactive\\", \\"RemoteInteractive\\", \\"CachedInteractive\\")
     AND event.outcome == \\"success\\"
     AND NOT user.name IN (\\"SYSTEM\\", \\"LOCAL SERVICE\\", \\"NETWORK SERVICE\\", \\"ANONYMOUS LOGON\\")
-    AND ((TO_STRING(event.outcome) IS NULL OR TO_STRING(event.outcome) != \\"failure\\") AND (TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\" OR TO_STRING(user.id) IS NOT NULL AND TO_STRING(user.id) != \\"\\" OR TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\"))
-    AND (TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" OR TO_STRING(host.name) IS NOT NULL AND TO_STRING(host.name) != \\"\\" OR TO_STRING(host.hostname) IS NOT NULL AND TO_STRING(host.hostname) != \\"\\")
-| EVAL _src_entity_source0 = MV_FIRST(TO_STRING(event.module)),
- _src_entity_source1 = MV_FIRST(TO_STRING(event.dataset)),
- _src_entity_source2 = MV_FIRST(TO_STRING(data_stream.dataset)),
- _src_entity_source = COALESCE(CASE(_src_entity_source0 IS NOT NULL AND _src_entity_source0 != \\"\\", _src_entity_source0), CASE(_src_entity_source1 IS NOT NULL AND _src_entity_source1 != \\"\\", _src_entity_source1), CASE(_src_entity_source2 IS NOT NULL AND _src_entity_source2 != \\"\\", _src_entity_source2)),
- entity.source = CASE(_src_entity_source IS NULL OR _src_entity_source == \\"\\", NULL, _src_entity_source)
-| EVAL _src_entity_namespace0 = MV_FIRST(TO_STRING(event.module)),
- _src_entity_namespace1 = MV_FIRST(SPLIT(MV_FIRST(TO_STRING(data_stream.dataset)), \\".\\")),
- _src_entity_namespace = COALESCE(CASE(_src_entity_namespace0 IS NOT NULL AND _src_entity_namespace0 != \\"\\", _src_entity_namespace0), CASE(_src_entity_namespace1 IS NOT NULL AND _src_entity_namespace1 != \\"\\", _src_entity_namespace1)),
- _eval_entity_namespace_arm0 = (TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\" AND TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\" AND NOT (TO_STRING(user.name) IN (\\"root\\", \\"bin\\", \\"daemon\\", \\"sys\\", \\"nobody\\", \\"jenkins\\", \\"ansible\\", \\"deploy\\", \\"terraform\\", \\"gitlab-runner\\", \\"postgres\\", \\"mysql\\", \\"redis\\", \\"elasticsearch\\", \\"kafka\\", \\"admin\\", \\"operator\\", \\"service\\")) AND (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR NOT (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") OR (TO_STRING(event.kind) != \\"enrichment\\" OR TO_STRING(event.kind) IS NULL) AND MV_CONTAINS(TO_STRING(event.category), \\"iam\\") AND (MV_CONTAINS(TO_STRING(event.type), \\"user\\") OR MV_CONTAINS(TO_STRING(event.type), \\"creation\\") OR MV_CONTAINS(TO_STRING(event.type), \\"deletion\\") OR MV_CONTAINS(TO_STRING(event.type), \\"group\\"))))),
- _eval_entity_namespace_arm1 = (MV_CONTAINS(TO_STRING(event.kind), \\"asset\\") AND MV_CONTAINS(TO_STRING(event.module), \\"asset_discovery\\")),
- entity.namespace = COALESCE(CASE(COALESCE(_eval_entity_namespace_arm0, FALSE), \\"local\\"), CASE(COALESCE(_eval_entity_namespace_arm1, FALSE), CASE(MV_FIRST(TO_STRING(cloud.provider)) == \\"aws\\", \\"aws\\", MV_FIRST(TO_STRING(cloud.provider)) == \\"gcp\\", \\"gcp\\", MV_FIRST(TO_STRING(cloud.provider)) == \\"azure\\", \\"entra_id\\")), CASE(COALESCE(_src_entity_namespace IN (\\"okta\\", \\"entityanalytics_okta\\"), FALSE), \\"okta\\"), CASE(COALESCE(_src_entity_namespace IN (\\"azure\\", \\"entityanalytics_entra_id\\"), FALSE), \\"entra_id\\"), CASE(COALESCE(_src_entity_namespace IN (\\"o365\\", \\"o365_metrics\\"), FALSE), \\"microsoft_365\\"), CASE(COALESCE(_src_entity_namespace IN (\\"entityanalytics_ad\\"), FALSE), \\"active_directory\\"), CASE(_src_entity_namespace IS NULL OR _src_entity_namespace == \\"\\", \\"unknown\\"), _src_entity_namespace),
- user_name_present = TO_STRING(user.name) IS NOT NULL AND TO_STRING(user.name) != \\"\\",
- host_id_present = TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\",
- entity_namespace_present = TO_STRING(entity.namespace) IS NOT NULL AND TO_STRING(entity.namespace) != \\"\\",
- user_email_present = TO_STRING(user.email) IS NOT NULL AND TO_STRING(user.email) != \\"\\",
- user_id_present = TO_STRING(user.id) IS NOT NULL AND TO_STRING(user.id) != \\"\\",
- user_domain_present = TO_STRING(user.domain) IS NOT NULL AND TO_STRING(user.domain) != \\"\\",
- user_name_present_or_null = CASE(user_name_present, TO_STRING(user.name)),
- host_id_present_or_null = CASE(host_id_present, TO_STRING(host.id)),
- entity_namespace_present_or_null = CASE(entity_namespace_present, TO_STRING(entity.namespace)),
- user_email_present_or_null = CASE(user_email_present, TO_STRING(user.email)),
- user_id_present_or_null = CASE(user_id_present, TO_STRING(user.id)),
- user_domain_present_or_null = CASE(user_domain_present, TO_STRING(user.domain)),
- _euid_branch_0_formula = CONCAT(user_name_present_or_null, \\"@\\", host_id_present_or_null, \\"@\\", entity_namespace_present_or_null),
- _euid_branch_0_cond = (TO_STRING(entity.namespace) == \\"local\\"),
- _euid_branch_1_formula = COALESCE(CONCAT(user_email_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_id_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, \\"@\\", user_domain_present_or_null, \\"@\\", entity_namespace_present_or_null), CONCAT(user_name_present_or_null, \\"@\\", entity_namespace_present_or_null)),
- actorUserId = CONCAT(\\"user:\\", CASE(_euid_branch_0_cond, _euid_branch_0_formula,
-TRUE, _euid_branch_1_formula, NULL))
+    AND ((\`user.name\` IS NOT NULL AND \`user.name\` != \\"\\") AND (\`host.id\` IS NOT NULL AND \`host.id\` != \\"\\"))
+| EVAL actorUserId = CONCAT(\\"user:\\", TO_STRING(\`user.name\`), \\"@\\", TO_STRING(\`host.id\`), \\"@local\\")
 | WHERE COALESCE(actorUserId, \\"\\") != \\"\\"
-| EVAL host_id_present = TO_STRING(host.id) IS NOT NULL AND TO_STRING(host.id) != \\"\\",
- host_name_present = TO_STRING(host.name) IS NOT NULL AND TO_STRING(host.name) != \\"\\",
- host_hostname_present = TO_STRING(host.hostname) IS NOT NULL AND TO_STRING(host.hostname) != \\"\\",
- host_id_present_or_null = CASE(host_id_present, TO_STRING(host.id)),
- host_name_present_or_null = CASE(host_name_present, TO_STRING(host.name)),
- host_hostname_present_or_null = CASE(host_hostname_present, TO_STRING(host.hostname)),
- targetEntityId = CONCAT(\\"host:\\", COALESCE(host_id_present_or_null, host_name_present_or_null, host_hostname_present_or_null))
+| EVAL targetEntityId = CONCAT(\\"host:\\", TO_STRING(\`host.id\`))
 | MV_EXPAND targetEntityId
 | WHERE COALESCE(targetEntityId, \\"\\") != \\"\\"
 | STATS communicates_with = VALUES(targetEntityId) BY actorUserId

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.test.ts
@@ -155,4 +155,27 @@ describe('COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS', () => {
       }
     );
   });
+
+  describe('hostScopedUsersOnly flag', () => {
+    it('system_auth has hostScopedUsersOnly: true', () => {
+      const cfg = COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS.find(
+        (c) => c.id === 'system_auth'
+      );
+      expect(cfg?.hostScopedUsersOnly).toBe(true);
+    });
+
+    it('system_security has hostScopedUsersOnly: true', () => {
+      const cfg = COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS.find(
+        (c) => c.id === 'system_security'
+      );
+      expect(cfg?.hostScopedUsersOnly).toBe(true);
+    });
+
+    it('elastic_defend does NOT have hostScopedUsersOnly', () => {
+      const cfg = COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS.find(
+        (c) => c.id === 'elastic_defend'
+      );
+      expect(cfg?.hostScopedUsersOnly).toBeUndefined();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/configs.ts
@@ -44,12 +44,13 @@ export const COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipInt
     relationshipKey: 'communicates_with',
     targetEntityType: 'host',
     requireTargetEntityIdExists: true,
-    // SSH auth events use local-namespace EUID: `user.name@host.id@local`.
-    // `user.id` is not part of the EUID for local entities — including it in
-    // the composite agg sources causes bucket explosion (the same username
-    // appears with dozens of distinct Unix UIDs / Windows SIDs across hosts),
-    // multiplying Step 1 pages and Step 2 ES|QL queries for zero benefit.
-    customActor: { fields: ['user.email', 'user.name'] },
+    // Host-scoped EUID is `user:<user.name>@<host.id>@local`, so `user.name` is
+    // the only actor field Step 2 reads. Listing anything else (`user.email`,
+    // `user.id`) only inflates the composite agg: extra sources multiply buckets
+    // — the same username appears with dozens of distinct Unix UIDs / Windows
+    // SIDs across hosts — so Step 1 pages and Step 2 ES|QL queries grow for
+    // actors Step 2 then discards.
+    customActor: { fields: ['user.name'] },
     // `event.category` is multivalued in ECS (Elastic Agent's syslog SSH events
     // emit `["authentication", "session"]`). ES|QL `IN` returns NULL for a
     // multivalued left-hand side, so `event.category IN (...)` silently drops
@@ -62,6 +63,7 @@ export const COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipInt
       { term: { 'event.action': 'ssh_login' } },
       SUCCESSFUL_OUTCOME_FILTER,
     ],
+    hostScopedUsersOnly: true,
   },
   {
     kind: 'standard',
@@ -71,6 +73,12 @@ export const COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipInt
     relationshipKey: 'communicates_with',
     targetEntityType: 'host',
     requireTargetEntityIdExists: true,
+    // Windows logon events carry `user.name`, which is the only actor field the
+    // host-scoped EUID (`user:<user.name>@<host.id>@local`) reads. A doc with
+    // `user.email` but no `user.name` is an IDP user that extraction indexed
+    // under a different EUID, so bucketing on it would surface actors Step 2
+    // cannot build an id for.
+    customActor: { fields: ['user.name'] },
     esqlWhereClause: `event.action IN ("logged-in", "logged-in-explicit")
     AND event.code IN ("4624", "4648")
     AND winlog.logon.type IN ("Interactive", "RemoteInteractive", "CachedInteractive")
@@ -80,6 +88,7 @@ export const COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS: RelationshipInt
       { terms: { 'event.action': ['logged-in', 'logged-in-explicit'] } },
       SUCCESSFUL_OUTCOME_FILTER,
     ],
+    hostScopedUsersOnly: true,
   },
   {
     kind: 'standard',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/communicates_with/index.ts
@@ -43,6 +43,7 @@ export const communicatesWithMaintainer: RegisterEntityMaintainerConfig = {
       crudClient,
       entityMetadataClient,
       integrations: COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS,
+      maintainerName: 'communicates_with',
       abortController,
       telemetryCollector: collector,
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_actor_discovery_query.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_actor_discovery_query.test.ts
@@ -8,6 +8,9 @@
 import { euid } from '@kbn/entity-store/common/euid_helpers';
 
 import { buildActorDiscoveryQuery, buildActorPageFilter } from './build_actor_discovery_query';
+import { buildTargetsPerActorQuery } from './build_targets_per_actor_query';
+import { COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS } from '../communicates_with/configs';
+import { ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS } from '../accesses/configs';
 import type { RelationshipIntegrationConfig, CompositeBucket } from './types';
 
 const HOST_EUID_FILTER = euid.dsl.getEuidDocumentsContainsIdFilter('host');
@@ -385,4 +388,51 @@ describe('buildActorPageFilter (page filter)', () => {
       expect(byField['user.email']).toBeUndefined();
     });
   });
+});
+
+describe('hostScopedUsersOnly configs: Step 1 actor fields agree with Step 2', () => {
+  // The host-scoped EUID reads `user.name` only, so Step 1 must bucket on exactly
+  // that. Listing extra fields (e.g. `user.email`) multiplies composite buckets —
+  // `missing_bucket: true` emits a bucket per (null, name) AND (email, null)
+  // combination — surfacing actors Step 2 discards when it cannot build an EUID.
+  const hostScopedConfigs = [
+    ...COMMUNICATES_WITH_INTEGRATION_RELATIONSHIP_CONFIGS,
+    ...ACCESSES_INTEGRATION_RELATIONSHIP_CONFIGS,
+  ].filter((c) => c.hostScopedUsersOnly);
+
+  it('covers the shipped host-scoped configs', () => {
+    expect(hostScopedConfigs.map((c) => c.id).sort()).toEqual([
+      'system_auth',
+      'system_auth',
+      'system_security',
+      'system_security',
+    ]);
+  });
+
+  it.each(hostScopedConfigs.map((c) => [c.id, c] as const))(
+    '%s buckets on user.name alone',
+    (_id, config) => {
+      expect(config.customActor?.fields).toEqual(['user.name']);
+
+      const { aggs } = buildActorDiscoveryQuery(config, undefined) as {
+        aggs: { users: { composite: { sources: Array<Record<string, unknown>> } } };
+      };
+      expect(aggs.users.composite.sources).toHaveLength(1);
+      expect(Object.keys(aggs.users.composite.sources[0])).toEqual(['user.name']);
+    }
+  );
+
+  it.each(hostScopedConfigs.map((c) => [c.id, c] as const))(
+    '%s Step 1 presence filter references no field the Step 2 EUID ignores',
+    (_id, config) => {
+      const { query } = buildActorDiscoveryQuery(config, undefined) as {
+        query: { bool: { filter: Array<Record<string, unknown>> } };
+      };
+      const step2 = buildTargetsPerActorQuery(config, 'default');
+
+      // `user.email` must appear in neither step for these configs.
+      expect(JSON.stringify(query.bool.filter)).not.toContain('user.email');
+      expect(step2).not.toContain('user.email');
+    }
+  );
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.test.ts
@@ -312,6 +312,148 @@ describe('buildTargetsPerActorQuery (targets per actor)', () => {
     });
   });
 
+  describe('hostScopedUsersOnly', () => {
+    const hostScopedStandard: RelationshipIntegrationConfig = {
+      kind: 'standard',
+      id: 'system_auth',
+      name: 'System Auth',
+      indexPattern: (ns) => `logs-system.auth-${ns}`,
+      relationshipKey: 'communicates_with',
+      targetEntityType: 'host',
+      requireTargetEntityIdExists: true,
+      hostScopedUsersOnly: true,
+      customActor: { fields: ['user.email', 'user.name'] },
+      esqlWhereClause: `(MV_CONTAINS(TO_STRING(event.category), "authentication") OR MV_CONTAINS(TO_STRING(event.category), "session"))
+    AND event.action == "ssh_login"
+    AND event.outcome == "success"`,
+    };
+
+    const hostScopedBucketed: RelationshipIntegrationConfig = {
+      kind: 'bucketed',
+      id: 'system_auth',
+      name: 'System Auth',
+      indexPattern: (ns) => `logs-system.auth-${ns}`,
+      targetEntityType: 'host',
+      bucketTargetByThreshold: {
+        threshold: 4,
+        aboveThresholdRelationship: 'accesses_frequently',
+        belowThresholdRelationship: 'accesses_infrequently',
+      },
+      requireTargetEntityIdExists: true,
+      hostScopedUsersOnly: true,
+      customActor: { fields: ['user.email', 'user.name'] },
+      esqlWhereClause: `(MV_CONTAINS(TO_STRING(event.category), "authentication") OR MV_CONTAINS(TO_STRING(event.category), "session"))
+    AND event.action == "ssh_login"
+    AND event.outcome == "success"`,
+    };
+
+    it('does NOT include entity.namespace EVAL chain', () => {
+      const query = buildTargetsPerActorQuery(hostScopedStandard, 'default');
+      expect(query).not.toContain('entity.namespace');
+      expect(query).not.toContain('_src_entity_namespace');
+      expect(query).not.toContain('getFieldEvaluations');
+    });
+
+    it('hardcodes @local in the actorUserId EVAL expression', () => {
+      const query = buildTargetsPerActorQuery(hostScopedStandard, 'default');
+      expect(query).toContain('@local');
+      expect(query).toContain('actorUserId');
+    });
+
+    it('builds the actor EUID from user.name + host.id only', () => {
+      const query = buildTargetsPerActorQuery(hostScopedStandard, 'default');
+      expect(query).toContain(
+        'actorUserId = CONCAT("user:", TO_STRING(`user.name`), "@", TO_STRING(`host.id`), "@local")'
+      );
+    });
+
+    it('never references user.email — that field belongs to the IDP ranking branch', () => {
+      const query = buildTargetsPerActorQuery(hostScopedStandard, 'default');
+
+      // A document with user.email but no user.name is an IDP user that extraction
+      // indexed under a different EUID, so neither the gate nor the EUID may read it.
+      expect(query).not.toContain('user.email');
+    });
+
+    it('emits a single WHERE gate covering both the actor and host-target EUIDs', () => {
+      const query = buildTargetsPerActorQuery(hostScopedStandard, 'default');
+
+      // `host.id` is the only field either EUID reads, so the actor gate doubles as
+      // the target gate — a second host.id check would be dead weight per row.
+      expect(query).toContain(
+        '(`user.name` IS NOT NULL AND `user.name` != "") AND (`host.id` IS NOT NULL AND `host.id` != "")'
+      );
+      expect(query.match(/`host\.id` IS NOT NULL/g)).toHaveLength(1);
+    });
+
+    it('includes host.id IS NOT NULL gate (requireTargetEntityIdExists host-scoped equivalent)', () => {
+      const query = buildTargetsPerActorQuery(hostScopedStandard, 'default');
+      expect(query).toContain('`host.id` IS NOT NULL');
+      expect(query).toContain('`host.id` != ""');
+    });
+
+    it('ignores customActor.fields — the host-scoped user EUID comes from the entity definition', () => {
+      // Step 1 (composite agg) still uses customActor.fields as bucket sources, but this
+      // EUID must not be steerable per-config or it would stop matching the store.
+      const withOddActorFields: RelationshipIntegrationConfig = {
+        ...hostScopedStandard,
+        customActor: { fields: ['user.id'] },
+      };
+
+      expect(buildTargetsPerActorQuery(withOddActorFields, 'default')).toBe(
+        buildTargetsPerActorQuery(hostScopedStandard, 'default')
+      );
+    });
+
+    it('appends additionalTargetFilter (shared pipeline with the standard builder)', () => {
+      const withAdditionalFilter: RelationshipIntegrationConfig = {
+        ...hostScopedStandard,
+        additionalTargetFilter: 'AND targetEntityId != "host:excluded"',
+      };
+
+      const query = buildTargetsPerActorQuery(withAdditionalFilter, 'default');
+
+      expect(query).toContain('AND targetEntityId != "host:excluded"');
+      expect(query.indexOf('COALESCE(targetEntityId, "") != ""')).toBeLessThan(
+        query.indexOf('AND targetEntityId != "host:excluded"')
+      );
+    });
+
+    it('emits correct STATS column for standard kind', () => {
+      const query = buildTargetsPerActorQuery(hostScopedStandard, 'default');
+      expect(query).toContain('communicates_with = VALUES(targetEntityId)');
+    });
+
+    it('emits bucketed STATS block for bucketed kind', () => {
+      const query = buildTargetsPerActorQuery(hostScopedBucketed, 'default');
+      expect(query).toContain('accesses_frequently');
+      expect(query).toContain('accesses_infrequently');
+      expect(query).toContain('access_count = COUNT(*)');
+    });
+
+    it('still includes LIMIT', () => {
+      const query = buildTargetsPerActorQuery(hostScopedStandard, 'default');
+      expect(query).toContain('| LIMIT 3500');
+    });
+
+    it('still prepends the engine preamble exactly once', () => {
+      const query = buildTargetsPerActorQuery(hostScopedStandard, 'default');
+      const matches = query.match(/SET unmapped_fields="nullify";/g) ?? [];
+      expect(matches).toHaveLength(1);
+    });
+
+    it('uses the namespace-derived index pattern', () => {
+      expect(buildTargetsPerActorQuery(hostScopedStandard, 'prod')).toContain(
+        'logs-system.auth-prod'
+      );
+    });
+
+    it('does NOT emit entity.namespace or EUID chain for host-scoped bucketed', () => {
+      const query = buildTargetsPerActorQuery(hostScopedBucketed, 'default');
+      expect(query).not.toContain('entity.namespace');
+    });
+  });
+
   // Regression guard for an ES|QL quirk where `WHERE col IS NOT NULL`
   // evaluates to FALSE for every row when `col` is produced by CONCAT() over
   // a CASE() with nested CASE arms (as the user EUID actorEval does). Using

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/build_targets_per_actor_query.ts
@@ -35,33 +35,85 @@ function buildAnyActorFieldNonEmptyEsql(fields: string[]): string {
   return fields.map((field) => `(\`${field}\` IS NOT NULL AND \`${field}\` != "")`).join(' OR ');
 }
 
-function buildRelationshipEsql(
-  config: StandardRelationshipIntegrationConfig | BucketedRelationshipIntegrationConfig,
-  namespace: string
-): string {
-  const indexPattern = config.indexPattern(namespace);
+/**
+ * Resolves the four actor/target ES|QL fragments that vary by config. Everything
+ * else in the pipeline (WHERE composition, MV_EXPAND, STATS, LIMIT) is identical
+ * across configs, so it lives in `buildRelationshipEsql` and is shared.
+ *
+ * `hostScopedUsersOnly` configs get minimized fragments from
+ * `euid.experimental.getHostScopedUserEuidEsql()` — ~2 EVAL columns per row instead of ~35,
+ * measured ~26× faster on logs-system.auth (~700M docs, 30d lookback). See
+ * `hostScopedUsersOnly` in `types.ts` for the data assumptions that make this valid.
+ *
+ * `config.customActor.fields` is deliberately ignored for those configs: which
+ * fields form the host-scoped user EUID is a property of the entity definition,
+ * not of the integration. Configs still declare `customActor.fields` because the
+ * Step 1 composite-agg builder uses them as bucket sources.
+ */
+function resolveActorAndTargetEsql(
+  config: StandardRelationshipIntegrationConfig | BucketedRelationshipIntegrationConfig
+): {
+  actorPresenceGate: string;
+  actorEvalLines: string;
+  targetGateLine: string;
+  targetEvalClause: string;
+} {
+  if (config.hostScopedUsersOnly) {
+    const { evalAssignment, presenceGate } = euid.experimental.getHostScopedUserEuidEsql();
+
+    return {
+      // Requires both `user.name` and `host.id`. For a host target that doubles as
+      // the target gate — `host.id` is the only field either EUID reads — so
+      // `targetGateLine` stays empty rather than emitting a redundant check.
+      actorPresenceGate: presenceGate,
+      actorEvalLines: `| EVAL ${ENGINE_COLUMNS.actor} = ${evalAssignment}`,
+      targetGateLine:
+        config.requireTargetEntityIdExists && config.targetEntityType !== 'host'
+          ? `    AND (${euid.esql.getEuidDocumentsContainsIdFilter(config.targetEntityType)})\n`
+          : '',
+      targetEvalClause:
+        config.targetEntityType === 'host'
+          ? `| EVAL targetEntityId = CONCAT("host:", TO_STRING(\`host.id\`))`
+          : `| EVAL ${euid.esql.getEuidEvaluation(config.targetEntityType, 'targetEntityId', {
+              withTypeId: true,
+            })}`,
+    };
+  }
+
   // TODO(#266748): 'user' hardcoded for actor — thread actorEntityType through config.
   const userFieldEvals = !config.customActor?.evalOverride
     ? getFieldEvaluationsEsql('user')
     : undefined;
   const userFieldEvalsLine = userFieldEvals ? `| EVAL ${userFieldEvals}\n` : '';
-  const userIdFilter = config.customActor
-    ? buildAnyActorFieldNonEmptyEsql(config.customActor.fields)
-    : euid.esql.getEuidDocumentsContainsIdFilter('user');
   const actorEvalClause = config.customActor?.evalOverride
     ? `| EVAL ${ENGINE_COLUMNS.actor} = ${config.customActor.evalOverride}`
     : `| EVAL ${euid.esql.getEuidEvaluation('user', ENGINE_COLUMNS.actor, { withTypeId: true })}`;
-  const targetEvalClause = config.targetEvalOverride
-    ? `| EVAL targetEntityId = ${config.targetEvalOverride}`
-    : `| EVAL ${euid.esql.getEuidEvaluation(config.targetEntityType, 'targetEntityId', {
-        withTypeId: true,
-      })}`;
+
+  return {
+    actorPresenceGate: config.customActor
+      ? buildAnyActorFieldNonEmptyEsql(config.customActor.fields)
+      : euid.esql.getEuidDocumentsContainsIdFilter('user'),
+    actorEvalLines: `${userFieldEvalsLine}${actorEvalClause}`,
+    targetGateLine: config.requireTargetEntityIdExists
+      ? `    AND (${euid.esql.getEuidDocumentsContainsIdFilter(config.targetEntityType)})\n`
+      : '',
+    targetEvalClause: config.targetEvalOverride
+      ? `| EVAL targetEntityId = ${config.targetEvalOverride}`
+      : `| EVAL ${euid.esql.getEuidEvaluation(config.targetEntityType, 'targetEntityId', {
+          withTypeId: true,
+        })}`,
+  };
+}
+
+function buildRelationshipEsql(
+  config: StandardRelationshipIntegrationConfig | BucketedRelationshipIntegrationConfig,
+  namespace: string
+): string {
+  const indexPattern = config.indexPattern(namespace);
+  const { actorPresenceGate, actorEvalLines, targetGateLine, targetEvalClause } =
+    resolveActorAndTargetEsql(config);
   const additionalTargetFilter = config.additionalTargetFilter
     ? `\n    ${config.additionalTargetFilter}`
-    : '';
-
-  const targetIdFilterLine = config.requireTargetEntityIdExists
-    ? `    AND (${euid.esql.getEuidDocumentsContainsIdFilter(config.targetEntityType)})\n`
     : '';
 
   const statsClause =
@@ -98,8 +150,8 @@ function buildRelationshipEsql(
   // intent (treat NULL as empty, then check non-empty) and sidesteps the bug.
   return `FROM ${indexPattern}
 | WHERE ${config.esqlWhereClause}
-    AND (${userIdFilter})
-${targetIdFilterLine}${userFieldEvalsLine}${actorEvalClause}
+    AND (${actorPresenceGate})
+${targetGateLine}${actorEvalLines}
 | WHERE COALESCE(${ENGINE_COLUMNS.actor}, "") != ""
 ${targetEvalClause}
 | MV_EXPAND targetEntityId
@@ -121,7 +173,9 @@ ${statsClause}
  *   results (see `parseTargetsPerActorRows` for the warning safety net).
  *   Override functions MUST NOT include `SET unmapped_fields="nullify"`
  *   themselves — the engine prepends it.
- * - `kind: 'standard' | 'bucketed'` → uses the default ES|QL builder.
+ * - `kind: 'standard' | 'bucketed'` → uses `buildRelationshipEsql`, which routes
+ *   its actor/target fragments through `resolveActorAndTargetEsql`. Configs with
+ *   `hostScopedUsersOnly` get the minimized host-scoped fragments there.
  */
 export const buildTargetsPerActorQuery = (
   config: RelationshipIntegrationConfig,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/constants.ts
@@ -8,6 +8,8 @@
 export const LOOKBACK_WINDOW = 'now-30d';
 export const COMPOSITE_PAGE_SIZE = 3500;
 export const MAX_ITERATIONS = 1000;
+/** Default per-request timeout (ms) for ES client calls made by the engine. */
+export const DEFAULT_ESQL_TIMEOUT_MS = 60_000;
 
 /**
  * Required ES|QL preamble for every Step 2 query the engine runs.

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.test.ts
@@ -142,6 +142,7 @@ describe('runRelationshipMaintainer', () => {
           crudClient,
           entityMetadataClient,
           integrations: [baseConfig],
+          maintainerName: 'communicates_with',
         })
       ).rejects.toThrow(/Invalid namespace/);
       // Engine never reached Step 1 / Step 2 / write — precondition guard ran first.
@@ -162,6 +163,7 @@ describe('runRelationshipMaintainer', () => {
           crudClient,
           entityMetadataClient,
           integrations: [baseConfig],
+          maintainerName: 'communicates_with',
         })
       ).resolves.toBeDefined();
     });
@@ -192,6 +194,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(result.totalNotFound).toBe(1);
       expect(result.totalWriteErrors).toBe(1);
@@ -208,6 +211,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(result.totalNotFound).toBe(0);
       expect(result.totalWriteErrors).toBe(0);
@@ -228,6 +232,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
         abortController: ac,
       });
       expect(result.totalNotFound).toBe(0);
@@ -245,6 +250,7 @@ describe('runRelationshipMaintainer', () => {
       crudClient,
       entityMetadataClient,
       integrations: [],
+      maintainerName: 'communicates_with',
     });
     expect(result.totalBuckets).toBe(0);
     expect(result.totalRecords).toBe(0);
@@ -266,6 +272,7 @@ describe('runRelationshipMaintainer', () => {
       crudClient,
       entityMetadataClient,
       integrations: [],
+      maintainerName: 'communicates_with',
     });
     const after = new Date().toISOString();
     expect(lastRunTimestamp >= before).toBe(true);
@@ -284,6 +291,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(result.totalBuckets).toBe(0);
       expect(esql).not.toHaveBeenCalled();
@@ -316,6 +324,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(search).toHaveBeenCalledTimes(2);
       expect(esql).toHaveBeenCalledTimes(2);
@@ -346,6 +355,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       // Two search calls because after_key was still set on the partial page.
       // (Old heuristic would have stopped after one because length < page size.)
@@ -369,6 +379,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       // search may have been called MAX_ITERATIONS or MAX_ITERATIONS+1 times
       // depending on the loop's stop point; the contract is that we stopped
@@ -396,6 +407,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(result.totalBuckets).toBe(0);
       expect(esql).not.toHaveBeenCalled();
@@ -419,6 +431,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(result.totalBuckets).toBe(0);
       expect(result.totalWritten).toBe(0);
@@ -441,6 +454,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(result.totalBuckets).toBe(0);
       expect(logger.error).toHaveBeenCalled();
@@ -462,6 +476,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
         abortController: ac,
       });
       expect(result.totalBuckets).toBe(0);
@@ -486,6 +501,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(result.totalBuckets).toBe(0);
       expect(result.totalWritten).toBe(0);
@@ -513,6 +529,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
         abortController: ac,
       });
       expect(result.totalBuckets).toBe(1);
@@ -539,12 +556,67 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
-      expect(result.totalBuckets).toBe(0); // error integration excluded from totals
+      // The page's buckets were scanned before ES|QL threw, so they count. Nothing
+      // reached the entity store, so written stays 0 — the counters describe work
+      // actually done, not a blanket zero for the whole integration.
+      expect(result.totalBuckets).toBe(1);
       expect(result.totalRecords).toBe(0);
       expect(result.totalWritten).toBe(0);
       expect(bulkUpdate).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('reports entities persisted by earlier pages when a later page throws mid-pagination', async () => {
+      // Regression guard for the per-page-write invariant: page 1 writes durably,
+      // then page 2's ES|QL throws (e.g. requestTimeoutMs fires). The already-
+      // persisted entities must still be reported — otherwise the completion log
+      // and telemetry claim `written=0` during exactly the timeout scenario the
+      // configurable requestTimeoutMs exists to surface.
+      const { esClient, search, esql } = makeEsClient();
+      const { crudClient, entityMetadataClient, bulkUpdate } = makeClients();
+
+      // Page 1: one actor, with an after_key so pagination continues.
+      search.mockResolvedValueOnce(
+        successResponse([{ key: { 'user.name': 'alice' }, doc_count: 1 }], {
+          'user.name': 'alice',
+        })
+      );
+      esql.mockResolvedValueOnce({
+        columns: [
+          { name: 'actorUserId', type: 'keyword' },
+          { name: 'accesses_frequently', type: 'keyword' },
+          { name: 'accesses_infrequently', type: 'keyword' },
+        ],
+        values: [['user:alice@corp', ['host:H1'], null]],
+      });
+      // Page 2: another actor, but ES|QL fails for it.
+      search.mockResolvedValueOnce(
+        successResponse([{ key: { 'user.name': 'bob' }, doc_count: 1 }])
+      );
+      esql.mockRejectedValueOnce(new Error('Request timed out'));
+
+      const logger = loggerMock.create();
+      const result = await runRelationshipMaintainer({
+        esClient,
+        logger,
+        namespace: 'default',
+        crudClient,
+        entityMetadataClient,
+        integrations: [baseConfig],
+        maintainerName: 'communicates_with',
+      });
+
+      expect(bulkUpdate).toHaveBeenCalledTimes(1);
+      expect(result.totalWritten).toBe(1);
+      expect(result.totalRecords).toBe(1);
+
+      // The completion log must agree with the returned totals.
+      const infos = logger.info.mock.calls.map((c) => c[0] as string);
+      const completion = infos.find((m) => m.includes('Integration complete:'));
+      expect(completion).toContain('outcome=error');
+      expect(completion).toContain('written=1');
     });
 
     // Defense in depth: ES|QL responses are typed loosely on the client. A
@@ -567,6 +639,7 @@ describe('runRelationshipMaintainer', () => {
           crudClient,
           entityMetadataClient,
           integrations: [baseConfig],
+          maintainerName: 'communicates_with',
         });
         expect(result.totalRecords).toBe(0);
         expect(bulkUpdate).not.toHaveBeenCalled();
@@ -591,6 +664,7 @@ describe('runRelationshipMaintainer', () => {
           crudClient,
           entityMetadataClient,
           integrations: [baseConfig],
+          maintainerName: 'communicates_with',
         });
         expect(result.totalRecords).toBe(0);
         expect(bulkUpdate).not.toHaveBeenCalled();
@@ -613,6 +687,7 @@ describe('runRelationshipMaintainer', () => {
             crudClient,
             entityMetadataClient,
             integrations: [baseConfig],
+            maintainerName: 'communicates_with',
           })
         ).resolves.toBeDefined();
       });
@@ -630,6 +705,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
         abortController: aborted(),
       });
       expect(search).not.toHaveBeenCalled();
@@ -660,6 +736,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
         abortController: ac,
       });
       expect(search).toHaveBeenCalledTimes(1); // only integration #1 ran
@@ -688,6 +765,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
         abortController: ac,
       });
       // With streamed per-integration write (C.3): the integration produced
@@ -736,6 +814,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
       });
       expect(result.totalBuckets).toBe(3);
       expect(result.totalRecords).toBe(2);
@@ -769,6 +848,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
       });
       expect(result.totalRecords).toBe(1);
       expect(bulkUpdate).toHaveBeenCalledTimes(1);
@@ -802,6 +882,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
         abortController: ac,
       });
       // baseConfig wrote 1 entity before the abort fired.
@@ -825,6 +906,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
       });
       const indexes = search.mock.calls.map((c) => (c[0] as { index: string }).index);
       expect(indexes).toEqual(['logs-endpoint.events.security-prod', 'logs-okta.system-prod']);
@@ -832,7 +914,7 @@ describe('runRelationshipMaintainer', () => {
   });
 
   describe('transport options', () => {
-    it('does not pass an AbortSignal to the ES client when no abortController is provided', async () => {
+    it('passes the default requestTimeout (DEFAULT_ESQL_TIMEOUT_MS) to both search and esql.query when no signal is provided', async () => {
       const { esClient, search, esql } = makeEsClient();
       const { crudClient, entityMetadataClient } = makeClients();
       search.mockResolvedValueOnce(
@@ -846,12 +928,15 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
-      expect(search.mock.calls[0][1]).toBeUndefined();
-      expect(esql.mock.calls[0][1]).toBeUndefined();
+      expect((search.mock.calls[0][1] as { requestTimeout: number }).requestTimeout).toBe(60_000);
+      expect((esql.mock.calls[0][1] as { requestTimeout: number }).requestTimeout).toBe(60_000);
+      expect((search.mock.calls[0][1] as { signal?: AbortSignal }).signal).toBeUndefined();
+      expect((esql.mock.calls[0][1] as { signal?: AbortSignal }).signal).toBeUndefined();
     });
 
-    it('passes the AbortSignal to both search and esql.query when abortController is provided', async () => {
+    it('passes the AbortSignal to both search and esql.query when signal is provided', async () => {
       const { esClient, search, esql } = makeEsClient();
       const { crudClient, entityMetadataClient } = makeClients();
       search.mockResolvedValueOnce(
@@ -866,10 +951,64 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
         abortController: ac,
       });
       expect((search.mock.calls[0][1] as { signal: AbortSignal }).signal).toBe(ac.signal);
       expect((esql.mock.calls[0][1] as { signal: AbortSignal }).signal).toBe(ac.signal);
+    });
+  });
+
+  describe('requestTimeoutMs', () => {
+    it('passes requestTimeout to esClient.search when requestTimeoutMs is set', async () => {
+      const { esClient, search } = makeEsClient();
+      const { crudClient, entityMetadataClient } = makeClients();
+      search.mockResolvedValueOnce({ aggregations: { users: { buckets: [] } } });
+
+      await runRelationshipMaintainer({
+        esClient,
+        logger: loggerMock.create(),
+        namespace: 'default',
+        crudClient,
+        entityMetadataClient,
+        integrations: [baseConfig],
+        maintainerName: 'communicates_with',
+        requestTimeoutMs: 90_000,
+      });
+
+      expect(search).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ requestTimeout: 90_000 })
+      );
+    });
+
+    it('passes requestTimeout to esClient.esql.query when requestTimeoutMs is set', async () => {
+      const { esClient, search, esql } = makeEsClient();
+      const { crudClient, entityMetadataClient } = makeClients();
+      search.mockResolvedValueOnce({
+        aggregations: {
+          users: {
+            buckets: [{ key: { 'user.name': 'alice' }, doc_count: 1 }],
+          },
+        },
+      });
+      esql.mockResolvedValueOnce({ columns: [], values: [] });
+
+      await runRelationshipMaintainer({
+        esClient,
+        logger: loggerMock.create(),
+        namespace: 'default',
+        crudClient,
+        entityMetadataClient,
+        integrations: [baseConfig],
+        maintainerName: 'communicates_with',
+        requestTimeoutMs: 90_000,
+      });
+
+      expect(esql).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ requestTimeout: 90_000 })
+      );
     });
   });
 
@@ -888,6 +1027,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       const [esqlArg] = esql.mock.calls[0] as [
         { query: string; filter: { bool: { filter: unknown[] } } }
@@ -912,6 +1052,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [{ ...baseConfig, disableLookbackWindow: true }],
+        maintainerName: 'communicates_with',
       });
       const [esqlArg] = esql.mock.calls[0] as [
         { query: string; filter: { bool: { filter: unknown[] } } }
@@ -949,6 +1090,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(bulkUpdate).toHaveBeenCalledTimes(1);
       expect(bulkAppend).toHaveBeenCalledTimes(1);
@@ -970,6 +1112,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(bulkAppend).not.toHaveBeenCalled();
     });
@@ -1009,6 +1152,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       const [docs] = bulkAppend.mock.calls[0] as [Array<Record<string, unknown>>];
       const actorIds = docs.map((d) => d['entity.id']);
@@ -1042,6 +1186,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
       });
       expect(bulkAppend).toHaveBeenCalledTimes(2);
       const scanIds = bulkAppend.mock.calls.flatMap(([docs]) =>
@@ -1075,6 +1220,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
       });
       const timestamps = bulkAppend.mock.calls.flatMap(([docs]) =>
         (docs as Array<{ '@timestamp': string }>).map((d) => d['@timestamp'])
@@ -1106,6 +1252,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
       });
       const sourcesPerCall = bulkAppend.mock.calls.map(([docs]) => {
         const set = new Set(
@@ -1137,6 +1284,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       const [docs] = bulkAppend.mock.calls[0] as [Array<Record<string, unknown>>];
       expect(docs).toHaveLength(3);
@@ -1160,8 +1308,13 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
-      expect(result.totalWritten).toBe(0); // error integration excluded from totals
+      // The entity write completed before the metadata write threw, so that entity
+      // IS durably in the store. Reporting 0 here would tell operators nothing was
+      // written when something was — counters must reflect persisted work even
+      // when the integration ends in `outcome: 'error'`.
+      expect(result.totalWritten).toBe(1);
       expect(logger.error).toHaveBeenCalled();
     });
 
@@ -1179,6 +1332,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       const [docs] = bulkAppend.mock.calls[0] as [
         Array<{ Maintainer: { kind: string; lookback_window: string } }>
@@ -1210,6 +1364,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       // Second run.
       search.mockResolvedValueOnce(
@@ -1230,6 +1385,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
       expect(bulkAppend).toHaveBeenCalledTimes(2);
       const [run1Docs] = bulkAppend.mock.calls[0] as [Array<{ Maintainer: { scan_id: string } }>];
@@ -1263,6 +1419,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
         telemetryCollector: collector,
       });
 
@@ -1303,6 +1460,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
         telemetryCollector: collector,
       });
 
@@ -1332,6 +1490,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
         telemetryCollector: collector,
       });
 
@@ -1359,6 +1518,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig, oktaConfig],
+        maintainerName: 'communicates_with',
       });
 
       // The first integration's failure should NOT throw; the loop should continue.
@@ -1381,9 +1541,66 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
 
       expect(result.totalBuckets).toBe(0);
+    });
+  });
+
+  describe('per-page write', () => {
+    it('calls bulkUpdateEntity once per page when there are multiple pages', async () => {
+      const { esClient, search, esql } = makeEsClient();
+      const { crudClient, entityMetadataClient, bulkUpdate } = makeClients();
+
+      // Page 1: returns after_key so pagination continues
+      search.mockResolvedValueOnce({
+        aggregations: {
+          users: {
+            buckets: [{ key: { 'user.name': 'alice' }, doc_count: 1 }],
+            after_key: { 'user.name': 'alice' },
+          },
+        },
+      });
+      // Page 2: no after_key — last page
+      search.mockResolvedValueOnce({
+        aggregations: {
+          users: {
+            buckets: [{ key: { 'user.name': 'bob' }, doc_count: 1 }],
+          },
+        },
+      });
+
+      esql.mockResolvedValue({
+        columns: [
+          { name: 'actorUserId', type: 'keyword' },
+          { name: 'communicates_with', type: 'keyword' },
+        ],
+        values: [['user:alice@host1@local', 'host:h1']],
+      });
+
+      await runRelationshipMaintainer({
+        esClient,
+        logger: loggerMock.create(),
+        namespace: 'default',
+        crudClient,
+        entityMetadataClient,
+        integrations: [
+          {
+            kind: 'standard',
+            id: 'system_auth',
+            name: 'System Auth',
+            indexPattern: (ns) => `logs-system.auth-${ns}`,
+            relationshipKey: 'communicates_with',
+            targetEntityType: 'host',
+            esqlWhereClause: 'event.action == "ssh_login"',
+          },
+        ],
+        maintainerName: 'communicates_with',
+      });
+
+      // bulkUpdateEntity called once per non-empty page (2 pages, both have esql results)
+      expect(bulkUpdate).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -1417,6 +1634,7 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
         telemetryCollector: collector,
       });
 
@@ -1443,10 +1661,42 @@ describe('runRelationshipMaintainer', () => {
         crudClient,
         entityMetadataClient,
         integrations: [baseConfig],
+        maintainerName: 'communicates_with',
       });
 
       expect(search).toHaveBeenCalledTimes(1);
       expect(esql).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('per-integration completion log', () => {
+    it('logs info on successful integration completion with key metrics', async () => {
+      const { esClient, search } = makeEsClient();
+      const { crudClient, entityMetadataClient } = makeClients();
+      const logger = loggerMock.create();
+
+      search.mockResolvedValueOnce({ aggregations: { users: { buckets: [] } } });
+
+      await runRelationshipMaintainer({
+        esClient,
+        logger,
+        namespace: 'default',
+        crudClient,
+        entityMetadataClient,
+        integrations: [baseConfig],
+        maintainerName: 'communicates_with',
+      });
+
+      const infoCalls = logger.info.mock.calls.map((c) => c[0] as string);
+      const completionLog = infoCalls.find((msg) =>
+        msg.includes('[communicates_with][elastic_defend] Integration complete:')
+      );
+      expect(completionLog).toBeDefined();
+      expect(completionLog).toContain('outcome=');
+      expect(completionLog).toContain('slices=');
+      expect(completionLog).toContain('records=');
+      expect(completionLog).toContain('written=');
+      expect(completionLog).toContain('truncated=');
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/run_relationship_maintainer.ts
@@ -15,9 +15,9 @@ import type { EntityUpdateClient, EntityMetadataClient } from '@kbn/entity-store
 
 import type {
   RelationshipIntegrationConfig,
+  RelationshipMaintainerName,
   CompositeAfterKey,
   CompositeBucket,
-  EntityRelationshipRecord,
 } from './types';
 import {
   buildActorDiscoveryQuery,
@@ -26,12 +26,16 @@ import {
 } from './build_actor_discovery_query';
 import { buildTargetsPerActorQuery } from './build_targets_per_actor_query';
 import { parseTargetsPerActorRows } from './parse_targets_per_actor_rows';
-import { writeEntityIds, type WriteEntityIdsResult } from './update_entities';
+import {
+  writeEntityIds,
+  type WriteEntityIdsResult,
+  type WriteEntityIdsPageState,
+} from './update_entities';
 import {
   writeRelationshipMetadatas,
   type WriteRelationshipMetadatasResult,
 } from './write_relationship_metadatas';
-import { LOOKBACK_WINDOW, MAX_ITERATIONS } from './constants';
+import { LOOKBACK_WINDOW, MAX_ITERATIONS, DEFAULT_ESQL_TIMEOUT_MS } from './constants';
 import { assertValidNamespace } from './validate_namespace';
 import type {
   RelationshipMaintainerSourceResult,
@@ -72,6 +76,17 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : JSON.stringify(err);
 }
 
+function mergeRelTypeApplied(
+  a: Record<string, number>,
+  b: Record<string, number>
+): Record<string, number> {
+  const merged = { ...a };
+  for (const [k, v] of Object.entries(b)) {
+    merged[k] = (merged[k] ?? 0) + v;
+  }
+  return merged;
+}
+
 /** Returns the actor page on success, null to stop iteration (index missing or aborted), throws on real error. */
 async function fetchActorPage(
   config: RelationshipIntegrationConfig,
@@ -79,8 +94,9 @@ async function fetchActorPage(
   logger: Logger,
   namespace: string,
   afterKey: CompositeAfterKey | undefined,
-  transportOpts: { signal: AbortSignal } | undefined,
-  abortController: AbortController | undefined
+  transportOpts: { signal?: AbortSignal; requestTimeout?: number } | undefined,
+  abortController: AbortController | undefined,
+  logPrefix: string
 ): Promise<{ buckets: CompositeBucket[]; newAfterKey: CompositeAfterKey | undefined } | null> {
   try {
     const result = await esClient.search(
@@ -94,14 +110,14 @@ async function fetchActorPage(
     };
   } catch (err) {
     if (isIndexNotFound(err)) {
-      logger.info(`[${config.id}] Index "${config.indexPattern(namespace)}" not found, skipping`);
+      logger.info(`${logPrefix} Index "${config.indexPattern(namespace)}" not found, skipping`);
       return null;
     }
     if (abortController?.signal.aborted) {
-      logger.info(`[${config.id}] Aborted during composite aggregation`);
+      logger.info(`${logPrefix} Aborted during composite aggregation`);
       return null;
     }
-    logger.error(`[${config.id}] Composite aggregation failed: ${errMsg(err)}`);
+    logger.error(`${logPrefix} Composite aggregation failed: ${errMsg(err)}`);
     throw err;
   }
 }
@@ -113,8 +129,9 @@ async function fetchTargetsForActors(
   logger: Logger,
   namespace: string,
   buckets: CompositeBucket[],
-  transportOpts: { signal: AbortSignal } | undefined,
-  abortController: AbortController | undefined
+  transportOpts: { signal?: AbortSignal; requestTimeout?: number } | undefined,
+  abortController: AbortController | undefined,
+  logPrefix: string
 ): Promise<EsqlQueryResult | null> {
   const esqlFilter = {
     bool: {
@@ -133,7 +150,7 @@ async function fetchTargetsForActors(
     const typed = result as unknown as Partial<EsqlQueryResult>;
     if (!Array.isArray(typed.columns) || !Array.isArray(typed.values)) {
       logger.warn(
-        `[${config.id}] ES|QL returned unexpected response shape (columns or values not arrays); skipping page`
+        `${logPrefix} ES|QL returned unexpected response shape (columns or values not arrays); skipping page`
       );
       return null;
     }
@@ -141,26 +158,22 @@ async function fetchTargetsForActors(
     return { columns: typed.columns, values: typed.values };
   } catch (err) {
     if (abortController?.signal.aborted) {
-      logger.info(`[${config.id}] Aborted during ES|QL query`);
+      logger.info(`${logPrefix} Aborted during ES|QL query`);
       return null;
     }
-    logger.error(`[${config.id}] ES|QL query failed: ${errMsg(err)}`);
+    logger.error(`${logPrefix} ES|QL query failed: ${errMsg(err)}`);
     throw err;
   }
 }
 
 /**
- * Runs Step 1 + Step 2 + write for one integration end-to-end. Writes the
- * integration's records to the entity store before returning, so the engine
- * never holds more than one integration's records in memory.
+ * Runs Step 1 + Step 2 + write for one integration end-to-end. Writes each
+ * page's records to the entity store immediately after parsing, so the engine
+ * never holds more than one page of records in memory at a time.
  *
- * Memory bound: previously the engine accumulated `allRecords` across all
- * integrations × all pages before a single write, with theoretical max
- * ≈ COMPOSITE_PAGE_SIZE × MAX_ITERATIONS × #integrations ≈ 14M records.
- * Streaming per-integration drops that to one integration's records.
+ * Memory bound: one page's records at a time (≤ COMPOSITE_PAGE_SIZE per page).
  *
- * Abort semantics: returns the count of records actually written for this
- * integration. If the abort fires mid-pagination, the partial records
+ * Abort semantics: if the abort fires mid-pagination, the partial records
  * collected so far are still written before returning (best-effort
  * persistence — the records are derived from the run, not authoritative,
  * and partial writes are no worse than a re-run).
@@ -173,7 +186,9 @@ async function runIntegration(
   crudClient: EntityUpdateClient,
   entityMetadataClient: EntityMetadataClient,
   abortController: AbortController | undefined,
-  metadataContext: { scanId: string; observedAt: string }
+  metadataContext: { scanId: string; observedAt: string },
+  requestTimeoutMs: number | undefined,
+  logPrefix: string
 ): Promise<{
   buckets: number;
   recordsCount: number;
@@ -187,20 +202,34 @@ async function runIntegration(
   let iterations = 0;
   let truncated = false;
   let totalBuckets = 0;
-  const records: EntityRelationshipRecord[] = [];
-  const transportOpts = abortController ? { signal: abortController.signal } : undefined;
+  let totalRecordsCount = 0;
+  const timeoutMs = requestTimeoutMs ?? DEFAULT_ESQL_TIMEOUT_MS;
+  const transportOpts: { signal?: AbortSignal; requestTimeout?: number } = {
+    requestTimeout: timeoutMs,
+  };
+  if (abortController) transportOpts.signal = abortController.signal;
   let outcome: 'index_missing' | 'empty' | 'partial' | 'producing' | 'error' = 'producing';
+
+  // Per-page write accumulators — initialized before the loop, accumulated inside.
+  let totalWriteResult: WriteEntityIdsResult = {
+    updated: 0,
+    notFound: 0,
+    errors: 0,
+    droppedTargets: 0,
+    relationshipTypeApplied: {},
+  };
+  let totalMetadataResult: WriteRelationshipMetadatasResult = { docsAttempted: 0, docsApplied: 0 };
 
   try {
     do {
       if (abortController?.signal.aborted) {
-        logger.info(`[${config.id}] Aborted during pagination`);
+        logger.info(`${logPrefix} Aborted during pagination`);
         outcome = totalBuckets === 0 ? 'empty' : 'partial';
         break;
       }
       iterations++;
       if (iterations > MAX_ITERATIONS) {
-        logger.warn(`[${config.id}] Reached MAX_ITERATIONS (${MAX_ITERATIONS}), stopping`);
+        logger.warn(`${logPrefix} Reached MAX_ITERATIONS (${MAX_ITERATIONS}), stopping`);
         outcome = 'partial';
         truncated = true;
         break;
@@ -213,7 +242,8 @@ async function runIntegration(
         namespace,
         afterKey,
         transportOpts,
-        abortController
+        abortController,
+        logPrefix
       );
       if (actorPage === null) {
         outcome = abortController?.signal.aborted
@@ -225,7 +255,7 @@ async function runIntegration(
       }
 
       const { buckets, newAfterKey } = actorPage;
-      logger.info(`[${config.id}] Found ${buckets.length} user buckets`);
+      logger.info(`${logPrefix} Found ${buckets.length} user buckets`);
       totalBuckets += buckets.length;
       if (buckets.length === 0) {
         if (iterations === 1) outcome = 'empty';
@@ -239,7 +269,8 @@ async function runIntegration(
         namespace,
         buckets,
         transportOpts,
-        abortController
+        abortController,
+        logPrefix
       );
       if (esqlResult === null) {
         outcome = 'partial';
@@ -248,8 +279,72 @@ async function runIntegration(
 
       const { columns, values } = esqlResult;
       const pageRecords = parseTargetsPerActorRows(columns, values, config, logger);
-      records.push(...pageRecords);
-      logger.debug(`[${config.id}] Produced ${pageRecords.length} records`);
+      logger.debug(`${logPrefix} Produced ${pageRecords.length} records`);
+      totalRecordsCount += pageRecords.length;
+
+      // Stream per-page: write entity IDs immediately after parsing each page.
+      // Both writes are inside the loop so any transport failure sets outcome:
+      // 'error' and the outer loop continues to other integrations.
+      if (pageRecords.length > 0) {
+        const pageWrite: WriteEntityIdsResult & WriteEntityIdsPageState = await writeEntityIds(
+          crudClient,
+          logger,
+          pageRecords,
+          esClient,
+          namespace,
+          config.validateTargetIds
+        );
+        // Accumulate the entity write immediately — BEFORE the metadata write,
+        // which can throw. These entities are already durable in the store, so
+        // the counter must reflect them even if the rest of this page fails.
+        totalWriteResult = {
+          updated: totalWriteResult.updated + pageWrite.updated,
+          notFound: totalWriteResult.notFound + pageWrite.notFound,
+          errors: totalWriteResult.errors + pageWrite.errors,
+          droppedTargets: totalWriteResult.droppedTargets + pageWrite.droppedTargets,
+          relationshipTypeApplied: mergeRelTypeApplied(
+            totalWriteResult.relationshipTypeApplied,
+            pageWrite.relationshipTypeApplied
+          ),
+        };
+
+        const { validTargetIds, succeededEntityIds } = pageWrite;
+        // Only write metadata for actors that actually landed in the latest index.
+        // When bulkUpdateEntity returns a 404 (actor not yet extracted), we skip
+        // the metadata write for that actor so the two stores stay in sync.
+        const actorFiltered = pageRecords.filter(
+          (r) => r.entityId !== null && succeededEntityIds.has(r.entityId)
+        );
+        // When target validation also ran, further restrict to the validated target set.
+        const metadataRecords = validTargetIds
+          ? actorFiltered.flatMap((r) => {
+              const filteredRels: Record<string, string[]> = {};
+              for (const [relType, targetEuids] of Object.entries(r.relationships)) {
+                const valid = targetEuids.filter((id) => validTargetIds.has(id));
+                if (valid.length > 0) filteredRels[relType] = valid;
+              }
+              return Object.keys(filteredRels).length > 0
+                ? [{ ...r, relationships: filteredRels }]
+                : [];
+            })
+          : actorFiltered;
+        const pageMetadata = await writeRelationshipMetadatas(
+          entityMetadataClient,
+          logger,
+          metadataRecords,
+          {
+            scanId: metadataContext.scanId,
+            lookbackWindow: config.disableLookbackWindow ? '' : LOOKBACK_WINDOW,
+            entitySource: config.id,
+            observedAt: metadataContext.observedAt,
+          }
+        );
+
+        totalMetadataResult = {
+          docsAttempted: totalMetadataResult.docsAttempted + pageMetadata.docsAttempted,
+          docsApplied: totalMetadataResult.docsApplied + pageMetadata.docsApplied,
+        };
+      }
 
       // Composite agg's documented termination contract is "stop when after_key
       // is absent." Trust newAfterKey directly rather than inferring termination
@@ -259,78 +354,33 @@ async function runIntegration(
       afterKey = newAfterKey;
     } while (afterKey);
 
-    // Stream per-integration: write latest entities first, then metadata.
-    // Both writes are inside the try so any transport failure sets outcome:
-    // 'error' and the outer loop continues to other integrations.
-    const write = await writeEntityIds(
-      crudClient,
-      logger,
-      records,
-      esClient,
-      namespace,
-      config.validateTargetIds
-    );
-    // Only write metadata for actors that actually landed in the latest index.
-    // When bulkUpdateEntity returns a 404 (actor not yet extracted), we skip
-    // the metadata write for that actor so the two stores stay in sync.
-    const { validTargetIds, succeededEntityIds } = write;
-    const actorFilteredRecords = records.filter(
-      (r) => r.entityId !== null && succeededEntityIds.has(r.entityId)
-    );
-
-    // When target validation also ran, further restrict to the validated target set.
-    const metadataRecords = validTargetIds
-      ? actorFilteredRecords.flatMap((r) => {
-          const filteredRels: Record<string, string[]> = {};
-          for (const [relType, targetEuids] of Object.entries(r.relationships)) {
-            const valid = targetEuids.filter((id) => validTargetIds.has(id));
-            if (valid.length > 0) filteredRels[relType] = valid;
-          }
-          return Object.keys(filteredRels).length > 0
-            ? [{ ...r, relationships: filteredRels }]
-            : [];
-        })
-      : actorFilteredRecords;
-    const metadata = await writeRelationshipMetadatas(
-      entityMetadataClient,
-      logger,
-      metadataRecords,
-      {
-        scanId: metadataContext.scanId,
-        lookbackWindow: config.disableLookbackWindow ? '' : LOOKBACK_WINDOW,
-        entitySource: config.id,
-        observedAt: metadataContext.observedAt,
-      }
-    );
     // When truncated, the final loop pass incremented `iterations` before
     // breaking without fetching a page — clamp to actual pages completed.
     const completedIterations = truncated ? MAX_ITERATIONS : iterations;
     return {
       buckets: totalBuckets,
-      recordsCount: records.length,
-      write,
-      metadata,
+      recordsCount: totalRecordsCount,
+      write: totalWriteResult,
+      metadata: totalMetadataResult,
       outcome,
       iterations: completedIterations,
       truncated,
     };
   } catch (err) {
-    logger.error(`[${config.id}] Integration failed: ${errMsg(err)}`);
+    logger.error(`${logPrefix} Integration failed: ${errMsg(err)}`);
+    // Return the counters accumulated so far, NOT zeros. Writes stream per page,
+    // so pages 1..N-1 are already durable in the entity store when a later page
+    // throws (e.g. requestTimeoutMs firing during esql.query or writeEntityIds).
+    // Reporting zeros here would tell operators `written=0 records=<big>` during
+    // exactly the timeout scenario the configurable timeout exists to surface.
     return {
       buckets: totalBuckets,
-      recordsCount: records.length,
-      write: {
-        updated: 0,
-        notFound: 0,
-        errors: 0,
-        droppedTargets: 0,
-        relationshipTypeApplied: {},
-        succeededEntityIds: new Set(),
-      },
-      metadata: { docsAttempted: 0, docsApplied: 0 },
+      recordsCount: totalRecordsCount,
+      write: totalWriteResult,
+      metadata: totalMetadataResult,
       outcome: 'error',
       iterations,
-      truncated: false,
+      truncated,
     };
   }
 }
@@ -358,7 +408,9 @@ export const runRelationshipMaintainer = async ({
   crudClient,
   entityMetadataClient,
   integrations,
+  maintainerName,
   abortController,
+  requestTimeoutMs,
   telemetryCollector,
 }: {
   esClient: ElasticsearchClient;
@@ -368,7 +420,11 @@ export const runRelationshipMaintainer = async ({
   crudClient: EntityUpdateClient;
   entityMetadataClient: EntityMetadataClient;
   integrations: RelationshipIntegrationConfig[];
+  /** Identifies which maintainer is running — embedded in per-integration completion logs for unambiguous attribution. */
+  maintainerName: RelationshipMaintainerName;
   abortController?: AbortController;
+  /** Per-request timeout in milliseconds for ES client calls (search + esql.query). Defaults to DEFAULT_ESQL_TIMEOUT_MS (60s). */
+  requestTimeoutMs?: number;
   /**
    * Optional. Engine populates one entry per integration into `sources` and
    * accumulates per-rel-type applied counts in `relationshipTypeApplied` for callers
@@ -434,7 +490,9 @@ export const runRelationshipMaintainer = async ({
       logger.info('Relationship maintainer aborted, skipping remaining integrations');
       break;
     }
-    logger.info(`[${config.id}] Processing integration: ${config.name}`);
+    const logPrefix = `[${maintainerName}][${config.id}]`;
+    logger.info(`${logPrefix} Processing integration: ${config.name}`);
+    const integrationStartMs = Date.now();
     const {
       buckets,
       recordsCount,
@@ -451,23 +509,43 @@ export const runRelationshipMaintainer = async ({
       crudClient,
       entityMetadataClient,
       abortController,
-      metadataContext
+      metadataContext,
+      requestTimeoutMs,
+      logPrefix
+    );
+
+    const durationMs = Date.now() - integrationStartMs;
+    logger.info(
+      `${logPrefix} Integration complete: ` +
+        `outcome=${outcome} slices=${iterations} records=${recordsCount} ` +
+        `written=${write.updated} notFound=${write.notFound} errors=${write.errors} ` +
+        `truncated=${integrationTruncated} durationMs=${durationMs}`
     );
 
     totalIterations += iterations;
     if (integrationTruncated) truncated = true;
 
+    // Accumulate unconditionally, including `outcome: 'error'`. Because writes
+    // stream per page, a failed integration has still durably persisted every
+    // page that completed before the throw — those entities are in the store
+    // whether or not the integration finished. Excluding them would make the
+    // run-level totals under-report real work and contradict the per-integration
+    // completion log. `outcome` is reported separately (log + telemetry
+    // `sources[].outcome`), so callers can still distinguish a clean run from a
+    // partial one without the counters lying about what was written.
     if (outcome === 'error') {
-      logger.warn(`[${config.id}] Integration failed; skipping totals accumulation for this run`);
-    } else {
-      totalBuckets += buckets;
-      totalRecords += recordsCount;
-      totalWritten += write.updated;
-      totalNotFound += write.notFound;
-      totalWriteErrors += write.errors;
-      totalMetadataDocsApplied += metadata.docsApplied;
-      totalDroppedTargets += write.droppedTargets;
+      logger.warn(
+        `${logPrefix} Integration failed after persisting ${write.updated} entities across ` +
+          `${iterations} page(s); counting them toward run totals`
+      );
     }
+    totalBuckets += buckets;
+    totalRecords += recordsCount;
+    totalWritten += write.updated;
+    totalNotFound += write.notFound;
+    totalWriteErrors += write.errors;
+    totalMetadataDocsApplied += metadata.docsApplied;
+    totalDroppedTargets += write.droppedTargets;
 
     if (telemetryCollector) {
       telemetryCollector.sources.push({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/types.ts
@@ -165,6 +165,30 @@ interface RelationshipIntegrationBase {
    * log-based maintainer behavior.
    */
   disableLookbackWindow?: boolean;
+  /**
+   * Declares that every document this integration reads describes a *host-scoped*
+   * (non-IDP) user — an identity meaningful only within one host, keyed by
+   * `user.name` + `host.id` — and always carries `host.id`. This is an assertion
+   * about the *data*, not a build directive, but it lets Step 2 skip work that
+   * only exists to handle the general case:
+   *
+   * - the actor EUID comes from `euid.experimental.getHostScopedUserEuidEsql()`, which emits
+   *   the namespace directly instead of deriving `entity.namespace` (a 7-arm
+   *   CASE/COALESCE tree over `event.module`, `event.dataset`,
+   *   `data_stream.dataset`, `cloud.provider` and `event.kind`);
+   * - the target EUID and its existence gate read `host.id` alone, skipping the
+   *   `host.name` / `host.hostname` fallback chain.
+   *
+   * Net effect is ~2 EVAL columns per row instead of ~35 — measured ~26× faster
+   * on logs-system.auth (~700M docs, 30d lookback).
+   *
+   * Both claims must hold. `system_auth` and `system_security` qualify (SSH and
+   * Windows logon events are host-scoped and always carry `host.id`). Setting
+   * this where IDP-issued users can appear silently produces EUIDs that do not
+   * match the entity store, 404-ing every write; setting it where `host.id` can
+   * be absent silently drops those documents.
+   */
+  hostScopedUsersOnly?: true;
 }
 
 /**
@@ -317,3 +341,15 @@ export interface EntityRelationshipRecord {
    */
   relationships: Record<string, string[]>;
 }
+
+/**
+ * Union of all known relationship maintainer identifiers. Passed into
+ * `runRelationshipMaintainer` as a required `maintainerName` field so that
+ * per-integration completion logs carry an unambiguous maintainer label.
+ */
+export type RelationshipMaintainerName =
+  | 'communicates_with'
+  | 'accesses_frequently_and_infrequently'
+  | 'administers'
+  | 'supervises'
+  | 'owns';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/engine/update_entities.ts
@@ -108,6 +108,7 @@ export const matchExistingTargetIds = async (
  * - `droppedTargets`: target EUIDs removed because they had no matching entity
  *   document in the store at write time (dangling-ID prevention).
  */
+/** Accumulated metrics from a writeEntityIds call — safe to sum across pages. */
 export interface WriteEntityIdsResult {
   updated: number;
   notFound: number;
@@ -122,6 +123,10 @@ export interface WriteEntityIdsResult {
    * EUID, so we hash each entityId to match against the failed-hash set.
    */
   relationshipTypeApplied: Record<string, number>;
+}
+
+/** Per-call state returned alongside WriteEntityIdsResult — not meaningful to accumulate across pages. */
+export interface WriteEntityIdsPageState {
   /**
    * Set of target EUIDs confirmed to exist in the entity store. Only populated
    * when `validateTargetIds` was true. Callers can use this to filter downstream
@@ -164,7 +169,7 @@ function pruneNonExistingTargets(
   return dropped;
 }
 
-const EMPTY_RESULT: WriteEntityIdsResult = {
+const EMPTY_RESULT: WriteEntityIdsResult & WriteEntityIdsPageState = {
   updated: 0,
   notFound: 0,
   errors: 0,
@@ -180,7 +185,7 @@ export const writeEntityIds = async (
   esClient: ElasticsearchClient,
   namespace: string,
   validateTargetIds = false
-): Promise<WriteEntityIdsResult> => {
+): Promise<WriteEntityIdsResult & WriteEntityIdsPageState> => {
   if (records.length === 0) return EMPTY_RESULT;
 
   const valid = filterValid(records);
@@ -244,7 +249,7 @@ export const writeEntityIds = async (
       droppedTargets,
       relationshipTypeApplied: {},
       validTargetIds,
-      succeededEntityIds: new Set(),
+      succeededEntityIds: new Set<string>(),
     };
 
   logger.info(`Writing relationship ids for ${objects.length} entity records`);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/owns/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/owns/index.ts
@@ -52,6 +52,7 @@ export const ownsMaintainer: RegisterEntityMaintainerConfig = {
       crudClient,
       entityMetadataClient,
       integrations: buildOwnsConfigs(lastProcessedTimestamp),
+      maintainerName: 'owns',
       abortController,
       telemetryCollector: collector,
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/supervises/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/supervises/index.ts
@@ -51,6 +51,7 @@ export const supervisesMaintainer: RegisterEntityMaintainerConfig = {
       crudClient,
       entityMetadataClient,
       integrations: buildSupervisesConfigs(lastProcessedTimestamp),
+      maintainerName: 'supervises',
       abortController,
       telemetryCollector: collector,
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Entity Analytics] Maintainers: DSL+ES|QL performance improvements for relationship maintainers (#281804)](https://github.com/elastic/kibana/pull/281804)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Prozorov","email":"alex.prozorov@elastic.co"},"sourceCommit":{"committedDate":"2026-08-05T10:52:45Z","message":"[Entity Analytics] Maintainers: DSL+ES|QL performance improvements for relationship maintainers (#281804)\n\nCloses https://github.com/elastic/kibana/issues/281758\n\n## Summary\n\nPerformance and correctness improvements for the \\`communicates_with\\`\nand \\`accesses\\` relationship maintainers (DSL composite-agg + ES|QL\npipeline).\n\n### Changes\n\n**1. \\`hostScopedUsersOnly\\` minimized ES|QL fragments (~26× speedup)**\n\nIntegrations whose documents describe only *host-scoped* (non-IDP) users\n— keyed by \\`user.name\\` + \\`host.id\\` — can skip the\n\\`entity.namespace\\` derivation the general case needs: ~2 EVAL columns\nper row instead of ~35. Measured ~26× faster on \\`logs-system.auth\\`\n(~700M docs, 30-day lookback). Opt in with \\`hostScopedUsersOnly: true\\`\n(\\`system_auth\\`, \\`system_security\\`), which also lets the target EUID\nread \\`host.id\\` alone.\n\nThe EUID expression moved into the entity store as\n\\`getHostScopedUserEuidEsql\\`, derived from the host-scoped branch of\n\\`userEntityDefinition\\` so it cannot drift from the definition that\nproduced the entities being written. A unit test pins that branch's\nshape.\n\n**Fixes an EUID correctness bug:** the previous builder used\n\\`COALESCE(user.name, user.email)\\`, but that branch is gated on\n\\`user.name\\` being non-empty — so the email fallback could only fire\nfor *IDP* users, emitting \\`user:alice@corp.com@h1@local\\`, an EUID\nabsent from the store. Those writes 404'd. The EUID now uses\n\\`user.name\\` alone; the presence gate still admits either field to\nmirror extraction's \\`documentsFilter\\`.\n\nInternally the separate fast-path builder is gone — it duplicated ~85%\nof \\`buildRelationshipEsql\\`, which also meant it silently dropped\n\\`config.additionalTargetFilter\\`.\n\n**2. Configurable \\`requestTimeoutMs\\` (default 60 s)**\n\nAdds a \\`requestTimeoutMs\\` parameter to \\`runRelationshipMaintainer\\`\n(default: \\`DEFAULT_ESQL_TIMEOUT_MS = 60_000\\`). Threaded through to\nboth the composite-agg search and the ES|QL query transport options so\nlong-running requests fail fast rather than hanging indefinitely.\n\n**3. Per-page entity writes**\n\nEntity IDs are now written to the store after each composite-agg page\nrather than accumulating all records in memory and writing at the end of\nan integration. Memory is bounded to one page at a time (≤\n\\`COMPOSITE_PAGE_SIZE\\` records). Correctness is preserved because\ncomposite agg pages are actor-disjoint — per-page OVERWRITE produces the\nsame result as end-of-integration.\n\n**4. Per-integration completion log**\n\nAfter each integration run, a structured \\`info\\` log is emitted:\n\\`\\`\\`\n[maintainerName][config.id] Integration complete: outcome=producing\nslices=3 records=1500 written=1498 notFound=2 errors=0 truncated=false\ndurationMs=4200\n\\`\\`\\`\nAll log lines in the engine now use the \\`[maintainerName][config.id]\\`\nprefix consistently.\n\n**5. \\`RelationshipMaintainerName\\` type + required \\`maintainerName\\`\nparam**\n\nAdds a \\`RelationshipMaintainerName\\` union type (\\`communicates_with |\naccesses_frequently_and_infrequently | administers | supervises |\nowns\\`) and makes \\`maintainerName\\` a required param on\n\\`runRelationshipMaintainer\\` so every caller explicitly declares which\nmaintainer is running.\n\n**6. \\`system_security\\` config alignment**\n\n\\`system_security\\` configs (both \\`communicates_with\\` and\n\\`accesses\\`) now declare \\`customActor: { fields: ['user.email',\n'user.name'] }\\`, matching \\`system_auth\\` and staying in sync with the\nextraction pipeline's document filter. Note this affects only the\nactor-presence gate and the Step 1 composite-agg bucket sources — per\nitem 1, the host-scoped EUID itself is built from \\`user.name\\` alone\n(\\`user:<user.name>@<host.id>@local\\`).\n\n**7. \\`WriteEntityIdsPageState\\` split from \\`WriteEntityIdsResult\\`**\n\n\\`succeededEntityIds\\` and \\`validTargetIds\\` are per-call state used\nonly within the same page's metadata write block. Splits them into\n\\`WriteEntityIdsPageState\\` (not meaningful to accumulate) vs\n\\`WriteEntityIdsResult\\` (safe to sum across pages).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n\\`release_note:breaking\\` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct \\`release_note:*\\` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable \\`backport:*\\` labels.\n\n### Testing\nTesting was done on a 1:100 CPS set up with overriden\n[origin](https://alexp-fix-2907-origin-f9d3b9.kb.us-central1.gcp.qa.elastic.cloud/)\nproject which runs the maintainers framework.\n\n**Communicates_with maintainer:**\n\n1. executed against `logs-system.auth-default` index with 1.6B logs:\n<img width=\"1810\" height=\"415\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/10fc1efc-63ab-478d-9878-9e339ed8b6c8\"\n/>\n\n2. dsl query took 3s\n\nGET logs-system.auth-*/_search\n```\n{\n  \"size\": 0,\n  \"query\": {\n    \"bool\": {\n      \"filter\": [\n        { \"range\": { \"@timestamp\": { \"gte\": \"now-30d\", \"lt\": \"now\" } } },\n        {\n          \"bool\": {\n            \"should\": [\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"user.name\" } },\n                    { \"bool\": { \"must_not\": { \"term\": { \"user.name\": \"\" } } } }\n                  ]\n                }\n              }\n            ],\n            \"minimum_should_match\": 1\n          }\n        },\n        {\n          \"bool\": {\n            \"should\": [\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"host.id\" } },\n                    { \"bool\": { \"must_not\": { \"match\": { \"host.id\": \"\" } } } }\n                  ]\n                }\n              },\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"host.name\" } },\n                    { \"bool\": { \"must_not\": { \"match\": { \"host.name\": \"\" } } } }\n                  ]\n                }\n              },\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"host.hostname\" } },\n                    { \"bool\": { \"must_not\": { \"match\": { \"host.hostname\": \"\" } } } }\n                  ]\n                }\n              }\n            ],\n            \"minimum_should_match\": 1\n          }\n        },\n        { \"term\": { \"event.action\": \"ssh_login\" } },\n        { \"term\": { \"event.outcome\": \"success\" } }\n      ]\n    }\n  },\n  \"aggs\": {\n    \"users\": {\n      \"composite\": {\n        \"size\": 3500,\n        \"sources\": [\n          { \"user.name\": { \"terms\": { \"field\": \"user.name\", \"missing_bucket\": true } } }\n        ]\n      }\n    }\n  }\n}\n\n```\n\n<img width=\"1516\" height=\"761\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/27f0e37a-565c-41a2-8041-79543253c1e9\"\n/>\n\n3. ESQL run ~6s against 400m+ docs spread across 100 linked projects\n\n```\nSET unmapped_fields=\"nullify\";\nFROM logs-system.auth-default\n| WHERE (MV_CONTAINS(TO_STRING(event.category), \"authentication\") OR MV_CONTAINS(TO_STRING(event.category), \"session\"))\n    AND event.action == \"ssh_login\"\n    AND event.outcome == \"success\"\n    AND (`user.name` IS NOT NULL AND `user.name` != \"\")\n    AND (`host.id` IS NOT NULL AND `host.id` != \"\")\n| EVAL actorUserId = CONCAT(\"user:\", TO_STRING(`user.name`), \"@\", TO_STRING(`host.id`), \"@local\")\n| WHERE COALESCE(actorUserId, \"\") != \"\"\n| EVAL targetEntityId = CONCAT(\"host:\", TO_STRING(`host.id`))\n| MV_EXPAND targetEntityId\n| WHERE COALESCE(targetEntityId, \"\") != \"\"\n| STATS communicates_with = VALUES(targetEntityId) BY actorUserId\n| LIMIT 3500\n```\n\n<img width=\"1910\" height=\"997\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/eb6bb0e5-a28a-4f12-b20e-2d591cc4210b\"\n/>\n\n4. entire maintainer run took ~ 70s\n\n<img width=\"678\" height=\"512\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b1c72956-5f6f-44a3-8460-3458b5b3756b\"\n/>\n\n5. validation\n\n<img width=\"1913\" height=\"1004\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/279fac28-2edb-4310-86f3-ef90c075e3d4\"\n/>\n\n\n**Accesses maintainer:**\n\n1. execution time ~42s:\n\n<img width=\"754\" height=\"503\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/94c28382-2563-41a4-be93-2841cf4721a4\"\n/>\n\n2. validation\n\n<img width=\"1489\" height=\"934\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fea8ef8b-662d-4d72-b99f-62746dbbdb80\"\n/>\n\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"124cfb144815d3e076fe62c520ad602670594e85","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Cloud Security","ci:cloud-deploy","ci:build-serverless-image","ci:project-deploy-security","ci:project-redeploy","backport:version","v9.5.0","v9.6.0","v9.5.1"],"title":"[Entity Analytics] Maintainers: DSL+ES|QL performance improvements for relationship maintainers","number":281804,"url":"https://github.com/elastic/kibana/pull/281804","mergeCommit":{"message":"[Entity Analytics] Maintainers: DSL+ES|QL performance improvements for relationship maintainers (#281804)\n\nCloses https://github.com/elastic/kibana/issues/281758\n\n## Summary\n\nPerformance and correctness improvements for the \\`communicates_with\\`\nand \\`accesses\\` relationship maintainers (DSL composite-agg + ES|QL\npipeline).\n\n### Changes\n\n**1. \\`hostScopedUsersOnly\\` minimized ES|QL fragments (~26× speedup)**\n\nIntegrations whose documents describe only *host-scoped* (non-IDP) users\n— keyed by \\`user.name\\` + \\`host.id\\` — can skip the\n\\`entity.namespace\\` derivation the general case needs: ~2 EVAL columns\nper row instead of ~35. Measured ~26× faster on \\`logs-system.auth\\`\n(~700M docs, 30-day lookback). Opt in with \\`hostScopedUsersOnly: true\\`\n(\\`system_auth\\`, \\`system_security\\`), which also lets the target EUID\nread \\`host.id\\` alone.\n\nThe EUID expression moved into the entity store as\n\\`getHostScopedUserEuidEsql\\`, derived from the host-scoped branch of\n\\`userEntityDefinition\\` so it cannot drift from the definition that\nproduced the entities being written. A unit test pins that branch's\nshape.\n\n**Fixes an EUID correctness bug:** the previous builder used\n\\`COALESCE(user.name, user.email)\\`, but that branch is gated on\n\\`user.name\\` being non-empty — so the email fallback could only fire\nfor *IDP* users, emitting \\`user:alice@corp.com@h1@local\\`, an EUID\nabsent from the store. Those writes 404'd. The EUID now uses\n\\`user.name\\` alone; the presence gate still admits either field to\nmirror extraction's \\`documentsFilter\\`.\n\nInternally the separate fast-path builder is gone — it duplicated ~85%\nof \\`buildRelationshipEsql\\`, which also meant it silently dropped\n\\`config.additionalTargetFilter\\`.\n\n**2. Configurable \\`requestTimeoutMs\\` (default 60 s)**\n\nAdds a \\`requestTimeoutMs\\` parameter to \\`runRelationshipMaintainer\\`\n(default: \\`DEFAULT_ESQL_TIMEOUT_MS = 60_000\\`). Threaded through to\nboth the composite-agg search and the ES|QL query transport options so\nlong-running requests fail fast rather than hanging indefinitely.\n\n**3. Per-page entity writes**\n\nEntity IDs are now written to the store after each composite-agg page\nrather than accumulating all records in memory and writing at the end of\nan integration. Memory is bounded to one page at a time (≤\n\\`COMPOSITE_PAGE_SIZE\\` records). Correctness is preserved because\ncomposite agg pages are actor-disjoint — per-page OVERWRITE produces the\nsame result as end-of-integration.\n\n**4. Per-integration completion log**\n\nAfter each integration run, a structured \\`info\\` log is emitted:\n\\`\\`\\`\n[maintainerName][config.id] Integration complete: outcome=producing\nslices=3 records=1500 written=1498 notFound=2 errors=0 truncated=false\ndurationMs=4200\n\\`\\`\\`\nAll log lines in the engine now use the \\`[maintainerName][config.id]\\`\nprefix consistently.\n\n**5. \\`RelationshipMaintainerName\\` type + required \\`maintainerName\\`\nparam**\n\nAdds a \\`RelationshipMaintainerName\\` union type (\\`communicates_with |\naccesses_frequently_and_infrequently | administers | supervises |\nowns\\`) and makes \\`maintainerName\\` a required param on\n\\`runRelationshipMaintainer\\` so every caller explicitly declares which\nmaintainer is running.\n\n**6. \\`system_security\\` config alignment**\n\n\\`system_security\\` configs (both \\`communicates_with\\` and\n\\`accesses\\`) now declare \\`customActor: { fields: ['user.email',\n'user.name'] }\\`, matching \\`system_auth\\` and staying in sync with the\nextraction pipeline's document filter. Note this affects only the\nactor-presence gate and the Step 1 composite-agg bucket sources — per\nitem 1, the host-scoped EUID itself is built from \\`user.name\\` alone\n(\\`user:<user.name>@<host.id>@local\\`).\n\n**7. \\`WriteEntityIdsPageState\\` split from \\`WriteEntityIdsResult\\`**\n\n\\`succeededEntityIds\\` and \\`validTargetIds\\` are per-call state used\nonly within the same page's metadata write block. Splits them into\n\\`WriteEntityIdsPageState\\` (not meaningful to accumulate) vs\n\\`WriteEntityIdsResult\\` (safe to sum across pages).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n\\`release_note:breaking\\` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct \\`release_note:*\\` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable \\`backport:*\\` labels.\n\n### Testing\nTesting was done on a 1:100 CPS set up with overriden\n[origin](https://alexp-fix-2907-origin-f9d3b9.kb.us-central1.gcp.qa.elastic.cloud/)\nproject which runs the maintainers framework.\n\n**Communicates_with maintainer:**\n\n1. executed against `logs-system.auth-default` index with 1.6B logs:\n<img width=\"1810\" height=\"415\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/10fc1efc-63ab-478d-9878-9e339ed8b6c8\"\n/>\n\n2. dsl query took 3s\n\nGET logs-system.auth-*/_search\n```\n{\n  \"size\": 0,\n  \"query\": {\n    \"bool\": {\n      \"filter\": [\n        { \"range\": { \"@timestamp\": { \"gte\": \"now-30d\", \"lt\": \"now\" } } },\n        {\n          \"bool\": {\n            \"should\": [\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"user.name\" } },\n                    { \"bool\": { \"must_not\": { \"term\": { \"user.name\": \"\" } } } }\n                  ]\n                }\n              }\n            ],\n            \"minimum_should_match\": 1\n          }\n        },\n        {\n          \"bool\": {\n            \"should\": [\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"host.id\" } },\n                    { \"bool\": { \"must_not\": { \"match\": { \"host.id\": \"\" } } } }\n                  ]\n                }\n              },\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"host.name\" } },\n                    { \"bool\": { \"must_not\": { \"match\": { \"host.name\": \"\" } } } }\n                  ]\n                }\n              },\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"host.hostname\" } },\n                    { \"bool\": { \"must_not\": { \"match\": { \"host.hostname\": \"\" } } } }\n                  ]\n                }\n              }\n            ],\n            \"minimum_should_match\": 1\n          }\n        },\n        { \"term\": { \"event.action\": \"ssh_login\" } },\n        { \"term\": { \"event.outcome\": \"success\" } }\n      ]\n    }\n  },\n  \"aggs\": {\n    \"users\": {\n      \"composite\": {\n        \"size\": 3500,\n        \"sources\": [\n          { \"user.name\": { \"terms\": { \"field\": \"user.name\", \"missing_bucket\": true } } }\n        ]\n      }\n    }\n  }\n}\n\n```\n\n<img width=\"1516\" height=\"761\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/27f0e37a-565c-41a2-8041-79543253c1e9\"\n/>\n\n3. ESQL run ~6s against 400m+ docs spread across 100 linked projects\n\n```\nSET unmapped_fields=\"nullify\";\nFROM logs-system.auth-default\n| WHERE (MV_CONTAINS(TO_STRING(event.category), \"authentication\") OR MV_CONTAINS(TO_STRING(event.category), \"session\"))\n    AND event.action == \"ssh_login\"\n    AND event.outcome == \"success\"\n    AND (`user.name` IS NOT NULL AND `user.name` != \"\")\n    AND (`host.id` IS NOT NULL AND `host.id` != \"\")\n| EVAL actorUserId = CONCAT(\"user:\", TO_STRING(`user.name`), \"@\", TO_STRING(`host.id`), \"@local\")\n| WHERE COALESCE(actorUserId, \"\") != \"\"\n| EVAL targetEntityId = CONCAT(\"host:\", TO_STRING(`host.id`))\n| MV_EXPAND targetEntityId\n| WHERE COALESCE(targetEntityId, \"\") != \"\"\n| STATS communicates_with = VALUES(targetEntityId) BY actorUserId\n| LIMIT 3500\n```\n\n<img width=\"1910\" height=\"997\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/eb6bb0e5-a28a-4f12-b20e-2d591cc4210b\"\n/>\n\n4. entire maintainer run took ~ 70s\n\n<img width=\"678\" height=\"512\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b1c72956-5f6f-44a3-8460-3458b5b3756b\"\n/>\n\n5. validation\n\n<img width=\"1913\" height=\"1004\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/279fac28-2edb-4310-86f3-ef90c075e3d4\"\n/>\n\n\n**Accesses maintainer:**\n\n1. execution time ~42s:\n\n<img width=\"754\" height=\"503\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/94c28382-2563-41a4-be93-2841cf4721a4\"\n/>\n\n2. validation\n\n<img width=\"1489\" height=\"934\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fea8ef8b-662d-4d72-b99f-62746dbbdb80\"\n/>\n\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"124cfb144815d3e076fe62c520ad602670594e85"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281804","number":281804,"mergeCommit":{"message":"[Entity Analytics] Maintainers: DSL+ES|QL performance improvements for relationship maintainers (#281804)\n\nCloses https://github.com/elastic/kibana/issues/281758\n\n## Summary\n\nPerformance and correctness improvements for the \\`communicates_with\\`\nand \\`accesses\\` relationship maintainers (DSL composite-agg + ES|QL\npipeline).\n\n### Changes\n\n**1. \\`hostScopedUsersOnly\\` minimized ES|QL fragments (~26× speedup)**\n\nIntegrations whose documents describe only *host-scoped* (non-IDP) users\n— keyed by \\`user.name\\` + \\`host.id\\` — can skip the\n\\`entity.namespace\\` derivation the general case needs: ~2 EVAL columns\nper row instead of ~35. Measured ~26× faster on \\`logs-system.auth\\`\n(~700M docs, 30-day lookback). Opt in with \\`hostScopedUsersOnly: true\\`\n(\\`system_auth\\`, \\`system_security\\`), which also lets the target EUID\nread \\`host.id\\` alone.\n\nThe EUID expression moved into the entity store as\n\\`getHostScopedUserEuidEsql\\`, derived from the host-scoped branch of\n\\`userEntityDefinition\\` so it cannot drift from the definition that\nproduced the entities being written. A unit test pins that branch's\nshape.\n\n**Fixes an EUID correctness bug:** the previous builder used\n\\`COALESCE(user.name, user.email)\\`, but that branch is gated on\n\\`user.name\\` being non-empty — so the email fallback could only fire\nfor *IDP* users, emitting \\`user:alice@corp.com@h1@local\\`, an EUID\nabsent from the store. Those writes 404'd. The EUID now uses\n\\`user.name\\` alone; the presence gate still admits either field to\nmirror extraction's \\`documentsFilter\\`.\n\nInternally the separate fast-path builder is gone — it duplicated ~85%\nof \\`buildRelationshipEsql\\`, which also meant it silently dropped\n\\`config.additionalTargetFilter\\`.\n\n**2. Configurable \\`requestTimeoutMs\\` (default 60 s)**\n\nAdds a \\`requestTimeoutMs\\` parameter to \\`runRelationshipMaintainer\\`\n(default: \\`DEFAULT_ESQL_TIMEOUT_MS = 60_000\\`). Threaded through to\nboth the composite-agg search and the ES|QL query transport options so\nlong-running requests fail fast rather than hanging indefinitely.\n\n**3. Per-page entity writes**\n\nEntity IDs are now written to the store after each composite-agg page\nrather than accumulating all records in memory and writing at the end of\nan integration. Memory is bounded to one page at a time (≤\n\\`COMPOSITE_PAGE_SIZE\\` records). Correctness is preserved because\ncomposite agg pages are actor-disjoint — per-page OVERWRITE produces the\nsame result as end-of-integration.\n\n**4. Per-integration completion log**\n\nAfter each integration run, a structured \\`info\\` log is emitted:\n\\`\\`\\`\n[maintainerName][config.id] Integration complete: outcome=producing\nslices=3 records=1500 written=1498 notFound=2 errors=0 truncated=false\ndurationMs=4200\n\\`\\`\\`\nAll log lines in the engine now use the \\`[maintainerName][config.id]\\`\nprefix consistently.\n\n**5. \\`RelationshipMaintainerName\\` type + required \\`maintainerName\\`\nparam**\n\nAdds a \\`RelationshipMaintainerName\\` union type (\\`communicates_with |\naccesses_frequently_and_infrequently | administers | supervises |\nowns\\`) and makes \\`maintainerName\\` a required param on\n\\`runRelationshipMaintainer\\` so every caller explicitly declares which\nmaintainer is running.\n\n**6. \\`system_security\\` config alignment**\n\n\\`system_security\\` configs (both \\`communicates_with\\` and\n\\`accesses\\`) now declare \\`customActor: { fields: ['user.email',\n'user.name'] }\\`, matching \\`system_auth\\` and staying in sync with the\nextraction pipeline's document filter. Note this affects only the\nactor-presence gate and the Step 1 composite-agg bucket sources — per\nitem 1, the host-scoped EUID itself is built from \\`user.name\\` alone\n(\\`user:<user.name>@<host.id>@local\\`).\n\n**7. \\`WriteEntityIdsPageState\\` split from \\`WriteEntityIdsResult\\`**\n\n\\`succeededEntityIds\\` and \\`validTargetIds\\` are per-call state used\nonly within the same page's metadata write block. Splits them into\n\\`WriteEntityIdsPageState\\` (not meaningful to accumulate) vs\n\\`WriteEntityIdsResult\\` (safe to sum across pages).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n\\`release_note:breaking\\` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct \\`release_note:*\\` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable \\`backport:*\\` labels.\n\n### Testing\nTesting was done on a 1:100 CPS set up with overriden\n[origin](https://alexp-fix-2907-origin-f9d3b9.kb.us-central1.gcp.qa.elastic.cloud/)\nproject which runs the maintainers framework.\n\n**Communicates_with maintainer:**\n\n1. executed against `logs-system.auth-default` index with 1.6B logs:\n<img width=\"1810\" height=\"415\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/10fc1efc-63ab-478d-9878-9e339ed8b6c8\"\n/>\n\n2. dsl query took 3s\n\nGET logs-system.auth-*/_search\n```\n{\n  \"size\": 0,\n  \"query\": {\n    \"bool\": {\n      \"filter\": [\n        { \"range\": { \"@timestamp\": { \"gte\": \"now-30d\", \"lt\": \"now\" } } },\n        {\n          \"bool\": {\n            \"should\": [\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"user.name\" } },\n                    { \"bool\": { \"must_not\": { \"term\": { \"user.name\": \"\" } } } }\n                  ]\n                }\n              }\n            ],\n            \"minimum_should_match\": 1\n          }\n        },\n        {\n          \"bool\": {\n            \"should\": [\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"host.id\" } },\n                    { \"bool\": { \"must_not\": { \"match\": { \"host.id\": \"\" } } } }\n                  ]\n                }\n              },\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"host.name\" } },\n                    { \"bool\": { \"must_not\": { \"match\": { \"host.name\": \"\" } } } }\n                  ]\n                }\n              },\n              {\n                \"bool\": {\n                  \"must\": [\n                    { \"exists\": { \"field\": \"host.hostname\" } },\n                    { \"bool\": { \"must_not\": { \"match\": { \"host.hostname\": \"\" } } } }\n                  ]\n                }\n              }\n            ],\n            \"minimum_should_match\": 1\n          }\n        },\n        { \"term\": { \"event.action\": \"ssh_login\" } },\n        { \"term\": { \"event.outcome\": \"success\" } }\n      ]\n    }\n  },\n  \"aggs\": {\n    \"users\": {\n      \"composite\": {\n        \"size\": 3500,\n        \"sources\": [\n          { \"user.name\": { \"terms\": { \"field\": \"user.name\", \"missing_bucket\": true } } }\n        ]\n      }\n    }\n  }\n}\n\n```\n\n<img width=\"1516\" height=\"761\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/27f0e37a-565c-41a2-8041-79543253c1e9\"\n/>\n\n3. ESQL run ~6s against 400m+ docs spread across 100 linked projects\n\n```\nSET unmapped_fields=\"nullify\";\nFROM logs-system.auth-default\n| WHERE (MV_CONTAINS(TO_STRING(event.category), \"authentication\") OR MV_CONTAINS(TO_STRING(event.category), \"session\"))\n    AND event.action == \"ssh_login\"\n    AND event.outcome == \"success\"\n    AND (`user.name` IS NOT NULL AND `user.name` != \"\")\n    AND (`host.id` IS NOT NULL AND `host.id` != \"\")\n| EVAL actorUserId = CONCAT(\"user:\", TO_STRING(`user.name`), \"@\", TO_STRING(`host.id`), \"@local\")\n| WHERE COALESCE(actorUserId, \"\") != \"\"\n| EVAL targetEntityId = CONCAT(\"host:\", TO_STRING(`host.id`))\n| MV_EXPAND targetEntityId\n| WHERE COALESCE(targetEntityId, \"\") != \"\"\n| STATS communicates_with = VALUES(targetEntityId) BY actorUserId\n| LIMIT 3500\n```\n\n<img width=\"1910\" height=\"997\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/eb6bb0e5-a28a-4f12-b20e-2d591cc4210b\"\n/>\n\n4. entire maintainer run took ~ 70s\n\n<img width=\"678\" height=\"512\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b1c72956-5f6f-44a3-8460-3458b5b3756b\"\n/>\n\n5. validation\n\n<img width=\"1913\" height=\"1004\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/279fac28-2edb-4310-86f3-ef90c075e3d4\"\n/>\n\n\n**Accesses maintainer:**\n\n1. execution time ~42s:\n\n<img width=\"754\" height=\"503\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/94c28382-2563-41a4-be93-2841cf4721a4\"\n/>\n\n2. validation\n\n<img width=\"1489\" height=\"934\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fea8ef8b-662d-4d72-b99f-62746dbbdb80\"\n/>\n\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"124cfb144815d3e076fe62c520ad602670594e85"}}]}] BACKPORT-->