### PR TITLE
[Evals CI] Cut weekly model list based on current rank scores

### DIFF
--- a/.buildkite/pipelines/evals/eval_pipeline.ts
+++ b/.buildkite/pipelines/evals/eval_pipeline.ts
@@ -94,12 +94,9 @@ export function getForwardablePrLabels(githubPrLabels: string): string {
  * `models:weekly-eis-models`. Keep in sync with &weekly_eis_core_models in llm_evals.yml.
  */
 const DEFAULT_WEEKLY_EIS_MODELS: string[] = [
-  'eis/anthropic-claude-4.6-sonnet',
   'eis/anthropic-claude-4.6-opus',
-  'eis/google-gemini-3.0-flash',
   'eis/google-gemini-3.1-pro',
   'eis/openai-gpt-5.4',
-  'eis/openai-gpt-oss-120b',
 ];
 
 const WEEKLY_EIS_MODELS_ALIAS = 'weekly-eis-models';

--- a/.buildkite/pipelines/evals/evals.suites.json
+++ b/.buildkite/pipelines/evals/evals.suites.json
@@ -83,20 +83,12 @@
         "evals:significant-events"
       ],
       "weeklyEisModelGroups": [
-        "eis/anthropic-claude-4.6-sonnet",
         "eis/anthropic-claude-4.6-opus",
         "eis/anthropic-claude-4.7-opus",
-        "eis/anthropic-claude-4.8-opus",
-        "eis/google-gemini-3.0-flash",
-        "eis/google-gemini-3.1-flash-lite",
         "eis/google-gemini-3.5-flash",
         "eis/openai-gpt-5.2",
         "eis/openai-gpt-5.4",
-        "eis/openai-gpt-5.4-mini",
-        "eis/openai-gpt-5.4-nano",
-        "eis/openai-gpt-5.6-luna",
-        "eis/openai-gpt-5.6-terra",
-        "eis/openai-gpt-oss-120b"
+        "eis/openai-gpt-5.6-luna"
       ]
     },
     {
@@ -296,7 +288,6 @@
         "evals:agent-builder-dashboards"
       ],
       "weeklyEisModelGroups": [
-        "eis/anthropic-claude-4.6-sonnet",
         "eis/anthropic-claude-4.6-opus",
         "eis/openai-gpt-5.2",
         "eis/openai-gpt-5.4"

--- a/.buildkite/pipelines/evals/llm_evals.yml
+++ b/.buildkite/pipelines/evals/llm_evals.yml
@@ -74,7 +74,7 @@ steps:
           #
           # NOTE: Use `eis/<modelId>` values (not connector ids) so we can filter purely on the discovered
           # EIS model ids in `target/eis_models.json`.
-          EVAL_MODEL_GROUPS: &weekly_eis_core_models 'eis/anthropic-claude-4.6-sonnet,eis/anthropic-claude-4.6-opus,eis/google-gemini-3.0-flash,eis/google-gemini-3.1-pro,eis/openai-gpt-5.4,eis/openai-gpt-oss-120b'
+          EVAL_MODEL_GROUPS: &weekly_eis_core_models 'eis/anthropic-claude-4.6-opus,eis/google-gemini-3.1-pro,eis/openai-gpt-5.4'
         timeout_in_minutes: 60
         agents:
           image: family/kibana-ubuntu-2404
@@ -187,7 +187,7 @@ steps:
           EVAL_INCLUDE_EIS_MODELS: '1'
           # Extended tier: includes smaller/cheaper models for cost-performance evaluation.
           # Keep in sync with `weeklyEisModelGroups` for significant-events in evals.suites.json.
-          EVAL_MODEL_GROUPS: &weekly_eis_extended_models 'eis/anthropic-claude-4.6-sonnet,eis/anthropic-claude-4.6-opus,eis/anthropic-claude-4.7-opus,eis/anthropic-claude-4.8-opus,eis/google-gemini-3.0-flash,eis/google-gemini-3.1-flash-lite,eis/google-gemini-3.5-flash,eis/openai-gpt-5.2,eis/openai-gpt-5.4,eis/openai-gpt-5.4-mini,eis/openai-gpt-5.4-nano,eis/openai-gpt-5.6-luna,eis/openai-gpt-5.6-terra,eis/openai-gpt-oss-120b'
+          EVAL_MODEL_GROUPS: &weekly_eis_extended_models 'eis/anthropic-claude-4.6-opus,eis/anthropic-claude-4.7-opus,eis/google-gemini-3.5-flash,eis/openai-gpt-5.2,eis/openai-gpt-5.4,eis/openai-gpt-5.6-luna'
         timeout_in_minutes: 60
         agents:
           image: family/kibana-ubuntu-2404


### PR DESCRIPTION
Reduces the weekly eval CI model lists based on Final Score rankings. Core tier 6→3 models, extended tier 14→6, agent-builder-dashboards 4→3. Three files kept in sync: llm_evals.yml, eval_pipeline.ts, evals.suites.json.