### PR TITLE
[One Workflow] Fix executions nav link not appearing when executionsViewEnabled is true

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/deep_links.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/deep_links.test.ts
@@ -33,4 +33,22 @@ describe('getDeepLinks', () => {
     expect(workflowsDeepLink).toEqual(expect.objectContaining({ id: 'list', path: '/' }));
     expect(workflowsDeepLink.visibleIn).toBeUndefined();
   });
+
+  it('includes projectSideNav in visibleIn for the executions deep link when executionsViewEnabled', () => {
+    const deepLinks = getDeepLinks({ executionsViewEnabled: true });
+    const executionsLink = deepLinks.find((l) => l.id === 'executions');
+
+    expect(executionsLink).toEqual(
+      expect.objectContaining({
+        id: 'executions',
+        visibleIn: ['globalSearch', 'projectSideNav'],
+      })
+    );
+  });
+
+  it('omits the executions deep link when executionsViewEnabled is false', () => {
+    const deepLinks = getDeepLinks({ executionsViewEnabled: false });
+
+    expect(deepLinks.find((l) => l.id === 'executions')).toBeUndefined();
+  });
 });

--- a/src/platform/plugins/shared/workflows_management/public/deep_links.ts
+++ b/src/platform/plugins/shared/workflows_management/public/deep_links.ts
@@ -57,6 +57,7 @@ export function getDeepLinks({
         defaultMessage: 'Executions',
       }),
       path: '/executions',
+      visibleIn: sideNavVisibleIn,
     });
   }
 


### PR DESCRIPTION
## Summary

The Executions nav link was not showing in the solution side nav even when `workflowsManagement:globalExecutionsView:enabled` was `true`.

**Root cause:** `getDeepLinks()` registered the `executions` deep link without `visibleIn`, so it defaulted to `['globalSearch']`. The core chrome project navigation renderer filters out any nav tree node whose deep link does not include `'projectSideNav'` in `visibleIn`, causing the node to be silently removed.

**Fix:** Add `visibleIn: sideNavVisibleIn` (`['globalSearch', 'projectSideNav']`) to the executions deep link registration, matching the pattern already used by the `library` deep link.

## Test plan

- [ ] Enable `workflowsManagement:globalExecutionsView:enabled` in Advanced Settings
- [ ] Verify the Executions link appears in the Workflows side nav panel
- [ ] Verify the link is absent when the setting is disabled

Unit tests updated in `deep_links.test.ts` to cover both cases.