### PR TITLE
[8.19] [ResponseOps][Alerting] propagate rule tags to event log tags (#281833)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.test.ts
@@ -387,6 +387,17 @@ describe('AlertingEventLogger', () => {
         },
       });
     });
+
+    test('should update standard event with rule tags correctly', () => {
+      const event = initializeExecuteRecord(ruleContextWithScheduleDelay, ruleData, [alertSO]);
+      alertingEventLogger.initialize({ context: ruleContext, runDate, ruleData });
+      alertingEventLogger.addOrUpdateRuleData({ tags: ['tag-1', 'tag-3'] });
+
+      expect(alertingEventLogger.getEvent()).toEqual({
+        ...event,
+        tags: ['tag-1', 'tag-3'],
+      });
+    });
   });
 
   describe('setExecutionSucceeded()', () => {
@@ -1588,6 +1599,7 @@ describe('helper functions', () => {
       type: ruleType,
       consumer: 'test-consumer',
       revision: 0,
+      tags: ['tag-1', 'tag-2'],
     };
     ruleDataWithName = { ...ruleData, name: 'my-super-cool-rule' };
     alertSO = { id: '123', relation: 'primary', type: 'alert', typeId: 'test' };
@@ -1609,6 +1621,7 @@ describe('helper functions', () => {
       expect(record.rule).toBeDefined();
 
       // these fields should be explicitly set
+      expect(record.tags).toEqual(['tag-1', 'tag-2']);
       expect(record.event?.action).toEqual('execute');
       expect(record.event?.kind).toEqual('alert');
       expect(record.event?.category).toEqual([ruleData.type?.producer]);
@@ -2093,6 +2106,14 @@ describe('helper functions', () => {
             },
           },
         },
+      });
+    });
+
+    test('updates event tags if provided', () => {
+      updateEventWithRuleData(event, { ruleTags: ['tag-1', 'tag-2'] });
+      expect(event).toEqual({
+        ...expectedEvent,
+        tags: ['tag-1', 'tag-2'],
       });
     });
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -28,6 +28,7 @@ export interface RuleContext {
   consumer?: string;
   name?: string;
   revision?: number;
+  tags?: string[];
 }
 export interface ContextOpts {
   savedObjectId: string;
@@ -217,12 +218,14 @@ export class AlertingEventLogger {
     consumer,
     type,
     revision,
+    tags,
   }: {
     name?: string;
     id?: string;
     consumer?: string;
     revision?: number;
     type?: UntypedNormalizedRuleType;
+    tags?: string[];
   }) {
     if (!this.isInitialized) {
       throw new Error(`AlertingEventLogger not initialized`);
@@ -248,6 +251,10 @@ export class AlertingEventLogger {
       this.ruleData.revision = revision;
     }
 
+    if (tags) {
+      this.ruleData.tags = tags;
+    }
+
     let updatedRelatedSavedObjects = false;
     if (id && type) {
       // add this to saved objects array if it doesn't already exists
@@ -267,6 +274,7 @@ export class AlertingEventLogger {
       ruleName: name,
       ruleId: id,
       ruleType: type,
+      ruleTags: tags,
       consumer,
       revision,
       savedObjects: updatedRelatedSavedObjects ? this.relatedSavedObjects : undefined,
@@ -468,6 +476,7 @@ export function createAlertRecord(
     flapping: alert.flapping,
     maintenanceWindowIds: alert.maintenanceWindowIds,
     ruleRevision: ruleData.revision,
+    ruleTags: ruleData.tags,
   });
 }
 
@@ -499,6 +508,7 @@ export function createActionExecuteRecord(
     ruleName: ruleData.name,
     alertSummary: action.alertSummary,
     ruleRevision: ruleData.revision,
+    ruleTags: ruleData.tags,
   });
 }
 
@@ -532,6 +542,7 @@ export function createExecuteTimeoutRecord(
     savedObjects,
     ruleName: ruleData?.name,
     ruleRevision: ruleData?.revision,
+    ruleTags: ruleData?.tags,
   });
 }
 
@@ -558,6 +569,7 @@ export function createGapRecord(
     savedObjects,
     ruleName: ruleData?.name,
     ruleRevision: ruleData?.revision,
+    ruleTags: ruleData?.tags,
     gap,
   });
 }
