### PR TITLE
[CI] Exclude Scout/FTR test-tree changes from Cypress suite triggers

### DIFF
--- a/.buildkite/pipeline-utils/affected-packages/utils.ts
+++ b/.buildkite/pipeline-utils/affected-packages/utils.ts
@@ -12,10 +12,10 @@ import { Minimatch } from 'minimatch';
 // Don't annotate the return type as `Minimatch[]`: the installed
 // @types/minimatch exports `Minimatch` as a value (not a type), and ts-node
 // will reject it. Inference + `ReturnType` keeps the file ts-node-clean.
-const compileMatchers = (patterns: readonly string[]) =>
+export const compileMatchers = (patterns: readonly string[]) =>
   patterns.map((p) => new Minimatch(p, { dot: true }));
 
-const matchesAny = (file: string, matchers: ReturnType<typeof compileMatchers>): boolean =>
+export const matchesAny = (file: string, matchers: ReturnType<typeof compileMatchers>): boolean =>
   matchers.some((m) => m.match(file));
 
 /**

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.test.ts
@@ -7,121 +7,58 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { isCypressSkippableDiff } from './selective_cypress';
+import { isCypressRelevantPath } from './selective_cypress';
 
-describe('isCypressSkippableDiff', () => {
-  it('returns false for an empty diff (no signal)', () => {
-    expect(isCypressSkippableDiff([])).toBe(false);
+describe('isCypressRelevantPath', () => {
+  describe('irrelevant paths (cannot affect Cypress)', () => {
+    it.each([
+      // Scout test trees (fixtures included — Cypress can't import Scout fixtures)
+      'x-pack/solutions/security/plugins/security_solution/test/scout/detection_engine/ui/tests/foo.spec.ts',
+      'src/platform/plugins/shared/discover/test/scout/ui/fixtures/page_objects/landing.ts',
+      'src/platform/plugins/shared/discover/test/scout/.meta/ui/standard.json',
+      'src/core/test/scout/api/tests/ui_settings_crud.spec.ts',
+      'x-pack/solutions/security/plugins/cloud_security_posture/test/scout_with_setup/ui/tests/findings.spec.ts',
+      // FTR test trees
+      'x-pack/platform/test/functional/apps/index_management/home_page.ts',
+      'x-pack/solutions/security/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts',
+      'x-pack/solutions/observability/test/api_integration/apis/slo/create_slo.ts',
+      'src/platform/test/api_integration/apis/status/status.ts',
+      'x-pack/platform/test/serverless/functional/test_suites/console/console.ts',
+      // FTR manifests only drive the Jest/FTR orchestrator
+      '.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml',
+      // Documentation noise (consistent with skip_ci_on_only_changed)
+      'README.md',
+      'docs/extend/testing/scout-best-practices.md',
+      'x-pack/solutions/security/plugins/security_solution/README.md',
+    ])('%s', (path) => {
+      expect(isCypressRelevantPath(path)).toBe(false);
+    });
   });
 
-  it('returns true for a Scout-tests-only diff', () => {
-    expect(
-      isCypressSkippableDiff([
-        'x-pack/solutions/security/plugins/security_solution/test/scout/detection_engine/ui/tests/foo.spec.ts',
-      ])
-    ).toBe(true);
-  });
-
-  it('returns true for Scout fixtures (not importable from Cypress, unlike other plugins)', () => {
-    expect(
-      isCypressSkippableDiff([
-        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/page_objects/landing.ts',
-      ])
-    ).toBe(true);
-  });
-
-  it('returns true for an FTR-only diff', () => {
-    expect(
-      isCypressSkippableDiff([
-        'x-pack/platform/test/functional/apps/index_management/home_page.ts',
-        'x-pack/solutions/security/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts',
-        'src/platform/test/api_integration/apis/status/status.ts',
-      ])
-    ).toBe(true);
-  });
-
-  it('returns true for a mixed Scout + FTR diff (e.g. an FTR-to-Scout migration)', () => {
-    expect(
-      isCypressSkippableDiff([
-        'x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/data_streams.spec.ts',
-        'x-pack/platform/test/functional/apps/index_management/data_streams.ts',
-        '.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml',
-      ])
-    ).toBe(true);
-  });
-
-  it('treats README / *.md / CHANGELOG as noise (still true if every other file is in scope)', () => {
-    expect(
-      isCypressSkippableDiff([
-        'x-pack/platform/test/functional/apps/index_management/README.md',
-        'x-pack/platform/test/functional/apps/index_management/home_page.ts',
-      ])
-    ).toBe(true);
-  });
-
-  it('returns false when the diff is noise-only (no test-tree signal)', () => {
-    expect(
-      isCypressSkippableDiff(['README.md', 'docs/extend/testing/scout-best-practices.md'])
-    ).toBe(false);
-  });
-
-  it('returns false when plugin source code changes alongside tests', () => {
-    expect(
-      isCypressSkippableDiff([
-        'x-pack/platform/test/functional/apps/index_management/home_page.ts',
-        'x-pack/solutions/security/plugins/security_solution/public/app/index.tsx',
-      ])
-    ).toBe(false);
-  });
-
-  it('returns false for changes inside Cypress trees under the FTR roots', () => {
-    expect(
-      isCypressSkippableDiff([
-        'x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/host_details.cy.ts',
-      ])
-    ).toBe(false);
-    expect(
-      isCypressSkippableDiff(['x-pack/solutions/security/test/osquery_cypress/runner.ts'])
-    ).toBe(false);
-    expect(
-      isCypressSkippableDiff(['x-pack/solutions/security/test/defend_workflows_cypress/config.ts'])
-    ).toBe(false);
-    expect(isCypressSkippableDiff(['x-pack/platform/test/fleet_cypress/cli_config.ts'])).toBe(
-      false
-    );
-  });
-
-  it('returns false for shared fixtures (es archives are loaded by Cypress es_archiver tasks)', () => {
-    expect(
-      isCypressSkippableDiff([
-        'x-pack/solutions/security/test/fixtures/es_archives/security_solution/alerts/data.json.gz',
-      ])
-    ).toBe(false);
-    expect(
-      isCypressSkippableDiff(['x-pack/platform/test/fixtures/es_archives/logstash/data.json.gz'])
-    ).toBe(false);
-  });
-
-  it('returns false for shared FTR config bases consumed by the Cypress FTR-runner configs', () => {
-    expect(isCypressSkippableDiff(['x-pack/platform/test/functional/config.base.ts'])).toBe(false);
-    expect(
-      isCypressSkippableDiff(['x-pack/platform/test/functional/services/ml/security_common.ts'])
-    ).toBe(false);
-    expect(isCypressSkippableDiff(['x-pack/platform/test/functional/page_objects/index.ts'])).toBe(
-      false
-    );
-    expect(isCypressSkippableDiff(['x-pack/platform/test/serverless/shared/config.base.ts'])).toBe(
-      false
-    );
-    expect(isCypressSkippableDiff(['src/platform/test/common/config.js'])).toBe(false);
-  });
-
-  it('returns false when a skippable file is mixed with a Cypress-relevant one', () => {
-    expect(
-      isCypressSkippableDiff([
-        'x-pack/platform/test/functional/apps/index_management/home_page.ts',
-        'x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/login.ts',
-      ])
-    ).toBe(false);
+  describe('relevant paths (must keep Cypress suites on)', () => {
+    it.each([
+      // Plugin source code
+      'x-pack/solutions/security/plugins/security_solution/public/app/index.tsx',
+      'src/platform/plugins/shared/discover/public/application/main.tsx',
+      // Cypress trees under the FTR roots
+      'x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/host_details.cy.ts',
+      'x-pack/solutions/security/test/osquery_cypress/runner.ts',
+      'x-pack/solutions/security/test/defend_workflows_cypress/config.ts',
+      'x-pack/platform/test/fleet_cypress/cli_config.ts',
+      // Shared fixtures (es archives are loaded by Cypress es_archiver tasks)
+      'x-pack/solutions/security/test/fixtures/es_archives/security_solution/alerts/data.json.gz',
+      'x-pack/platform/test/fixtures/es_archives/logstash/data.json.gz',
+      // Shared FTR config bases consumed by the Cypress FTR-runner configs
+      'x-pack/platform/test/functional/config.base.ts',
+      'x-pack/platform/test/functional/services/ml/security_common.ts',
+      'x-pack/platform/test/functional/page_objects/index.ts',
+      'x-pack/platform/test/serverless/shared/config.base.ts',
+      'src/platform/test/common/config.js',
+      // Anything unrecognised stays relevant
+      'package.json',
+      '.buildkite/pipelines/pull_request/security_solution/explore.yml',
+    ])('%s', (path) => {
+      expect(isCypressRelevantPath(path)).toBe(true);
+    });
   });
 });

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isCypressSkippableDiff } from './selective_cypress';
+
+describe('isCypressSkippableDiff', () => {
+  it('returns false for an empty diff (no signal)', () => {
+    expect(isCypressSkippableDiff([])).toBe(false);
+  });
+
+  it('returns true for a Scout-tests-only diff', () => {
+    expect(
+      isCypressSkippableDiff([
+        'x-pack/solutions/security/plugins/security_solution/test/scout/detection_engine/ui/tests/foo.spec.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for Scout fixtures (not importable from Cypress, unlike other plugins)', () => {
+    expect(
+      isCypressSkippableDiff([
+        'src/platform/plugins/shared/discover/test/scout/ui/fixtures/page_objects/landing.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for an FTR-only diff', () => {
+    expect(
+      isCypressSkippableDiff([
+        'x-pack/platform/test/functional/apps/index_management/home_page.ts',
+        'x-pack/solutions/security/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts',
+        'src/platform/test/api_integration/apis/status/status.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for a mixed Scout + FTR diff (e.g. an FTR-to-Scout migration)', () => {
+    expect(
+      isCypressSkippableDiff([
+        'x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/data_streams.spec.ts',
+        'x-pack/platform/test/functional/apps/index_management/data_streams.ts',
+        '.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml',
+      ])
+    ).toBe(true);
+  });
+
+  it('treats README / *.md / CHANGELOG as noise (still true if every other file is in scope)', () => {
+    expect(
+      isCypressSkippableDiff([
+        'x-pack/platform/test/functional/apps/index_management/README.md',
+        'x-pack/platform/test/functional/apps/index_management/home_page.ts',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false when the diff is noise-only (no test-tree signal)', () => {
+    expect(
+      isCypressSkippableDiff(['README.md', 'docs/extend/testing/scout-best-practices.md'])
+    ).toBe(false);
+  });
+
+  it('returns false when plugin source code changes alongside tests', () => {
+    expect(
+      isCypressSkippableDiff([
+        'x-pack/platform/test/functional/apps/index_management/home_page.ts',
+        'x-pack/solutions/security/plugins/security_solution/public/app/index.tsx',
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false for changes inside Cypress trees under the FTR roots', () => {
+    expect(
+      isCypressSkippableDiff([
+        'x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/host_details.cy.ts',
+      ])
+    ).toBe(false);
+    expect(
+      isCypressSkippableDiff(['x-pack/solutions/security/test/osquery_cypress/runner.ts'])
+    ).toBe(false);
+    expect(
+      isCypressSkippableDiff(['x-pack/solutions/security/test/defend_workflows_cypress/config.ts'])
+    ).toBe(false);
+    expect(isCypressSkippableDiff(['x-pack/platform/test/fleet_cypress/cli_config.ts'])).toBe(
+      false
+    );
+  });
+
+  it('returns false for shared fixtures (es archives are loaded by Cypress es_archiver tasks)', () => {
+    expect(
+      isCypressSkippableDiff([
+        'x-pack/solutions/security/test/fixtures/es_archives/security_solution/alerts/data.json.gz',
+      ])
+    ).toBe(false);
+    expect(
+      isCypressSkippableDiff(['x-pack/platform/test/fixtures/es_archives/logstash/data.json.gz'])
+    ).toBe(false);
+  });
+
+  it('returns false for shared FTR config bases consumed by the Cypress FTR-runner configs', () => {
+    expect(isCypressSkippableDiff(['x-pack/platform/test/functional/config.base.ts'])).toBe(false);
+    expect(
+      isCypressSkippableDiff(['x-pack/platform/test/functional/services/ml/security_common.ts'])
+    ).toBe(false);
+    expect(isCypressSkippableDiff(['x-pack/platform/test/functional/page_objects/index.ts'])).toBe(
+      false
+    );
+    expect(isCypressSkippableDiff(['x-pack/platform/test/serverless/shared/config.base.ts'])).toBe(
+      false
+    );
+    expect(isCypressSkippableDiff(['src/platform/test/common/config.js'])).toBe(false);
+  });
+
+  it('returns false when a skippable file is mixed with a Cypress-relevant one', () => {
+    expect(
+      isCypressSkippableDiff([
+        'x-pack/platform/test/functional/apps/index_management/home_page.ts',
+        'x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/login.ts',
+      ])
+    ).toBe(false);
+  });
+});

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.ts
@@ -7,18 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { allChangedFilesInScope } from '../../affected-packages';
+import { Minimatch } from 'minimatch';
 import { SCOUT_TESTS_ONLY_IGNORE_PATTERNS, SCOUT_TESTS_ONLY_SCOPE_GLOBS } from './selective_scout';
 
 /**
- * Cypress skip fast path for the PR pipeline.
+ * Cypress trigger relevance for the PR pipeline.
  *
  * Cypress suites are added to the PR pipeline by path matchers that cover
- * whole plugin directories, so a PR that only touches Scout test trees (which
- * live inside plugins) or FTR test trees still triggers every matching
- * Cypress suite. Neither tree can affect Cypress: Scout files aren't
- * importable from Cypress code, and FTR trees only share the surfaces that
- * are explicitly carved out in `CYPRESS_RELEVANT_EXCLUDE_GLOBS`.
+ * whole plugin directories, so changes inside Scout test trees (which live
+ * inside plugins) or FTR test trees trigger every matching Cypress suite
+ * even though neither tree can affect Cypress: Scout files aren't importable
+ * from Cypress code, and FTR trees only share the surfaces that are
+ * explicitly carved out in `CYPRESS_RELEVANT_EXCLUDE_GLOBS`.
+ *
+ * The PR pipeline filters such changes out before evaluating the Cypress
+ * suites' path matchers, so they only see changes that can actually affect
+ * Cypress. Label triggers (e.g. `ci:all-cypress-suites`) are not affected.
  */
 
 /**
@@ -57,18 +61,33 @@ const CYPRESS_RELEVANT_EXCLUDE_GLOBS: readonly string[] = [
   'x-pack/solutions/*/test/fixtures/**',
 ];
 
+const compileMatchers = (patterns: readonly string[]) =>
+  patterns.map((pattern) => new Minimatch(pattern, { dot: true }));
+
+const matchesAny = (path: string, matchers: ReturnType<typeof compileMatchers>): boolean =>
+  matchers.some((matcher) => matcher.match(path));
+
+const ignoreMatchers = compileMatchers(SCOUT_TESTS_ONLY_IGNORE_PATTERNS);
+const excludeMatchers = compileMatchers(CYPRESS_RELEVANT_EXCLUDE_GLOBS);
+const scopeMatchers = compileMatchers([
+  ...SCOUT_TESTS_ONLY_SCOPE_GLOBS,
+  ...FTR_TEST_TREE_SCOPE_GLOBS,
+]);
+
 /**
- * Returns `true` when every changed file is either documentation noise
- * (README, *.md, CHANGELOG*) or sits inside a Scout or FTR test tree that
- * Cypress cannot consume. Falls back to `false` on an empty diff or anything
- * unrecognised, so unrelated changes keep the Cypress suites' default path
- * matchers in charge.
+ * Returns `false` when the changed path cannot affect Cypress suites: either
+ * documentation noise (README, *.md, CHANGELOG* — consistent with the PR
+ * pipeline's `skip_ci_on_only_changed` policy) or a file inside a Scout or
+ * FTR test tree that Cypress does not consume. Anything unrecognised is
+ * treated as relevant, so unrelated changes keep the Cypress suites' default
+ * path matchers in charge.
  */
