### PR TITLE
[ES|QL] Support `LOAD_ALL` as `unmapped_fields` setting value

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/settings.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/settings.test.ts
@@ -41,6 +41,12 @@ describe('getUnmappedFieldsStrategy', () => {
     expect(strategy).toBe(UnmappedFieldsStrategy.LOAD);
   });
 
+  it('should return the LOAD_ALL strategy based on the unmapped_fields setting', () => {
+    const headers = [synth.header`SET unmapped_fields = "LOAD_ALL"`];
+    const strategy = getUnmappedFieldsStrategy(headers);
+    expect(strategy).toBe(UnmappedFieldsStrategy.LOAD_ALL);
+  });
+
   it('should return the NULLIFY strategy based on the unmapped_fields setting', () => {
     const headers = [synth.header`SET unmapped_fields = "NULLIFY"`];
     const strategy = getUnmappedFieldsStrategy(headers);

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/settings.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/settings.ts
@@ -10,7 +10,11 @@
 import type { ESQLAstHeaderCommand, ESQLAstSetHeaderCommand } from '@elastic/esql/types';
 import { isBinaryExpression, isIdentifier, isMap, isStringLiteral } from '@elastic/esql';
 import { withAutoSuggest } from '../../../..';
-import { UnmappedFieldsStrategy, type ISuggestionItem } from '../../registry/types';
+import {
+  isUnmappedFieldsStrategy,
+  UnmappedFieldsStrategy,
+  type ISuggestionItem,
+} from '../../registry/types';
 import { SuggestionCategory } from '../../../language/autocomplete/utils/sorting/types';
 import { EsqlSettingNames, settings } from '../generated/settings';
 
@@ -59,13 +63,6 @@ function getSettingData(settingCommand: ESQLAstSetHeaderCommand): {
     settingName,
     settingValue,
   };
-}
-
-export function isUnmappedFieldsStrategy(
-  value: string | undefined
-): value is UnmappedFieldsStrategy {
-  if (!value) return false;
-  return (Object.values(UnmappedFieldsStrategy) as string[]).includes(value);
 }
 
 /**

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/settings.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/settings.ts
@@ -61,6 +61,13 @@ function getSettingData(settingCommand: ESQLAstSetHeaderCommand): {
   };
 }
 
+export function isUnmappedFieldsStrategy(
+  value: string | undefined
+): value is UnmappedFieldsStrategy {
+  if (!value) return false;
+  return (Object.values(UnmappedFieldsStrategy) as string[]).includes(value);
+}
+
 /**
  * Checks the headers commmands looking for an unmapped_fields setting and returns its strategy value.
  * Default is DEFAULT.
@@ -74,13 +81,9 @@ export function getUnmappedFieldsStrategy(
     if (comand.name.toUpperCase() === 'SET') {
       const { settingName, settingValue } = getSettingData(comand as ESQLAstSetHeaderCommand);
       if (settingName?.toUpperCase() === EsqlSettingNames.UNMAPPED_FIELDS.toUpperCase()) {
-        switch (settingValue?.toUpperCase()) {
-          case UnmappedFieldsStrategy.NULLIFY:
-            unmappedFieldsStrategy = UnmappedFieldsStrategy.NULLIFY;
-            break;
-          case UnmappedFieldsStrategy.LOAD:
-            unmappedFieldsStrategy = UnmappedFieldsStrategy.LOAD;
-            break;
+        const normalized = settingValue?.toUpperCase();
+        if (normalized && isUnmappedFieldsStrategy(normalized)) {
+          unmappedFieldsStrategy = normalized;
         }
       }
     }
@@ -94,6 +97,7 @@ export function getUnmappedFieldsStrategy(
 export function getUnmappedFieldType(unmappedFieldsStrategy: UnmappedFieldsStrategy): string {
   switch (unmappedFieldsStrategy) {
     case UnmappedFieldsStrategy.LOAD:
+    case UnmappedFieldsStrategy.LOAD_ALL:
       return 'keyword';
     case UnmappedFieldsStrategy.NULLIFY:
       return 'null';

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/column.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/column.ts
@@ -14,6 +14,7 @@ import { errors, getMessageFromId } from '../errors';
 import { getColumnExists, getColumnName } from '../columns';
 import { getExpressionType } from '../expressions';
 import type { ESQLMessage } from '../../types';
+import { isUnmappedFieldsStrategy } from '../settings';
 
 interface ColumnValidationOptions {
   skipUnsupportedOrConflictingColumnValidation?: boolean;
@@ -91,8 +92,8 @@ export class ColumnValidator {
   private get isUnmappedColumnAllowed(): boolean {
     const unmappedFieldsStrategy = this.context.unmappedFieldsStrategy;
     return (
-      unmappedFieldsStrategy === UnmappedFieldsStrategy.LOAD ||
-      unmappedFieldsStrategy === UnmappedFieldsStrategy.NULLIFY
+      isUnmappedFieldsStrategy(unmappedFieldsStrategy) &&
+      unmappedFieldsStrategy !== UnmappedFieldsStrategy.DEFAULT
     );
   }
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/column.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/column.ts
@@ -9,12 +9,15 @@
 
 import type { ESQLColumn, ESQLIdentifier, ESQLSingleAstItem } from '@elastic/esql/types';
 import { isParametrized } from '@elastic/esql';
-import { UnmappedFieldsStrategy, type ICommandContext } from '../../../registry/types';
+import {
+  isUnmappedFieldsStrategy,
+  UnmappedFieldsStrategy,
+  type ICommandContext,
+} from '../../../registry/types';
 import { errors, getMessageFromId } from '../errors';
 import { getColumnExists, getColumnName } from '../columns';
 import { getExpressionType } from '../expressions';
 import type { ESQLMessage } from '../../types';
-import { isUnmappedFieldsStrategy } from '../settings';
 
 interface ColumnValidationOptions {
   skipUnsupportedOrConflictingColumnValidation?: boolean;

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/eval/columns_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/eval/columns_after.test.ts
@@ -192,6 +192,27 @@ describe('EVAL > columnsAfter', () => {
     ]);
   });
 
+  it('handles unmapped field with LOAD_ALL strategy', () => {
+    const command = synth.cmd`EVAL newField = unmappedField`;
+    const result = columnsAfter(
+      command,
+      baseColumns,
+      '',
+      additionalFieldsMock,
+      UnmappedFieldsStrategy.LOAD_ALL
+    );
+
+    expect(result).toEqual([
+      {
+        name: 'newField',
+        type: 'keyword',
+        location: { min: 0, max: 0 },
+        userDefined: true,
+      },
+      ...baseColumns,
+    ]);
+  });
+
   it('handles unmapped field with NULLIFY strategy', () => {
     const command = synth.cmd`EVAL newField = unmappedField`;
     const result = columnsAfter(

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/set/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/set/utils.ts
@@ -73,7 +73,7 @@ const getUnmappedFieldsCompletionItems = (): ISuggestionItem[] => {
       kind: 'Value',
       detail: i18n.translate('kbn-esql-language.esql.autocomplete.set.unmappedFields.loadDoc', {
         defaultMessage:
-          'Attempts to load the fields from the source that are explicity mentioned in the query',
+          'Attempts to load the fields from the source that are explicitly mentioned in the query',
       }),
       category: SuggestionCategory.CONSTANT_VALUE,
     },

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/set/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/set/utils.ts
@@ -72,10 +72,22 @@ const getUnmappedFieldsCompletionItems = (): ISuggestionItem[] => {
       text: UnmappedFieldsStrategy.LOAD,
       kind: 'Value',
       detail: i18n.translate('kbn-esql-language.esql.autocomplete.set.unmappedFields.loadDoc', {
-        defaultMessage: 'Attempts to load the fields from the source',
+        defaultMessage:
+          'Attempts to load the fields from the source that are explicity mentioned in the query',
       }),
       category: SuggestionCategory.CONSTANT_VALUE,
     },
+    // Currently LOAD_ALL is only supported in snapshots.
+    // {
+    //   label: UnmappedFieldsStrategy.LOAD_ALL,
+    //   text: UnmappedFieldsStrategy.LOAD_ALL,
+    //   kind: 'Value',
+    //   detail: i18n.translate('kbn-esql-language.esql.autocomplete.set.unmappedFields.loadAllDoc', {
+    //     defaultMessage:
+    //       'Attempts to load all the fields from the source, even if they are not mentioned in the query',
+    //   }),
+    //   category: SuggestionCategory.CONSTANT_VALUE,
+    // },
   ];
 };
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/types.ts
@@ -340,4 +340,5 @@ export enum UnmappedFieldsStrategy {
   DEFAULT = 'DEFAULT',
   NULLIFY = 'NULLIFY',
   LOAD = 'LOAD',
+  LOAD_ALL = 'LOAD_ALL',
 }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/types.ts
@@ -342,3 +342,11 @@ export enum UnmappedFieldsStrategy {
   LOAD = 'LOAD',
   LOAD_ALL = 'LOAD_ALL',
 }
+const UNMAPPED_FIELD_STRATEGIES = new Set<string>(Object.values(UnmappedFieldsStrategy));
+
+export function isUnmappedFieldsStrategy(
+  value: string | undefined
+): value is UnmappedFieldsStrategy {
+  if (!value) return false;
+  return UNMAPPED_FIELD_STRATEGIES.has(value);
+}


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/280652
## Summary
- Adds support to `LOAD_ALL` unmapped_field setting.
- It allows to get back all unmapped fields even if not referenced in the query.
- Editor wise, it behaves the same way as 'LOAD'.
- Suggestion of the `LOAD_ALL`  value is disabled as it's only available in snapshots, we should uncomment it when available.

### Screenshots
<img width="1214" height="294" alt="image" src="https://github.com/user-attachments/assets/df0bf835-ce53-41a2-a3e6-2d6faa0abd01" />

<img width="1213" height="599" alt="image" src="https://github.com/user-attachments/assets/ac88b4b5-10a6-4a1a-b7b9-84cfb16e422e" />

### How to test
* Create an index with unmapped fields.
```
PUT /my-index
{
  "mappings": {
    "dynamic": false, <---
    "properties": {
      "title": { "type": "keyword" }
    }
  }
}


POST /my-index/_doc
{
  "title": "hello",
  "unmapped_a": "foo",
  "unmapped_b": 42
}
```

* Run 
```
SET unmapped_fields = "LOAD_ALL";
FROM my-index 
| WHERE unmapped_a == "foo"
```

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


