### PR TITLE
[discover-scout] Fix rename tab flakiness

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.test.tsx
@@ -12,6 +12,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Tab } from './tab';
 import { MAX_TAB_WIDTH, MIN_TAB_WIDTH } from '../../constants';
+import { TabMenuItemName } from '../../types';
 import { servicesMock } from '../../../__mocks__/services';
 import { getPreviewDataMock } from '../../../__mocks__/get_preview_data';
 
@@ -152,6 +153,64 @@ describe('Tab', () => {
 
     expect(screen.queryByTestId(tabButtonTestSubj)).toBeInTheDocument();
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('can enter rename mode with Shift+F10 and Enter', async () => {
+    const user = userEvent.setup({ delay: null, advanceTimers: jest.advanceTimersByTime });
+    const onLabelEdited = jest.fn();
+    const getTabMenuItems = jest.fn(() => [
+      {
+        'data-test-subj': 'unifiedTabs_tabMenuItem_enterRenamingMode',
+        name: TabMenuItemName.enterRenamingMode,
+        label: 'Rename',
+        onClick: null,
+      },
+    ]);
+
+    render(
+      <Tab
+        tabContentId={tabContentId}
+        tabsSizeConfig={tabsSizeConfig}
+        item={tabItem}
+        isSelected
+        services={servicesMock}
+        getTabMenuItems={getTabMenuItems}
+        getPreviewData={getPreviewDataMock}
+        onLabelEdited={onLabelEdited}
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    const tabButton = screen.getByTestId(tabButtonTestSubj);
+    tabButton.focus();
+    await user.keyboard('{Shift>}{F10}{/Shift}');
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    const renameItem = await screen.findByTestId('unifiedTabs_tabMenuItem_enterRenamingMode');
+    // jsdom does not reliably run EUI's popover→menuitem focus transfer; place focus
+    // on Rename (as initialFocusedItemIndex={0} does in the browser) then activate it.
+    renameItem.focus();
+    expect(renameItem).toHaveFocus();
+    await user.keyboard('{Enter}');
+
+    // TabMenu defers onEnterRenaming with setTimeout(100); onEnterRenaming uses setTimeout(0)
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    await user.type(input, 'keyboard-label');
+    await user.keyboard('{Enter}');
+    expect(onLabelEdited).toHaveBeenCalledWith(tabItem, 'keyboard-label');
   });
 
   it('can cancel editing of tab label', async () => {

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab_menu/tab_menu.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab_menu/tab_menu.tsx
@@ -107,7 +107,7 @@ export const TabMenu: React.FC<TabMenuProps> = ({
         </EuiToolTip>
       }
     >
-      <EuiContextMenuPanel items={panelItems} />
+      <EuiContextMenuPanel initialFocusedItemIndex={0} items={panelItems} />
     </EuiPopover>
   );
 };

--- a/src/platform/test/examples/unified_tabs_examples/manage_tabs.ts
+++ b/src/platform/test/examples/unified_tabs_examples/manage_tabs.ts
@@ -22,8 +22,20 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
   const browser = getService('browser');
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
+  const find = getService('find');
 
   const openTabContextMenuWithKeyboard = async () => {
+    // createNewTab() focuses the "new tab" button via mouse click, so keyboard
+    // focus may sit on that button rather than the newly-created tab. Shift+F10
+    // only opens the menu when the selected tab has focus.
+    const selectedTab = await unifiedTabs.getSelectedTab();
+    if (selectedTab) {
+      const tabButton = await selectedTab.element.findByCssSelector(
+        '[data-test-subj^="unifiedTabs_selectTabBtn_"]'
+      );
+      await tabButton.click();
+    }
+
     await browser
       .getActions()
       .keyDown(Key.SHIFT)
@@ -31,8 +43,17 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       .keyUp(Key.SHIFT)
       .perform();
 
-    await retry.waitFor('open tab context menu', async () => {
-      return await testSubjects.exists('unifiedTabs_tabMenuItem_enterRenamingMode');
+    // Wait until Rename is focused — EUI moves focus into the menu asynchronously
+    // after the popover is stable. DOM presence alone is not enough.
+    await retry.waitFor('Rename menu item to be focused', async () => {
+      if (!(await testSubjects.exists('unifiedTabs_tabMenuItem_enterRenamingMode'))) {
+        return false;
+      }
+      const activeElement = await find.activeElement();
+      return (
+        (await activeElement.getAttribute('data-test-subj')) ===
+        'unifiedTabs_tabMenuItem_enterRenamingMode'
+      );
     });
   };
 
@@ -112,7 +133,8 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       expect(await unifiedTabs.getNumberOfTabs()).to.be(7);
       await unifiedTabs.createNewTab();
       await openTabContextMenuWithKeyboard();
-      await browser.pressKeys(browser.keys.ARROW_DOWN);
+      // Rename is the first item and is focused when the menu opens via keyboard;
+      // pressing ENTER activates it directly (ARROW_DOWN would move to Duplicate).
       await browser.pressKeys(browser.keys.ENTER);
       await unifiedTabs.enterNewTabLabel('Test label');
       expect(await unifiedTabs.getTabLabels()).to.eql([


### PR DESCRIPTION
## Summary

Closes #222113

This PR tries to fix renaming tab label flakiness. It adds 3 things:
1) Product - added `initialFocusedItemIndex` prop to the popover and focused first element after by default
2) Adjusted FTR to reflect that and reduce race condition
3) Added RTL for covering rename mode

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



