### PR TITLE
[scout] improve datePicker setTextRange

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/date_picker.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/date_picker.ts
@@ -330,10 +330,11 @@ export class DatePicker {
     // `onInputKeyDown` calls `applyRange`, which the query bar's `onChange`
     // forwards to `onSubmit`. No separate querySubmitButton click is needed.
     await input.press('Enter');
-    // `applyRange` sets `isEditing=false`, which unmounts the input and closes
-    // the popover. Wait for edit mode to end so a following open/read isn't
-    // racing that close.
+    // The input unmounts immediately, but the popover panel closes with an
+    // animation and stays visible a bit longer — wait for it too, so a
+    // following `openDateRangePickerPresetsPanel()` doesn't skip re-opening it.
     await input.waitFor({ state: 'hidden' });
+    await this.page.testSubj.locator('dateRangePickerPopoverPanel').waitFor({ state: 'hidden' });
   }
 
   async saveCurrentRangeAsPreset() {


### PR DESCRIPTION
## Summary

Fixes flaky test `src/platform/plugins/shared/unified_search/test/scout/ui/tests/date_range_picker_presets_persistence.spec.ts`

Copying FTR implementation (`src/platform/test/functional/page_objects/time_picker.ts`), which explicitly does `testSubjects.missingOrFail('dateRangePickerPopoverPanel', ...)` after applying a typed range.

Based on comment it was a missing step in Scout: "Ensure the popover is fully closed before returning, so it doesn't overlay other elements and intercept clicks."





<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->