### PR TITLE
[Alerting V2] Fixing logging audit findings part 1

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
@@ -142,10 +142,19 @@ export type AlertingV2ErrorCode = (typeof ALERTING_ERROR_CODES)[keyof typeof ALE
  * group and alert on specific degraded code paths without parsing free-form
  * `message` strings.
  *
- * Naming convention: `<DOMAIN>_<WHAT_FAILED>`. Read-path failures that
- * degrade gracefully should encode the degradation (e.g.
- * `*_LOOKUP_FAILED` — the page was still returned, just without that piece
- * of enrichment).
+ * Naming convention: `<DOMAIN>_<WHAT_HAPPENED>`.
+ *
+ * The domain matches the subsystem that owns the failure, so an operator can
+ * filter a whole area with a prefix: `RULE_*` (rule executor / rules client),
+ * `DIRECTOR_*`, `DISPATCH_*`, `POLICY_*`, `EXECUTION_HISTORY_*`, `EVENTS_*`,
+ * `STORAGE_*`, `QUERY_*`, `RESOURCES_*`, `MAINTENANCE_WINDOW_*`,
+ * `SAVED_OBJECTS_*`, `AGENT_BUILDER_*`, `TASKS_*`.
+ *
+ * The suffix encodes the outcome, from a closed vocabulary:
+ * - `warn` (degraded but continued): `_FAILED`, `_SKIPPED`, `_TIMED_OUT`,
+ *   `_NOT_FOUND`, `_LOOKUP_FAILED`, `_DEGRADED`, `_INVALID`, `_UNMAPPED`.
+ * - `error` (operation could not complete): `_FAILED`, `_UNAVAILABLE`,
+ *   `_INVALID`, `_UNRECOVERABLE`.
  */
 export const ALERTING_LOG_CODES = {
   // ──────────────── Action policy API key invalidation ───────────────
@@ -175,7 +184,7 @@ export const ALERTING_LOG_CODES = {
    * to prevent this. Emission of this code signals that the invariant
    * has been violated and the read path silently shrank a page.
    */
-  EXECUTION_HISTORY_NORMALIZER_REJECTED_EVENTS: 'EXECUTION_HISTORY_NORMALIZER_REJECTED_EVENTS',
+  EXECUTION_HISTORY_NORMALIZER_DEGRADED: 'EXECUTION_HISTORY_NORMALIZER_DEGRADED',
   /**
    * Action-policy id resolution failed while building the search filter for
    * the action-policy execution-history search. The search proceeds without
@@ -213,42 +222,50 @@ export const ALERTING_LOG_CODES = {
    * unhandled rejection captured by `captureRejections`). Caught by the bus's
    * permanent defensive listener so it can never crash the process.
    */
-  EVENT_BUS_EMITTER_ERROR: 'EVENT_BUS_EMITTER_ERROR',
+  EVENTS_BUS_EMITTER_FAILED: 'EVENTS_BUS_EMITTER_FAILED',
   /**
    * A subscribed handler threw (sync throw or rejected promise) while
    * processing a published domain event. The failure is isolated: sibling
    * handlers for the same event still run and the publisher is unaffected.
    */
-  EVENT_BUS_HANDLER_FAILURE: 'EVENT_BUS_HANDLER_FAILURE',
+  EVENTS_BUS_HANDLER_FAILED: 'EVENTS_BUS_HANDLER_FAILED',
   /**
    * The rule-lifecycle → workflow subscriber failed to emit a workflow event
    * for a rule domain event. The originating rule operation already
    * succeeded; only the workflow fan-out for this event was lost.
    */
-  RULE_WORKFLOW_SUBSCRIBER_FAILURE: 'RULE_WORKFLOW_SUBSCRIBER_FAILURE',
+  EVENTS_RULE_WORKFLOW_SUBSCRIBER_FAILED: 'EVENTS_RULE_WORKFLOW_SUBSCRIBER_FAILED',
   /**
    * The alert-action → workflow subscriber failed to emit a workflow event
    * for an alert-action domain event. The originating action already
    * succeeded; only the workflow fan-out for this event was lost.
    */
-  ALERT_ACTION_WORKFLOW_SUBSCRIBER_FAILURE: 'ALERT_ACTION_WORKFLOW_SUBSCRIBER_FAILURE',
+  EVENTS_ALERT_ACTION_WORKFLOW_SUBSCRIBER_FAILED: 'EVENTS_ALERT_ACTION_WORKFLOW_SUBSCRIBER_FAILED',
   /**
    * The rule-executor → workflow subscriber failed to emit a workflow event
    * for a rule-execution domain event. The rule run already completed; only
    * the workflow fan-out for this event was lost.
    */
-  RULE_EXECUTOR_WORKFLOW_SUBSCRIBER_FAILURE: 'RULE_EXECUTOR_WORKFLOW_SUBSCRIBER_FAILURE',
+  EVENTS_RULE_EXECUTOR_WORKFLOW_SUBSCRIBER_FAILED:
+    'EVENTS_RULE_EXECUTOR_WORKFLOW_SUBSCRIBER_FAILED',
   /**
    * The rule-changes-history subscriber failed to record a change entry for a
    * rule domain event. The rule operation itself already succeeded; only the
    * audit entry for this change was lost.
    */
-  RULE_CHANGES_HISTORY_SUBSCRIBER_FAILURE: 'RULE_CHANGES_HISTORY_SUBSCRIBER_FAILURE',
+  EVENTS_RULE_CHANGES_HISTORY_SUBSCRIBER_FAILED: 'EVENTS_RULE_CHANGES_HISTORY_SUBSCRIBER_FAILED',
   /**
    * A domain event was refused by the bus because its `type` collides with a
    * reserved emitter event name. The publisher continued; no subscriber ran.
    */
-  EVENT_BUS_PUBLISH_REJECTED: 'EVENT_BUS_PUBLISH_REJECTED',
+  EVENTS_BUS_PUBLISH_SKIPPED: 'EVENTS_BUS_PUBLISH_SKIPPED',
+  /**
+   * An alert action carried an `action_type` with no domain-event mapping, so
+   * no event was published for it. The action itself already applied; only
+   * the workflow fan-out for that action type is missing, which happens when
+   * the action-type vocabulary grows ahead of the publisher's mapping.
+   */
+  EVENTS_ALERT_ACTION_TYPE_UNMAPPED: 'EVENTS_ALERT_ACTION_TYPE_UNMAPPED',
 
   // ──────────────────────────── Dispatcher ───────────────────────────
   /**
@@ -274,6 +291,37 @@ export const ALERTING_LOG_CODES = {
    * (outer catch of the per-group dispatch loop). Sibling groups still run.
    */
   DISPATCH_GROUP_UNHANDLED_ERROR: 'DISPATCH_GROUP_UNHANDLED_ERROR',
+  /**
+   * A dispatch pipeline step threw. The failing step's name is carried in
+   * `labels.step` — this code stays stable across steps so a single filter
+   * returns every step failure.
+   */
+  DISPATCH_STEP_FAILED: 'DISPATCH_STEP_FAILED',
+  /**
+   * An action policy's `throttle.interval` could not be parsed, so the group
+   * was treated as if the interval had elapsed. Throttling is effectively
+   * bypassed for that policy until the interval is corrected.
+   */
+  DISPATCH_THROTTLE_INTERVAL_INVALID: 'DISPATCH_THROTTLE_INTERVAL_INVALID',
+  /**
+   * An action policy could not be read while assembling the policies for a
+   * dispatch tick. The policy is excluded from dispatch consideration; the
+   * remaining policies still dispatch.
+   */
+  DISPATCH_POLICY_LOOKUP_FAILED: 'DISPATCH_POLICY_LOOKUP_FAILED',
+
+  // ────────────────────────────── Director ───────────────────────────
+  /**
+   * Releasing the per-run alert-state cache failed after processing. Logged
+   * and swallowed so it can never mask the error that ended the run.
+   */
+  DIRECTOR_CLEANUP_FAILED: 'DIRECTOR_CLEANUP_FAILED',
+  /**
+   * A rule's `pending_timeframe` / `recovering_timeframe` could not be
+   * parsed, so the timeframe threshold was ignored and the transition fell
+   * back to count-only semantics.
+   */
+  DIRECTOR_TIMEFRAME_INVALID: 'DIRECTOR_TIMEFRAME_INVALID',
 
   // ────────────────────────── Action policies ────────────────────────
   /**
@@ -282,6 +330,18 @@ export const ALERTING_LOG_CODES = {
    * the evaluation of the remaining policies.
    */
   POLICY_MATCHER_KQL_INVALID: 'POLICY_MATCHER_KQL_INVALID',
+  /**
+   * A superseded action policy API key could not be queued for invalidation.
+   * The policy update itself already committed, so the old credential stays
+   * valid until an operator revokes it.
+   */
+  POLICY_API_KEY_INVALIDATION_FAILED: 'POLICY_API_KEY_INVALIDATION_FAILED',
+  /**
+   * An action policy's stored auth could not be decrypted, so its API key
+   * could not be identified for invalidation. The superseded credential stays
+   * valid until an operator revokes it.
+   */
+  POLICY_API_KEY_LOOKUP_FAILED: 'POLICY_API_KEY_LOOKUP_FAILED',
 
   // ─────────────────────────── Rule executor ─────────────────────────
   /**
@@ -312,6 +372,12 @@ export const ALERTING_LOG_CODES = {
    * failed, leaving the rule's task state diverged from its saved object.
    */
   RULE_TASK_MANAGER_DRIFT: 'RULE_TASK_MANAGER_DRIFT',
+  /**
+   * Scheduling a new rule's executor task failed and the compensating delete
+   * of the already-persisted saved object failed too. The rule is left
+   * orphaned — enabled, but with no executor task — and needs manual removal.
+   */
+  RULE_CREATE_ROLLBACK_FAILED: 'RULE_CREATE_ROLLBACK_FAILED',
 
   // ────────────────────────── Storage & queries ──────────────────────
   /** A bulk index request into an alerting datastream failed or was rejected. */
@@ -325,6 +391,14 @@ export const ALERTING_LOG_CODES = {
    * failed to bootstrap. Rule execution stays degraded until it succeeds.
    */
   RESOURCES_BOOTSTRAP_FAILED: 'RESOURCES_BOOTSTRAP_FAILED',
+
+  // ─────────────────────────── Saved objects ─────────────────────────
+  /**
+   * A saved object (or encrypted saved object) type failed to register at
+   * setup. The plugin cannot read or write that type for the lifetime of the
+   * process; distinct from a runtime document migration failure.
+   */
+  SAVED_OBJECTS_TYPE_REGISTRATION_FAILED: 'SAVED_OBJECTS_TYPE_REGISTRATION_FAILED',
 
   // ──────────────────────── Maintenance windows ──────────────────────
   /** Fetching active maintenance windows failed. */
@@ -373,6 +447,11 @@ export const ALERTING_LOG_CODES = {
    * task retries on its next scheduled run.
    */
   TASKS_TELEMETRY_RUN_FAILED: 'TASKS_TELEMETRY_RUN_FAILED',
+  /**
+   * A background task could not be scheduled at boot, so it will not run
+   * until the next restart. The task type is carried in `labels.task_id`.
+   */
+  TASKS_SCHEDULE_FAILED: 'TASKS_SCHEDULE_FAILED',
 } as const;
 
 export type AlertingV2LogCode = (typeof ALERTING_LOG_CODES)[keyof typeof ALERTING_LOG_CODES];

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/alert_action_workflow_subscriber/alert_action_workflow_subscriber.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/alert_action_workflow_subscriber/alert_action_workflow_subscriber.test.ts
@@ -100,7 +100,7 @@ describe('AlertActionWorkflowSubscriber', () => {
           space_id: episodeAssignedEvent.spaceId,
           episode_id: episodeAssignedEvent.episodeId,
           rule_id: episodeAssignedEvent.ruleId,
-          code: ALERTING_LOG_CODES.ALERT_ACTION_WORKFLOW_SUBSCRIBER_FAILURE,
+          code: ALERTING_LOG_CODES.EVENTS_ALERT_ACTION_WORKFLOW_SUBSCRIBER_FAILED,
         },
         error: expect.objectContaining({ message: 'workflows unreachable' }),
       });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/alert_action_workflow_subscriber/alert_action_workflow_subscriber.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/alert_action_workflow_subscriber/alert_action_workflow_subscriber.ts
@@ -102,7 +102,7 @@ export class AlertActionWorkflowSubscriber {
     } catch (err) {
       this.logger.error({
         error: err,
-        code: ALERTING_LOG_CODES.ALERT_ACTION_WORKFLOW_SUBSCRIBER_FAILURE,
+        code: ALERTING_LOG_CODES.EVENTS_ALERT_ACTION_WORKFLOW_SUBSCRIBER_FAILED,
         labels: {
           event_type: trigger.eventType,
           space_id: event.spaceId,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/event_bus/event_bus.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/event_bus/event_bus.test.ts
@@ -159,7 +159,7 @@ describe('AsyncDomainEventBus', () => {
         expect(mockLogger.warn).toHaveBeenCalledWith(expect.any(Function), {
           labels: {
             event_type: reservedType,
-            code: ALERTING_LOG_CODES.EVENT_BUS_PUBLISH_REJECTED,
+            code: ALERTING_LOG_CODES.EVENTS_BUS_PUBLISH_SKIPPED,
           },
         });
       }
@@ -182,7 +182,7 @@ describe('AsyncDomainEventBus', () => {
       expect(failing).toHaveBeenCalledTimes(1);
       expect(succeeding).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith('boom', {
-        labels: { event_type: 'foo', code: ALERTING_LOG_CODES.EVENT_BUS_HANDLER_FAILURE },
+        labels: { event_type: 'foo', code: ALERTING_LOG_CODES.EVENTS_BUS_HANDLER_FAILED },
         error: expect.objectContaining({ message: 'boom' }),
       });
     });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/event_bus/event_bus.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/event_bus/event_bus.ts
@@ -26,8 +26,8 @@ const ASYNC_RESOURCE_NAME = 'AsyncDomainEventBus';
 type AnyHandler = (event: DomainEvent, ...extra: unknown[]) => Promise<void> | void;
 
 type EventBusErrorCode =
-  | typeof ALERTING_LOG_CODES.EVENT_BUS_HANDLER_FAILURE
-  | typeof ALERTING_LOG_CODES.EVENT_BUS_EMITTER_ERROR;
+  | typeof ALERTING_LOG_CODES.EVENTS_BUS_HANDLER_FAILED
+  | typeof ALERTING_LOG_CODES.EVENTS_BUS_EMITTER_FAILED;
 
 /**
  * Event names that have special semantics on Node's {@link EventEmitter} and
@@ -93,7 +93,7 @@ export class AsyncDomainEventBus<TEvent extends DomainEvent = DomainEvent, TCont
     // safe regardless of what is published or what `captureRejections`
     // routes here.
     this.#emitter.on('error', (err) =>
-      this.#logError(err, ALERTING_LOG_CODES.EVENT_BUS_EMITTER_ERROR)
+      this.#logError(err, ALERTING_LOG_CODES.EVENTS_BUS_EMITTER_FAILED)
     );
   }
 
@@ -112,7 +112,7 @@ export class AsyncDomainEventBus<TEvent extends DomainEvent = DomainEvent, TCont
         message: () =>
           `[alerting_v2.EventBus] Refused to publish event with reserved \`type\` "${event.type}". ` +
           `These names are reserved by Node's EventEmitter.`,
-        code: ALERTING_LOG_CODES.EVENT_BUS_PUBLISH_REJECTED,
+        code: ALERTING_LOG_CODES.EVENTS_BUS_PUBLISH_SKIPPED,
         labels: { event_type: event.type },
       });
 
@@ -141,7 +141,7 @@ export class AsyncDomainEventBus<TEvent extends DomainEvent = DomainEvent, TCont
         try {
           await (handler as (...args: unknown[]) => Promise<void> | void)(event, ...extra);
         } catch (err) {
-          this.#logError(err, ALERTING_LOG_CODES.EVENT_BUS_HANDLER_FAILURE, {
+          this.#logError(err, ALERTING_LOG_CODES.EVENTS_BUS_HANDLER_FAILED, {
             event_type: event.type,
           });
         }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_changes_history_subscriber/rule_changes_history_subscriber.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_changes_history_subscriber/rule_changes_history_subscriber.test.ts
@@ -197,7 +197,7 @@ describe('RuleChangesHistorySubscriber', () => {
           event_type: RULE_CREATED_EVENT_TYPE,
           rule_id: payload.ruleId,
           space_id: payload.spaceId,
-          code: ALERTING_LOG_CODES.RULE_CHANGES_HISTORY_SUBSCRIBER_FAILURE,
+          code: ALERTING_LOG_CODES.EVENTS_RULE_CHANGES_HISTORY_SUBSCRIBER_FAILED,
         },
         error: expect.objectContaining({ message: 'es unreachable' }),
       });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_changes_history_subscriber/rule_changes_history_subscriber.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_changes_history_subscriber/rule_changes_history_subscriber.ts
@@ -116,7 +116,7 @@ export class RuleChangesHistorySubscriber {
     } catch (err) {
       this.logger.error({
         error: err,
-        code: ALERTING_LOG_CODES.RULE_CHANGES_HISTORY_SUBSCRIBER_FAILURE,
+        code: ALERTING_LOG_CODES.EVENTS_RULE_CHANGES_HISTORY_SUBSCRIBER_FAILED,
         labels: {
           event_type: event.type,
           rule_id: ruleId,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_executor_workflow_subscriber/rule_executor_workflow_subscriber.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_executor_workflow_subscriber/rule_executor_workflow_subscriber.test.ts
@@ -142,7 +142,7 @@ describe('RuleExecutorWorkflowSubscriber', () => {
           event_type: RULE_EXECUTION_SUCCEEDED_EVENT_TYPE,
           rule_id: succeededEvent.payload.rule.ruleId,
           space_id: succeededEvent.payload.rule.spaceId,
-          code: ALERTING_LOG_CODES.RULE_EXECUTOR_WORKFLOW_SUBSCRIBER_FAILURE,
+          code: ALERTING_LOG_CODES.EVENTS_RULE_EXECUTOR_WORKFLOW_SUBSCRIBER_FAILED,
         },
         error: expect.objectContaining({ message: 'workflows unreachable' }),
       });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_executor_workflow_subscriber/rule_executor_workflow_subscriber.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_executor_workflow_subscriber/rule_executor_workflow_subscriber.ts
@@ -94,7 +94,7 @@ export class RuleExecutorWorkflowSubscriber {
 
       this.logger.error({
         error: err,
-        code: ALERTING_LOG_CODES.RULE_EXECUTOR_WORKFLOW_SUBSCRIBER_FAILURE,
+        code: ALERTING_LOG_CODES.EVENTS_RULE_EXECUTOR_WORKFLOW_SUBSCRIBER_FAILED,
         labels: {
           event_type: trigger.eventType,
           rule_id: 'ruleId' in rule ? rule.ruleId : rule.id,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_workflow_subscriber/rule_workflow_subscriber.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_workflow_subscriber/rule_workflow_subscriber.test.ts
@@ -96,7 +96,7 @@ describe('RuleWorkflowSubscriber', () => {
           event_type: RULE_CREATED_EVENT_TYPE,
           rule_id: ruleCreatedEvent.payload.ruleId,
           space_id: ruleCreatedEvent.payload.spaceId,
-          code: ALERTING_LOG_CODES.RULE_WORKFLOW_SUBSCRIBER_FAILURE,
+          code: ALERTING_LOG_CODES.EVENTS_RULE_WORKFLOW_SUBSCRIBER_FAILED,
         },
         error: expect.objectContaining({ message: 'workflows unreachable' }),
       });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_workflow_subscriber/rule_workflow_subscriber.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/events/rule_workflow_subscriber/rule_workflow_subscriber.ts
@@ -76,7 +76,7 @@ export class RuleWorkflowSubscriber {
     } catch (err) {
       this.logger.error({
         error: err,
-        code: ALERTING_LOG_CODES.RULE_WORKFLOW_SUBSCRIBER_FAILURE,
+        code: ALERTING_LOG_CODES.EVENTS_RULE_WORKFLOW_SUBSCRIBER_FAILED,
         labels: {
           event_type: trigger.eventType,
           rule_id: event.payload.ruleId,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/event_log_service/event_log_service.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/event_log_service/event_log_service.ts
@@ -144,7 +144,7 @@ export class EventLogService implements EventLogServiceContract {
         error: new Error(
           `Dropped ${droppedCount} of ${response.hits.hits.length} task-run hit(s) on the rule executions read path. The normalizer rejected rows the ES query is supposed to have excluded. Investigate Task Manager schema drift or rule_executions_query filter coverage.`
         ),
-        code: ALERTING_LOG_CODES.EXECUTION_HISTORY_NORMALIZER_REJECTED_EVENTS,
+        code: ALERTING_LOG_CODES.EXECUTION_HISTORY_NORMALIZER_DEGRADED,
       });
     }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/event_log_service/normalizers/rule_execution_normalizer.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/event_log_service/normalizers/rule_execution_normalizer.test.ts
@@ -220,7 +220,7 @@ describe('normalizeRuleExecution', () => {
    * pass `isRuleExecutionOutcome` cannot reach the normalizer in
    * steady state. If they ever do, it means the ES filter and this
    * check have drifted out of sync — the `EventLogService` drop log
-   * (`EXECUTION_HISTORY_NORMALIZER_REJECTED_EVENTS`) surfaces it. The
+   * (`EXECUTION_HISTORY_NORMALIZER_DEGRADED`) surfaces it. The
    * cases below pin the projection-safe behaviour: drop the row
    * rather than emitting a `RuleExecution` with an out-of-schema
    * outcome.

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/event_log_service/normalizers/rule_execution_normalizer.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/event_log_service/normalizers/rule_execution_normalizer.ts
@@ -61,7 +61,7 @@ const isRuleExecutionOutcome = (value: unknown): value is RuleExecutionOutcome =
  *    structurally-valid set, so this branch is defence-in-depth —
  *    it should not fire in steady state. If it does, the
  *    `EventLogService` drop counter emits
- *    `EXECUTION_HISTORY_NORMALIZER_REJECTED_EVENTS`, signalling that
+ *    `EXECUTION_HISTORY_NORMALIZER_DEGRADED`, signalling that
  *    the ES filter, this check, the public schema, and Task Manager's
  *    source enum have fallen out of lock-step.
  */

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/event_log_service/queries/rule_executions_query.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/event_log_service/queries/rule_executions_query.ts
@@ -18,7 +18,7 @@ import type { FindRuleExecutionsQuery, RuleExecutionSortField } from '../types';
  * schema so the four layers — TM source, ES filter, normalizer, public
  * schema — move in lock-step: widening any one of them without the
  * others triggers the
- * `EXECUTION_HISTORY_NORMALIZER_REJECTED_EVENTS` drop log.
+ * `EXECUTION_HISTORY_NORMALIZER_DEGRADED` drop log.
  */
 const STRUCTURALLY_VALID_OUTCOMES: string[] = [...ruleExecutionOutcomeSchema.options];
 
@@ -62,7 +62,7 @@ const SORT_FIELD_TO_ES: Record<RuleExecutionSortField, string> = {
  *     `isRuleExecutionOutcome` check, and the public
  *     `ruleExecutionOutcomeSchema`. Widening any one of them without
  *     the others surfaces immediately via the
- *     `EXECUTION_HISTORY_NORMALIZER_REJECTED_EVENTS` drop log — which
+ *     `EXECUTION_HISTORY_NORMALIZER_DEGRADED` drop log — which
  *     therefore should not fire in steady state. The caller-supplied
  *     outcome filter, when present, is a subset of the structurally
  *     valid set (enforced by the public schema) and is forwarded

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/logger_service/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/logger_service/types.ts
@@ -20,6 +20,8 @@ export type AlertingLabels = Partial<{
   space_id: string;
   policy_id: string;
   group_id: string;
+  /** Hash identifying an alert group, the director's per-alert-event key. */
+  group_hash: string;
   episode_id: string;
   workflow_id: string;
   execution_id: string;
@@ -29,6 +31,11 @@ export type AlertingLabels = Partial<{
   event_type: string;
   step: string;
   subsystem: string;
+  /**
+   * Which member of a fixed, statically declared set failed — a saved object
+   * type, a datastream, an ES|QL view. Enum-like rather than an entity id.
+   */
+  resource: string;
 }>;
 
 /**

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/logger_service/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/logger_service/types.ts
@@ -20,7 +20,6 @@ export type AlertingLabels = Partial<{
   space_id: string;
   policy_id: string;
   group_id: string;
-  /** Hash identifying an alert group, the director's per-alert-event key. */
   group_hash: string;
   episode_id: string;
   workflow_id: string;
@@ -32,7 +31,7 @@ export type AlertingLabels = Partial<{
   step: string;
   subsystem: string;
   /**
-   * Which member of a fixed, statically declared set failed — a saved object
+   * Which member of a fixed, statically declared set failed - e.g. a saved object
    * type, a datastream, an ES|QL view. Enum-like rather than an entity id.
    */
   resource: string;


### PR DESCRIPTION
## Summary

Addresses elastic/rna-program#708 (part 1 of the logging retrofit).

Vocabulary-only change to the alerting v2 log-code catalog and label set. No behavior changes and no new log call sites.

From the original issue:
- **New `EVENTS_*` domain.**
- **Suffix normalization.**
- **Eleven new codes**
- **Two new labels**


### Checklist

- [x] Unit tests updated for the renamed codes