### PR TITLE
[8.19] [js-yaml to yaml migration] @elastic/nightshift-context-and-research-team (#283668)

### DIFF
--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -55,7 +55,6 @@ const JS_YAML_LEGACY_CONSUMERS = [
   'x-pack/platform/plugins/shared/integration_assistant/server/util/samples.ts',
   'x-pack/solutions/observability/plugins/apm/scripts/shared/read_kibana_config.ts',
   'x-pack/solutions/observability/plugins/apm/server/routes/fleet/get_apm_package_policy_definition.ts',
-  'x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/read_kibana_config.ts',
   'x-pack/solutions/security/plugins/cloud_defend/common/utils/helpers.ts',
   'x-pack/solutions/security/plugins/cloud_defend/public/components/control_general_view/index.test.tsx',
   'x-pack/solutions/security/test/security_solution_playwright/api_utils/api_key.ts',

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/read_kibana_config.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/read_kibana_config.ts
@@ -7,7 +7,7 @@
 
 import path from 'path';
 import fs from 'fs';
-import yaml from 'js-yaml';
+import { parse } from 'yaml';
 import { identity, pickBy } from 'lodash';
 
 export type KibanaConfig = ReturnType<typeof readKibanaConfig>;
@@ -17,7 +17,7 @@ export const readKibanaConfig = () => {
   const kibanaDevConfig = path.join(kibanaConfigDir, 'kibana.dev.yml');
   const kibanaConfig = path.join(kibanaConfigDir, 'kibana.yml');
 
-  const loadedKibanaConfig = (yaml.load(
+  const loadedKibanaConfig = (parse(
     fs.readFileSync(fs.existsSync(kibanaDevConfig) ? kibanaDevConfig : kibanaConfig, 'utf8')
   ) || {}) as {};
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[js-yaml to yaml migration] @elastic/nightshift-context-and-research-team (#283668)](https://github.com/elastic/kibana/pull/283668)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-08-10T08:19:52Z","message":"[js-yaml to yaml migration] @elastic/nightshift-context-and-research-team (#283668)\n\n## Summary\n\nMigrates the 3 files owned by\n@elastic/nightshift-context-and-research-team from `js-yaml` to the\n`yaml` package as part of the incremental `js-yaml` dependency removal\ninitiative tracked in `JS_YAML_LEGACY_CONSUMERS` in\n`packages/kbn-eslint-config/.eslintrc.js`.\n\nCloses #283667\n\n### Files migrated\n\n| File | Change |\n|---|---|\n|\n`src/platform/packages/shared/kbn-edot-collector/src/read_kibana_config.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`x-pack/.../observability_ai_assistant_app/scripts/evaluation/read_kibana_config.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-edot-collector/src/get_edot_collector_configuration.ts`\n| `import yaml from 'js-yaml'` → `import { stringify } from 'yaml'`;\n`yaml.dump(...)` → `stringify(..., { schema: 'yaml-1.1', singleQuote:\ntrue })` |\n\n3 corresponding entries removed from `JS_YAML_LEGACY_CONSUMERS`. 24\nentries remain after this PR.\n\n### Why `import { parse } from 'yaml'` (not `loadYaml` from\n`@kbn/yaml-loader`)\n\n`loadYaml` is a lazy loader for browser bundles. All three files here\nare Node-side dev tooling — `@kbn/edot-collector` is `\"type\":\n\"shared-server\"` with `\"devOnly\": true`, and the third is an evaluation\nCLI script under `scripts/` — so a plain static import is correct.\n\nThe two config readers are also the same job Kibana's own config loader\nalready does:\n`src/platform/packages/shared/kbn-config/src/raw/read_config.ts` reads\nthe very same `kibana.dev.yml` with `parse` from `yaml`. This change\nbrings these readers in line with it.\n\n### Serializer parity (the one non-mechanical change)\n\n`getEdotCollectorConfiguration` output is written to disk and mounted\ninto the EDOT Collector container, so it is parsed by the collector's\n**Go** YAML parser, not by Kibana. That makes quoting semantically\nload-bearing in a way it isn't for the config readers.\n\n`js-yaml`'s `dump` defaults quote scalars that would be ambiguous under\nYAML 1.1 — a password of literal `yes` is emitted as `password: 'yes'`.\nThe `yaml` package defaults to the YAML 1.2 core schema, where `yes` is\nalready a string, so it emits `password: yes` unquoted. Anything\ndownstream that still resolves YAML 1.1 booleans would then read that\npassword as `true`.\n\nPassing `{ schema: 'yaml-1.1', singleQuote: true }` restores the\noriginal behaviour. This is the same approach Fleet uses in\n`common/services/full_agent_policy_to_yaml.ts`, which also serializes\nYAML for an agent-side consumer.\n\nOutput was diffed against `js-yaml` over a probe covering `yes` / `off`\n/ `0123456` / `1.2.3` / `2024-01-01` / `0.0.0.0:13133` /\n`metrics/aggregated` / `1s` / booleans / a password containing `@ * : #\n' \" \\`. With these options the two serializers are **byte-identical**.\nAcross six full collector configs (default creds, cloud endpoint, nasty\npassword, `yes` password, numeric-ish password, 200-char password), 5/6\nare byte-identical; the sixth differs only in how a 200-character\npassword is wrapped (`js-yaml` folds to a `>-` block scalar, `yaml`\ncontinues the plain scalar), which folds back to the identical string.\n\n**Value fidelity was checked in both directions** — for all six configs,\nthe output of each serializer parsed by each parser (`yaml.parse` and\n`jsYaml.load`, 24 combinations) deep-equals the original object: 0\nfailures. So YAML previously written by `js-yaml` still parses\nidentically, and the new output is readable by either library.\n\n## Test plan\n\nThere are no existing unit tests over these three files, so the changed\ncode paths were exercised directly via `node -r ./src/setup_node_env`:\n\n- [x] `getEdotCollectorConfiguration({ password: 'yes', ... })` → emits\n`password: 'yes'` and round-trips back as the string `\"yes\"` (not a\nboolean)\n- [x] `readKibanaConfig(log, <nested kibana.dev.yml>)` → returns the\nfile's `elasticsearch` values\n- [x] `readKibanaConfig(log, <missing path>)` → still logs the not-found\nwarning and falls back to defaults\n- [x] `parse(text)` deep-equals `jsYaml.load(text)` for both the nested\nand flat dotted-key config styles the two readers consume\n- [x] `node scripts/eslint <changed files>` — ✅ no errors (confirms the\nallowlist edit is correct and no `js-yaml` imports remain)\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-edot-collector/tsconfig.json` — ✅ exits\n0\n- [x] `node scripts/type_check --project\nx-pack/solutions/observability/plugins/observability_ai_assistant_app/tsconfig.json`\n— ✅ exits 0\n- [x] `node scripts/jest src/platform/packages/shared/kbn-otel-demo/` —\n✅ 146/146 passed (consumes `getEdotCollectorConfig`)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>","sha":"6ee12b6c6144cf1dee795deb7b6784007ba8af1a","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","backport:all-open","ci:project-deploy-observability","dependency-reduction","evals:smoke-tests","v9.6.0","Team:nightshift-context-and-research"],"title":"[js-yaml to yaml migration] @elastic/nightshift-context-and-research-team","number":283668,"url":"https://github.com/elastic/kibana/pull/283668","mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/nightshift-context-and-research-team (#283668)\n\n## Summary\n\nMigrates the 3 files owned by\n@elastic/nightshift-context-and-research-team from `js-yaml` to the\n`yaml` package as part of the incremental `js-yaml` dependency removal\ninitiative tracked in `JS_YAML_LEGACY_CONSUMERS` in\n`packages/kbn-eslint-config/.eslintrc.js`.\n\nCloses #283667\n\n### Files migrated\n\n| File | Change |\n|---|---|\n|\n`src/platform/packages/shared/kbn-edot-collector/src/read_kibana_config.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`x-pack/.../observability_ai_assistant_app/scripts/evaluation/read_kibana_config.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-edot-collector/src/get_edot_collector_configuration.ts`\n| `import yaml from 'js-yaml'` → `import { stringify } from 'yaml'`;\n`yaml.dump(...)` → `stringify(..., { schema: 'yaml-1.1', singleQuote:\ntrue })` |\n\n3 corresponding entries removed from `JS_YAML_LEGACY_CONSUMERS`. 24\nentries remain after this PR.\n\n### Why `import { parse } from 'yaml'` (not `loadYaml` from\n`@kbn/yaml-loader`)\n\n`loadYaml` is a lazy loader for browser bundles. All three files here\nare Node-side dev tooling — `@kbn/edot-collector` is `\"type\":\n\"shared-server\"` with `\"devOnly\": true`, and the third is an evaluation\nCLI script under `scripts/` — so a plain static import is correct.\n\nThe two config readers are also the same job Kibana's own config loader\nalready does:\n`src/platform/packages/shared/kbn-config/src/raw/read_config.ts` reads\nthe very same `kibana.dev.yml` with `parse` from `yaml`. This change\nbrings these readers in line with it.\n\n### Serializer parity (the one non-mechanical change)\n\n`getEdotCollectorConfiguration` output is written to disk and mounted\ninto the EDOT Collector container, so it is parsed by the collector's\n**Go** YAML parser, not by Kibana. That makes quoting semantically\nload-bearing in a way it isn't for the config readers.\n\n`js-yaml`'s `dump` defaults quote scalars that would be ambiguous under\nYAML 1.1 — a password of literal `yes` is emitted as `password: 'yes'`.\nThe `yaml` package defaults to the YAML 1.2 core schema, where `yes` is\nalready a string, so it emits `password: yes` unquoted. Anything\ndownstream that still resolves YAML 1.1 booleans would then read that\npassword as `true`.\n\nPassing `{ schema: 'yaml-1.1', singleQuote: true }` restores the\noriginal behaviour. This is the same approach Fleet uses in\n`common/services/full_agent_policy_to_yaml.ts`, which also serializes\nYAML for an agent-side consumer.\n\nOutput was diffed against `js-yaml` over a probe covering `yes` / `off`\n/ `0123456` / `1.2.3` / `2024-01-01` / `0.0.0.0:13133` /\n`metrics/aggregated` / `1s` / booleans / a password containing `@ * : #\n' \" \\`. With these options the two serializers are **byte-identical**.\nAcross six full collector configs (default creds, cloud endpoint, nasty\npassword, `yes` password, numeric-ish password, 200-char password), 5/6\nare byte-identical; the sixth differs only in how a 200-character\npassword is wrapped (`js-yaml` folds to a `>-` block scalar, `yaml`\ncontinues the plain scalar), which folds back to the identical string.\n\n**Value fidelity was checked in both directions** — for all six configs,\nthe output of each serializer parsed by each parser (`yaml.parse` and\n`jsYaml.load`, 24 combinations) deep-equals the original object: 0\nfailures. So YAML previously written by `js-yaml` still parses\nidentically, and the new output is readable by either library.\n\n## Test plan\n\nThere are no existing unit tests over these three files, so the changed\ncode paths were exercised directly via `node -r ./src/setup_node_env`:\n\n- [x] `getEdotCollectorConfiguration({ password: 'yes', ... })` → emits\n`password: 'yes'` and round-trips back as the string `\"yes\"` (not a\nboolean)\n- [x] `readKibanaConfig(log, <nested kibana.dev.yml>)` → returns the\nfile's `elasticsearch` values\n- [x] `readKibanaConfig(log, <missing path>)` → still logs the not-found\nwarning and falls back to defaults\n- [x] `parse(text)` deep-equals `jsYaml.load(text)` for both the nested\nand flat dotted-key config styles the two readers consume\n- [x] `node scripts/eslint <changed files>` — ✅ no errors (confirms the\nallowlist edit is correct and no `js-yaml` imports remain)\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-edot-collector/tsconfig.json` — ✅ exits\n0\n- [x] `node scripts/type_check --project\nx-pack/solutions/observability/plugins/observability_ai_assistant_app/tsconfig.json`\n— ✅ exits 0\n- [x] `node scripts/jest src/platform/packages/shared/kbn-otel-demo/` —\n✅ 146/146 passed (consumes `getEdotCollectorConfig`)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>","sha":"6ee12b6c6144cf1dee795deb7b6784007ba8af1a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283668","number":283668,"mergeCommit":{"message":"[js-yaml to yaml migration] @elastic/nightshift-context-and-research-team (#283668)\n\n## Summary\n\nMigrates the 3 files owned by\n@elastic/nightshift-context-and-research-team from `js-yaml` to the\n`yaml` package as part of the incremental `js-yaml` dependency removal\ninitiative tracked in `JS_YAML_LEGACY_CONSUMERS` in\n`packages/kbn-eslint-config/.eslintrc.js`.\n\nCloses #283667\n\n### Files migrated\n\n| File | Change |\n|---|---|\n|\n`src/platform/packages/shared/kbn-edot-collector/src/read_kibana_config.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`x-pack/.../observability_ai_assistant_app/scripts/evaluation/read_kibana_config.ts`\n| `import yaml from 'js-yaml'` → `import { parse } from 'yaml'`;\n`yaml.load(...)` → `parse(...)` |\n|\n`src/platform/packages/shared/kbn-edot-collector/src/get_edot_collector_configuration.ts`\n| `import yaml from 'js-yaml'` → `import { stringify } from 'yaml'`;\n`yaml.dump(...)` → `stringify(..., { schema: 'yaml-1.1', singleQuote:\ntrue })` |\n\n3 corresponding entries removed from `JS_YAML_LEGACY_CONSUMERS`. 24\nentries remain after this PR.\n\n### Why `import { parse } from 'yaml'` (not `loadYaml` from\n`@kbn/yaml-loader`)\n\n`loadYaml` is a lazy loader for browser bundles. All three files here\nare Node-side dev tooling — `@kbn/edot-collector` is `\"type\":\n\"shared-server\"` with `\"devOnly\": true`, and the third is an evaluation\nCLI script under `scripts/` — so a plain static import is correct.\n\nThe two config readers are also the same job Kibana's own config loader\nalready does:\n`src/platform/packages/shared/kbn-config/src/raw/read_config.ts` reads\nthe very same `kibana.dev.yml` with `parse` from `yaml`. This change\nbrings these readers in line with it.\n\n### Serializer parity (the one non-mechanical change)\n\n`getEdotCollectorConfiguration` output is written to disk and mounted\ninto the EDOT Collector container, so it is parsed by the collector's\n**Go** YAML parser, not by Kibana. That makes quoting semantically\nload-bearing in a way it isn't for the config readers.\n\n`js-yaml`'s `dump` defaults quote scalars that would be ambiguous under\nYAML 1.1 — a password of literal `yes` is emitted as `password: 'yes'`.\nThe `yaml` package defaults to the YAML 1.2 core schema, where `yes` is\nalready a string, so it emits `password: yes` unquoted. Anything\ndownstream that still resolves YAML 1.1 booleans would then read that\npassword as `true`.\n\nPassing `{ schema: 'yaml-1.1', singleQuote: true }` restores the\noriginal behaviour. This is the same approach Fleet uses in\n`common/services/full_agent_policy_to_yaml.ts`, which also serializes\nYAML for an agent-side consumer.\n\nOutput was diffed against `js-yaml` over a probe covering `yes` / `off`\n/ `0123456` / `1.2.3` / `2024-01-01` / `0.0.0.0:13133` /\n`metrics/aggregated` / `1s` / booleans / a password containing `@ * : #\n' \" \\`. With these options the two serializers are **byte-identical**.\nAcross six full collector configs (default creds, cloud endpoint, nasty\npassword, `yes` password, numeric-ish password, 200-char password), 5/6\nare byte-identical; the sixth differs only in how a 200-character\npassword is wrapped (`js-yaml` folds to a `>-` block scalar, `yaml`\ncontinues the plain scalar), which folds back to the identical string.\n\n**Value fidelity was checked in both directions** — for all six configs,\nthe output of each serializer parsed by each parser (`yaml.parse` and\n`jsYaml.load`, 24 combinations) deep-equals the original object: 0\nfailures. So YAML previously written by `js-yaml` still parses\nidentically, and the new output is readable by either library.\n\n## Test plan\n\nThere are no existing unit tests over these three files, so the changed\ncode paths were exercised directly via `node -r ./src/setup_node_env`:\n\n- [x] `getEdotCollectorConfiguration({ password: 'yes', ... })` → emits\n`password: 'yes'` and round-trips back as the string `\"yes\"` (not a\nboolean)\n- [x] `readKibanaConfig(log, <nested kibana.dev.yml>)` → returns the\nfile's `elasticsearch` values\n- [x] `readKibanaConfig(log, <missing path>)` → still logs the not-found\nwarning and falls back to defaults\n- [x] `parse(text)` deep-equals `jsYaml.load(text)` for both the nested\nand flat dotted-key config styles the two readers consume\n- [x] `node scripts/eslint <changed files>` — ✅ no errors (confirms the\nallowlist edit is correct and no `js-yaml` imports remain)\n- [x] `node scripts/type_check --project\nsrc/platform/packages/shared/kbn-edot-collector/tsconfig.json` — ✅ exits\n0\n- [x] `node scripts/type_check --project\nx-pack/solutions/observability/plugins/observability_ai_assistant_app/tsconfig.json`\n— ✅ exits 0\n- [x] `node scripts/jest src/platform/packages/shared/kbn-otel-demo/` —\n✅ 146/146 passed (consumes `getEdotCollectorConfig`)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>","sha":"6ee12b6c6144cf1dee795deb7b6784007ba8af1a"}},{"url":"https://github.com/elastic/kibana/pull/283849","number":283849,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/283850","number":283850,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->