@@ -572,6 +584,7 @@ export function initializeExecuteRecord(
     ruleType: ruleData.type,
     consumer: ruleData.consumer,
     ruleRevision: ruleData.revision,
+    ruleTags: ruleData.tags,
     namespace: context.namespace,
     spaceId: context.spaceId,
     executionId: context.executionId,
@@ -614,6 +627,7 @@ interface UpdateEventOpts {
 interface UpdateRuleOpts {
   ruleName?: string;
   ruleId?: string;
+  ruleTags?: string[];
   consumer?: string;
   ruleType?: UntypedNormalizedRuleType;
   revision?: number;
@@ -621,7 +635,7 @@ interface UpdateRuleOpts {
 }
 
 export function updateEventWithRuleData(event: IEvent, opts: UpdateRuleOpts) {
-  const { ruleName, ruleId, consumer, ruleType, revision, savedObjects } = opts;
+  const { ruleName, ruleId, consumer, ruleType, revision, ruleTags, savedObjects } = opts;
   if (!event) {
     throw new Error('Cannot update event because it is not initialized.');
   }
@@ -638,6 +652,10 @@ export function updateEventWithRuleData(event: IEvent, opts: UpdateRuleOpts) {
       ...event.rule,
       id: ruleId,
     };
+  }
+
+  if (ruleTags && ruleTags.length > 0) {
+    event.tags = ruleTags;
   }
 
   if (consumer) {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/create_alert_event_log_record_object.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/create_alert_event_log_record_object.test.ts
@@ -55,9 +55,11 @@ describe('createAlertEventLogRecordObject', () => {
         ],
         spaceId: 'default',
         maintenanceWindowIds: MAINTENANCE_WINDOW_IDS,
+        ruleTags: ['tag-1', 'tag-2'],
       })
     ).toStrictEqual({
       '@timestamp': '1970-01-01T00:00:00.000Z',
+      tags: ['tag-1', 'tag-2'],
       event: {
         action: 'execute-start',
         category: ['alerts'],
@@ -128,8 +130,10 @@ describe('createAlertEventLogRecordObject', () => {
         ],
         spaceId: 'default',
         maintenanceWindowIds: MAINTENANCE_WINDOW_IDS,
+        ruleTags: ['tag-1', 'tag-2'],
       })
     ).toStrictEqual({
+      tags: ['tag-1', 'tag-2'],
       event: {
         action: 'recovered-instance',
         category: ['alerts'],
@@ -215,8 +219,10 @@ describe('createAlertEventLogRecordObject', () => {
           recovered: 1,
         },
         maintenanceWindowIds: MAINTENANCE_WINDOW_IDS,
+        ruleTags: ['tag-1', 'tag-2'],
       })
     ).toStrictEqual({
+      tags: ['tag-1', 'tag-2'],
       event: {
         action: 'execute-action',
         category: ['alerts'],

--- a/x-pack/platform/plugins/shared/alerting/server/lib/create_alert_event_log_record_object.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/create_alert_event_log_record_object.ts
@@ -19,6 +19,7 @@ interface CreateAlertEventLogRecordParams {
   spaceId?: string;
   consumer?: string;
   ruleName?: string;
+  ruleTags?: string[];
   instanceId?: string;
   message?: string;
   state?: AlertInstanceState;
@@ -71,6 +72,7 @@ export function createAlertEventLogRecordObject(params: CreateAlertEventLogRecor
     alertSummary,
     maintenanceWindowIds,
     ruleRevision,
+    ruleTags,
     gap,
   } = params;
   const alerting =
@@ -93,6 +95,7 @@ export function createAlertEventLogRecordObject(params: CreateAlertEventLogRecor
       : undefined;
   const event: Event = {
     ...(params.timestamp ? { '@timestamp': params.timestamp } : {}),
+    ...(ruleTags && ruleTags.length > 0 ? { tags: ruleTags } : {}),
     event: {
       action,
       kind: 'alert',

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/untrack_rule_alerts.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/untrack_rule_alerts.ts
@@ -54,6 +54,7 @@ export const untrackRuleAlerts = async (
 
         const event = createAlertEventLogRecordObject({
           ruleId: id,
+          ruleTags: attributes.tags,
           ruleName: attributes.name,
           ruleRevision: attributes.revision,
           ruleType,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
@@ -291,7 +291,7 @@ describe('Ad Hoc Task Runner', () => {
         end: '2024-03-01T05:00:00.000Z',
         rule: {
           name: 'test',
-          tags: [],
+          tags: ['tag-1', 'tag-2'],
           alertTypeId: 'siem.queryRule',
           actions: [],
           params: {
@@ -477,7 +477,7 @@ describe('Ad Hoc Task Runner', () => {
     expect(call.rule).not.toBe(null);
     expect(call.rule.id).toBe(RULE_ID);
     expect(call.rule.name).toBe('test');
-    expect(call.rule.tags).toEqual([]);
+    expect(call.rule.tags).toEqual(['tag-1', 'tag-2']);
     expect(call.rule.consumer).toBe('siem');
     expect(call.rule.enabled).toBe(true);
     expect(call.rule.schedule).toEqual({ interval: '1h' });
@@ -1657,6 +1657,7 @@ describe('Ad Hoc Task Runner', () => {
         name: mockedAdHocRunSO.attributes.rule.name,
         consumer: mockedAdHocRunSO.attributes.rule.consumer,
         revision: mockedAdHocRunSO.attributes.rule.revision,
+        tags: mockedAdHocRunSO.attributes.rule.tags,
       });
     }
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
@@ -377,6 +377,7 @@ export class AdHocTaskRunner implements CancellableTask {
         name: rule.name,
         consumer: rule.consumer,
         revision: rule.revision,
+        tags: rule.tags,
       });
 
       try {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -3676,6 +3676,7 @@ describe('Task Runner', () => {
         name: mockedRuleTypeSavedObject.name,
         consumer: mockedRuleTypeSavedObject.consumer,
         revision: mockedRuleTypeSavedObject.revision,
+        tags: mockedRuleTypeSavedObject.tags,
       });
     } else {
       expect(alertingEventLogger.addOrUpdateRuleData).not.toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -541,6 +541,7 @@ export class TaskRunner<
         name: runRuleParams.rule.name,
         consumer: runRuleParams.rule.consumer,
         revision: runRuleParams.rule.revision,
+        tags: runRuleParams.rule.tags,
       });
 
       // Set rule monitoring data

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
@@ -557,6 +557,7 @@ describe('Task Runner Cancel', () => {
       name: mockedRuleTypeSavedObject.name,
       consumer: mockedRuleTypeSavedObject.consumer,
       revision: mockedRuleTypeSavedObject.revision,
+      tags: mockedRuleTypeSavedObject.tags,
     });
     expect(alertingEventLogger.getStartAndDuration).toHaveBeenCalled();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Alerting] propagate rule tags to event log tags (#281833)](https://github.com/elastic/kibana/pull/281833)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"lu(cia)","email":"lucia.petracca@elastic.co"},"sourceCommit":{"committedDate":"2026-08-07T14:14:08Z","message":"[ResponseOps][Alerting] propagate rule tags to event log tags (#281833)\n\nResolves https://github.com/elastic/kibana/issues/263824\n\nPropagates rule's tags to populate event log \"tags\" property when\navailable.\n\n\n<img width=\"595\" height=\"431\" alt=\"Screenshot 2026-08-03 at 14 32 20\"\nsrc=\"https://github.com/user-attachments/assets/159c703e-3b41-4b46-ae24-9e4ec62f9ec0\"\n/>\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"480c389c494ce96e24e53ac182f7ab8f047ac4a2","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","backport:all-open","v9.6.0","v9.5.1"],"title":"[ResponseOps][Alerting] propagate rule tags to event log tags","number":281833,"url":"https://github.com/elastic/kibana/pull/281833","mergeCommit":{"message":"[ResponseOps][Alerting] propagate rule tags to event log tags (#281833)\n\nResolves https://github.com/elastic/kibana/issues/263824\n\nPropagates rule's tags to populate event log \"tags\" property when\navailable.\n\n\n<img width=\"595\" height=\"431\" alt=\"Screenshot 2026-08-03 at 14 32 20\"\nsrc=\"https://github.com/user-attachments/assets/159c703e-3b41-4b46-ae24-9e4ec62f9ec0\"\n/>\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"480c389c494ce96e24e53ac182f7ab8f047ac4a2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281833","number":281833,"mergeCommit":{"message":"[ResponseOps][Alerting] propagate rule tags to event log tags (#281833)\n\nResolves https://github.com/elastic/kibana/issues/263824\n\nPropagates rule's tags to populate event log \"tags\" property when\navailable.\n\n\n<img width=\"595\" height=\"431\" alt=\"Screenshot 2026-08-03 at 14 32 20\"\nsrc=\"https://github.com/user-attachments/assets/159c703e-3b41-4b46-ae24-9e4ec62f9ec0\"\n/>\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"480c389c494ce96e24e53ac182f7ab8f047ac4a2"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/283689","number":283689,"state":"MERGED","mergeCommit":{"sha":"254b52471c0c6162d624069ac2add82f4baa1743","message":"[9.5] [ResponseOps][Alerting] propagate rule tags to event log tags (#281833) (#283689)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[ResponseOps][Alerting] propagate rule tags to event log tags\n(#281833)](https://github.com/elastic/kibana/pull/281833)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: lu(cia) <lucia.petracca@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"url":"https://github.com/elastic/kibana/pull/283688","number":283688,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->