### PR TITLE
[Alerting V2] Fix ALERTING_ERROR_CODES reference in rules_client

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
@@ -420,13 +420,13 @@ export class RulesClient {
 
     if (!isSignalUsingStandaloneFormat(nextAttrs)) {
       throw Boom.badRequest('kind "signal" requires query.format "standalone".', {
-        code: ALERTING_V2_ERROR_CODES.INVALID_SIGNAL_RULE,
+        code: ALERTING_ERROR_CODES.INVALID_SIGNAL_RULE,
         details: { rule_id: id, rule_kind: existingAttrs.kind },
       });
     }
     if (!isSignalQueryBreachOnly(nextAttrs)) {
       throw Boom.badRequest('Signal rules cannot set recovery_strategy or no_data_strategy.', {
-        code: ALERTING_V2_ERROR_CODES.INVALID_SIGNAL_RULE,
+        code: ALERTING_ERROR_CODES.INVALID_SIGNAL_RULE,
         details: { rule_id: id, rule_kind: existingAttrs.kind },
       });
     }


### PR DESCRIPTION
## Summary

Fixes the kibana-on-merge build break introduced by #283754.

Root cause: merge race between these PRs:
- https://github.com/elastic/kibana/pull/282316
- https://github.com/elastic/kibana/pull/283754

#283754 added two `rules_client.ts` throw sites referencing `ALERTING_V2_ERROR_CODES` after #282316 had already renamed the catalog to `ALERTING_ERROR_CODES`, producing a semantic merge conflict that compiled on the PR branch but broke on main.