### PR TITLE
[CPS] Project routing string codec

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/utils/filter_input_codec.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/utils/filter_input_codec.ts
@@ -93,7 +93,7 @@ const NoValueFilterExpression = filterBase.extend({
   tagValue: z.undefined(),
 });
 
-const FilterExpressionSchema = z.union([
+export const FilterExpressionSchema = z.union([
   SingleValueFilterExpression,
   MultiValueFilterExpression,
   NoValueFilterExpression,
@@ -189,5 +189,9 @@ export type FilterExpressionCodecOutput = z.output<typeof FilterExpressionSchema
 
 /** Canonical Map key for a stored filter expression (matches encoded badge text semantics). */
 export function getFilterExpressionLookupKey(expression: FilterExpressionValue): string {
-  return filterExpressionCodec.encode(expression) as string;
+  const encoded = filterExpressionCodec.encode(expression);
+  if (encoded === undefined) {
+    throw new Error('Cannot encode filter expression lookup key');
+  }
+  return encoded;
 }

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/utils/project_routing_codec.test.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/utils/project_routing_codec.test.ts
@@ -1,0 +1,424 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FilterOperator, type FilterExpressionValue } from './filter_input_codec';
+import type { ProjectRoutingExpression } from './project_routing_codec';
+import {
+  decodeTagFilterRoutingClause,
+  encodeTagFilterRoutingClause,
+  projectRoutingCodec,
+  ProjectRoutingExpressionSchema,
+} from './project_routing_codec';
+
+const typeSecurityExpression = {
+  operator: FilterOperator.EQUALS,
+  tagName: '_type',
+  tagValue: 'security',
+} as const;
+
+const emptyEncodeInput: ProjectRoutingExpression = {
+  filterExpressions: [],
+  excludedProjectIds: [],
+  selectedProjectIds: [],
+  projectRoutingStrategy: 'dynamic',
+};
+
+describe('encodeTagFilterRoutingClause', () => {
+  it('encodes an equals filter as a tag:value clause', () => {
+    expect(
+      encodeTagFilterRoutingClause({
+        operator: FilterOperator.EQUALS,
+        tagName: 'env',
+        tagValue: 'prod',
+      })
+    ).toBe('env:prod');
+  });
+
+  it('encodes a not-equals filter as an exists clause minus the value', () => {
+    expect(
+      encodeTagFilterRoutingClause({
+        operator: FilterOperator.NOT_EQUALS,
+        tagName: 'env',
+        tagValue: 'prod',
+      })
+    ).toBe('env:* AND NOT env:prod');
+  });
+
+  it('encodes a one-of filter as OR-joined tag:value clauses', () => {
+    expect(
+      encodeTagFilterRoutingClause({
+        operator: FilterOperator.ONE_OF,
+        tagName: 'env',
+        tagValue: ['prod', 'staging'],
+      })
+    ).toBe('(env:prod OR env:staging)');
+  });
+
+  it('encodes a not-one-of filter as an exists clause minus the OR group', () => {
+    expect(
+      encodeTagFilterRoutingClause({
+        operator: FilterOperator.NOT_ONE_OF,
+        tagName: 'env',
+        tagValue: ['prod', 'staging'],
+      })
+    ).toBe('env:* AND NOT (env:prod OR env:staging)');
+  });
+
+  it('encodes an exists filter as a wildcard clause', () => {
+    expect(
+      encodeTagFilterRoutingClause({
+        operator: FilterOperator.EXISTS,
+        tagName: 'env',
+        tagValue: undefined,
+      })
+    ).toBe('env:*');
+  });
+
+  it('encodes a not-exists filter as a negated wildcard clause', () => {
+    expect(
+      encodeTagFilterRoutingClause({
+        operator: FilterOperator.NOT_EXISTS,
+        tagName: 'env',
+        tagValue: undefined,
+      })
+    ).toBe('NOT env:*');
+  });
+});
+
+describe('decodeTagFilterRoutingClause', () => {
+  it('decodes an equals filter from a tag:value clause', () => {
+    expect(decodeTagFilterRoutingClause('env:prod')).toEqual({
+      operator: FilterOperator.EQUALS,
+      tagName: 'env',
+      tagValue: 'prod',
+    });
+  });
+
+  it('decodes a not-equals filter from an exists clause minus the value', () => {
+    expect(decodeTagFilterRoutingClause('env:* AND NOT env:prod')).toEqual({
+      operator: FilterOperator.NOT_EQUALS,
+      tagName: 'env',
+      tagValue: 'prod',
+    });
+  });
+
+  it('decodes a one-of filter from OR-joined tag:value clauses', () => {
+    expect(decodeTagFilterRoutingClause('env:prod OR env:staging')).toEqual({
+      operator: FilterOperator.ONE_OF,
+      tagName: 'env',
+      tagValue: ['prod', 'staging'],
+    });
+  });
+
+  it('decodes a not-one-of filter from an exists clause minus the OR group', () => {
+    expect(decodeTagFilterRoutingClause('env:* AND NOT (env:prod OR env:staging)')).toEqual({
+      operator: FilterOperator.NOT_ONE_OF,
+      tagName: 'env',
+      tagValue: ['prod', 'staging'],
+    });
+  });
+
+  it('decodes an exists filter from a wildcard clause', () => {
+    expect(decodeTagFilterRoutingClause('env:*')).toEqual({
+      operator: FilterOperator.EXISTS,
+      tagName: 'env',
+      tagValue: undefined,
+    });
+  });
+
+  it('decodes a not-exists filter from a negated wildcard clause', () => {
+    expect(decodeTagFilterRoutingClause('NOT env:*')).toEqual({
+      operator: FilterOperator.NOT_EXISTS,
+      tagName: 'env',
+      tagValue: undefined,
+    });
+  });
+
+  it('decodes tag names and values containing underscores and colons', () => {
+    expect(decodeTagFilterRoutingClause('_alias:_origin')).toEqual({
+      operator: FilterOperator.EQUALS,
+      tagName: '_alias',
+      tagValue: '_origin',
+    });
+  });
+
+  it('throws for empty input', () => {
+    expect(() => decodeTagFilterRoutingClause('')).toThrow(
+      'Cannot decode empty project routing clause'
+    );
+    expect(() => decodeTagFilterRoutingClause('   ')).toThrow(
+      'Cannot decode empty project routing clause'
+    );
+  });
+
+  it('throws for named project routing references', () => {
+    expect(() => decodeTagFilterRoutingClause('@custom-expression')).toThrow(
+      'Cannot decode named project routing reference'
+    );
+  });
+
+  it('throws on colon-free input without quadratic regex cost', () => {
+    expect(() => decodeTagFilterRoutingClause('no-colon')).toThrow(
+      'Invalid project routing Lucene clause: missing tag:value atom'
+    );
+
+    const start = performance.now();
+    expect(() => decodeTagFilterRoutingClause('a'.repeat(50_000))).toThrow(
+      'Invalid project routing Lucene clause: missing tag:value atom'
+    );
+    expect(performance.now() - start).toBeLessThan(100);
+  });
+
+  it('throws for mixed-tag OR groups', () => {
+    expect(() => decodeTagFilterRoutingClause('env:prod OR region:us')).toThrow(
+      'Invalid project routing OR group: mixed tag names'
+    );
+  });
+
+  it('throws for unrecognized clauses', () => {
+    expect(() => decodeTagFilterRoutingClause('env:prod AND region:us')).toThrow(
+      'Cannot decode project routing AND clause'
+    );
+  });
+});
+
+describe('tag filter round-tripping', () => {
+  const cases: FilterExpressionValue[] = [
+    { operator: FilterOperator.EQUALS, tagName: 'env', tagValue: 'prod' },
+    { operator: FilterOperator.NOT_EQUALS, tagName: 'env', tagValue: 'prod' },
+    { operator: FilterOperator.ONE_OF, tagName: 'env', tagValue: ['prod', 'staging'] },
+    { operator: FilterOperator.NOT_ONE_OF, tagName: 'env', tagValue: ['prod', 'staging'] },
+    { operator: FilterOperator.EXISTS, tagName: 'env', tagValue: undefined },
+    { operator: FilterOperator.NOT_EXISTS, tagName: 'env', tagValue: undefined },
+  ];
+
+  it.each(cases)('recovers $operator after encode -> decode', (expression) => {
+    expect(decodeTagFilterRoutingClause(encodeTagFilterRoutingClause(expression))).toEqual(
+      expression
+    );
+  });
+});
+
+describe('projectRoutingCodec.encode', () => {
+  it('returns an empty string when there are no filters or exclusions', () => {
+    expect(
+      projectRoutingCodec.encode({
+        ...emptyEncodeInput,
+        selectedProjectIds: ['origin', 'linked1'],
+      })
+    ).toBe('');
+  });
+
+  it('emits tag filters without _id clauses when there are no exclusions', () => {
+    expect(
+      projectRoutingCodec.encode({
+        ...emptyEncodeInput,
+        filterExpressions: [typeSecurityExpression],
+        selectedProjectIds: ['origin'],
+      })
+    ).toBe('_type:security');
+  });
+
+  it('emits _id wildcard and NOT clauses when exclusions exist in dynamic mode', () => {
+    expect(
+      projectRoutingCodec.encode({
+        ...emptyEncodeInput,
+        excludedProjectIds: ['linked1'],
+        selectedProjectIds: ['origin', 'linked2'],
+      })
+    ).toBe('_id:* AND NOT _id:linked1');
+  });
+
+  it('combines tag filters with dynamic id exclusions', () => {
+    expect(
+      projectRoutingCodec.encode({
+        ...emptyEncodeInput,
+        filterExpressions: [typeSecurityExpression],
+        excludedProjectIds: ['linked1'],
+        selectedProjectIds: ['origin', 'linked2'],
+      })
+    ).toBe('_type:security AND _id:* AND NOT _id:linked1');
+  });
+
+  it('emits explicit id clauses in snapshot mode when exclusions exist', () => {
+    expect(
+      projectRoutingCodec.encode({
+        ...emptyEncodeInput,
+        excludedProjectIds: ['linked1'],
+        selectedProjectIds: ['origin', 'linked2'],
+        projectRoutingStrategy: 'snapshot',
+      })
+    ).toBe('_id:origin AND _id:linked2');
+  });
+
+  it('ANDs together multiple independent tag filters', () => {
+    expect(
+      projectRoutingCodec.encode({
+        ...emptyEncodeInput,
+        filterExpressions: [
+          typeSecurityExpression,
+          { operator: FilterOperator.EQUALS, tagName: 'region', tagValue: 'us' },
+        ],
+        selectedProjectIds: ['origin'],
+      })
+    ).toBe('_type:security AND region:us');
+  });
+});
+
+describe('projectRoutingCodec.decode', () => {
+  it('returns empty defaults for blank routing', () => {
+    expect(projectRoutingCodec.decode('')).toEqual({
+      filterExpressions: [],
+      excludedProjectIds: [],
+      selectedProjectIds: [],
+      projectRoutingStrategy: 'dynamic',
+    });
+  });
+
+  it('decodes a single tag filter', () => {
+    expect(projectRoutingCodec.decode('env:prod')).toEqual({
+      filterExpressions: [
+        {
+          operator: FilterOperator.EQUALS,
+          tagName: 'env',
+          tagValue: 'prod',
+        },
+      ],
+      excludedProjectIds: [],
+      selectedProjectIds: [],
+      projectRoutingStrategy: 'snapshot',
+    });
+  });
+
+  it('decodes multiple independent tag filters ANDed together', () => {
+    expect(projectRoutingCodec.decode('env:prod AND region:us')).toEqual({
+      filterExpressions: [
+        {
+          operator: FilterOperator.EQUALS,
+          tagName: 'env',
+          tagValue: 'prod',
+        },
+        {
+          operator: FilterOperator.EQUALS,
+          tagName: 'region',
+          tagValue: 'us',
+        },
+      ],
+      excludedProjectIds: [],
+      selectedProjectIds: [],
+      projectRoutingStrategy: 'snapshot',
+    });
+  });
+
+  it('returns selected and excluded project ids explicitly without reconciliation', () => {
+    expect(projectRoutingCodec.decode('_id:origin AND _id:linked1')).toEqual({
+      filterExpressions: [],
+      excludedProjectIds: [],
+      selectedProjectIds: ['origin', 'linked1'],
+      projectRoutingStrategy: 'snapshot',
+    });
+  });
+
+  it('classifies dynamic exclusions without selected ids', () => {
+    expect(projectRoutingCodec.decode('_id:* AND NOT _id:linked1')).toEqual({
+      filterExpressions: [],
+      excludedProjectIds: ['linked1'],
+      selectedProjectIds: [],
+      projectRoutingStrategy: 'dynamic',
+    });
+  });
+
+  it('groups compound tag filters split by _id clauses', () => {
+    expect(
+      projectRoutingCodec.decode(
+        '_type:* AND NOT _type:observability AND _id:* AND NOT _id:linked1'
+      )
+    ).toEqual({
+      filterExpressions: [
+        {
+          operator: FilterOperator.NOT_EQUALS,
+          tagName: '_type',
+          tagValue: 'observability',
+        },
+      ],
+      excludedProjectIds: ['linked1'],
+      selectedProjectIds: [],
+      projectRoutingStrategy: 'dynamic',
+    });
+  });
+
+  it('decodes an independent filter alongside a compound filter and _id clauses', () => {
+    expect(
+      projectRoutingCodec.decode(
+        'region:us AND _type:* AND NOT _type:observability AND _id:* AND NOT _id:linked1'
+      )
+    ).toEqual({
+      filterExpressions: [
+        {
+          operator: FilterOperator.EQUALS,
+          tagName: 'region',
+          tagValue: 'us',
+        },
+        {
+          operator: FilterOperator.NOT_EQUALS,
+          tagName: '_type',
+          tagValue: 'observability',
+        },
+      ],
+      excludedProjectIds: ['linked1'],
+      selectedProjectIds: [],
+      projectRoutingStrategy: 'dynamic',
+    });
+  });
+
+  it('returns named references as empty defaults', () => {
+    expect(projectRoutingCodec.decode('@custom-expression')).toEqual({
+      filterExpressions: [],
+      excludedProjectIds: [],
+      selectedProjectIds: [],
+      projectRoutingStrategy: 'dynamic',
+    });
+  });
+
+  it('validates decode output against ProjectRoutingExpressionSchema', () => {
+    const decoded = projectRoutingCodec.decode('_type:security AND _id:* AND NOT _id:linked1');
+    expect(ProjectRoutingExpressionSchema.parse(decoded)).toEqual(decoded);
+  });
+});
+
+describe('projectRoutingCodec round-trip', () => {
+  it('round-trips parsed defaults through encode in dynamic mode', () => {
+    const defaultProjectRouting = '_type:security AND _id:* AND NOT _id:linked1';
+    const decoded = projectRoutingCodec.decode(defaultProjectRouting);
+
+    expect(
+      projectRoutingCodec.encode({
+        filterExpressions: decoded.filterExpressions,
+        excludedProjectIds: decoded.excludedProjectIds,
+        selectedProjectIds: ['origin', 'linked2'],
+        projectRoutingStrategy: 'dynamic',
+      })
+    ).toBe(defaultProjectRouting);
+  });
+
+  it('round-trips multiple independent tag filters mixed with a compound filter and exclusions', () => {
+    const defaultProjectRouting =
+      'region:us AND _type:* AND NOT _type:observability AND _id:* AND NOT _id:linked1';
+    const decoded = projectRoutingCodec.decode(defaultProjectRouting);
+
+    expect(
+      projectRoutingCodec.encode({
+        filterExpressions: decoded.filterExpressions,
+        excludedProjectIds: decoded.excludedProjectIds,
+        selectedProjectIds: ['origin', 'linked2'],
+        projectRoutingStrategy: 'dynamic',
+      })
+    ).toBe(defaultProjectRouting);
+  });
+});

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/utils/project_routing_codec.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/utils/project_routing_codec.ts
@@ -1,0 +1,460 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Parser, isColumn, isFunctionExpression, isLiteral } from '@elastic/esql';
+import type { ESQLAstExpression } from '@elastic/esql/types';
+import type { ProjectRouting } from '@kbn/es-query';
+import { uniq } from 'lodash';
+import { z } from '@kbn/zod';
+import {
+  FilterExpressionSchema,
+  FilterOperator,
+  type FilterExpressionValue,
+} from './filter_input_codec';
+
+const projectRoutingClausePattern = /([^:\s()]+):([^()\s]+)/g;
+
+export const ROUTING_WILDCARD = '*';
+
+/** Reserved routing dimension for project selection/exclusion — never a filter badge. */
+export const PROJECT_SELECTION_DIMENSION = '_id';
+
+export const ProjectRoutingStrategySchema = z.enum(['dynamic', 'snapshot']);
+export type ProjectRoutingStrategy = z.output<typeof ProjectRoutingStrategySchema>;
+
+export const ProjectRoutingExpressionSchema = z.strictObject({
+  filterExpressions: z.array(FilterExpressionSchema).max(100),
+  excludedProjectIds: z.array(z.string().max(256)).max(1000),
+  selectedProjectIds: z.array(z.string().max(256)).max(1000),
+  projectRoutingStrategy: ProjectRoutingStrategySchema,
+});
+
+export type ProjectRoutingExpression = z.output<typeof ProjectRoutingExpressionSchema>;
+
+interface TagEquality {
+  tagName: string;
+  tagValue: string;
+}
+
+/**
+ * Converts project routing Lucene query syntax string to an ESQL expression string,
+ * so we might use the ESQL parser to extract boolean conditions.
+ */
+const luceneQuerySyntaxToEsqlExpression = (clause: NonNullable<ProjectRouting>): string => {
+  const trimmed = clause.trim();
+
+  if (!trimmed.includes(':')) {
+    throw new Error('Invalid project routing Lucene clause: missing tag:value atom');
+  }
+
+  return trimmed.replace(projectRoutingClausePattern, (_, tagName, tagValue) => {
+    const escapedValue = tagValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    return `${tagName} == "${escapedValue}"`;
+  });
+};
+
+const encodeTagFilterClause = ({ operator, tagName, tagValue }: FilterExpressionValue): string => {
+  switch (operator) {
+    case FilterOperator.EQUALS:
+      return `${tagName}:${tagValue}`;
+    case FilterOperator.NOT_EQUALS:
+      return `${tagName}:* AND NOT ${tagName}:${tagValue}`;
+    case FilterOperator.ONE_OF:
+      return `(${tagValue.map((value) => `${tagName}:${value}`).join(' OR ')})`;
+    case FilterOperator.NOT_ONE_OF:
+      return `${tagName}:* AND NOT (${tagValue
+        .map((value) => `${tagName}:${value}`)
+        .join(' OR ')})`;
+    case FilterOperator.EXISTS:
+      return `${tagName}:*`;
+    case FilterOperator.NOT_EXISTS:
+      return `NOT ${tagName}:*`;
+    default: {
+      const _exhaustive: never = operator;
+      throw new Error(`Unsupported filter operator: ${String(_exhaustive)}`);
+    }
+  }
+};
+
+const decodeTagFilterClause = (value: string): FilterExpressionValue => {
+  if (value.trim() === '') {
+    throw new Error('Cannot decode empty project routing clause');
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.startsWith('@')) {
+    throw new Error('Cannot decode named project routing reference');
+  }
+
+  if (!trimmed.includes(':')) {
+    throw new Error('Invalid project routing Lucene clause: missing tag:value atom');
+  }
+
+  const esqlExpression = luceneQuerySyntaxToEsqlExpression(trimmed);
+
+  let root: ESQLAstExpression;
+  try {
+    ({ root } = Parser.parseExpression(esqlExpression));
+  } catch (error) {
+    throw new Error(
+      `Cannot parse project routing clause: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  return filterExpressionFromRoutingAst(root);
+};
+
+const readTagEquality = (node: unknown): TagEquality => {
+  if (!isFunctionExpression(node) || node.name !== '==') {
+    throw new Error('Expected project routing equality expression');
+  }
+
+  const [columnNode, valueNode] = node.args;
+  if (!isColumn(columnNode) || !isLiteral(valueNode) || valueNode.literalType !== 'keyword') {
+    throw new Error('Expected project routing column == string literal');
+  }
+
+  const tagValue = valueNode.valueUnquoted;
+  if (tagValue === undefined) {
+    throw new Error('Expected project routing literal value');
+  }
+
+  return {
+    tagName: columnNode.name,
+    tagValue,
+  };
+};
+
+const readSameTagEqualities = (nodes: unknown[]): TagEquality[] => {
+  const equalities = nodes.map(readTagEquality);
+  const tagName = equalities[0]?.tagName;
+
+  if (!tagName || !equalities.every(({ tagName: columnName }) => columnName === tagName)) {
+    throw new Error('Invalid project routing OR group: mixed tag names');
+  }
+
+  if (equalities.some(({ tagValue }) => tagValue === ROUTING_WILDCARD)) {
+    throw new Error('Invalid project routing OR group: wildcard values not allowed');
+  }
+
+  return equalities;
+};
+
+const filterExpressionFromRoutingAst = (node: ESQLAstExpression): FilterExpressionValue => {
+  if (!isFunctionExpression(node)) {
+    throw new Error('Cannot decode project routing clause');
+  }
+
+  if (node.name === 'not') {
+    const { tagName, tagValue } = readTagEquality(node.args[0]);
+    if (tagValue !== ROUTING_WILDCARD) {
+      throw new Error('Cannot decode project routing NOT EXISTS clause');
+    }
+
+    return {
+      operator: FilterOperator.NOT_EXISTS,
+      tagName,
+      tagValue: undefined,
+    };
+  }
+
+  if (node.name === '==') {
+    const { tagName, tagValue } = readTagEquality(node);
+    if (tagValue === ROUTING_WILDCARD) {
+      return {
+        operator: FilterOperator.EXISTS,
+        tagName,
+        tagValue: undefined,
+      };
+    }
+
+    return {
+      operator: FilterOperator.EQUALS,
+      tagName,
+      tagValue,
+    };
+  }
+
+  if (node.name === 'or') {
+    const equalities = readSameTagEqualities(node.args);
+    return {
+      operator: FilterOperator.ONE_OF,
+      tagName: equalities[0].tagName,
+      tagValue: equalities.map(({ tagValue }) => tagValue),
+    };
+  }
+
+  if (node.name === 'and') {
+    if (node.args.length !== 2) {
+      throw new Error('Cannot decode project routing AND clause');
+    }
+
+    const [existsNode, negatedNode] = node.args;
+    const existsEquality = readTagEquality(existsNode);
+    if (existsEquality.tagValue !== ROUTING_WILDCARD) {
+      throw new Error('Cannot decode project routing AND clause');
+    }
+
+    if (!isFunctionExpression(negatedNode) || negatedNode.name !== 'not') {
+      throw new Error('Cannot decode project routing AND clause');
+    }
+
+    const negatedExpression = negatedNode.args[0];
+    if (isFunctionExpression(negatedExpression) && negatedExpression.name === 'or') {
+      const equalities = readSameTagEqualities(negatedExpression.args);
+      if (existsEquality.tagName !== equalities[0].tagName) {
+        throw new Error('Invalid project routing NOT ONE OF clause: tag name mismatch');
+      }
+
+      return {
+        operator: FilterOperator.NOT_ONE_OF,
+        tagName: existsEquality.tagName,
+        tagValue: equalities.map(({ tagValue }) => tagValue),
+      };
+    }
+
+    const notEqualsEquality = readTagEquality(negatedExpression);
+    if (existsEquality.tagName !== notEqualsEquality.tagName) {
+      throw new Error('Invalid project routing NOT EQUALS clause: tag name mismatch');
+    }
+
+    return {
+      operator: FilterOperator.NOT_EQUALS,
+      tagName: existsEquality.tagName,
+      tagValue: notEqualsEquality.tagValue,
+    };
+  }
+
+  throw new Error('Cannot decode project routing clause');
+};
+
+const flattenTopLevelAndArgs = (root: ESQLAstExpression): ESQLAstExpression[] => {
+  if (isFunctionExpression(root) && root.name === 'and') {
+    return root.args.flatMap((arg) => flattenTopLevelAndArgs(arg as ESQLAstExpression));
+  }
+
+  return [root];
+};
+
+const createSyntheticAndNode = (nodes: readonly ESQLAstExpression[]): ESQLAstExpression => {
+  if (nodes.length === 1) {
+    return nodes[0];
+  }
+
+  return {
+    type: 'function',
+    name: 'and',
+    args: [...nodes],
+  } as ESQLAstExpression;
+};
+
+const readIdEquality = (
+  node: ESQLAstExpression
+): { projectId: string; isWildcard: boolean } | null => {
+  if (!isFunctionExpression(node) || node.name !== '==') {
+    return null;
+  }
+
+  try {
+    const { tagName, tagValue } = readTagEquality(node);
+
+    if (tagName !== PROJECT_SELECTION_DIMENSION) {
+      return null;
+    }
+
+    return {
+      projectId: tagValue,
+      isWildcard: tagValue === ROUTING_WILDCARD,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const readIdExclusion = (node: ESQLAstExpression): string | null => {
+  if (!isFunctionExpression(node) || node.name !== 'not') {
+    return null;
+  }
+
+  const inner = node.args[0];
+  if (!isFunctionExpression(inner) || inner.name !== '==') {
+    return null;
+  }
+
+  try {
+    const { tagName, tagValue } = readTagEquality(inner);
+
+    if (tagName !== PROJECT_SELECTION_DIMENSION || tagValue === ROUTING_WILDCARD) {
+      return null;
+    }
+
+    return tagValue;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Decodes a run of top-level AND nodes (with `_id` clauses already stripped out) into the
+ * filter expressions it represents. A single filter can itself span two adjacent nodes — the
+ * `tag:* AND NOT tag:value` / `tag:* AND NOT (a OR b)` shape produced by {@link encodeTagFilterClause}
+ * for `NOT_EQUALS`/`NOT_ONE_OF` — so pairs are tried greedily before falling back to decoding a
+ * node on its own, which keeps independent filters that happen to be ANDed together from being
+ * discarded as a single unrecognized group.
+ */
+const decodeFilterNodeGroup = (nodes: readonly ESQLAstExpression[]): FilterExpressionValue[] => {
+  const expressions: FilterExpressionValue[] = [];
+  let index = 0;
+
+  while (index < nodes.length) {
+    const pairCandidate = nodes[index + 1];
+
+    if (pairCandidate) {
+      try {
+        expressions.push(
+          filterExpressionFromRoutingAst(createSyntheticAndNode([nodes[index], pairCandidate]))
+        );
+        index += 2;
+        continue;
+      } catch {
+        // not a recognized two-node pattern — fall through and try the node on its own.
+      }
+    }
+
+    try {
+      expressions.push(filterExpressionFromRoutingAst(nodes[index]));
+    } catch {
+      // unrecognized clause — skip it rather than losing the rest of the group.
+    }
+    index += 1;
+  }
+
+  return expressions;
+};
+
+const buildProjectSelectionClauses = ({
+  excludedProjectIds,
+  selectedProjectIds,
+  projectRoutingStrategy,
+}: Pick<
+  z.infer<typeof ProjectRoutingExpressionSchema>,
+  'excludedProjectIds' | 'selectedProjectIds' | 'projectRoutingStrategy'
+>): string[] => {
+  if (projectRoutingStrategy === 'dynamic') {
+    return excludedProjectIds.length === 0
+      ? []
+      : [
+          `${PROJECT_SELECTION_DIMENSION}:${ROUTING_WILDCARD}`,
+          ...excludedProjectIds.map((override) => `NOT ${PROJECT_SELECTION_DIMENSION}:${override}`),
+        ];
+  }
+
+  return selectedProjectIds.map((id) => `${PROJECT_SELECTION_DIMENSION}:${id}`);
+};
+
+/**
+ * Codec for project routing, leverages zod for validation and transforms.
+ */
+export const projectRoutingCodec = z.codec(z.optional(z.string()), ProjectRoutingExpressionSchema, {
+  encode: (input) => {
+    const filterClauses = input.filterExpressions.map((expression) =>
+      encodeTagFilterClause(expression)
+    );
+
+    return [
+      ...filterClauses,
+      ...buildProjectSelectionClauses({
+        excludedProjectIds: input.excludedProjectIds,
+        selectedProjectIds: input.selectedProjectIds,
+        projectRoutingStrategy: input.projectRoutingStrategy,
+      }),
+    ]
+      .filter(Boolean)
+      .join(' AND ');
+  },
+  decode: (value) => {
+    const trimmed = value?.trim();
+
+    if (!trimmed || trimmed.startsWith('@')) {
+      return {
+        filterExpressions: [],
+        excludedProjectIds: [],
+        selectedProjectIds: [],
+        projectRoutingStrategy: 'dynamic' as const,
+      };
+    }
+
+    let root: ESQLAstExpression;
+
+    try {
+      ({ root } = Parser.parseExpression(luceneQuerySyntaxToEsqlExpression(trimmed)));
+    } catch {
+      return {
+        filterExpressions: [],
+        excludedProjectIds: [],
+        selectedProjectIds: [],
+        projectRoutingStrategy: 'dynamic' as const,
+      };
+    }
+
+    const filterExpressions: FilterExpressionValue[] = [];
+    const excludedProjectIds: string[] = [];
+    const selectedProjectIds: string[] = [];
+    let pendingFilterNodes: ESQLAstExpression[] = [];
+
+    const flushFilterGroup = () => {
+      filterExpressions.push(...decodeFilterNodeGroup(pendingFilterNodes));
+      pendingFilterNodes = [];
+    };
+
+    for (const node of flattenTopLevelAndArgs(root)) {
+      const idEquality = readIdEquality(node);
+
+      if (idEquality) {
+        flushFilterGroup();
+
+        if (!idEquality.isWildcard) {
+          selectedProjectIds.push(idEquality.projectId);
+        }
+
+        continue;
+      }
+
+      const excludedId = readIdExclusion(node);
+
+      if (excludedId) {
+        flushFilterGroup();
+        excludedProjectIds.push(excludedId);
+        continue;
+      }
+
+      pendingFilterNodes.push(node);
+    }
+
+    flushFilterGroup();
+
+    return {
+      filterExpressions,
+      excludedProjectIds: uniq(excludedProjectIds),
+      selectedProjectIds: uniq(selectedProjectIds),
+      projectRoutingStrategy: (excludedProjectIds.length > 0
+        ? 'dynamic'
+        : 'snapshot') as ProjectRoutingStrategy,
+    };
+  },
+});
+
+/** Decode a single Lucene tag-filter routing clause (for tests and internal round-trips). */
+export const decodeTagFilterRoutingClause = decodeTagFilterClause;
+
+/** Encode a single Lucene tag-filter routing clause (for tests and internal round-trips). */
+export const encodeTagFilterRoutingClause = encodeTagFilterClause;


### PR DESCRIPTION
## Summary

Culled from https://github.com/elastic/kibana/pull/279522

Extracts the project codec used within the project picker used for generating project routing strings; 

### Project routing generation

- Adds `projectRoutingCodec` to encode in-memory `FilterExpression` (i.e.  equals, not-equals, one-of, not-one-of, exists, not-exists), `excludedOverrides` and `selectedProjects` objects into project routing string
- Introduces `projectRoutingStrategy` to control how project IDs appear in the routing string generated:

	| Strategy | Shape |  Behaviour | 
	|---|---|---|
	| **`dynamic`** (default) | `_id:* AND NOT _id:…` | filter rules stay live and newly linked projects can match. |
	| **`snapshot`**  | `_id:p1 AND _id:p2 …` | routing is frozen to the current selection. |

	`snapshot` is intended and more appropriate for instances where the generated project routing should pin to an explicit project set, think space defaults, configuration for workflows.

_N.B. See the test file for how to use this outside of the project picker implementation._

<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->

