### PR TITLE
[Cases] Dedupe required-on-close errors for global fields referenced by templates

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/cases/validators.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/validators.test.ts
@@ -1461,6 +1461,88 @@ describe('validators', () => {
         })
       ).not.toThrow();
     });
+
+    it('mentions a global required_on_close field once when the template also resolves the same key', () => {
+      // FAILURE SCENARIO (before fix): naive concat of global + template `$ref` listed the same
+      // field twice in the close error ("Field X is required; Field X is required").
+      const globalResolutionNotes = makeGlobalFields([
+        {
+          name: 'resolution_notes',
+          type: 'keyword',
+          label: 'Resolution notes',
+          validation: { required_on_close: true },
+        },
+      ]);
+      const templateRefToSameField = makeTemplateField({
+        name: 'resolution_notes',
+        label: 'Resolution notes',
+        validation: { required_on_close: true },
+      });
+
+      expect(() =>
+        validateExtendedFieldsOnClose({
+          updateReq: { id: 'case-1', version: '1', status: CaseStatuses.closed },
+          originalCase: makeOriginalCase(),
+          templateFields: [templateRefToSameField],
+          globalFields: globalResolutionNotes,
+        })
+      ).toThrow(
+        'Cannot close case case-1, required fields must be filled: Field "Resolution notes" is required'
+      );
+    });
+
+    it('ignores template required_on_close when a colliding global field is not required on close', () => {
+      // Global wins: template `$ref` override must not block close if the global definition
+      // does not set required_on_close.
+      const globalWithoutRequiredOnClose = makeGlobalFields([
+        {
+          name: 'resolution_notes',
+          type: 'keyword',
+          label: 'Resolution notes',
+        },
+      ]);
+      const templateRefRequiredOnClose = makeTemplateField({
+        name: 'resolution_notes',
+        label: 'Resolution notes',
+        validation: { required_on_close: true },
+      });
+
+      expect(() =>
+        validateExtendedFieldsOnClose({
+          updateReq: { id: 'case-1', version: '1', status: CaseStatuses.closed },
+          originalCase: makeOriginalCase(),
+          templateFields: [templateRefRequiredOnClose],
+          globalFields: globalWithoutRequiredOnClose,
+        })
+      ).not.toThrow();
+    });
+
+    it('lists distinct global and template required_on_close fields once each', () => {
+      const globalRequiredOnClose = makeGlobalFields([
+        {
+          name: 'resolution_notes',
+          type: 'keyword',
+          label: 'Resolution notes',
+          validation: { required_on_close: true },
+        },
+      ]);
+      const templateOnlyRequiredOnClose = makeTemplateField({
+        name: 'recovery_approach',
+        label: 'Recovery approach',
+        validation: { required_on_close: true },
+      });
+
+      expect(() =>
+        validateExtendedFieldsOnClose({
+          updateReq: { id: 'case-1', version: '1', status: CaseStatuses.closed },
+          originalCase: makeOriginalCase(),
+          templateFields: [templateOnlyRequiredOnClose],
+          globalFields: globalRequiredOnClose,
+        })
+      ).toThrow(
+        'Cannot close case case-1, required fields must be filled: Field "Resolution notes" is required; Field "Recovery approach" is required'
+      );
+    });
   });
 
   describe('resolveTemplateFieldsForClose', () => {

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/validators.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/validators.ts
@@ -35,6 +35,20 @@ interface CustomFieldValidationParams {
   customFieldsConfiguration?: CustomFieldsConfiguration;
 }
 
+/**
+ * Drops template fields whose storage key already belongs to a global field.
+ * On a storage-key collision the global definition is authoritative (see
+ * resolveApplicableFields) — shared by write-time and close-time validation so a
+ * template `$ref` to a global library field is not validated twice.
+ */
+export const excludeTemplateFieldsCollidingWithGlobal = (
+  templateFields: readonly InlineField[],
+  globalFields: readonly InlineField[]
+): InlineField[] => {
+  const globalKeySet = new Set(globalFields.map((f) => getFieldSnakeKey(f.name, f.type)));
+  return templateFields.filter((f) => !globalKeySet.has(getFieldSnakeKey(f.name, f.type)));
+};
+
 export const validateCustomFields = (params: CustomFieldValidationParams) => {
   validateDuplicatedKeysInRequest({
     requestFields: params.requestCustomFields,
@@ -283,8 +297,9 @@ export const validateCaseExtendedFields = async ({
   const templateOnlyFields = Object.fromEntries(
     Object.entries(extendedFields).filter(([k]) => !globalKeySet.has(k))
   );
-  const templateNonGlobalFields = resolvedTemplateFields.filter(
-    (f) => !globalKeySet.has(getFieldSnakeKey(f.name, f.type))
+  const templateNonGlobalFields = excludeTemplateFieldsCollidingWithGlobal(
+    resolvedTemplateFields,
+    globalFields
   );
   const templateErrors = validateExtendedFields(templateOnlyFields, templateNonGlobalFields, {
     partial,
@@ -422,7 +437,12 @@ export const validateExtendedFieldsOnClose = ({
     ...(updateReq.extended_fields ?? {}),
   };
 
-  const allFields = [...globalFields, ...templateFields];
+  // Same global-wins exclusion as write-time validation — template `$ref`s to global fields
+  // must not be checked a second time (duplicate "Field X is required" on close).
+  const allFields = [
+    ...globalFields,
+    ...excludeTemplateFieldsCollidingWithGlobal(templateFields, globalFields),
+  ];
 
   // Build helper maps for condition evaluation (show_when).
   const fieldValues: Record<string, string | undefined> = {};


### PR DESCRIPTION
## Summary

Fixes duplicate required-on-close errors when closing a case whose template `$ref`s a global library field that is also required on close. Close-time validation now applies the same “global wins on storage-key collision” rule already used at write time and for applicable fields, so the user sees a single “Field … is required” message for that field.

## Motivation

Closing a case with one Custom Fields entry for a global required-on-close field (e.g. Resolution notes) incorrectly returned a concatenated duplicate: `Field Resolution notes is required; Field Resolution notes is required`. Write-time extended-field validation already dropped colliding template fields; close-time validation naively concatenated owner global defs with template-resolved fields, so a `$ref` to the same storage key was enforced twice.

## Changes

- Shared helper excludes template fields whose storage key already belongs to a global definition (“global wins”).
- Close-time required-on-close validation uses that exclusion so template `$ref`s to global fields are not checked twice.
- Write-time extended-fields validation uses the same helper for consistency with close and applicable-fields behavior.
- Unit coverage for duplicate, global-wins-over-template-required_on_close, and distinct global+template error cases.

## Risk & Migration

**Score: 2** — Isolated server-side Cases client validation; no SO/schema, route, or RBAC changes. Backward compatible: only removes duplicate close errors and aligns close with existing global-wins semantics.

## Testing

**Manual:**
1. Create a global field (e.g. Resolution notes) with required on close; add a case template that `$ref`s that field.
2. Create a case from the template; leave Resolution notes empty; attempt to close.
3. Confirm the error lists the field once (not duplicated).
4. Fill Resolution notes and close successfully.
5. Optional: global field without required on close + template `$ref` with required on close — close should succeed (global wins).
6. Optional: distinct global and template-only required-on-close fields — both appear once in the error when empty.

**Automated:**
- [x] Unit tests added/updated: `x-pack/platform/plugins/shared/cases/server/client/cases/validators.test.ts`
- [ ] Integration tests added/updated: N/A
- [x] Verified: `node scripts/jest` on `validators.test.ts`; `node scripts/type_check --project` for Cases; `node scripts/eslint --fix` on changed files. Local exploratory verification on Kibana `:5602` confirmed a single toast line for Resolution notes.

## Checklist

- [x] Unit or functional tests were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes (none — error text dedupe only)
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->