### PR TITLE
Skip Saved Objects test-mode fallback and ES startup on PRs without SO changes

### DIFF
--- a/.buildkite/scripts/steps/check_saved_objects.sh
+++ b/.buildkite/scripts/steps/check_saved_objects.sh
@@ -39,6 +39,20 @@ if is_pr; then
     SERVERLESS_BASELINE_FLAG=(--serverless-baseline "$GITHUB_SERVERLESS_RELEASE_SHA")
   fi
 
+  # On PRs, skip the synthetic test-mode rollback smoke (and the ES startup it requires)
+  # when no SO types changed. Keep it when the PR touches the check machinery itself, so
+  # such PRs still exercise the full migration test flow. If the diff cannot be computed,
+  # err on the side of running the full flow.
+  SKIP_TEST_FALLBACK_FLAG=(--skip-test-fallback)
+  if ! MACHINERY_CHANGES="$(git diff --name-only "$GITHUB_PR_MERGE_BASE"...HEAD -- \
+    'packages/kbn-check-saved-objects-cli' \
+    'src/core/packages/saved-objects' \
+    'src/core/packages/test-helpers/so-type-serializer')"; then
+    SKIP_TEST_FALLBACK_FLAG=()
+  elif [[ -n "$MACHINERY_CHANGES" ]]; then
+    SKIP_TEST_FALLBACK_FLAG=()
+  fi
+
   SO_REPORT_PATH="$(mktemp -t so-check-report.XXXXXX).json"
   CHECK_EXIT=0
 
@@ -46,10 +60,10 @@ if is_pr; then
     # The step might update files like removed_types.json and/or SO fixtures.
     # `check_for_changed_files` runs unconditionally so that any files produced by --fix
     # are auto-committed even when the check also reports non-fixable violations.
-    node scripts/check_saved_objects --baseline "$GITHUB_PR_MERGE_BASE" "${SERVERLESS_BASELINE_FLAG[@]}" --algorithm both --report-path "$SO_REPORT_PATH" --fix || CHECK_EXIT=$?
+    node scripts/check_saved_objects --baseline "$GITHUB_PR_MERGE_BASE" "${SERVERLESS_BASELINE_FLAG[@]}" "${SKIP_TEST_FALLBACK_FLAG[@]}" --algorithm both --report-path "$SO_REPORT_PATH" --fix || CHECK_EXIT=$?
     check_for_changed_files "node scripts/check_saved_objects" true
   else
-    node scripts/check_saved_objects --baseline "$GITHUB_PR_MERGE_BASE" "${SERVERLESS_BASELINE_FLAG[@]}" --algorithm both --report-path "$SO_REPORT_PATH" || CHECK_EXIT=$?
+    node scripts/check_saved_objects --baseline "$GITHUB_PR_MERGE_BASE" "${SERVERLESS_BASELINE_FLAG[@]}" "${SKIP_TEST_FALLBACK_FLAG[@]}" --algorithm both --report-path "$SO_REPORT_PATH" || CHECK_EXIT=$?
   fi
 
   echo --- Post Saved Objects PR comment

--- a/.buildkite/scripts/steps/check_saved_objects.sh
+++ b/.buildkite/scripts/steps/check_saved_objects.sh
@@ -39,10 +39,9 @@ if is_pr; then
     SERVERLESS_BASELINE_FLAG=(--serverless-baseline "$GITHUB_SERVERLESS_RELEASE_SHA")
   fi
 
-  # On PRs, skip the synthetic test-mode rollback smoke (and the ES startup it requires)
-  # when no SO types changed. Keep it when the PR touches the check machinery itself, so
-  # such PRs still exercise the full migration test flow. If the diff cannot be computed,
-  # err on the side of running the full flow.
+  # Run the synthetic test-mode rollback smoke even if no SO types changed when the PR
+  # touches the check machinery itself (or the diff cannot be computed). All other PRs
+  # pass --skip-test-fallback: no test-mode fallback, and no ES unless SO types changed.
   SKIP_TEST_FALLBACK_FLAG=(--skip-test-fallback)
   if ! MACHINERY_CHANGES="$(git diff --name-only "$GITHUB_PR_MERGE_BASE"...HEAD -- \
     'packages/kbn-check-saved-objects-cli' \

--- a/packages/kbn-check-saved-objects-cli/README.md
+++ b/packages/kbn-check-saved-objects-cli/README.md
@@ -16,6 +16,7 @@ On a PR, the step:
 
 1. **Resolves a baseline commit**: It uses the PR merge-base commit (`GITHUB_PR_MERGE_BASE`). Because a snapshot may not exist for that exact SHA, the script walks the commit’s parent chain (up to a limit) until it finds a commit for which a snapshot exists in the cloud bucket (`findExistingSnapshotSha`).
 2. **Runs the check**: It calls `node scripts/check_saved_objects --baseline <resolved-sha> --algorithm both` (and `--fix` when auto-commit is enabled). The script fetches the baseline snapshot from the bucket, starts Kibana to build the current type registry, and runs validations comparing current state to that baseline.
+3. **Skips the test-data fallback**: The step passes `--skip-test-fallback`, so when the PR does not change any SO types, the run finishes right after validation without starting Elasticsearch. The flag is omitted (full flow, including the synthetic rollback smoke test) when the PR touches the check machinery itself (`packages/kbn-check-saved-objects-cli`, `src/core/packages/saved-objects`, or `src/core/packages/test-helpers/so-type-serializer`). The on-merge pipeline always runs the full flow.
 
 ### Work-in-progress SO types
 
