### PR TITLE
[9.5] fix flaky entity flyout anomalies test (#283664)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/entity_flyout_anomalies_page.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/entity_flyout_anomalies_page.ts
@@ -135,17 +135,16 @@ export class EntityFlyoutAnomaliesPage {
   }
 
   async clickAnomaliesCountLink() {
-    // The anomalies section sits below the entity risk contributions section in the right
-    // panel and may be off-screen. Wait for the expandable panel to be in the DOM (anomaly
-    // data has loaded), then click.
+    // Attached rather than visible: the section sits below risk contributions and may be
+    // off-screen until the click scrolls to it.
     await this.anomaliesExpandablePanel.waitFor({ state: 'attached' });
-    // In rare cases the entity store resolves fast enough that the flyout auto-navigates to
-    // both panels before this click fires. EUI's panel slide-in uses CSS transform, so the
-    // anomalies tab is already Playwright-visible during the animation. Skip the click if so.
+    // The flyout sometimes auto-navigates to both panels before this runs, and clicking then
+    // would toggle the tab back off.
     if (!(await this.anomaliesTab.isVisible())) {
-      // noWaitAfter: true skips Playwright's post-click navigation wait — the URL update that
-      // opens the left panel triggers unmocked API calls that keep the tracker pending.
-      await this.anomaliesExpandablePanelTitleLink.click({ noWaitAfter: true });
+      // noWaitAfter: the URL update that opens the left panel triggers unmocked API calls that
+      // keep Playwright's navigation tracker pending. The extended timeout covers the tab mount,
+      // which React flushes synchronously before the browser acknowledges mouseup.
+      await this.anomaliesExpandablePanelTitleLink.click({ noWaitAfter: true, timeout: 30000 });
     }
     await this.anomaliesTab.waitFor({ state: 'visible' });
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_row_actions_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_row_actions_menu.test.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { AnomalyRowActionsMenu } from './anomaly_row_actions_menu';
+import type { AnomalyTableRowAction } from '../../../api/hooks/use_anomaly_table_row_actions';
+import { useAnomalyTableRowActions } from '../../../api/hooks/use_anomaly_table_row_actions';
+import type { TableRow } from './types';
+
+jest.mock('../../../api/hooks/use_anomaly_table_row_actions');
+
+const useAnomalyTableRowActionsMock = useAnomalyTableRowActions as jest.MockedFunction<
+  typeof useAnomalyTableRowActions
+>;
+
+const ACTIONS_BUTTON = 'entity-anomalies-table-row-actions-button';
+const ADD_TO_TIMELINE = 'entity-anomalies-table-row-action-add-to-timeline';
+const VIEW_IN_DISCOVER = 'entity-anomalies-table-row-action-view-in-discover';
+const VIEW_IN_SMV = 'entity-anomalies-table-row-action-view-in-single-metric-viewer';
+
+const row: TableRow = {
+  id: 'row-1',
+  jobId: 'job-1',
+  jobDisplayName: 'Spike in Logon Events',
+  recordId: 'record-1',
+  mitreTactics: ['Credential Access'],
+  timestamp: 1735689600000,
+  detectorIndex: 0,
+  baseline: '10 events',
+  anomaly: '100 events',
+  anomalyScore: 76,
+  description: 'Unusual logon activity',
+  anomalyCount: 1,
+  keyFields: ['host.name'],
+};
+
+const timeRange = { from: 'now-30d', to: 'now' };
+
+const addToTimeline = jest.fn();
+const viewInDiscover = jest.fn();
+const viewInSingleMetricViewer = jest.fn();
+
+const allActions: AnomalyTableRowAction[] = [
+  { key: 'add-to-timeline', label: 'Add to timeline', icon: 'timeline', onClick: addToTimeline },
+  {
+    key: 'view-in-discover',
+    label: 'View in Discover',
+    icon: 'productDiscover',
+    onClick: viewInDiscover,
+  },
+  {
+    key: 'view-in-single-metric-viewer',
+    label: 'View in Single metric viewer',
+    icon: 'singleMetricViewer',
+    onClick: viewInSingleMetricViewer,
+  },
+];
+
+const renderMenu = () =>
+  render(
+    <IntlProvider locale="en">
+      <AnomalyRowActionsMenu row={row} timeRange={timeRange} />
+    </IntlProvider>
+  );
+
+// EuiPopover positions its panel from a MutationObserver callback, so settle on the rendered
+// panel rather than returning straight after the click.
+const openMenu = async () => {
+  fireEvent.click(screen.getByTestId(ACTIONS_BUTTON));
+  await screen.findByTestId(VIEW_IN_DISCOVER);
+};
+
+describe('AnomalyRowActionsMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAnomalyTableRowActionsMock.mockReturnValue({ actions: allActions });
+  });
+
+  it('keeps the menu closed until the actions button is clicked', () => {
+    renderMenu();
+
+    expect(screen.getByTestId(ACTIONS_BUTTON)).toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_TIMELINE)).toBeNull();
+    expect(screen.queryByTestId(VIEW_IN_DISCOVER)).toBeNull();
+    expect(screen.queryByTestId(VIEW_IN_SMV)).toBeNull();
+  });
+
+  it('exposes the investigation actions when the actions button is clicked', async () => {
+    renderMenu();
+
+    await openMenu();
+
+    expect(screen.getByTestId(ADD_TO_TIMELINE)).toBeInTheDocument();
+    expect(screen.getByTestId(VIEW_IN_DISCOVER)).toBeInTheDocument();
+    expect(screen.getByTestId(VIEW_IN_SMV)).toBeInTheDocument();
+  });
+
+  it('labels each investigation action', async () => {
+    renderMenu();
+
+    await openMenu();
+
+    expect(screen.getByTestId(ADD_TO_TIMELINE)).toHaveTextContent('Add to timeline');
+    expect(screen.getByTestId(VIEW_IN_DISCOVER)).toHaveTextContent('View in Discover');
+    expect(screen.getByTestId(VIEW_IN_SMV)).toHaveTextContent('View in Single metric viewer');
+  });
+
+  it('renders only the actions the hook returns', async () => {
+    useAnomalyTableRowActionsMock.mockReturnValue({
+      actions: allActions.filter((action) => action.key === 'view-in-discover'),
+    });
+    renderMenu();
+
+    await openMenu();
+
+    expect(screen.getByTestId(VIEW_IN_DISCOVER)).toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_TIMELINE)).toBeNull();
+    expect(screen.queryByTestId(VIEW_IN_SMV)).toBeNull();
+  });
+
+  it('invokes the action handler when a menu item is clicked', async () => {
+    renderMenu();
+
+    await openMenu();
+    fireEvent.click(screen.getByTestId(ADD_TO_TIMELINE));
+
+    expect(addToTimeline).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives the actions hook the row, the time range and a way to close the menu', () => {
+    renderMenu();
+
+    expect(useAnomalyTableRowActionsMock).toHaveBeenCalledWith({
+      row,
+      timeRange,
+      closePopover: expect.any(Function),
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/entity_analytics/ui/parallel_tests/entity_analytics/entity_flyout_anomalies.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/entity_analytics/ui/parallel_tests/entity_analytics/entity_flyout_anomalies.spec.ts
@@ -190,16 +190,31 @@ spaceTest.describe(
     spaceTest(
       'host right panel shows an error state in the anomalies section when the anomaly overview API returns an error',
       async ({ page, pageObjects }) => {
-        await page.route(ANOMALY_OVERVIEW_ROUTE, (route) => route.fulfill({ status: 500 }));
+        // 400 is the only status useAnomalyOverview's retry predicate refuses to retry, so the
+        // query fails on the first response. Any retried status (e.g. 500) puts the section into
+        // a ~7s exponential backoff during which it renders the loading skeleton, and the
+        // backoff is not resumable: the query function consumes the abort signal, so React Query
+        // reverts the query to its pre-fetch `loading` state whenever the last observer
+        // unmounts. The section unmounts on any re-render that briefly drops
+        // `entityStoreEntityId` (it gates `loadAnomalies`), which restarts the whole chain and
+        // pushes the error state past the assertion timeout.
+        await page.route(ANOMALY_OVERVIEW_ROUTE, (route) =>
+          route.fulfill({
+            status: 400,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              statusCode: 400,
+              error: 'Bad Request',
+              message: 'Invalid anomaly overview request',
+            }),
+          })
+        );
 
         await pageObjects.entityFlyoutAnomaliesPage.navigateToHostRightPanel();
 
         await expect(pageObjects.entityFlyoutAnomaliesPage.anomaliesSection).toBeVisible();
-        // React Query retries failed requests 3 times with exponential backoff (~1s + 2s + 4s = ~7s)
-        // before setting isError, so we need more than the default 10s assertion timeout.
         await expect(pageObjects.entityFlyoutAnomaliesPage.anomaliesExpandablePanel).toContainText(
-          'Unable to load behavioral anomalies',
-          { timeout: 15000 }
+          'Unable to load behavioral anomalies'
         );
       }
     );
@@ -290,39 +305,6 @@ spaceTest.describe(
         await pageObjects.entityFlyoutAnomaliesPage.clickAnomaliesCountLink();
 
         await expect(pageObjects.entityFlyoutAnomaliesPage.anomaliesTab).toBeVisible();
-      }
-    );
-
-    spaceTest(
-      'anomalies table row actions menu exposes investigation actions',
-      async ({ page, pageObjects }) => {
-        await page.route(ANOMALY_OVERVIEW_ROUTE, async (route) => {
-          await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify(MOCK_ANOMALY_OVERVIEW_WITH_ANOMALIES),
-          });
-        });
-        await page.route(ANOMALY_SUMMARY_ROUTE, async (route) => {
-          await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify(MOCK_ANOMALY_SUMMARY),
-          });
-        });
-        await pageObjects.entityFlyoutAnomaliesPage.navigateToHostBothPanels();
-        await pageObjects.entityFlyoutAnomaliesPage.clickAnomaliesTab();
-        await pageObjects.entityFlyoutAnomaliesPage.openRowActionsMenu();
-
-        await expect(
-          pageObjects.entityFlyoutAnomaliesPage.getRowAction('add-to-timeline')
-        ).toBeVisible();
-        await expect(
-          pageObjects.entityFlyoutAnomaliesPage.getRowAction('view-in-discover')
-        ).toBeVisible();
-        await expect(
-          pageObjects.entityFlyoutAnomaliesPage.getRowAction('view-in-single-metric-viewer')
-        ).toBeVisible();
       }
     );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [fix flaky entity flyout anomalies test (#283664)](https://github.com/elastic/kibana/pull/283664)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-08-07T17:01:43Z","message":"fix flaky entity flyout anomalies test (#283664)\n\n## Summary\n\nFixes 3 flaky failures in `entity_flyout_anomalies.spec.ts` (the first\none has flakiness rate over 6%)\n\n`Error state test` : the mock returned a 500, which React Query retries\nfor ~7s while the loading skeleton stays up. Switched the mock to 400,\nthe one status the retry predicate skips, so the error renders right\naway. Dropped the 15s assertion timeout that was working around this.\n\n`Row actions menu test` : it only checked which items the popover\nrenders, which doesn't need a browser? Moved to\n`anomaly_row_actions_menu.test.tsx` (RTL) and deleted the Scout test.\nThe \"Add to timeline\" test still opens the menu for real, nothing is\nlost.\n\n`Anomalies count link test`: the click timed out even though the panel\nopened fine. `Theory`: React mounts the whole anomalies tab\nsynchronously before the browser acknowledges the click, and on a busy\nCI agent that takes longer than Scout's 10s action timeout. Gave that\none click 30s. No retries anywhere; the assertions are unchanged.\n\nNote: the last one buys time, it doesn't make the app faster. That tab\nmount blocks the main thread for real users too, and lazy-loading it is\nworth a separate look.\n\nTest plan\n\n- [ ] Flaky test runner, 30+ runs\n- [x] node scripts/jest\nx-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_row_actions_menu.test.tsx","sha":"8efa5247afc9e29cff883971e2c223f8c6768238","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","reviewer:scout","v9.6.0"],"title":"fix flaky entity flyout anomalies test","number":283664,"url":"https://github.com/elastic/kibana/pull/283664","mergeCommit":{"message":"fix flaky entity flyout anomalies test (#283664)\n\n## Summary\n\nFixes 3 flaky failures in `entity_flyout_anomalies.spec.ts` (the first\none has flakiness rate over 6%)\n\n`Error state test` : the mock returned a 500, which React Query retries\nfor ~7s while the loading skeleton stays up. Switched the mock to 400,\nthe one status the retry predicate skips, so the error renders right\naway. Dropped the 15s assertion timeout that was working around this.\n\n`Row actions menu test` : it only checked which items the popover\nrenders, which doesn't need a browser? Moved to\n`anomaly_row_actions_menu.test.tsx` (RTL) and deleted the Scout test.\nThe \"Add to timeline\" test still opens the menu for real, nothing is\nlost.\n\n`Anomalies count link test`: the click timed out even though the panel\nopened fine. `Theory`: React mounts the whole anomalies tab\nsynchronously before the browser acknowledges the click, and on a busy\nCI agent that takes longer than Scout's 10s action timeout. Gave that\none click 30s. No retries anywhere; the assertions are unchanged.\n\nNote: the last one buys time, it doesn't make the app faster. That tab\nmount blocks the main thread for real users too, and lazy-loading it is\nworth a separate look.\n\nTest plan\n\n- [ ] Flaky test runner, 30+ runs\n- [x] node scripts/jest\nx-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_row_actions_menu.test.tsx","sha":"8efa5247afc9e29cff883971e2c223f8c6768238"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283664","number":283664,"mergeCommit":{"message":"fix flaky entity flyout anomalies test (#283664)\n\n## Summary\n\nFixes 3 flaky failures in `entity_flyout_anomalies.spec.ts` (the first\none has flakiness rate over 6%)\n\n`Error state test` : the mock returned a 500, which React Query retries\nfor ~7s while the loading skeleton stays up. Switched the mock to 400,\nthe one status the retry predicate skips, so the error renders right\naway. Dropped the 15s assertion timeout that was working around this.\n\n`Row actions menu test` : it only checked which items the popover\nrenders, which doesn't need a browser? Moved to\n`anomaly_row_actions_menu.test.tsx` (RTL) and deleted the Scout test.\nThe \"Add to timeline\" test still opens the menu for real, nothing is\nlost.\n\n`Anomalies count link test`: the click timed out even though the panel\nopened fine. `Theory`: React mounts the whole anomalies tab\nsynchronously before the browser acknowledges the click, and on a busy\nCI agent that takes longer than Scout's 10s action timeout. Gave that\none click 30s. No retries anywhere; the assertions are unchanged.\n\nNote: the last one buys time, it doesn't make the app faster. That tab\nmount blocks the main thread for real users too, and lazy-loading it is\nworth a separate look.\n\nTest plan\n\n- [ ] Flaky test runner, 30+ runs\n- [x] node scripts/jest\nx-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_row_actions_menu.test.tsx","sha":"8efa5247afc9e29cff883971e2c223f8c6768238"}}]}] BACKPORT-->