### PR TITLE
[Lens][FTR] Commit dimension state before closing the dimension editor

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/lens_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/lens_app.ts
@@ -203,6 +203,9 @@ export class LensApp {
     }
     if (opts.field) {
       await this.selectField(opts.field);
+      if (opts.isPreviousIncompatible) {
+        await this.waitForIncompatibleFieldTransition(opts.operation);
+      }
     }
     if (opts.formula) {
       await this.typeInFormula(opts.formula, { replace: true });
@@ -246,6 +249,33 @@ export class LensApp {
 
   private async selectField(field: string) {
     await this.page.components.comboBox('indexPattern-dimension-field').setSelectedOptions([field]);
+  }
+
+  /**
+   * Waits until an incompatible operation + field selection has been committed by Lens.
+   * Closing the editor before this clears incompleteColumns and reverts the previous column.
+   */
+  private async waitForIncompatibleFieldTransition(operation: string) {
+    const compatibleOpSelector = `lns-indexPatternDimension-${operation}`;
+    await this.page.waitForFunction(
+      ({ opSelector, checkLastValueParams }) => {
+        const opEl = document.querySelector(`[data-test-subj="${opSelector}"]`);
+        if (opEl?.getAttribute('aria-pressed') !== 'true') {
+          return false;
+        }
+        if (!checkLastValueParams) {
+          return true;
+        }
+        return Boolean(
+          document.querySelector('[data-test-subj="lns-indexPattern-lastValue-sortField"]')
+        );
+      },
+      {
+        opSelector: compatibleOpSelector,
+        checkLastValueParams: operation === 'last_value',
+      },
+      { timeout: WAIT_FOR_FUNCTION_TIMEOUT_MS }
+    );
   }
 
   /**

--- a/x-pack/platform/test/functional/page_objects/lens_page.ts
+++ b/x-pack/platform/test/functional/page_objects/lens_page.ts
@@ -249,10 +249,9 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
         await this.selectOptionFromComboBox('indexPattern-dimension-field', opts.field);
         if (opts.isPreviousIncompatible) {
           // Incomplete → field must commit before close, or close discards the transition.
-          await retry.waitFor('incompatible field transition to complete', async () => {
-            const fieldCombo = await testSubjects.find('indexPattern-dimension-field');
-            return await comboBox.isOptionSelected(fieldCombo, opts.field!);
-          });
+          // Wait on Lens commit signals (op loses `incompatible`, params appear), not picker text alone.
+          await this.waitForIncompatibleFieldTransition(opts.operation);
+          await header.waitUntilLoadingHasFinished();
         }
       }
 
@@ -674,6 +673,34 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       await retry.waitFor('aria pressed to be true', async () => {
         const ariaPressedStatus = await getAriaPressed();
         return ariaPressedStatus === 'true';
+      });
+    },
+
+    /**
+     * Waits until an incompatible operation + field selection has been committed by Lens.
+     * Closing the editor before this clears incompleteColumns and reverts the previous column.
+     */
+    async waitForIncompatibleFieldTransition(operation: string) {
+      await retry.waitFor('incompatible field transition to complete', async () => {
+        // Compatible op button (without `incompatible`) only appears after incompleteColumns clears.
+        const compatibleOpExists = await testSubjects.exists(
+          `lns-indexPatternDimension-${operation}`,
+          { timeout: 500 }
+        );
+        if (!compatibleOpExists) {
+          return false;
+        }
+        const opEl = await testSubjects.find(`lns-indexPatternDimension-${operation}`);
+        if ((await opEl.getAttribute('aria-pressed')) !== 'true') {
+          return false;
+        }
+        // last_value param editors only render when !incompleteInfo
+        if (operation === 'last_value') {
+          return await testSubjects.exists('lns-indexPattern-lastValue-sortField', {
+            timeout: 500,
+          });
+        }
+        return true;
       });
     },
 

--- a/x-pack/platform/test/functional/page_objects/lens_page.ts
+++ b/x-pack/platform/test/functional/page_objects/lens_page.ts
@@ -251,8 +251,12 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
           // Incomplete → field must commit before close, or close discards the transition.
           // Wait on Lens commit signals (op loses `incompatible`, params appear), not picker text alone.
           await this.waitForIncompatibleFieldTransition(opts.operation);
-          await header.waitUntilLoadingHasFinished();
+        } else {
+          // Same hazard on the compatible path: the column stays incomplete until the field lands,
+          // and closing the editor while incomplete makes Lens drop the whole dimension.
+          await this.waitForFieldSelectionToCommit('indexPattern-dimension-field', opts.field);
         }
+        await header.waitUntilLoadingHasFinished();
       }
 
       if (opts.formula) {
@@ -292,6 +296,10 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
           'indexPattern-subFunction-selection-row',
           opts.operation
         );
