### PR TITLE
[9.4] [js-yaml to yaml migration] @elastic/fleet (#283600)

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -49,8 +49,6 @@ const JS_YAML_LEGACY_CONSUMERS = [
   'x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils/yaml_form_utils.ts',
   'x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/yaml_rule_form.test.tsx',
   'x-pack/platform/plugins/shared/agent_builder/server/services/plugins/utils/parsing/parse_skill_file.ts',
-  'x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx',
-  'x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts',
   'x-pack/platform/plugins/shared/inference/scripts/util/read_kibana_config.ts',
   'x-pack/solutions/observability/plugins/apm/scripts/shared/read_kibana_config.ts',
   'x-pack/solutions/observability/plugins/apm/server/routes/fleet/get_apm_package_policy_definition.ts',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/add_collector_flyout.tsx
@@ -7,7 +7,6 @@
 
 import React, { useMemo, useRef, useState } from 'react';
 import { useQuery } from '@kbn/react-query';
-import { dump } from 'js-yaml';
 import { v4 as uuidv4 } from 'uuid';
 import {
   EuiFlyout,
@@ -47,6 +46,7 @@ import {
 } from '../../../../hooks';
 import { AgentEnrollmentConfirmationStep, usePollingAgentCount } from '../../../../components';
 import { useGetCreateApiKey } from '../../../../../../components/agent_enrollment_flyout/hooks';
+import { useYaml } from '../../../../../../services';
 
 interface AddCollectorFlyoutProps {
   onClose: () => void;
@@ -135,6 +135,7 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
 }) => {
   const instanceUid = useRef(uuidv4());
   const { cloud } = useStartServices();
+  const yaml = useYaml();
 
   const {
     apiKeyEncoded: esApiKeyEncoded,
@@ -204,6 +205,10 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
   };
 
   const opampConfig = useMemo(() => {
+    if (!yaml) {
+      return '';
+    }
+
     const nonIdentifyingAttrs: Record<string, any> = {
       'elastic.collector.group_name': groupDisplayName,
       'elastic.collector.group': collectorGroup,
@@ -290,8 +295,15 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
         },
       },
     };
-    return dump(config, { lineWidth: -1, quotingType: '"', forceQuotes: true, noRefs: true });
+    return yaml.stringify(config, {
+      lineWidth: 0,
+      singleQuote: false,
+      defaultStringType: 'QUOTE_DOUBLE',
+      defaultKeyType: 'PLAIN',
+      aliasDuplicateObjects: false,
+    });
   }, [
+    yaml,
     groupDisplayName,
     collectorGroup,
     serviceName,
@@ -508,7 +520,7 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
               </p>
             </EuiText>
           )}
-          {token && defaultFleetServerHost && isFormValid ? (
+          {token && defaultFleetServerHost && isFormValid && yaml ? (
             <>
               <EuiText>
                 <p>
@@ -566,7 +578,7 @@ export const AddCollectorFlyout: React.FunctionComponent<AddCollectorFlyoutProps
                 {opampConfig}
               </EuiCodeBlock>
             </>
-          ) : loading ? (
+          ) : loading || !yaml ? (
             <EuiCallOut
               announceOnMount
               size="m"

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
@@ -2299,7 +2299,7 @@ describe('generateOtelcolConfig', () => {
     it('should handle malformed YAML without throwing', () => {
       const outputWithBadYaml: Output = {
         ...defaultOutput,
-        otel_exporter_config_yaml: ': invalid yaml',
+        otel_exporter_config_yaml: '{ unclosed',
       };
 
       expect(() => generateOtelcolConfig({ inputs, dataOutput: outputWithBadYaml })).not.toThrow();
@@ -2423,7 +2423,7 @@ describe('generateOtelcolConfig', () => {
     it('should throw when config_yaml contains malformed YAML', () => {
       const outputWithBadYaml: Output = {
         ...defaultOutput,
-        config_yaml: ': invalid yaml',
+        config_yaml: '{ unclosed',
       };
 
       expect(() => generateOtelcolConfig({ inputs, dataOutput: outputWithBadYaml })).toThrow();

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { load } from 'js-yaml';
+import { parse } from 'yaml';
 
 import type { Logger } from '@kbn/logging';
 
@@ -667,7 +667,7 @@ function buildBeatsauthConfig(
 function parseOutputConfigYaml(yaml: string | null | undefined): Record<string, unknown> {
   if (!yaml) return {};
   try {
-    const parsed = load(yaml);
+    const parsed = parse(yaml);
     if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return parsed as Record<string, unknown>;
     }
@@ -745,7 +745,7 @@ function parseOtelExporterConfigYaml(
 ): Record<string, unknown> {
   if (!yaml) return {};
   try {
-    const parsed = load(yaml);
+    const parsed = parse(yaml);
     if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return parsed as Record<string, unknown>;
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[js-yaml to yaml migration] @elastic/fleet (#283600)](https://github.com/elastic/kibana/pull/283600)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-08-07T12:53:50Z","message":"[js-yaml to yaml migration] @elastic/fleet (#283600)\n\n## Summary\n\nMigrates the 5 files owned by @elastic/fleet from `js-yaml` to the\n`yaml` package (YAML 1.2 core schema) as part of the incremental\n`js-yaml` dependency removal initiative tracked in\n`JS_YAML_LEGACY_CONSUMERS` in `packages/kbn-eslint-config/.eslintrc.js`.\n\n### Why a follow-up\n\nFleet's original migration was done under #260674, which is already\nclosed. Every file in this PR is OTel collector code (the collector\nconfig viewer, the Add Collector flyout, and OTel agent-policy\ngeneration) that landed in Fleet *after* that issue was closed, so these\nfiles were added to the `JS_YAML_LEGACY_CONSUMERS` allowlist rather than\nmigrated at the time. This PR clears Fleet's remaining entries; 22\nentries remain across other teams.\n\n### Files migrated\n\n| File | Change |\n|---|---|\n| `x-pack/.../fleet/server/services/agent_policies/otel_collector.ts` |\n`import { load } from 'js-yaml'` → `import { parse } from 'yaml'`; both\n`load(...)` call sites → `parse(...)` |\n|\n`x-pack/.../fleet/public/.../agent_list_page/components/add_collector_flyout.tsx`\n| `import { dump } from 'js-yaml'` → `useYaml()` hook +\n`yaml.stringify(...)` |\n|\n`x-pack/.../fleet/public/components/otel_ui/collector_config_view/yaml_viewer.tsx`\n| `import { dump } from 'js-yaml'` → `useYaml()` hook +\n`yaml.stringify(...)` |\n|\n`x-pack/.../fleet/public/components/otel_ui/collector_config_view/component_detail/component_config_tab.tsx`\n| `import { dump } from 'js-yaml'` → `useYaml()` hook +\n`yaml.stringify(...)` |\n|\n`x-pack/.../fleet/public/components/otel_ui/collector_config_view/yaml_viewer.test.tsx`\n| `dump` from `js-yaml` → `stringify` from `yaml`; adds the `useYaml`\njest mock |\n\n5 corresponding entries removed from `JS_YAML_LEGACY_CONSUMERS`.\n\nTwo additional files are touched as required follow-on, but had no\n`js-yaml` import of their own:\n- `component_detail.test.tsx` — adds the same `useYaml` jest mock, since\nit renders `ComponentConfigTab`.\n- `otel_collector.test.ts` — malformed-YAML fixtures updated, see below.\n\n### `useYaml` in the browser, static `parse`/`stringify` on the server\n\nThe three public files use Fleet's existing `useYaml()` hook (backed by\n`loadYaml` from `@kbn/yaml-loader`) rather than a static `import {\nstringify } from 'yaml'`. Fleet built that hook specifically to keep the\nfull `yaml` library out of the initial browser bundle, and it is already\nused by `agent_effective_config_flyout.tsx`, `use_output_form.tsx`,\n`use_package_policy.tsx` and others. A static import in `public/` would\nundo that for the whole Fleet bundle.\n\nBecause the module now loads asynchronously, each of the three\ncomponents renders a loading state until it resolves. The Add Collector\nflyout reuses its existing \"Preparing OpAMP configuration…\" callout; the\ntwo OTel viewers render an `EuiLoadingSpinner`.\n\n`otel_collector.ts` is server-side, so it takes a plain static `import {\nparse } from 'yaml'` — the same thing `server/services/output.ts` and\n`server/services/agent_policies/full_agent_policy.ts` already do when\nparsing the very same `output.config_yaml` field.\n\n### Serializer parity\n\n`js-yaml`'s `dump` options were mapped to the `yaml` package's\n`stringify` options as follows:\n\n| `js-yaml` `dump` | `yaml` `stringify` |\n|---|---|\n| `lineWidth: -1` (no wrapping) | `lineWidth: 0` |\n| `quotingType: '\"'` | `singleQuote: false` |\n| `forceQuotes: true` | `defaultStringType: 'QUOTE_DOUBLE'` +\n`defaultKeyType: 'PLAIN'` |\n| `noRefs: true` | `aliasDuplicateObjects: false` |\n\nBoth option sets used in these files were diffed against the originals\nover representative OTel collector configs (including duplicate object\nreferences, `${env:…}` placeholders, embedded newlines, and non-string\nscalars): output is **byte-identical**. This is also covered by existing\nassertions — `add_collector_flyout.test.tsx` checks the emitted YAML\nverbatim (e.g. `Authorization: \"ApiKey existing-token\"`,\n`insecure_skip_verify: true`) and passes unchanged against the real\nasync loader.\n\n### Parser parity, and one deliberate fixture change\n\n`js-yaml`'s `load` rejects `\": invalid yaml\"`, whereas YAML 1.2 accepts\nit as a mapping with a null key. Both malformed-YAML fixtures in\n`otel_collector.test.ts` used exactly that string, so they were changed\nto `\"{ unclosed\"` — an unterminated flow mapping that **both** libraries\nreject. The assertions themselves (graceful skip for\n`otel_exporter_config_yaml`, throw for `config_yaml`) are unchanged and\nstill pass; only the no-longer-malformed input was replaced.\n\nThis does make `otel_collector.ts` marginally more lenient for input\nthat YAML 1.2 considers valid. That is the intended outcome: the Fleet\nUI already validates these fields with `yaml.parse` before saving, and\nthe other Fleet server-side readers of `config_yaml` already use\n`yaml.parse`, so this change makes validation and parsing consistent\nend-to-end rather than diverging per call site.\n\n## Test plan\n\n- [x] `node scripts/eslint <changed files>` — ✅ no errors (confirms the\nallowlist edit is correct and no `js-yaml` imports remain)\n- [x] `node scripts/type_check --project\nx-pack/platform/plugins/shared/fleet/tsconfig.json` — ✅ exits 0\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/fleet/public/components/otel_ui/` — ✅\n131/131 passed (13 suites)\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/fleet/server/services/agent_policies/` —\n✅ 306/306 passed (12 suites)\n- [x] `node scripts/jest\n.../agent_list_page/components/add_collector_flyout.test.tsx` — ✅ 30/30\npassed\n- [x] Serializer output diffed byte-for-byte between `js-yaml` `dump`\nand `yaml` `stringify` for both option sets used\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>","sha":"9b79cd12305b4fa44715a0803be9331354c71dac","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","Team:Fleet","backport:all-open","dependency-reduction","v9.6.0"],"title":"[js-yaml to yaml migration] @elastic/fleet","number":283600,"url":"https://github.com/elastic/kibana/pull/283600","mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/fleet (#283600)\n\n## Summary\n\nMigrates the 5 files owned by @elastic/fleet from `js-yaml` to the\n`yaml` package (YAML 1.2 core schema) as part of the incremental\n`js-yaml` dependency removal initiative tracked in\n`JS_YAML_LEGACY_CONSUMERS` in `packages/kbn-eslint-config/.eslintrc.js`.\n\n### Why a follow-up\n\nFleet's original migration was done under #260674, which is already\nclosed. Every file in this PR is OTel collector code (the collector\nconfig viewer, the Add Collector flyout, and OTel agent-policy\ngeneration) that landed in Fleet *after* that issue was closed, so these\nfiles were added to the `JS_YAML_LEGACY_CONSUMERS` allowlist rather than\nmigrated at the time. This PR clears Fleet's remaining entries; 22\nentries remain across other teams.\n\n### Files migrated\n\n| File | Change |\n|---|---|\n| `x-pack/.../fleet/server/services/agent_policies/otel_collector.ts` |\n`import { load } from 'js-yaml'` → `import { parse } from 'yaml'`; both\n`load(...)` call sites → `parse(...)` |\n|\n`x-pack/.../fleet/public/.../agent_list_page/components/add_collector_flyout.tsx`\n| `import { dump } from 'js-yaml'` → `useYaml()` hook +\n`yaml.stringify(...)` |\n|\n`x-pack/.../fleet/public/components/otel_ui/collector_config_view/yaml_viewer.tsx`\n| `import { dump } from 'js-yaml'` → `useYaml()` hook +\n`yaml.stringify(...)` |\n|\n`x-pack/.../fleet/public/components/otel_ui/collector_config_view/component_detail/component_config_tab.tsx`\n| `import { dump } from 'js-yaml'` → `useYaml()` hook +\n`yaml.stringify(...)` |\n|\n`x-pack/.../fleet/public/components/otel_ui/collector_config_view/yaml_viewer.test.tsx`\n| `dump` from `js-yaml` → `stringify` from `yaml`; adds the `useYaml`\njest mock |\n\n5 corresponding entries removed from `JS_YAML_LEGACY_CONSUMERS`.\n\nTwo additional files are touched as required follow-on, but had no\n`js-yaml` import of their own:\n- `component_detail.test.tsx` — adds the same `useYaml` jest mock, since\nit renders `ComponentConfigTab`.\n- `otel_collector.test.ts` — malformed-YAML fixtures updated, see below.\n\n### `useYaml` in the browser, static `parse`/`stringify` on the server\n\nThe three public files use Fleet's existing `useYaml()` hook (backed by\n`loadYaml` from `@kbn/yaml-loader`) rather than a static `import {\nstringify } from 'yaml'`. Fleet built that hook specifically to keep the\nfull `yaml` library out of the initial browser bundle, and it is already\nused by `agent_effective_config_flyout.tsx`, `use_output_form.tsx`,\n`use_package_policy.tsx` and others. A static import in `public/` would\nundo that for the whole Fleet bundle.\n\nBecause the module now loads asynchronously, each of the three\ncomponents renders a loading state until it resolves. The Add Collector\nflyout reuses its existing \"Preparing OpAMP configuration…\" callout; the\ntwo OTel viewers render an `EuiLoadingSpinner`.\n\n`otel_collector.ts` is server-side, so it takes a plain static `import {\nparse } from 'yaml'` — the same thing `server/services/output.ts` and\n`server/services/agent_policies/full_agent_policy.ts` already do when\nparsing the very same `output.config_yaml` field.\n\n### Serializer parity\n\n`js-yaml`'s `dump` options were mapped to the `yaml` package's\n`stringify` options as follows:\n\n| `js-yaml` `dump` | `yaml` `stringify` |\n|---|---|\n| `lineWidth: -1` (no wrapping) | `lineWidth: 0` |\n| `quotingType: '\"'` | `singleQuote: false` |\n| `forceQuotes: true` | `defaultStringType: 'QUOTE_DOUBLE'` +\n`defaultKeyType: 'PLAIN'` |\n| `noRefs: true` | `aliasDuplicateObjects: false` |\n\nBoth option sets used in these files were diffed against the originals\nover representative OTel collector configs (including duplicate object\nreferences, `${env:…}` placeholders, embedded newlines, and non-string\nscalars): output is **byte-identical**. This is also covered by existing\nassertions — `add_collector_flyout.test.tsx` checks the emitted YAML\nverbatim (e.g. `Authorization: \"ApiKey existing-token\"`,\n`insecure_skip_verify: true`) and passes unchanged against the real\nasync loader.\n\n### Parser parity, and one deliberate fixture change\n\n`js-yaml`'s `load` rejects `\": invalid yaml\"`, whereas YAML 1.2 accepts\nit as a mapping with a null key. Both malformed-YAML fixtures in\n`otel_collector.test.ts` used exactly that string, so they were changed\nto `\"{ unclosed\"` — an unterminated flow mapping that **both** libraries\nreject. The assertions themselves (graceful skip for\n`otel_exporter_config_yaml`, throw for `config_yaml`) are unchanged and\nstill pass; only the no-longer-malformed input was replaced.\n\nThis does make `otel_collector.ts` marginally more lenient for input\nthat YAML 1.2 considers valid. That is the intended outcome: the Fleet\nUI already validates these fields with `yaml.parse` before saving, and\nthe other Fleet server-side readers of `config_yaml` already use\n`yaml.parse`, so this change makes validation and parsing consistent\nend-to-end rather than diverging per call site.\n\n## Test plan\n\n- [x] `node scripts/eslint <changed files>` — ✅ no errors (confirms the\nallowlist edit is correct and no `js-yaml` imports remain)\n- [x] `node scripts/type_check --project\nx-pack/platform/plugins/shared/fleet/tsconfig.json` — ✅ exits 0\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/fleet/public/components/otel_ui/` — ✅\n131/131 passed (13 suites)\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/fleet/server/services/agent_policies/` —\n✅ 306/306 passed (12 suites)\n- [x] `node scripts/jest\n.../agent_list_page/components/add_collector_flyout.test.tsx` — ✅ 30/30\npassed\n- [x] Serializer output diffed byte-for-byte between `js-yaml` `dump`\nand `yaml` `stringify` for both option sets used\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>","sha":"9b79cd12305b4fa44715a0803be9331354c71dac"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283600","number":283600,"mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/fleet (#283600)\n\n## Summary\n\nMigrates the 5 files owned by @elastic/fleet from `js-yaml` to the\n`yaml` package (YAML 1.2 core schema) as part of the incremental\n`js-yaml` dependency removal initiative tracked in\n`JS_YAML_LEGACY_CONSUMERS` in `packages/kbn-eslint-config/.eslintrc.js`.\n\n### Why a follow-up\n\nFleet's original migration was done under #260674, which is already\nclosed. Every file in this PR is OTel collector code (the collector\nconfig viewer, the Add Collector flyout, and OTel agent-policy\ngeneration) that landed in Fleet *after* that issue was closed, so these\nfiles were added to the `JS_YAML_LEGACY_CONSUMERS` allowlist rather than\nmigrated at the time. This PR clears Fleet's remaining entries; 22\nentries remain across other teams.\n\n### Files migrated\n\n| File | Change |\n|---|---|\n| `x-pack/.../fleet/server/services/agent_policies/otel_collector.ts` |\n`import { load } from 'js-yaml'` → `import { parse } from 'yaml'`; both\n`load(...)` call sites → `parse(...)` |\n|\n`x-pack/.../fleet/public/.../agent_list_page/components/add_collector_flyout.tsx`\n| `import { dump } from 'js-yaml'` → `useYaml()` hook +\n`yaml.stringify(...)` |\n|\n`x-pack/.../fleet/public/components/otel_ui/collector_config_view/yaml_viewer.tsx`\n| `import { dump } from 'js-yaml'` → `useYaml()` hook +\n`yaml.stringify(...)` |\n|\n`x-pack/.../fleet/public/components/otel_ui/collector_config_view/component_detail/component_config_tab.tsx`\n| `import { dump } from 'js-yaml'` → `useYaml()` hook +\n`yaml.stringify(...)` |\n|\n`x-pack/.../fleet/public/components/otel_ui/collector_config_view/yaml_viewer.test.tsx`\n| `dump` from `js-yaml` → `stringify` from `yaml`; adds the `useYaml`\njest mock |\n\n5 corresponding entries removed from `JS_YAML_LEGACY_CONSUMERS`.\n\nTwo additional files are touched as required follow-on, but had no\n`js-yaml` import of their own:\n- `component_detail.test.tsx` — adds the same `useYaml` jest mock, since\nit renders `ComponentConfigTab`.\n- `otel_collector.test.ts` — malformed-YAML fixtures updated, see below.\n\n### `useYaml` in the browser, static `parse`/`stringify` on the server\n\nThe three public files use Fleet's existing `useYaml()` hook (backed by\n`loadYaml` from `@kbn/yaml-loader`) rather than a static `import {\nstringify } from 'yaml'`. Fleet built that hook specifically to keep the\nfull `yaml` library out of the initial browser bundle, and it is already\nused by `agent_effective_config_flyout.tsx`, `use_output_form.tsx`,\n`use_package_policy.tsx` and others. A static import in `public/` would\nundo that for the whole Fleet bundle.\n\nBecause the module now loads asynchronously, each of the three\ncomponents renders a loading state until it resolves. The Add Collector\nflyout reuses its existing \"Preparing OpAMP configuration…\" callout; the\ntwo OTel viewers render an `EuiLoadingSpinner`.\n\n`otel_collector.ts` is server-side, so it takes a plain static `import {\nparse } from 'yaml'` — the same thing `server/services/output.ts` and\n`server/services/agent_policies/full_agent_policy.ts` already do when\nparsing the very same `output.config_yaml` field.\n\n### Serializer parity\n\n`js-yaml`'s `dump` options were mapped to the `yaml` package's\n`stringify` options as follows:\n\n| `js-yaml` `dump` | `yaml` `stringify` |\n|---|---|\n| `lineWidth: -1` (no wrapping) | `lineWidth: 0` |\n| `quotingType: '\"'` | `singleQuote: false` |\n| `forceQuotes: true` | `defaultStringType: 'QUOTE_DOUBLE'` +\n`defaultKeyType: 'PLAIN'` |\n| `noRefs: true` | `aliasDuplicateObjects: false` |\n\nBoth option sets used in these files were diffed against the originals\nover representative OTel collector configs (including duplicate object\nreferences, `${env:…}` placeholders, embedded newlines, and non-string\nscalars): output is **byte-identical**. This is also covered by existing\nassertions — `add_collector_flyout.test.tsx` checks the emitted YAML\nverbatim (e.g. `Authorization: \"ApiKey existing-token\"`,\n`insecure_skip_verify: true`) and passes unchanged against the real\nasync loader.\n\n### Parser parity, and one deliberate fixture change\n\n`js-yaml`'s `load` rejects `\": invalid yaml\"`, whereas YAML 1.2 accepts\nit as a mapping with a null key. Both malformed-YAML fixtures in\n`otel_collector.test.ts` used exactly that string, so they were changed\nto `\"{ unclosed\"` — an unterminated flow mapping that **both** libraries\nreject. The assertions themselves (graceful skip for\n`otel_exporter_config_yaml`, throw for `config_yaml`) are unchanged and\nstill pass; only the no-longer-malformed input was replaced.\n\nThis does make `otel_collector.ts` marginally more lenient for input\nthat YAML 1.2 considers valid. That is the intended outcome: the Fleet\nUI already validates these fields with `yaml.parse` before saving, and\nthe other Fleet server-side readers of `config_yaml` already use\n`yaml.parse`, so this change makes validation and parsing consistent\nend-to-end rather than diverging per call site.\n\n## Test plan\n\n- [x] `node scripts/eslint <changed files>` — ✅ no errors (confirms the\nallowlist edit is correct and no `js-yaml` imports remain)\n- [x] `node scripts/type_check --project\nx-pack/platform/plugins/shared/fleet/tsconfig.json` — ✅ exits 0\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/fleet/public/components/otel_ui/` — ✅\n131/131 passed (13 suites)\n- [x] `node scripts/jest\nx-pack/platform/plugins/shared/fleet/server/services/agent_policies/` —\n✅ 306/306 passed (12 suites)\n- [x] `node scripts/jest\n.../agent_list_page/components/add_collector_flyout.test.tsx` — ✅ 30/30\npassed\n- [x] Serializer output diffed byte-for-byte between `js-yaml` `dump`\nand `yaml` `stringify` for both option sets used\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>","sha":"9b79cd12305b4fa44715a0803be9331354c71dac"}}]}] BACKPORT-->