### PR TITLE
[FTR-to-Scout Visualizations] Remove duplicate "open button" tests from `show_underlying_data_dashboard.ts`

### DIFF
--- a/x-pack/platform/test/functional/apps/lens/group4/show_underlying_data_dashboard.ts
+++ b/x-pack/platform/test/functional/apps/lens/group4/show_underlying_data_dashboard.ts
@@ -32,7 +32,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
 
   describe('lens show underlying data from dashboard', () => {
-    it('should show the open button for a compatible saved visualization', async () => {
+    it('should bring both dashboard context and visualization context to discover', async () => {
       await visualize.gotoVisualizationLandingPage();
       await listingTable.searchForItemWithName('lnsXYvis');
       await lens.clickVisualizeListItemTitle('lnsXYvis');
@@ -40,56 +40,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await dashboard.saveDashboard(`Open in Discover Testing ${uuidv4()}`, {
         saveAsNew: true,
-        exitFromEditMode: true,
+        exitFromEditMode: false,
       });
 
-      await dashboardPanelActions.clickPanelAction(OPEN_IN_DISCOVER_DATA_TEST_SUBJ);
-
-      const [dashboardWindowHandle, discoverWindowHandle] = await browser.getAllWindowHandles();
-      await browser.switchToWindow(discoverWindowHandle);
-
-      await header.waitUntilLoadingHasFinished();
-      await testSubjects.existOrFail('unifiedHistogramChart');
-      // check the table columns
-      const columns = await discover.getColumnHeaders();
-      expect(columns).to.eql(['@timestamp', 'ip', 'bytes']);
-
-      await browser.closeCurrentWindow();
-      await browser.switchToWindow(dashboardWindowHandle);
-    });
-
-    it('should show the open button for a compatible saved visualization with annotations and reference line', async () => {
-      await dashboard.switchToEditMode();
-      await dashboardPanelActions.navigateToEditorFromFlyout();
-      await header.waitUntilLoadingHasFinished();
-      await lens.createLayer('annotations');
-      await lens.waitForVisualization('xyVisChart');
-
-      await lens.createLayer('referenceLine');
-      await lens.save('Embedded Visualization', false);
-
-      await dashboard.saveDashboard(`Open in Discover Testing ${uuidv4()}`, {
-        saveAsNew: false,
-        exitFromEditMode: true,
-      });
-
-      await dashboardPanelActions.clickPanelAction(OPEN_IN_DISCOVER_DATA_TEST_SUBJ);
-
-      const [dashboardWindowHandle, discoverWindowHandle] = await browser.getAllWindowHandles();
-      await browser.switchToWindow(discoverWindowHandle);
-
-      await header.waitUntilLoadingHasFinished();
-      await testSubjects.existOrFail('unifiedHistogramChart');
-      // check the table columns
-      const columns = await discover.getColumnHeaders();
-      expect(columns).to.eql(['@timestamp', 'ip', 'bytes']);
-
-      await browser.closeCurrentWindow();
-      await browser.switchToWindow(dashboardWindowHandle);
-    });
-
-    it('should bring both dashboard context and visualization context to discover', async () => {
-      await dashboard.switchToEditMode();
       await dashboardPanelActions.navigateToEditorFromFlyout();
       await savedQueryManagementComponent.openSavedQueryManagementComponent();
       await queryBar.switchQueryLanguage('lucene');


### PR DESCRIPTION
## Summary

Closes #267491

Remove duplicate "open button" tests from `show_underlying_data_dashboard.ts`.

The removed assertions live in:
- `x-pack/platform/test/functional/apps/lens/group4/show_underlying_data.ts`
- `x-pack/platform/plugins/shared/lens/public/app_plugin/show_underlying_data.test.ts`


## Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.