+        await this.waitForFieldSelectionToCommit(
+          'indexPattern-subFunction-selection-row',
+          opts.operation
+        );
       }
 
       if (opts.field) {
@@ -299,7 +307,15 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
           'indexPattern-reference-field-selection-row',
           opts.field
         );
+        await this.waitForFieldSelectionToCommit(
+          'indexPattern-reference-field-selection-row',
+          opts.field
+        );
       }
+
+      // Reference columns stay incomplete until Lens commits the selection. Callers close the
+      // dimension editor right after, which drops an incomplete column and leaves the chart empty.
+      await header.waitUntilLoadingHasFinished();
     },
 
     /**
@@ -677,6 +693,18 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     },
 
     /**
+     * Waits until a combo box selection is reflected back by the component that owns it.
+     * `comboBox.setElement` does not verify the click landed, so without this the caller can move
+     * on while the selection is still pending.
+     */
+    async waitForFieldSelectionToCommit(testTargetId: string, value: string) {
+      await retry.waitFor(`${testTargetId} to show "${value}"`, async () => {
+        const target = await testSubjects.find(testTargetId);
+        return await comboBox.isOptionSelected(target, value);
+      });
+    },
+
+    /**
      * Waits until an incompatible operation + field selection has been committed by Lens.
      * Closing the editor before this clears incompleteColumns and reverts the previous column.
      */