-export function isCypressSkippableDiff(changedFiles: readonly string[]): boolean {
-  return allChangedFilesInScope(
-    changedFiles,
-    [...SCOUT_TESTS_ONLY_SCOPE_GLOBS, ...FTR_TEST_TREE_SCOPE_GLOBS],
-    SCOUT_TESTS_ONLY_IGNORE_PATTERNS,
-    CYPRESS_RELEVANT_EXCLUDE_GLOBS
-  );
+export function isCypressRelevantPath(path: string): boolean {
+  if (matchesAny(path, ignoreMatchers)) {
+    return false;
+  }
+  if (matchesAny(path, excludeMatchers)) {
+    return true;
+  }
+  return !matchesAny(path, scopeMatchers);
 }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Minimatch } from 'minimatch';
+import { compileMatchers, matchesAny } from '../../affected-packages';
 import { SCOUT_TESTS_ONLY_IGNORE_PATTERNS, SCOUT_TESTS_ONLY_SCOPE_GLOBS } from './selective_scout';
 
 /**
@@ -60,12 +60,6 @@ const CYPRESS_RELEVANT_EXCLUDE_GLOBS: readonly string[] = [
   'x-pack/platform/test/serverless/shared/**',
   'x-pack/solutions/*/test/fixtures/**',
 ];
-
-const compileMatchers = (patterns: readonly string[]) =>
-  patterns.map((pattern) => new Minimatch(pattern, { dot: true }));
-
-const matchesAny = (path: string, matchers: ReturnType<typeof compileMatchers>): boolean =>
-  matchers.some((matcher) => matcher.match(path));
 
 const ignoreMatchers = compileMatchers(SCOUT_TESTS_ONLY_IGNORE_PATTERNS);
 const excludeMatchers = compileMatchers(CYPRESS_RELEVANT_EXCLUDE_GLOBS);

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_cypress.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { allChangedFilesInScope } from '../../affected-packages';
+import { SCOUT_TESTS_ONLY_IGNORE_PATTERNS, SCOUT_TESTS_ONLY_SCOPE_GLOBS } from './selective_scout';
+
+/**
+ * Cypress skip fast path for the PR pipeline.
+ *
+ * Cypress suites are added to the PR pipeline by path matchers that cover
+ * whole plugin directories, so a PR that only touches Scout test trees (which
+ * live inside plugins) or FTR test trees still triggers every matching
+ * Cypress suite. Neither tree can affect Cypress: Scout files aren't
+ * importable from Cypress code, and FTR trees only share the surfaces that
+ * are explicitly carved out in `CYPRESS_RELEVANT_EXCLUDE_GLOBS`.
+ */
+
+/**
+ * FTR test roots, plus the FTR manifests that only drive the Jest/FTR
+ * orchestrator (FTR migrations always touch them; Cypress never reads them).
+ */
+const FTR_TEST_TREE_SCOPE_GLOBS: readonly string[] = [
+  'src/platform/test/**',
+  'x-pack/platform/test/**',
+  'x-pack/solutions/*/test/**',
+  '.buildkite/ftr-manifests/**',
+];
+
+/**
+ * Files inside the FTR test roots that Cypress runs do consume — changes here
+ * must keep the Cypress suites on:
+ * - Cypress suites and their FTR-runner configs live inside the FTR roots
+ *   (`security_solution_cypress`, `osquery_cypress`, `defend_workflows_cypress`,
+ *   `fleet_cypress`).
+ * - `security_solution_cypress` loads es archives from the shared `fixtures/`
+ *   trees via its es_archiver Cypress tasks.
+ * - The Cypress FTR-runner configs extend `@kbn/test-suites-src/common/config`
+ *   and `@kbn/test-suites-xpack-platform`'s `functional/config.base` /
+ *   `serverless/shared/config.base`, which import their own services and
+ *   page objects.
+ */
+const CYPRESS_RELEVANT_EXCLUDE_GLOBS: readonly string[] = [
+  '**/*cypress*/**',
+  'src/platform/test/common/**',
+  'x-pack/platform/test/fixtures/**',
+  'x-pack/platform/test/functional/config.base*',
+  'x-pack/platform/test/functional/services/**',
+  'x-pack/platform/test/functional/page_objects/**',
+  'x-pack/platform/test/serverless/fixtures/**',
+  'x-pack/platform/test/serverless/shared/**',
+  'x-pack/solutions/*/test/fixtures/**',
+];
+
+/**
+ * Returns `true` when every changed file is either documentation noise
+ * (README, *.md, CHANGELOG*) or sits inside a Scout or FTR test tree that
+ * Cypress cannot consume. Falls back to `false` on an empty diff or anything
+ * unrecognised, so unrelated changes keep the Cypress suites' default path
+ * matchers in charge.
+ */
+export function isCypressSkippableDiff(changedFiles: readonly string[]): boolean {
+  return allChangedFilesInScope(
+    changedFiles,
+    [...SCOUT_TESTS_ONLY_SCOPE_GLOBS, ...FTR_TEST_TREE_SCOPE_GLOBS],
+    SCOUT_TESTS_ONLY_IGNORE_PATTERNS,
+    CYPRESS_RELEVANT_EXCLUDE_GLOBS
+  );
+}

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_scout.ts
@@ -26,13 +26,13 @@ import { allChangedFilesInScope } from '../../affected-packages';
  * in `kbn-scout-info` fails CI if the copies drift.
  */
 