@@ -54,6 +55,7 @@ node scripts/check_saved_objects --baseline <gitRev> [--algorithm <v2|zdt|both>]
 | `--server` | Start Elasticsearch only and keep it running so you can run the check multiple times without restarting ES. |
 | `--client` | Do not start Elasticsearch; assume it is already running (e.g. from a previous `--server` run). Use with `--baseline` to run the validation. |
 | `--test` | Use a built-in test type registry and hardcoded snapshots instead of starting Kibana or fetching a baseline. No network or ES required. |
+| `--skip-test-fallback` | Disable the fallback to test data (see below). When no SO types changed, the run exits successfully right after validation, and Elasticsearch is only started if SO types actually changed (rollback tests need it). Used by the PR pipeline to keep the check cheap on unrelated PRs. |
 
 You must provide a baseline (e.g. `--baseline <sha>`) unless you use `--server`, `--client`, or `--test`.
 
@@ -100,3 +102,5 @@ Each `--client` run starts Kibana, runs the validation against the given baselin
 ### Fallback to test data (no SO type changes)
 
 When the logic detects that there are **no changes in existing Saved Object types** compared to the baseline, the script will fall back to running with test data (same behavior as passing `--test`). This allows smoke testing the migration logic with dummy SO types.
+
+Pass `--skip-test-fallback` to disable this fallback. In that case a run with no SO type changes never starts Elasticsearch and finishes right after validation. The PR pipeline uses this flag (unless the PR modifies the check machinery itself); the on-merge pipeline keeps the fallback so the migration test flow is still exercised on every merge to `main`.

--- a/packages/kbn-check-saved-objects-cli/src/commands/run_check_saved_objects_cli.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/run_check_saved_objects_cli.ts
@@ -64,8 +64,13 @@ export function runCheckSavedObjectsCli() {
       const server = flagsReader.boolean('server');
       const client = flagsReader.boolean('client');
       const test = flagsReader.boolean('test');
+      const skipTestFallback = flagsReader.boolean('skipTestFallback');
       const algorithmFlag = flagsReader.string('algorithm') ?? 'v2';
       const reportPath = flagsReader.string('reportPath');
+
+      // With '--skip-test-fallback' (normal mode only), ES is not started upfront:
+      // it is only needed for rollback tests, which run solely when SO types changed.
+      const lazyEsStart = skipTestFallback && !server && !client && !test;
 
       let migrationAlgorithms: MigrationAlgorithm[];
       if (algorithmFlag === 'both') {
@@ -139,7 +144,7 @@ export function runCheckSavedObjectsCli() {
             task: (ctx) => {
               ctx.esServer = startElasticsearch();
             },
-            enabled: !client, // we skip this step if '--client' is passed
+            enabled: !client && !lazyEsStart, // we skip this step if '--client' is passed
           },
           {
             title: `Wait for ES startup`,
@@ -192,8 +197,18 @@ export function runCheckSavedObjectsCli() {
             task: (ctx) => {
               ctx.test = true;
             },
-            enabled: !server && !test,
+            enabled: !server && !test && !skipTestFallback,
             skip: (ctx) => ctx.typesWithNewModelVersions.length > 0,
+          },
+          {
+            title: 'Start ES asynchronously (SO changes detected)',
+            task: (ctx) => {
+              ctx.esServer = startElasticsearch();
+            },
+            enabled: lazyEsStart,
+            skip: (ctx) =>
+              ctx.typesWithNewModelVersions.length === 0 &&
+              'No SO types gained model versions; rollback tests are not needed',
           },
           /**
            * ==================================================================
@@ -213,6 +228,7 @@ export function runCheckSavedObjectsCli() {
             title: 'Wait for ES startup',
             task: async (ctx) => await ctx.esServer,
             enabled: !server,
+            skip: (ctx) => !ctx.esServer && 'ES was not started; rollback tests are not needed',
           },
           {
             title: 'Automated rollback tests',
@@ -318,8 +334,9 @@ export function runCheckSavedObjectsCli() {
           baseline: 'gitRev',
           'serverless-baseline': 'serverlessGitRev',
           'report-path': 'reportPath',
+          'skip-test-fallback': 'skipTestFallback',
         },
-        boolean: ['fix', 'server', 'client', 'test'],
+        boolean: ['fix', 'server', 'client', 'test', 'skip-test-fallback', 'skipTestFallback'],
         string: ['gitRev', 'serverlessGitRev', 'algorithm', 'reportPath'],
         default: {
           verify: true,
@@ -332,6 +349,7 @@ export function runCheckSavedObjectsCli() {
         --server           Start ES in order to repeatedly execute the 'check_saved_objects' script
         --client           Do not start ES server (requires running the command above on a separate term)
         --test             Use a sample type registry with dummy types and hardcoded snapshots (no longer starts Kibana)
+        --skip-test-fallback  When no SO types changed, exit successfully without running the synthetic test-mode rollback smoke (also skips starting ES unless SO types changed)
         --algorithm <v2|zdt|both>  Migration algorithm to use for rollback tests (default: v2)
         --report-path <file>       Write a structured JSON report of changes and findings to this file
       `,


### PR DESCRIPTION
### Context

The `Check changes in Saved Objects` job checks whether a given PR changes any Saved Object types. It boots a real Kibana instance to see all the registered types, and compares them against how they looked on `main`.

### Improvement

The check also starts a real Elasticsearch instance to run upgrade + rollback migration tests on the types that changed, but this instance is only useful if any types changed at all (which isn't the case for most PRs).

* If a PR doesn't change types (most PRs) --> we don't start Elasticsearch.
* If a PR changes types --> we start Elasticsearch and run the real migration tests, same as before.

This change is expected to run the check in **4-5 mins instead of 8-12 mins in pull requests**.