@@ -873,7 +901,11 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       description?: string
     ) {
       await header.waitUntilLoadingHasFinished();
+      // Lens disables this button whenever `isSaveable` is false, and clicking a disabled button is
+      // a silent no-op that only surfaces much later as a save modal timeout.
+      await testSubjects.waitForEnabled('lnsApp_saveButton');
       await testSubjects.click('lnsApp_saveButton');
+      await testSubjects.existOrFail('savedObjectTitle', { timeout: 5000 });
 
       await this.saveModal(
         title,
@@ -902,6 +934,11 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
 
     async editDimensionLabel(label: string) {
       await testSubjects.setValue('name-input', label, { clearWithKeyboard: true });
+      // `name-input` is debounced, so closing the editor too early discards the new label and the
+      // dimension trigger keeps whatever it had before.
+      await retry.waitFor('dimension label to be applied', async () => {
+        return (await testSubjects.getAttribute('name-input', 'value')) === label;
+      });
     },
     async editDimensionFormat(format: string, options?: { decimals?: number; prefix?: string }) {
       await this.selectOptionFromComboBox('indexPattern-dimension-format', format);
@@ -2031,6 +2068,9 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     },
 
     async filterLegend(value: string) {
+      // Legend items only exist once the chart has rendered, otherwise the click below spends the
+      // full retry budget waiting for an element that was never going to appear.
+      await this.waitForVisualization();
       await testSubjects.click(`legend-${value}`);
       const filterIn = await testSubjects.find(`legend-${value}-filterIn`);
       await filterIn.click();

--- a/x-pack/platform/test/serverless/functional/test_suites/visualizations/group1/smokescreen.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/visualizations/group1/smokescreen.ts
@@ -18,6 +18,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const elasticChart = getService('elasticChart');
   const filterBar = getService('filterBar');
   const config = getService('config');
+  const retry = getService('retry');
 
   describe('lens smokescreen tests', () => {
     before(async () => {
@@ -447,12 +448,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       expect(await PageObjects.lens.hasChartSwitchWarning('bar')).to.eql(false);
       await PageObjects.lens.switchToVisualization('bar');
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_xDimensionPanel')).to.eql(
-        '@timestamp'
-      );
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_yDimensionPanel')).to.eql(
-        'Average of bytes'
-      );
+      // Chart switch remaps dimensions asynchronously; wait for triggers to settle.
+      await retry.try(async () => {
+        expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_xDimensionPanel')).to.eql(
+          '@timestamp'
+        );
+        expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_yDimensionPanel')).to.eql(
+          'Average of bytes'
+        );
+      });
     });
 
     it('should create a valid XY chart with references', async () => {


### PR DESCRIPTION
## Summary

Fixes a cluster of Lens FTR flakiness that all traces back to a single race: the tests close the dimension editor before Lens has committed the column, Lens then drops the incomplete column, and the damage shows up several steps later in unrelated-looking ways.

### What was broken

`FormBasedDimensionEditor` keeps a pending selection in `incompleteColumns` until the operation and field both land. Closing the editor before that discards the column entirely. Two consequences:

1. **Directly visible** — the dimension is simply gone, so the chart renders with no series (`expected [] to have a length of 2 but got 0`, `legend-jpg` never appears, `expected undefined to sort of equal 'Average of bytes'`).
2. **Visible much later** — a chart missing a dimension is not saveable. In `lens_top_nav.tsx` both save permissions are gated on `isSaveable`:

   ```ts
   const savingToLibraryPermitted = Boolean(isSaveable && application.capabilities.visualize_v2.save);
   const savingToDashboardPermitted = Boolean(isSaveable && application.capabilities.dashboard_v2?.showWriteControls);
   const enableSaveButton = savingToLibraryPermitted || (savingToDashboardPermitted && !isByValueMode && !showSaveAndReturn);
   ```

   so `isSaveable === false` renders `lnsApp_saveButton` disabled. `testSubjects.click` on a disabled button is a silent no-op, and the failure only surfaces 120s later as `TimeoutError: Waiting for element to be located By(css selector, [data-test-subj="savedObjectTitle"])` — with a stack pointing at the save modal, nowhere near the actual cause.

The same "closed before commit" mechanism applies to the debounced `name-input` label field, which reverts to its previous value.

### How it was fixed

All changes are in `x-pack/platform/test/functional/page_objects/lens_page.ts`.

- **`configureDimension`** — the commit wait only ran for `isPreviousIncompatible`; the compatible path closed the editor with no wait at all. Both paths now wait, then settle on `waitUntilLoadingHasFinished`.
- **`configureReference`** — had no waits at all, and every caller closes the editor immediately afterwards. Now waits for the sub-function and reference field to be reflected back.
- **`editDimensionLabel`** — polls until `name-input` reports the new value, so the debounce flushes before close.
- **`save`** — asserts `lnsApp_saveButton` is enabled before clicking, and that the modal actually opened. This does not paper over the bug: it makes a disabled-button click fail at the point of failure with a clear message instead of a misleading 120s save-modal timeout.
- **`filterLegend`** — waits for the chart to render, so a genuinely missing legend fails fast instead of consuming the full retry budget.

New shared helper `waitForFieldSelectionToCommit` wraps `comboBox.isOptionSelected`, the same predicate `comboBox.setElement` already uses internally to short-circuit, so value normalisation is guaranteed consistent with whatever the click matched.

`waitForIncompatibleFieldTransition` for the incompatible-operation path, which supersedes the narrower attempt in #283495.

### Builds with the related test evidence

Serverless MKI, `appex-qa-serverless-kibana-ftr-tests`, all four on the same Kibana SHA `9a262cb`:

| Build | Test | Failure |
|---|---|---|
| [10340](https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/10340) | should create a valid XY chart with references | `expected [] to have a length of 2 but got 0` |
| [10339](https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/10339) | should allow creation of lens xy chart | `savedObjectTitle` timeout |
| [10333](https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/10333) | should allow filtering by legend on an xy chart | `legend-jpg` timeout |
| [10330](https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/10330) | multi-layer stacked bar to treemap (obs + security), very long labels (search) | `savedObjectTitle` timeout, `expected 'Test of label'` |

Stateful and CCS, same root cause outside the serverless suite: #283797, #283814 (`lens/group1/layers.ts`), #283813 (`lens/group14/lens_tagging.ts`), #283808 (`lens/group1/chart_switching.ts`), #283766 (serverless, filter by legend).

Related: #283191, #283188 (addressed by the incompatible-operation wait).

### Known gaps

- `lens_tagging.ts`, `lens/group3/add_to_dashboard.ts` and `dashboard/group1/feature_controls/time_to_visualize_security.ts` click `lnsApp_saveButton` inline rather than via `lens.save()`, so they do not pick up the enabled-state assertion. Worth extracting a shared `openSaveModal()` in a follow-up.
- Why the race started losing around Aug 5 is unconfirmed. The `@elastic/charts` v72.0.1 upgrade (#280018, merged Aug 4) is the leading temporal suspect since it would shift render timing and therefore when `waitForVisualization` returns, but this has not been bisected.

### Testing

Flaky test runner, in priority order:

- `x-pack/platform/test/serverless/functional/configs/observability/config.group2.ts`
- `x-pack/platform/test/serverless/functional/configs/search/config.group2.ts`
- `x-pack/platform/test/serverless/functional/configs/security/config.group2.ts`
- `x-pack/platform/test/functional/apps/lens/group1/config.ts`
- `x-pack/platform/test/functional/apps/lens/group14/config.ts`

Regression coverage for the shared page object edits: lens groups 2, 3, 4, 13, 15. Note the flaky runner uses a local stack and will not reproduce the MKI cloud latency the original alerts came from.