### PR TITLE
[Cases] Remove unknown-key validation from extended fields

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/validate_extended_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/validate_extended_fields.test.ts
@@ -145,7 +145,6 @@ describe('validateExtendedFields', () => {
         fields
       );
 
-      expect(errors).toContain('Unknown extended field key: "rogue_as_keyword"');
       expect(errors).toContain(
         `Extended field "rogue_as_keyword" exceeds the maximum size of ${MAX_EXTENDED_FIELD_VALUE_BYTES} bytes`
       );
@@ -165,19 +164,19 @@ describe('validateExtendedFields', () => {
   });
 
   describe('unknown keys', () => {
-    it('reports error for unknown key', () => {
+    it('silently ignores an unknown key', () => {
       const fields: FieldSchemaType[] = [makeInputTextField()];
       const extendedFields = { unknown_as_keyword: 'value' };
       const errors = validateExtendedFields(extendedFields, fields);
-      expect(errors).toContain('Unknown extended field key: "unknown_as_keyword"');
+      expect(errors).toEqual([]);
     });
 
-    it('reports error for key with mismatched type', () => {
+    it('silently ignores a key with mismatched type suffix', () => {
       const fields: FieldSchemaType[] = [makeInputTextField()];
       // the key uses wrong type suffix
       const extendedFields = { summary_as_long: 'value' };
       const errors = validateExtendedFields(extendedFields, fields);
-      expect(errors).toContain('Unknown extended field key: "summary_as_long"');
+      expect(errors).toEqual([]);
     });
   });
 
@@ -224,10 +223,10 @@ describe('validateExtendedFields', () => {
       expect(errors).toEqual([]);
     });
 
-    it('treats a value submitted for a display-only field as an unknown key', () => {
+    it('silently ignores a value submitted for a display-only field', () => {
       const fields: FieldSchemaType[] = [makeMarkdownField()];
       const errors = validateExtendedFields({ instructions_as_keyword: 'value' }, fields);
-      expect(errors).toContain('Unknown extended field key: "instructions_as_keyword"');
+      expect(errors).toEqual([]);
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/validate_extended_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/validate_extended_fields.ts
@@ -151,19 +151,10 @@ export const validateExtendedFields = (
 ): string[] => {
   let errors: string[] = [];
   // Display-only fields (e.g. MARKDOWN) hold no value and are excluded from a case's stored
-  // `extended_fields`, so they take no part in value/required validation. Dropping them here also
-  // ensures their snake key is treated as an unknown key if it is ever submitted.
+  // `extended_fields`, so they take no part in value/required validation.
   const inlineFields = fields.filter(isInlineField).filter((f) => !isDisplayOnlyField(f));
 
-  // 1. Build valid key set
-  const validKeys = new Set(inlineFields.map((f) => getFieldSnakeKey(f.name, f.type)));
-
-  // 2. Unknown keys + value-size backstop
-  for (const key of Object.keys(extendedFields)) {
-    if (!validKeys.has(key)) {
-      errors.push(`Unknown extended field key: "${key}"`);
-    }
-  }
+  // 1. Value-size backstop
   errors = errors.concat(validateExtendedFieldValueSizes(extendedFields));
 
   // 3. Build helper maps

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.test.ts
@@ -1488,21 +1488,20 @@ describe('create', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('validates the merged extended_fields (template fetched once)', async () => {
+    it('creates the case and fetches the template once when extended_fields contains an unknown key', async () => {
       const clientArgs = createClientArgs();
 
-      await expect(
-        create(
-          {
-            ...minimalRequest,
-            template: { id: 'tmpl-exp' },
-            extended_fields: { unknown_key_as_keyword: 'x' },
-          },
-          clientArgs,
-          expansionCasesClientMock
-        )
-      ).rejects.toThrow('Unknown extended field key: "unknown_key_as_keyword"');
-      expect(clientArgs.services.caseService.createCase).not.toHaveBeenCalled();
+      await create(
+        {
+          ...minimalRequest,
+          template: { id: 'tmpl-exp' },
+          extended_fields: { unknown_key_as_keyword: 'x' },
+        },
+        clientArgs,
+        expansionCasesClientMock
+      );
+
+      expect(clientArgs.services.caseService.createCase).toHaveBeenCalledTimes(1);
       // Expansion resolved the template; validation reused it instead of fetching again.
       expect(clientArgs.services.templatesService.getTemplate).toHaveBeenCalledTimes(1);
     });

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/cases/create_case_from_template.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/cases/create_case_from_template.ts
@@ -191,18 +191,16 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(JSON.stringify(res)).to.contain('not found');
     });
 
-    it('rejects a merged map that violates the template validation (unknown key)', async () => {
+    it('silently accepts an unknown key in extended_fields (no longer rejected)', async () => {
       const template = await createTemplate(kitchenSinkDefinition);
 
-      await createCase(
-        supertest,
-        {
-          ...getPostCaseRequest({ owner: OWNER }),
-          template: { id: template.templateId },
-          extended_fields: { not_a_field_as_keyword: 'x' },
-        },
-        400
-      );
+      const createdCase = await createCase(supertest, {
+        ...getPostCaseRequest({ owner: OWNER }),
+        template: { id: template.templateId },
+        extended_fields: { not_a_field_as_keyword: 'x' },
+      });
+
+      expect(createdCase.template?.id).to.eql(template.templateId);
     });
 
     it('allows a user with only case-create privileges (no manageTemplates) to create from a template', async () => {


### PR DESCRIPTION
## TLDR

Unknown keys in `extended_fields` are now silently accepted instead of rejected, allowing template schema evolution without breaking existing clients or case imports that reference stale field keys.

## Summary

- Removed the unknown-key check from `validateExtendedFields`. Any key whose snake-case `name_as_type` does not match a template-defined field is now ignored rather than producing a validation error.
- The value-size backstop (`MAX_EXTENDED_FIELD_VALUE_BYTES`) still applies to all keys, including unknown ones.
- All per-field validation (required, pattern, length, numeric, options, toggle) is unaffected — it only runs for keys that do match a known field definition.
- Updated tests to reflect the new behaviour: unknown-key and display-only-field assertions now expect no errors; the `create` integration test verifies the case is created rather than rejected.

## What stays the same

- Global field validation is unaffected. `validateCaseExtendedFields` still rejects non-global keys at the outer level on the no-template path before `validateExtendedFields` is called.
- Required, pattern, and constraint validation continue to run for all recognised fields.
- The byte-size limit is enforced for every key regardless of whether it maps to a known field.

## Trade-off

Typos in field keys (e.g. `summery_as_keyword`) will no longer surface as validation errors — the value is silently stored and the intended field is treated as absent.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->