### PR TITLE
[ES|QL] Supports double_range types

### DIFF
--- a/src/platform/packages/shared/kbn-esql-types/src/editor_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/editor_types.ts
@@ -47,6 +47,7 @@ export const esqlFieldTypes: readonly string[] = [
   'boolean',
   'date',
   'double',
+  'double_range',
   'ip',
   'keyword',
   'integer',

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/esql_fields_utils.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/esql_fields_utils.test.ts
@@ -55,6 +55,19 @@ describe('esql fields helpers', () => {
       expect(isESQLColumnSortable(flattenedField)).toBeFalsy();
     });
 
+    it('returns false for number_range fields', () => {
+      const rangeField = {
+        id: 'my_range',
+        name: 'my_range',
+        meta: {
+          type: 'number_range',
+          esType: 'double_range',
+        },
+        isNull: false,
+      } as DatatableColumn;
+      expect(isESQLColumnSortable(rangeField)).toBeFalsy();
+    });
+
     it('returns false for counter fields', () => {
       const tsdbField = {
         id: 'tsbd_counter',
@@ -122,6 +135,19 @@ describe('esql fields helpers', () => {
       expect(isESQLColumnGroupable(flattenedField)).toBeFalsy();
     });
 
+    it('returns false for number_range fields', () => {
+      const rangeField = {
+        id: 'my_range',
+        name: 'my_range',
+        meta: {
+          type: 'number_range',
+          esType: 'double_range',
+        },
+        isNull: false,
+      } as DatatableColumn;
+      expect(isESQLColumnGroupable(rangeField)).toBeFalsy();
+    });
+
     it('returns true for everything else', () => {
       const keywordField = {
         id: 'sortable',
@@ -169,6 +195,19 @@ describe('esql fields helpers', () => {
         name: 'my_flattened',
         type: 'flattened',
         esTypes: ['flattened'],
+        searchable: true,
+        aggregatable: false,
+        isNull: false,
+      };
+
+      expect(isESQLFieldGroupable(fieldSpec)).toBeFalsy();
+    });
+
+    it('returns false for number_range fields', () => {
+      const fieldSpec: FieldSpec = {
+        name: 'my_range',
+        type: 'number_range',
+        esTypes: ['double_range'],
         searchable: true,
         aggregatable: false,
         isNull: false,

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/esql_fields_utils.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/esql_fields_utils.ts
@@ -15,6 +15,7 @@ import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 const SPATIAL_FIELDS = ['geo_point', 'geo_shape', 'point', 'shape'];
 const SOURCE_FIELD = '_source';
 const FLATTENED_FIELD = 'flattened';
+const NUMBER_RANGE_FIELD = 'number_range';
 const TSDB_COUNTER_FIELDS_PREFIX = 'counter_';
 const UNKNOWN_FIELD = 'unknown';
 const HISTOGRAM_FIELDS = ['exponential_histogram', 'tdigest'];
@@ -42,6 +43,11 @@ export const isESQLColumnSortable = (column: DatatableColumn): boolean => {
     return false;
   }
 
+  // we don't allow sorting on range fields (objects with gte/lte)
+  if (column.meta?.type === NUMBER_RANGE_FIELD) {
+    return false;
+  }
+
   // we don't allow sorting on tsdb counter fields
   if (column.meta?.esType && column.meta?.esType?.indexOf(TSDB_COUNTER_FIELDS_PREFIX) !== -1) {
     return false;
@@ -66,6 +72,10 @@ const isGroupable = (type: string | undefined, esType: string | undefined): bool
   }
   // we don't allow grouping on flattened fields (rendered as JSON)
   if (type === FLATTENED_FIELD) {
+    return false;
+  }
+  // we don't allow grouping on range fields (objects with gte/lte)
+  if (type === NUMBER_RANGE_FIELD) {
     return false;
   }
   return true;

--- a/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
+++ b/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
@@ -55,6 +55,7 @@ export type DatatableColumnType =
   | 'nested'
   | 'histogram'
   | 'flattened'
+  | 'number_range'
   | 'null';
 
 /**


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/283827

ES|QL is ready to support double_range types, this PR just adds the support at the missing places.

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