-const SCOUT_TESTS_ONLY_IGNORE_PATTERNS: readonly string[] = [
+export const SCOUT_TESTS_ONLY_IGNORE_PATTERNS: readonly string[] = [
   '**/README*',
   '**/*.md',
   '**/CHANGELOG*',
 ];
 
-const SCOUT_TESTS_ONLY_SCOPE_GLOBS: readonly string[] = [
+export const SCOUT_TESTS_ONLY_SCOPE_GLOBS: readonly string[] = [
   '**/test/scout{_*,}/{api,ui}/**',
   '**/test/scout{_*,}/*/{api,ui}/**',
   '**/test/scout{_*,}/.meta/{api,ui}/**',

--- a/.buildkite/pipeline-utils/index.ts
+++ b/.buildkite/pipeline-utils/index.ts
@@ -12,6 +12,7 @@ export * from './agent_images';
 export * from './buildkite';
 export * as CiStats from './ci-stats';
 export { isScoutTestsOnlyDiff } from './ci-stats/pick_test_group_run_order/selective_scout';
+export { isCypressSkippableDiff } from './ci-stats/pick_test_group_run_order/selective_cypress';
 export * from './github';
 export * as TestFailures from './test-failures';
 export * from './utils';

--- a/.buildkite/pipeline-utils/index.ts
+++ b/.buildkite/pipeline-utils/index.ts
@@ -12,7 +12,7 @@ export * from './agent_images';
 export * from './buildkite';
 export * as CiStats from './ci-stats';
 export { isScoutTestsOnlyDiff } from './ci-stats/pick_test_group_run_order/selective_scout';
-export { isCypressSkippableDiff } from './ci-stats/pick_test_group_run_order/selective_cypress';
+export { isCypressRelevantPath } from './ci-stats/pick_test_group_run_order/selective_cypress';
 export * from './github';
 export * as TestFailures from './test-failures';
 export * from './utils';

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.test.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.test.ts
@@ -212,6 +212,76 @@ describe('pull_request pipeline generation', () => {
     );
   });
 
+  describe('Cypress suite skipping on Scout/FTR-test-tree-only diffs', () => {
+    const CYPRESS_STEP_SCRIPTS = [
+      'response_ops.sh',
+      'response_ops_cases.sh',
+      'fleet_cypress.sh',
+      'defend_workflows.sh',
+      'security_solution_explore.sh',
+      'security_solution_investigations.sh',
+      'osquery_cypress.sh',
+    ];
+
+    it('omits Cypress suites when the diff only touches Scout/FTR test trees, even when path matchers hit', async () => {
+      mockDoAnyChangesMatch.mockResolvedValue(true);
+      mockGetPrChangesCached.mockResolvedValue([
+        { filename: 'x-pack/platform/test/functional/apps/index_management/home_page.ts' },
+        {
+          filename:
+            'x-pack/solutions/security/plugins/security_solution/test/scout/detection_engine/ui/tests/foo.spec.ts',
+        },
+        { filename: '.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml' },
+      ]);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const emitted = waitForEmission();
+
+      await importPipelineModule();
+      const output = await emitted;
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Scout/FTR-test-tree-only diff detected — skipping Cypress test suites'
+      );
+      for (const script of CYPRESS_STEP_SCRIPTS) {
+        expect(output).not.toContain(script);
+      }
+    });
+
+    it('keeps Cypress suites on for a skippable diff when ci:all-cypress-suites is set', async () => {
+      process.env.GITHUB_PR_LABELS = 'ci:all-cypress-suites';
+      mockDoAnyChangesMatch.mockResolvedValue(false);
+      mockGetPrChangesCached.mockResolvedValue([
+        { filename: 'x-pack/platform/test/functional/apps/index_management/home_page.ts' },
+      ]);
+      jest.spyOn(console, 'warn').mockImplementation();
+      const emitted = waitForEmission();
+
+      await importPipelineModule();
+      const output = await emitted;
+
+      for (const script of CYPRESS_STEP_SCRIPTS) {
+        expect(output).toContain(script);
+      }
+    });
+
+    it('keeps Cypress suites on when the diff also touches plugin source code', async () => {
+      mockDoAnyChangesMatch.mockResolvedValue(true);
+      mockGetPrChangesCached.mockResolvedValue([
+        { filename: 'x-pack/platform/test/functional/apps/index_management/home_page.ts' },
+        { filename: 'x-pack/solutions/security/plugins/security_solution/public/app/index.tsx' },
+      ]);
+      jest.spyOn(console, 'warn').mockImplementation();
+      const emitted = waitForEmission();
+
+      await importPipelineModule();
+      const output = await emitted;
+
+      for (const script of CYPRESS_STEP_SCRIPTS) {
+        expect(output).toContain(script);
+      }
+    });
+  });
+
   it('emits empty pipeline for automated version bump PRs from kibanamachine', async () => {
     mockIsAutomatedVersionBumpPR.mockResolvedValueOnce(true);
     const emitted = waitForEmission();

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.test.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.test.ts
@@ -212,7 +212,7 @@ describe('pull_request pipeline generation', () => {
     );
   });
 
-  describe('Cypress suite skipping on Scout/FTR-test-tree-only diffs', () => {
+  describe('Cypress suite triggers ignore Scout/FTR-test-tree changes', () => {
     const CYPRESS_STEP_SCRIPTS = [
       'response_ops.sh',
       'response_ops_cases.sh',
@@ -223,8 +223,22 @@ describe('pull_request pipeline generation', () => {
       'osquery_cypress.sh',
     ];
 
-    it('omits Cypress suites when the diff only touches Scout/FTR test trees, even when path matchers hit', async () => {
-      mockDoAnyChangesMatch.mockResolvedValue(true);
+    // The Cypress suite conditions pass an explicit (filtered) changes array to
+    // doAnyChangesMatch; delegate those calls to the real matcher implementation
+    // while keeping every other doAnyChangesMatch call inert. Require the concrete
+    // github module (not the #pipeline-utils index) to avoid re-entering the
+    // module mock while it is being constructed.
+    const delegateCypressMatchesToActual = () => {
+      const { doAnyChangesMatch: actualDoAnyChangesMatch } = jest.requireActual(
+        '#pipeline-utils/github/github'
+      );
+      mockDoAnyChangesMatch.mockImplementation((regexes, changes) =>
+        changes ? actualDoAnyChangesMatch(regexes, changes) : Promise.resolve(false)
+      );
+    };
+
+    it('omits Cypress suites when the diff only touches Scout/FTR test trees, even though plugin matchers would hit', async () => {
+      delegateCypressMatchesToActual();
       mockGetPrChangesCached.mockResolvedValue([
         { filename: 'x-pack/platform/test/functional/apps/index_management/home_page.ts' },
         {
@@ -240,16 +254,16 @@ describe('pull_request pipeline generation', () => {
       const output = await emitted;
 
       expect(warnSpy).toHaveBeenCalledWith(
-        'Scout/FTR-test-tree-only diff detected — skipping Cypress test suites'
+        expect.stringContaining('Cypress trigger evaluation ignores 3 of 3 changed file(s)')
       );
       for (const script of CYPRESS_STEP_SCRIPTS) {
         expect(output).not.toContain(script);
       }
     });
 
-    it('keeps Cypress suites on for a skippable diff when ci:all-cypress-suites is set', async () => {
+    it('keeps Cypress suites on for a test-tree-only diff when ci:all-cypress-suites is set', async () => {
       process.env.GITHUB_PR_LABELS = 'ci:all-cypress-suites';
-      mockDoAnyChangesMatch.mockResolvedValue(false);
+      delegateCypressMatchesToActual();
       mockGetPrChangesCached.mockResolvedValue([
         { filename: 'x-pack/platform/test/functional/apps/index_management/home_page.ts' },
       ]);
@@ -264,11 +278,17 @@ describe('pull_request pipeline generation', () => {
       }
     });
 
-    it('keeps Cypress suites on when the diff also touches plugin source code', async () => {
-      mockDoAnyChangesMatch.mockResolvedValue(true);
+    it('keeps Cypress suites on when the diff also touches matching source code', async () => {
+      delegateCypressMatchesToActual();
       mockGetPrChangesCached.mockResolvedValue([
         { filename: 'x-pack/platform/test/functional/apps/index_management/home_page.ts' },
-        { filename: 'x-pack/solutions/security/plugins/security_solution/public/app/index.tsx' },
+        { filename: 'src/platform/plugins/shared/data/public/index.ts' },
+        { filename: 'x-pack/platform/plugins/shared/cases/server/plugin.ts' },
+        { filename: 'x-pack/platform/plugins/shared/fleet/server/plugin.ts' },
+        {
+          filename:
+            'x-pack/solutions/security/plugins/security_solution/public/asset_inventory/index.tsx',
+        },
       ]);
       jest.spyOn(console, 'warn').mockImplementation();
       const emitted = waitForEmission();
@@ -279,6 +299,30 @@ describe('pull_request pipeline generation', () => {
       for (const script of CYPRESS_STEP_SCRIPTS) {
         expect(output).toContain(script);
       }
+    });
+
+    it('only triggers the suites matched by Cypress-relevant files in a mixed diff', async () => {
+      delegateCypressMatchesToActual();
+      mockGetPrChangesCached.mockResolvedValue([
+        // Scout tree inside security_solution: must NOT trigger the security suites
+        {
+          filename:
+            'x-pack/solutions/security/plugins/security_solution/test/scout/detection_engine/ui/tests/foo.spec.ts',
+        },
+        // Fleet source: triggers fleet_cypress only
+        { filename: 'x-pack/platform/plugins/shared/fleet/server/plugin.ts' },
+      ]);
+      jest.spyOn(console, 'warn').mockImplementation();
+      const emitted = waitForEmission();
+
+      await importPipelineModule();
+      const output = await emitted;
+
+      expect(output).toContain('fleet_cypress.sh');
+      expect(output).not.toContain('security_solution_explore.sh');
+      expect(output).not.toContain('security_solution_investigations.sh');
+      expect(output).not.toContain('defend_workflows.sh');
+      expect(output).not.toContain('osquery_cypress.sh');
     });
   });
 

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -25,6 +25,7 @@ import {
   emitPipeline,
   getPipeline,
   getPrChangesCached,
+  isCypressSkippableDiff,
   isScoutTestsOnlyDiff,
   registerCancelKeys,
   flushCancelOnGateFailureMetadata,
@@ -64,17 +65,24 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       return;
     }
 
-    // Scout-test-only diffs can't change OAS, API contracts, or Saved Objects, so skip those checks below.
     const prChanges = await getPrChangesCached();
-    const scoutTestsOnly = isScoutTestsOnlyDiff(
-      prChanges.flatMap((change) =>
-        change.previous_filename ? [change.filename, change.previous_filename] : [change.filename]
-      )
+    const prChangedPaths = prChanges.flatMap((change) =>
+      change.previous_filename ? [change.filename, change.previous_filename] : [change.filename]
     );
+
+    // Scout-test-only diffs can't change OAS, API contracts, or Saved Objects, so skip those checks below.
+    const scoutTestsOnly = isScoutTestsOnlyDiff(prChangedPaths);
     if (scoutTestsOnly) {
       console.warn(
         'Scout-tests-only diff detected — skipping OAS Snapshot, API Contracts, and Saved Objects checks'
       );
+    }
+
+    // Scout/FTR test trees can't affect Cypress, but the Cypress suites' path matchers
+    // cover whole plugin directories, so gate them below. Labels still force suites on.
+    const cypressSkippable = isCypressSkippableDiff(prChangedPaths);
+    if (cypressSkippable) {
+      console.warn('Scout/FTR-test-tree-only diff detected — skipping Cypress test suites');
     }
 
     pipeline.push(getAgentImageConfig({ returnYaml: true }));
@@ -126,15 +134,16 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^src\/platform\/plugins\/shared\/data/,
-        /^x-pack\/platform\/plugins\/shared\/actions/,
-        /^x-pack\/platform\/plugins\/shared\/alerting/,
-        /^x-pack\/platform\/plugins\/shared\/event_log/,
-        /^x-pack\/platform\/plugins\/shared\/rule_registry/,
-        /^x-pack\/platform\/plugins\/shared\/task_manager/,
-        /^\.buildkite\/pipelines\/pull_request\/response_ops\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^src\/platform\/plugins\/shared\/data/,
+          /^x-pack\/platform\/plugins\/shared\/actions/,
+          /^x-pack\/platform\/plugins\/shared\/alerting/,
+          /^x-pack\/platform\/plugins\/shared\/event_log/,
+          /^x-pack\/platform\/plugins\/shared\/rule_registry/,
+          /^x-pack\/platform\/plugins\/shared\/task_manager/,
+          /^\.buildkite\/pipelines\/pull_request\/response_ops\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -142,10 +151,11 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^x-pack\/platform\/plugins\/shared\/cases/,
-        /^\.buildkite\/pipelines\/pull_request\/response_ops_cases\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^x-pack\/platform\/plugins\/shared\/cases/,
+          /^\.buildkite\/pipelines\/pull_request\/response_ops_cases\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -155,11 +165,12 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^x-pack\/platform\/plugins\/shared\/fleet/,
-        /^x-pack\/test\/fleet_cypress/,
-        /^\.buildkite\/pipelines\/pull_request\/fleet_cypress\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^x-pack\/platform\/plugins\/shared\/fleet/,
+          /^x-pack\/test\/fleet_cypress/,
+          /^\.buildkite\/pipelines\/pull_request\/fleet_cypress\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -305,9 +316,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/cypress_burn\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/cypress_burn\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:cypress-burn') ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
@@ -321,15 +333,16 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution/,
-        /^x-pack\/solutions\/security\/test\/defend_workflows_cypress/,
-        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-        /^fleet_packages\.json/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/defend_workflows\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution/,
+          /^x-pack\/solutions\/security\/test\/defend_workflows_cypress/,
+          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+          /^fleet_packages\.json/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/defend_workflows\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -342,36 +355,37 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^package.json/,
-        /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
-        /^x-pack\/platform\/plugins\/shared\/alerting/,
-        /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
-        /^x-pack\/solutions\/security\/plugins\/lists/,
-        /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
-        /^x-pack\/platform\/plugins\/shared\/task_manager/,
-        /^x-pack\/solutions\/security\/plugins\/timelines/,
-        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/public\/application\/sections\/action_connector_form/,
-        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/public\/application\/context\/actions_connectors_context\.tsx/,
-        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/server\/connector_types\/openai/,
-        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/server\/connector_types\/bedrock/,
-        /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
-        /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
-        /^x-pack\/solutions\/security\/packages/,
-        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
-        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
-        /^x-pack\/test\/functional\/es_archives\/security_solution/,
-        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/ai_assistant\.yml/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/ai4dsoc\.yml/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/detection_engine\.yml/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/entity_analytics\.yml/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/rule_management\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^package.json/,
+          /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
+          /^x-pack\/platform\/plugins\/shared\/alerting/,
+          /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
+          /^x-pack\/solutions\/security\/plugins\/lists/,
+          /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
+          /^x-pack\/platform\/plugins\/shared\/task_manager/,
+          /^x-pack\/solutions\/security\/plugins\/timelines/,
+          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/public\/application\/sections\/action_connector_form/,
+          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/public\/application\/context\/actions_connectors_context\.tsx/,
+          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/server\/connector_types\/openai/,
+          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/server\/connector_types\/bedrock/,
+          /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
+          /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
+          /^x-pack\/solutions\/security\/packages/,
+          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
+          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
+          /^x-pack\/test\/functional\/es_archives\/security_solution/,
+          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/ai_assistant\.yml/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/ai4dsoc\.yml/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/detection_engine\.yml/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/entity_analytics\.yml/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/rule_management\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -405,67 +419,68 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^package.json/,
-        /^src\/platform\/packages\/shared\/kbn-discover-utils/,
-        /^src\/platform\/packages\/shared\/kbn-doc-links/,
-        /^src\/platform\/packages\/shared\/kbn-dom-drag-drop/,
-        /^src\/platform\/packages\/shared\/kbn-es-query/,
-        /^src\/platform\/packages\/shared\/kbn-i18n/,
-        /^src\/platform\/packages\/shared\/kbn-i18n-react/,
-        /^src\/platform\/packages\/shared\/kbn-grouping/,
-        /^src\/platform\/packages\/shared\/kbn-resizable-layout/,
-        /^src\/platform\/packages\/shared\/kbn-rison/,
-        /^src\/platform\/packages\/shared\/kbn-rule-data-utils/,
-        /^src\/platform\/packages\/shared\/kbn-safer-lodash-set/,
-        /^src\/platform\/packages\/shared\/kbn-search-types/,
-        /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
-        /^src\/platform\/packages\/shared\/kbn-securitysolution-ecs/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-alerting-types/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-list-types/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-list-hooks/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-t-grid/,
-        /^src\/platform\/packages\/shared\/kbn-ui-theme/,
-        /^src\/platform\/packages\/shared\/kbn-utility-types/,
-        /^src\/platform\/packages\/shared\/react/,
-        /^src\/platform\/packages\/shared\/shared-ux/,
-        /^src\/core/,
-        /^src\/platform\/plugins\/shared\/charts/,
-        /^src\/platform\/plugins\/shared\/controls/,
-        /^src\/platform\/plugins\/shared\/dashboard/,
-        /^src\/platform\/plugins\/shared\/data/,
-        /^src\/platform\/plugins\/shared\/data_views/,
-        /^src\/platform\/plugins\/shared\/discover/,
-        /^src\/platform\/plugins\/shared\/field_formats/,
-        /^src\/platform\/plugins\/shared\/inspector/,
-        /^src\/platform\/plugins\/shared\/kibana_react/,
-        /^src\/platform\/plugins\/shared\/kibana_utils/,
-        /^src\/platform\/plugins\/shared\/saved_search/,
-        /^src\/platform\/plugins\/shared\/ui_actions/,
-        /^src\/platform\/plugins\/shared\/unified_histogram/,
-        /^src\/platform\/plugins\/shared\/unified_search/,
-        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
-        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
-        /^x-pack\/solutions\/security\/packages/,
-        /^x-pack\/platform\/plugins\/shared\/alerting/,
-        /^x-pack\/platform\/plugins\/shared\/cases/,
-        /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
-        /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
-        /^x-pack\/solutions\/security\/plugins\/lists/,
-        /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
-        /^x-pack\/platform\/plugins\/shared\/task_manager/,
-        /^x-pack\/solutions\/security\/plugins\/threat_intelligence/,
-        /^x-pack\/solutions\/security\/plugins\/timelines/,
-        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui/,
-        /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
-        /^x-pack\/test\/functional\/es_archives\/security_solution/,
-        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/explore\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^package.json/,
+          /^src\/platform\/packages\/shared\/kbn-discover-utils/,
+          /^src\/platform\/packages\/shared\/kbn-doc-links/,
+          /^src\/platform\/packages\/shared\/kbn-dom-drag-drop/,
+          /^src\/platform\/packages\/shared\/kbn-es-query/,
+          /^src\/platform\/packages\/shared\/kbn-i18n/,
+          /^src\/platform\/packages\/shared\/kbn-i18n-react/,
+          /^src\/platform\/packages\/shared\/kbn-grouping/,
+          /^src\/platform\/packages\/shared\/kbn-resizable-layout/,
+          /^src\/platform\/packages\/shared\/kbn-rison/,
+          /^src\/platform\/packages\/shared\/kbn-rule-data-utils/,
+          /^src\/platform\/packages\/shared\/kbn-safer-lodash-set/,
+          /^src\/platform\/packages\/shared\/kbn-search-types/,
+          /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
+          /^src\/platform\/packages\/shared\/kbn-securitysolution-ecs/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-alerting-types/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-list-types/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-list-hooks/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-t-grid/,
+          /^src\/platform\/packages\/shared\/kbn-ui-theme/,
+          /^src\/platform\/packages\/shared\/kbn-utility-types/,
+          /^src\/platform\/packages\/shared\/react/,
+          /^src\/platform\/packages\/shared\/shared-ux/,
+          /^src\/core/,
+          /^src\/platform\/plugins\/shared\/charts/,
+          /^src\/platform\/plugins\/shared\/controls/,
+          /^src\/platform\/plugins\/shared\/dashboard/,
+          /^src\/platform\/plugins\/shared\/data/,
+          /^src\/platform\/plugins\/shared\/data_views/,
+          /^src\/platform\/plugins\/shared\/discover/,
+          /^src\/platform\/plugins\/shared\/field_formats/,
+          /^src\/platform\/plugins\/shared\/inspector/,
+          /^src\/platform\/plugins\/shared\/kibana_react/,
+          /^src\/platform\/plugins\/shared\/kibana_utils/,
+          /^src\/platform\/plugins\/shared\/saved_search/,
+          /^src\/platform\/plugins\/shared\/ui_actions/,
+          /^src\/platform\/plugins\/shared\/unified_histogram/,
+          /^src\/platform\/plugins\/shared\/unified_search/,
+          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
+          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
+          /^x-pack\/solutions\/security\/packages/,
+          /^x-pack\/platform\/plugins\/shared\/alerting/,
+          /^x-pack\/platform\/plugins\/shared\/cases/,
+          /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
+          /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
+          /^x-pack\/solutions\/security\/plugins\/lists/,
+          /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
+          /^x-pack\/platform\/plugins\/shared\/task_manager/,
+          /^x-pack\/solutions\/security\/plugins\/threat_intelligence/,
+          /^x-pack\/solutions\/security\/plugins\/timelines/,
+          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui/,
+          /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
+          /^x-pack\/test\/functional\/es_archives\/security_solution/,
+          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/explore\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -475,64 +490,65 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^package.json/,
-        /^src\/platform\/packages\/shared\/kbn-discover-utils/,
-        /^src\/platform\/packages\/shared\/kbn-doc-links/,
-        /^src\/platform\/packages\/shared\/kbn-dom-drag-drop/,
-        /^src\/platform\/packages\/shared\/kbn-es-query/,
-        /^src\/platform\/packages\/shared\/kbn-i18n/,
-        /^src\/platform\/packages\/shared\/kbn-i18n-react/,
-        /^src\/platform\/packages\/shared\/kbn-grouping/,
-        /^src\/platform\/packages\/shared\/kbn-resizable-layout/,
-        /^src\/platform\/packages\/shared\/kbn-rison/,
-        /^src\/platform\/packages\/shared\/kbn-rule-data-utils/,
-        /^src\/platform\/packages\/shared\/kbn-safer-lodash-set/,
-        /^src\/platform\/packages\/shared\/kbn-search-types/,
-        /^src\/platform\/packages\/shared\/kbn-securitysolution-ecs/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-alerting-types/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-list-types/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-list-hooks/,
-        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-t-grid/,
-        /^src\/platform\/packages\/shared\/kbn-ui-theme/,
-        /^src\/platform\/packages\/shared\/kbn-utility-types/,
-        /^src\/platform\/packages\/shared\/react/,
-        /^src\/platform\/packages\/shared\/shared-ux/,
-        /^src\/core/,
-        /^src\/platform\/plugins\/shared\/charts/,
-        /^src\/platform\/plugins\/shared\/controls/,
-        /^src\/platform\/plugins\/shared\/data/,
-        /^src\/platform\/plugins\/shared\/data_views/,
-        /^src\/platform\/plugins\/shared\/discover/,
-        /^src\/platform\/plugins\/shared\/field_formats/,
-        /^src\/platform\/plugins\/shared\/inspector/,
-        /^src\/platform\/plugins\/shared\/kibana_react/,
-        /^src\/platform\/plugins\/shared\/kibana_utils/,
-        /^src\/platform\/plugins\/shared\/saved_search/,
-        /^src\/platform\/plugins\/shared\/ui_actions/,
-        /^src\/platform\/plugins\/shared\/unified_histogram/,
-        /^src\/platform\/plugins\/shared\/unified_search/,
-        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
-        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
-        /^x-pack\/solutions\/security\/packages/,
-        /^x-pack\/platform\/plugins\/shared\/alerting/,
-        /^x-pack\/platform\/plugins\/shared\/cases/,
-        /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
-        /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
-        /^x-pack\/solutions\/security\/plugins\/lists/,
-        /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
-        /^x-pack\/platform\/plugins\/shared\/task_manager/,
-        /^x-pack\/solutions\/security\/plugins\/threat_intelligence/,
-        /^x-pack\/solutions\/security\/plugins\/timelines/,
-        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui/,
-        /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
-        /^x-pack\/test\/functional\/es_archives\/security_solution/,
-        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/investigations\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^package.json/,
+          /^src\/platform\/packages\/shared\/kbn-discover-utils/,
+          /^src\/platform\/packages\/shared\/kbn-doc-links/,
+          /^src\/platform\/packages\/shared\/kbn-dom-drag-drop/,
+          /^src\/platform\/packages\/shared\/kbn-es-query/,
+          /^src\/platform\/packages\/shared\/kbn-i18n/,
+          /^src\/platform\/packages\/shared\/kbn-i18n-react/,
+          /^src\/platform\/packages\/shared\/kbn-grouping/,
+          /^src\/platform\/packages\/shared\/kbn-resizable-layout/,
+          /^src\/platform\/packages\/shared\/kbn-rison/,
+          /^src\/platform\/packages\/shared\/kbn-rule-data-utils/,
+          /^src\/platform\/packages\/shared\/kbn-safer-lodash-set/,
+          /^src\/platform\/packages\/shared\/kbn-search-types/,
+          /^src\/platform\/packages\/shared\/kbn-securitysolution-ecs/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-alerting-types/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-list-types/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-list-hooks/,
+          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-t-grid/,
+          /^src\/platform\/packages\/shared\/kbn-ui-theme/,
+          /^src\/platform\/packages\/shared\/kbn-utility-types/,
+          /^src\/platform\/packages\/shared\/react/,
+          /^src\/platform\/packages\/shared\/shared-ux/,
+          /^src\/core/,
+          /^src\/platform\/plugins\/shared\/charts/,
+          /^src\/platform\/plugins\/shared\/controls/,
+          /^src\/platform\/plugins\/shared\/data/,
+          /^src\/platform\/plugins\/shared\/data_views/,
+          /^src\/platform\/plugins\/shared\/discover/,
+          /^src\/platform\/plugins\/shared\/field_formats/,
+          /^src\/platform\/plugins\/shared\/inspector/,
+          /^src\/platform\/plugins\/shared\/kibana_react/,
+          /^src\/platform\/plugins\/shared\/kibana_utils/,
+          /^src\/platform\/plugins\/shared\/saved_search/,
+          /^src\/platform\/plugins\/shared\/ui_actions/,
+          /^src\/platform\/plugins\/shared\/unified_histogram/,
+          /^src\/platform\/plugins\/shared\/unified_search/,
+          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
+          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
+          /^x-pack\/solutions\/security\/packages/,
+          /^x-pack\/platform\/plugins\/shared\/alerting/,
+          /^x-pack\/platform\/plugins\/shared\/cases/,
+          /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
+          /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
+          /^x-pack\/solutions\/security\/plugins\/lists/,
+          /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
+          /^x-pack\/platform\/plugins\/shared\/task_manager/,
+          /^x-pack\/solutions\/security\/plugins\/threat_intelligence/,
+          /^x-pack\/solutions\/security\/plugins\/timelines/,
+          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui/,
+          /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
+          /^x-pack\/test\/functional\/es_archives\/security_solution/,
+          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/investigations\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -545,12 +561,13 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      ((await doAnyChangesMatch([
-        /^x-pack\/platform\/plugins\/shared\/osquery/,
-        /^x-pack\/solutions\/security\/test\/osquery_cypress/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/osquery_cypress\.yml/,
-      ])) ||
+      ((!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^x-pack\/platform\/plugins\/shared\/osquery/,
+          /^x-pack\/solutions\/security\/test\/osquery_cypress/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/osquery_cypress\.yml/,
+        ]))) ||
         GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
         ALL_UI_TEST_SUITES) &&
       !GITHUB_PR_LABELS.includes('ci:skip-cypress-osquery')
@@ -564,13 +581,14 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^x-pack\/packages\/kbn-cloud-security-posture/,
-        /^x-pack\/solutions\/security\/plugins\/cloud_security_posture/,
-        /^x-pack\/solutions\/security\/plugins\/security_solution/,
-        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/cloud_security_posture\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^x-pack\/packages\/kbn-cloud-security-posture/,
+          /^x-pack\/solutions\/security\/plugins\/cloud_security_posture/,
+          /^x-pack\/solutions\/security\/plugins\/security_solution/,
+          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/cloud_security_posture\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -629,11 +647,12 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch([
-        /^x-pack\/solutions\/security\/plugins\/security_solution\/public\/asset_inventory/,
-        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-        /^\.buildkite\/pipelines\/pull_request\/security_solution\/asset_inventory\.yml/,
-      ])) ||
+      (!cypressSkippable &&
+        (await doAnyChangesMatch([
+          /^x-pack\/solutions\/security\/plugins\/security_solution\/public\/asset_inventory/,
+          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+          /^\.buildkite\/pipelines\/pull_request\/security_solution\/asset_inventory\.yml/,
+        ]))) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -98,6 +98,8 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
         } of ${prChanges.length} changed file(s) (Scout/FTR test trees or docs)`
       );
     }
+    const doAnyCypressRelevantChangesMatch = (matchers: RegExp[]) =>
+      doAnyChangesMatch(matchers, cypressRelevantChanges);
 
     pipeline.push(getAgentImageConfig({ returnYaml: true }));
 
@@ -148,18 +150,15 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [
-          /^src\/platform\/plugins\/shared\/data/,
-          /^x-pack\/platform\/plugins\/shared\/actions/,
-          /^x-pack\/platform\/plugins\/shared\/alerting/,
-          /^x-pack\/platform\/plugins\/shared\/event_log/,
-          /^x-pack\/platform\/plugins\/shared\/rule_registry/,
-          /^x-pack\/platform\/plugins\/shared\/task_manager/,
-          /^\.buildkite\/pipelines\/pull_request\/response_ops\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^src\/platform\/plugins\/shared\/data/,
+        /^x-pack\/platform\/plugins\/shared\/actions/,
+        /^x-pack\/platform\/plugins\/shared\/alerting/,
+        /^x-pack\/platform\/plugins\/shared\/event_log/,
+        /^x-pack\/platform\/plugins\/shared\/rule_registry/,
+        /^x-pack\/platform\/plugins\/shared\/task_manager/,
+        /^\.buildkite\/pipelines\/pull_request\/response_ops\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -167,13 +166,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [
-          /^x-pack\/platform\/plugins\/shared\/cases/,
-          /^\.buildkite\/pipelines\/pull_request\/response_ops_cases\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^x-pack\/platform\/plugins\/shared\/cases/,
+        /^\.buildkite\/pipelines\/pull_request\/response_ops_cases\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -183,14 +179,11 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [
-          /^x-pack\/platform\/plugins\/shared\/fleet/,
-          /^x-pack\/test\/fleet_cypress/,
-          /^\.buildkite\/pipelines\/pull_request\/fleet_cypress\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^x-pack\/platform\/plugins\/shared\/fleet/,
+        /^x-pack\/test\/fleet_cypress/,
+        /^\.buildkite\/pipelines\/pull_request\/fleet_cypress\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -336,10 +329,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [/^\.buildkite\/pipelines\/pull_request\/security_solution\/cypress_burn\.yml/],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/cypress_burn\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:cypress-burn') ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
@@ -353,18 +345,15 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [
-          /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution/,
-          /^x-pack\/solutions\/security\/test\/defend_workflows_cypress/,
-          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-          /^fleet_packages\.json/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/defend_workflows\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
+        /^x-pack\/solutions\/security\/test\/defend_workflows_cypress/,
+        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+        /^fleet_packages\.json/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/defend_workflows\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -377,39 +366,36 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [
-          /^package.json/,
-          /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
-          /^x-pack\/platform\/plugins\/shared\/alerting/,
-          /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
-          /^x-pack\/solutions\/security\/plugins\/lists/,
-          /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
-          /^x-pack\/platform\/plugins\/shared\/task_manager/,
-          /^x-pack\/solutions\/security\/plugins\/timelines/,
-          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/public\/application\/sections\/action_connector_form/,
-          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/public\/application\/context\/actions_connectors_context\.tsx/,
-          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/server\/connector_types\/openai/,
-          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/server\/connector_types\/bedrock/,
-          /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
-          /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
-          /^x-pack\/solutions\/security\/packages/,
-          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
-          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
-          /^x-pack\/test\/functional\/es_archives\/security_solution/,
-          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/ai_assistant\.yml/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/ai4dsoc\.yml/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/detection_engine\.yml/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/entity_analytics\.yml/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/rule_management\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^package.json/,
+        /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
+        /^x-pack\/platform\/plugins\/shared\/alerting/,
+        /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
+        /^x-pack\/solutions\/security\/plugins\/lists/,
+        /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
+        /^x-pack\/platform\/plugins\/shared\/task_manager/,
+        /^x-pack\/solutions\/security\/plugins\/timelines/,
+        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/public\/application\/sections\/action_connector_form/,
+        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/public\/application\/context\/actions_connectors_context\.tsx/,
+        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/server\/connector_types\/openai/,
+        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/server\/connector_types\/bedrock/,
+        /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
+        /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
+        /^x-pack\/solutions\/security\/packages/,
+        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
+        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
+        /^x-pack\/test\/functional\/es_archives\/security_solution/,
+        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/ai_assistant\.yml/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/ai4dsoc\.yml/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/detection_engine\.yml/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/entity_analytics\.yml/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/rule_management\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -443,70 +429,67 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [
-          /^package.json/,
-          /^src\/platform\/packages\/shared\/kbn-discover-utils/,
-          /^src\/platform\/packages\/shared\/kbn-doc-links/,
-          /^src\/platform\/packages\/shared\/kbn-dom-drag-drop/,
-          /^src\/platform\/packages\/shared\/kbn-es-query/,
-          /^src\/platform\/packages\/shared\/kbn-i18n/,
-          /^src\/platform\/packages\/shared\/kbn-i18n-react/,
-          /^src\/platform\/packages\/shared\/kbn-grouping/,
-          /^src\/platform\/packages\/shared\/kbn-resizable-layout/,
-          /^src\/platform\/packages\/shared\/kbn-rison/,
-          /^src\/platform\/packages\/shared\/kbn-rule-data-utils/,
-          /^src\/platform\/packages\/shared\/kbn-safer-lodash-set/,
-          /^src\/platform\/packages\/shared\/kbn-search-types/,
-          /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
-          /^src\/platform\/packages\/shared\/kbn-securitysolution-ecs/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-alerting-types/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-list-types/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-list-hooks/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-t-grid/,
-          /^src\/platform\/packages\/shared\/kbn-ui-theme/,
-          /^src\/platform\/packages\/shared\/kbn-utility-types/,
-          /^src\/platform\/packages\/shared\/react/,
-          /^src\/platform\/packages\/shared\/shared-ux/,
-          /^src\/core/,
-          /^src\/platform\/plugins\/shared\/charts/,
-          /^src\/platform\/plugins\/shared\/controls/,
-          /^src\/platform\/plugins\/shared\/dashboard/,
-          /^src\/platform\/plugins\/shared\/data/,
-          /^src\/platform\/plugins\/shared\/data_views/,
-          /^src\/platform\/plugins\/shared\/discover/,
-          /^src\/platform\/plugins\/shared\/field_formats/,
-          /^src\/platform\/plugins\/shared\/inspector/,
-          /^src\/platform\/plugins\/shared\/kibana_react/,
-          /^src\/platform\/plugins\/shared\/kibana_utils/,
-          /^src\/platform\/plugins\/shared\/saved_search/,
-          /^src\/platform\/plugins\/shared\/ui_actions/,
-          /^src\/platform\/plugins\/shared\/unified_histogram/,
-          /^src\/platform\/plugins\/shared\/unified_search/,
-          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
-          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
-          /^x-pack\/solutions\/security\/packages/,
-          /^x-pack\/platform\/plugins\/shared\/alerting/,
-          /^x-pack\/platform\/plugins\/shared\/cases/,
-          /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
-          /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
-          /^x-pack\/solutions\/security\/plugins\/lists/,
-          /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
-          /^x-pack\/platform\/plugins\/shared\/task_manager/,
-          /^x-pack\/solutions\/security\/plugins\/threat_intelligence/,
-          /^x-pack\/solutions\/security\/plugins\/timelines/,
-          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui/,
-          /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
-          /^x-pack\/test\/functional\/es_archives\/security_solution/,
-          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/explore\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^package.json/,
+        /^src\/platform\/packages\/shared\/kbn-discover-utils/,
+        /^src\/platform\/packages\/shared\/kbn-doc-links/,
+        /^src\/platform\/packages\/shared\/kbn-dom-drag-drop/,
+        /^src\/platform\/packages\/shared\/kbn-es-query/,
+        /^src\/platform\/packages\/shared\/kbn-i18n/,
+        /^src\/platform\/packages\/shared\/kbn-i18n-react/,
+        /^src\/platform\/packages\/shared\/kbn-grouping/,
+        /^src\/platform\/packages\/shared\/kbn-resizable-layout/,
+        /^src\/platform\/packages\/shared\/kbn-rison/,
+        /^src\/platform\/packages\/shared\/kbn-rule-data-utils/,
+        /^src\/platform\/packages\/shared\/kbn-safer-lodash-set/,
+        /^src\/platform\/packages\/shared\/kbn-search-types/,
+        /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
+        /^src\/platform\/packages\/shared\/kbn-securitysolution-ecs/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-alerting-types/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-list-types/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-list-hooks/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-t-grid/,
+        /^src\/platform\/packages\/shared\/kbn-ui-theme/,
+        /^src\/platform\/packages\/shared\/kbn-utility-types/,
+        /^src\/platform\/packages\/shared\/react/,
+        /^src\/platform\/packages\/shared\/shared-ux/,
+        /^src\/core/,
+        /^src\/platform\/plugins\/shared\/charts/,
+        /^src\/platform\/plugins\/shared\/controls/,
+        /^src\/platform\/plugins\/shared\/dashboard/,
+        /^src\/platform\/plugins\/shared\/data/,
+        /^src\/platform\/plugins\/shared\/data_views/,
+        /^src\/platform\/plugins\/shared\/discover/,
+        /^src\/platform\/plugins\/shared\/field_formats/,
+        /^src\/platform\/plugins\/shared\/inspector/,
+        /^src\/platform\/plugins\/shared\/kibana_react/,
+        /^src\/platform\/plugins\/shared\/kibana_utils/,
+        /^src\/platform\/plugins\/shared\/saved_search/,
+        /^src\/platform\/plugins\/shared\/ui_actions/,
+        /^src\/platform\/plugins\/shared\/unified_histogram/,
+        /^src\/platform\/plugins\/shared\/unified_search/,
+        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
+        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
+        /^x-pack\/solutions\/security\/packages/,
+        /^x-pack\/platform\/plugins\/shared\/alerting/,
+        /^x-pack\/platform\/plugins\/shared\/cases/,
+        /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
+        /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
+        /^x-pack\/solutions\/security\/plugins\/lists/,
+        /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
+        /^x-pack\/platform\/plugins\/shared\/task_manager/,
+        /^x-pack\/solutions\/security\/plugins\/threat_intelligence/,
+        /^x-pack\/solutions\/security\/plugins\/timelines/,
+        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui/,
+        /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
+        /^x-pack\/test\/functional\/es_archives\/security_solution/,
+        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/explore\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -516,67 +499,64 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [
-          /^package.json/,
-          /^src\/platform\/packages\/shared\/kbn-discover-utils/,
-          /^src\/platform\/packages\/shared\/kbn-doc-links/,
-          /^src\/platform\/packages\/shared\/kbn-dom-drag-drop/,
-          /^src\/platform\/packages\/shared\/kbn-es-query/,
-          /^src\/platform\/packages\/shared\/kbn-i18n/,
-          /^src\/platform\/packages\/shared\/kbn-i18n-react/,
-          /^src\/platform\/packages\/shared\/kbn-grouping/,
-          /^src\/platform\/packages\/shared\/kbn-resizable-layout/,
-          /^src\/platform\/packages\/shared\/kbn-rison/,
-          /^src\/platform\/packages\/shared\/kbn-rule-data-utils/,
-          /^src\/platform\/packages\/shared\/kbn-safer-lodash-set/,
-          /^src\/platform\/packages\/shared\/kbn-search-types/,
-          /^src\/platform\/packages\/shared\/kbn-securitysolution-ecs/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-alerting-types/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-list-types/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-list-hooks/,
-          /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-t-grid/,
-          /^src\/platform\/packages\/shared\/kbn-ui-theme/,
-          /^src\/platform\/packages\/shared\/kbn-utility-types/,
-          /^src\/platform\/packages\/shared\/react/,
-          /^src\/platform\/packages\/shared\/shared-ux/,
-          /^src\/core/,
-          /^src\/platform\/plugins\/shared\/charts/,
-          /^src\/platform\/plugins\/shared\/controls/,
-          /^src\/platform\/plugins\/shared\/data/,
-          /^src\/platform\/plugins\/shared\/data_views/,
-          /^src\/platform\/plugins\/shared\/discover/,
-          /^src\/platform\/plugins\/shared\/field_formats/,
-          /^src\/platform\/plugins\/shared\/inspector/,
-          /^src\/platform\/plugins\/shared\/kibana_react/,
-          /^src\/platform\/plugins\/shared\/kibana_utils/,
-          /^src\/platform\/plugins\/shared\/saved_search/,
-          /^src\/platform\/plugins\/shared\/ui_actions/,
-          /^src\/platform\/plugins\/shared\/unified_histogram/,
-          /^src\/platform\/plugins\/shared\/unified_search/,
-          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
-          /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
-          /^x-pack\/solutions\/security\/packages/,
-          /^x-pack\/platform\/plugins\/shared\/alerting/,
-          /^x-pack\/platform\/plugins\/shared\/cases/,
-          /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
-          /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
-          /^x-pack\/solutions\/security\/plugins\/lists/,
-          /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
-          /^x-pack\/platform\/plugins\/shared\/task_manager/,
-          /^x-pack\/solutions\/security\/plugins\/threat_intelligence/,
-          /^x-pack\/solutions\/security\/plugins\/timelines/,
-          /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui/,
-          /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
-          /^x-pack\/test\/functional\/es_archives\/security_solution/,
-          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/investigations\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^package.json/,
+        /^src\/platform\/packages\/shared\/kbn-discover-utils/,
+        /^src\/platform\/packages\/shared\/kbn-doc-links/,
+        /^src\/platform\/packages\/shared\/kbn-dom-drag-drop/,
+        /^src\/platform\/packages\/shared\/kbn-es-query/,
+        /^src\/platform\/packages\/shared\/kbn-i18n/,
+        /^src\/platform\/packages\/shared\/kbn-i18n-react/,
+        /^src\/platform\/packages\/shared\/kbn-grouping/,
+        /^src\/platform\/packages\/shared\/kbn-resizable-layout/,
+        /^src\/platform\/packages\/shared\/kbn-rison/,
+        /^src\/platform\/packages\/shared\/kbn-rule-data-utils/,
+        /^src\/platform\/packages\/shared\/kbn-safer-lodash-set/,
+        /^src\/platform\/packages\/shared\/kbn-search-types/,
+        /^src\/platform\/packages\/shared\/kbn-securitysolution-ecs/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-alerting-types/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-io-ts-list-types/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-list-hooks/,
+        /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-t-grid/,
+        /^src\/platform\/packages\/shared\/kbn-ui-theme/,
+        /^src\/platform\/packages\/shared\/kbn-utility-types/,
+        /^src\/platform\/packages\/shared\/react/,
+        /^src\/platform\/packages\/shared\/shared-ux/,
+        /^src\/core/,
+        /^src\/platform\/plugins\/shared\/charts/,
+        /^src\/platform\/plugins\/shared\/controls/,
+        /^src\/platform\/plugins\/shared\/data/,
+        /^src\/platform\/plugins\/shared\/data_views/,
+        /^src\/platform\/plugins\/shared\/discover/,
+        /^src\/platform\/plugins\/shared\/field_formats/,
+        /^src\/platform\/plugins\/shared\/inspector/,
+        /^src\/platform\/plugins\/shared\/kibana_react/,
+        /^src\/platform\/plugins\/shared\/kibana_utils/,
+        /^src\/platform\/plugins\/shared\/saved_search/,
+        /^src\/platform\/plugins\/shared\/ui_actions/,
+        /^src\/platform\/plugins\/shared\/unified_histogram/,
+        /^src\/platform\/plugins\/shared\/unified_search/,
+        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant/,
+        /^x-pack\/platform\/packages\/shared\/kbn-elastic-assistant-common/,
+        /^x-pack\/solutions\/security\/packages/,
+        /^x-pack\/platform\/plugins\/shared\/alerting/,
+        /^x-pack\/platform\/plugins\/shared\/cases/,
+        /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
+        /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
+        /^x-pack\/solutions\/security\/plugins\/lists/,
+        /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
+        /^x-pack\/platform\/plugins\/shared\/task_manager/,
+        /^x-pack\/solutions\/security\/plugins\/threat_intelligence/,
+        /^x-pack\/solutions\/security\/plugins\/timelines/,
+        /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui/,
+        /^x-pack\/platform\/plugins\/shared\/usage_collection\/public/,
+        /^x-pack\/test\/functional\/es_archives\/security_solution/,
+        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/investigations\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -589,15 +569,12 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      ((await doAnyChangesMatch(
-        [
-          /^x-pack\/platform\/plugins\/shared\/osquery/,
-          /^x-pack\/solutions\/security\/test\/osquery_cypress/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/osquery_cypress\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      ((await doAnyCypressRelevantChangesMatch([
+        /^x-pack\/platform\/plugins\/shared\/osquery/,
+        /^x-pack\/solutions\/security\/test\/osquery_cypress/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/osquery_cypress\.yml/,
+      ])) ||
         GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
         ALL_UI_TEST_SUITES) &&
       !GITHUB_PR_LABELS.includes('ci:skip-cypress-osquery')
@@ -611,16 +588,13 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [
-          /^x-pack\/packages\/kbn-cloud-security-posture/,
-          /^x-pack\/solutions\/security\/plugins\/cloud_security_posture/,
-          /^x-pack\/solutions\/security\/plugins\/security_solution/,
-          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/cloud_security_posture\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^x-pack\/packages\/kbn-cloud-security-posture/,
+        /^x-pack\/solutions\/security\/plugins\/cloud_security_posture/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
+        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/cloud_security_posture\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -679,14 +653,11 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (await doAnyChangesMatch(
-        [
-          /^x-pack\/solutions\/security\/plugins\/security_solution\/public\/asset_inventory/,
-          /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/asset_inventory\.yml/,
-        ],
-        cypressRelevantChanges
-      )) ||
+      (await doAnyCypressRelevantChangesMatch([
+        /^x-pack\/solutions\/security\/plugins\/security_solution\/public\/asset_inventory/,
+        /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
+        /^\.buildkite\/pipelines\/pull_request\/security_solution\/asset_inventory\.yml/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -25,7 +25,7 @@ import {
   emitPipeline,
   getPipeline,
   getPrChangesCached,
-  isCypressSkippableDiff,
+  isCypressRelevantPath,
   isScoutTestsOnlyDiff,
   registerCancelKeys,
   flushCancelOnGateFailureMetadata,
@@ -79,10 +79,24 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     // Scout/FTR test trees can't affect Cypress, but the Cypress suites' path matchers
-    // cover whole plugin directories, so gate them below. Labels still force suites on.
-    const cypressSkippable = isCypressSkippableDiff(prChangedPaths);
-    if (cypressSkippable) {
-      console.warn('Scout/FTR-test-tree-only diff detected — skipping Cypress test suites');
+    // below cover whole plugin directories, so those matchers are evaluated only against
+    // changes that can affect Cypress. Labels still force suites on. Past 3000 files the
+    // GitHub file list is truncated, so keep it unfiltered and let doAnyChangesMatch's
+    // own safety valve run everything.
+    const cypressRelevantChanges =
+      prChanges.length >= 3000
+        ? prChanges
+        : prChanges.filter(
+            (change) =>
+              isCypressRelevantPath(change.filename) ||
+              (!!change.previous_filename && isCypressRelevantPath(change.previous_filename))
+          );
+    if (cypressRelevantChanges.length < prChanges.length) {
+      console.warn(
+        `Cypress trigger evaluation ignores ${
+          prChanges.length - cypressRelevantChanges.length
+        } of ${prChanges.length} changed file(s) (Scout/FTR test trees or docs)`
+      );
     }
 
     pipeline.push(getAgentImageConfig({ returnYaml: true }));
@@ -134,8 +148,8 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
+      (await doAnyChangesMatch(
+        [
           /^src\/platform\/plugins\/shared\/data/,
           /^x-pack\/platform\/plugins\/shared\/actions/,
           /^x-pack\/platform\/plugins\/shared\/alerting/,
@@ -143,7 +157,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
           /^x-pack\/platform\/plugins\/shared\/rule_registry/,
           /^x-pack\/platform\/plugins\/shared\/task_manager/,
           /^\.buildkite\/pipelines\/pull_request\/response_ops\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -151,11 +167,13 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
+      (await doAnyChangesMatch(
+        [
           /^x-pack\/platform\/plugins\/shared\/cases/,
           /^\.buildkite\/pipelines\/pull_request\/response_ops_cases\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -165,12 +183,14 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
+      (await doAnyChangesMatch(
+        [
           /^x-pack\/platform\/plugins\/shared\/fleet/,
           /^x-pack\/test\/fleet_cypress/,
           /^\.buildkite\/pipelines\/pull_request\/fleet_cypress\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -316,10 +336,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
-          /^\.buildkite\/pipelines\/pull_request\/security_solution\/cypress_burn\.yml/,
-        ]))) ||
+      (await doAnyChangesMatch(
+        [/^\.buildkite\/pipelines\/pull_request\/security_solution\/cypress_burn\.yml/],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:cypress-burn') ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
@@ -333,8 +353,8 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
+      (await doAnyChangesMatch(
+        [
           /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
           /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
           /^x-pack\/solutions\/security\/plugins\/security_solution/,
@@ -342,7 +362,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
           /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
           /^fleet_packages\.json/,
           /^\.buildkite\/pipelines\/pull_request\/security_solution\/defend_workflows\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -355,8 +377,8 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
+      (await doAnyChangesMatch(
+        [
           /^package.json/,
           /^src\/platform\/packages\/shared\/kbn-securitysolution-.*/,
           /^x-pack\/solutions\/security\/packages\/kbn-securitysolution-.*/,
@@ -385,7 +407,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
           /^\.buildkite\/pipelines\/pull_request\/security_solution\/detection_engine\.yml/,
           /^\.buildkite\/pipelines\/pull_request\/security_solution\/entity_analytics\.yml/,
           /^\.buildkite\/pipelines\/pull_request\/security_solution\/rule_management\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -419,8 +443,8 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
+      (await doAnyChangesMatch(
+        [
           /^package.json/,
           /^src\/platform\/packages\/shared\/kbn-discover-utils/,
           /^src\/platform\/packages\/shared\/kbn-doc-links/,
@@ -480,7 +504,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
           /^x-pack\/test\/functional\/es_archives\/security_solution/,
           /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
           /^\.buildkite\/pipelines\/pull_request\/security_solution\/explore\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -490,8 +516,8 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
+      (await doAnyChangesMatch(
+        [
           /^package.json/,
           /^src\/platform\/packages\/shared\/kbn-discover-utils/,
           /^src\/platform\/packages\/shared\/kbn-doc-links/,
@@ -548,7 +574,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
           /^x-pack\/test\/functional\/es_archives\/security_solution/,
           /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
           /^\.buildkite\/pipelines\/pull_request\/security_solution\/investigations\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -561,13 +589,15 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      ((!cypressSkippable &&
-        (await doAnyChangesMatch([
+      ((await doAnyChangesMatch(
+        [
           /^x-pack\/platform\/plugins\/shared\/osquery/,
           /^x-pack\/solutions\/security\/test\/osquery_cypress/,
           /^x-pack\/solutions\/security\/plugins\/security_solution/,
           /^\.buildkite\/pipelines\/pull_request\/security_solution\/osquery_cypress\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
         GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
         ALL_UI_TEST_SUITES) &&
       !GITHUB_PR_LABELS.includes('ci:skip-cypress-osquery')
@@ -581,14 +611,16 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
+      (await doAnyChangesMatch(
+        [
           /^x-pack\/packages\/kbn-cloud-security-posture/,
           /^x-pack\/solutions\/security\/plugins\/cloud_security_posture/,
           /^x-pack\/solutions\/security\/plugins\/security_solution/,
           /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
           /^\.buildkite\/pipelines\/pull_request\/security_solution\/cloud_security_posture\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
@@ -647,12 +679,14 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     }
 
     if (
-      (!cypressSkippable &&
-        (await doAnyChangesMatch([
+      (await doAnyChangesMatch(
+        [
           /^x-pack\/solutions\/security\/plugins\/security_solution\/public\/asset_inventory/,
           /^x-pack\/solutions\/security\/test\/security_solution_cypress/,
           /^\.buildkite\/pipelines\/pull_request\/security_solution\/asset_inventory\.yml/,
-        ]))) ||
+        ],
+        cypressRelevantChanges
+      )) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {


### PR DESCRIPTION
## Summary

Cypress suites are added to the `kibana-pull-request` pipeline by path matchers that cover whole plugin directories, so a PR that only touches Scout test trees (which live inside plugins) or FTR test trees still triggers every matching Cypress suite — even though neither tree can affect Cypress.

This PR filters those changes out **per file** before the Cypress suites' path matchers are evaluated: each suite's matcher only sees changes that can actually affect Cypress. Consequences:

- A PR that only touches Scout/FTR test trees (e.g. FTR→Scout migrations) skips all Cypress suites.
- A mixed PR (e.g. a security Scout spec + Fleet source change) only triggers the suites its Cypress-relevant files match (`fleet_cypress`), instead of every suite whose matcher hits the test-tree files.
- Unrelated changes are unaffected: any file outside the filtered scopes keeps the default path matchers in charge.

### What counts as Cypress-irrelevant

A changed path is excluded from Cypress trigger evaluation when it is:

- documentation noise (`README*`, `*.md`, `CHANGELOG*`) — consistent with the existing `skip_ci_on_only_changed` policy in `.buildkite/pull_requests.json`, or
- inside a Scout test tree (same globs the Jest/FTR selective-testing fast path uses, drift-tested against `kbn-scout-info`), or
- inside an FTR test root (`src/platform/test`, `x-pack/platform/test`, `x-pack/solutions/*/test`, `.buildkite/ftr-manifests`), **except** the surfaces Cypress actually consumes, which always stay relevant:
  - the Cypress trees themselves (`**/*cypress*/**`: `security_solution_cypress`, `osquery_cypress`, `defend_workflows_cypress`, `fleet_cypress`),
  - shared es-archive fixtures (`x-pack/{platform,solutions/*}/test/fixtures`, `x-pack/platform/test/serverless/fixtures`) loaded by the Cypress es_archiver tasks,
  - the shared FTR config bases the Cypress FTR-runner configs extend (`x-pack/platform/test/functional/config.base*` + its `services`/`page_objects`, `x-pack/platform/test/serverless/shared`, `src/platform/test/common`).

Anything unrecognised is treated as relevant, so the filter can only skip work it can prove is safe to skip.

### Escape hatches

Label triggers are untouched: `ci:all-cypress-suites`, `ci:all-ui-test-suites`, and the per-suite labels (`ci:cypress-burn`, `ci:security-*`, etc.) still force the suites on regardless of the diff.

When files are filtered, the pipeline logs `Cypress trigger evaluation ignores N of M changed file(s) (Scout/FTR test trees or docs)` so it's observable in the annotation logs why a suite didn't run.

### Impact

Sampling recent PRs: FTR→Scout migration PRs like https://github.com/elastic/kibana/pull/283793 currently trigger the full Security Solution Cypress matrix (~140 Cypress jobs) purely because the touched test trees sit inside matched plugin directories; with this change those jobs are not scheduled.

## Testing

- `selective_cypress.test.ts`: per-path relevance table (Scout trees, FTR trees, manifests, docs vs Cypress trees, fixtures, shared config bases, plugin source).
- `pipeline.test.ts`: end-to-end pipeline generation — suites omitted on test-tree-only diffs, forced on by labels, kept on by matching source changes, and only the matched suites triggered on mixed diffs.
