### PR TITLE
[CI] Pass ES snapshot manifest to verify step in version bump pipeline

### DIFF
--- a/.buildkite/pipelines/version_bump.yml
+++ b/.buildkite/pipelines/version_bump.yml
@@ -59,9 +59,23 @@ steps:
 
   - key: verify-es-snapshot
     label: 'Verify ES Snapshot'
-    trigger: kibana-elasticsearch-snapshot-verify
-    async: true
-    soft_fail: true
     if: build.env("DRY_RUN") != "true"
-    build:
-      branch: $BRANCH
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+    command: |
+      ES_SNAPSHOT_MANIFEST="$(buildkite-agent meta-data get es_snapshot_manifest)"
+
+      buildkite-agent pipeline upload << PIPELINE
+      steps:
+        - label: 'Verify ES Snapshot'
+          trigger: kibana-elasticsearch-snapshot-verify
+          async: true
+          soft_fail: true
+          build:
+            branch: '$BRANCH'
+            env:
+              ES_SNAPSHOT_MANIFEST: '$${ES_SNAPSHOT_MANIFEST}'
+      PIPELINE


### PR DESCRIPTION
## Summary

The `verify-es-snapshot` step in `.buildkite/pipelines/version_bump.yml` triggered `kibana-elasticsearch-snapshot-verify` without passing `ES_SNAPSHOT_MANIFEST`, so the triggered verify build hit its `block` step and waited indefinitely for manual input.

This change converts the static trigger into a command step that reads the manifest URL from build meta-data (`es_snapshot_manifest`, set by the ES snapshot build via `buildkite-agent meta-data set --job $PARENT_TRIGGER_JOB_ID`) and uploads the verify trigger dynamically with `ES_SNAPSHOT_MANIFEST` as a build env — the same pattern already used by `promote-es-snapshot` in `trigger_es_build_and_promote.yml`.

Ordering is safe: the ES snapshot build is uploaded during `bump-version` (before the `wait` preceding `fetch-dra-artifacts`), so the meta-data is guaranteed to exist by the time this step runs. The step position after `fetch-dra-artifacts` is unchanged.

With `ES_SNAPSHOT_MANIFEST` set, the verify pipeline's `block` step is skipped and verification runs automatically.