### PR TITLE
[Action Policy] Improvements after moving to content list

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.test.tsx
@@ -138,6 +138,38 @@ describe('SelectableFilterPopover', () => {
     expect(screen.queryByText('1')).not.toBeInTheDocument();
   });
 
+  it('hides the search box when hideSearch is set', async () => {
+    render(
+      <SelectableFilterPopover
+        fieldName="tag"
+        title="Tags"
+        options={options}
+        hideSearch
+        renderOption={(option) => <span>{option.label}</span>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Tags'));
+
+    await screen.findByText('Production');
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+  });
+
+  it('shows the search box by default', async () => {
+    render(
+      <SelectableFilterPopover
+        fieldName="tag"
+        title="Tags"
+        options={options}
+        renderOption={(option) => <span>{option.label}</span>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Tags'));
+
+    expect(await screen.findByRole('searchbox')).toBeInTheDocument();
+  });
+
   it('uses the captured modifier key to add an exclude filter', async () => {
     const onChange = jest.fn();
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/selectable_filter_popover.tsx
@@ -76,6 +76,13 @@ export interface SelectableFilterPopoverProps<T extends object = Record<string, 
    * @default false
    */
   singleSelection?: boolean;
+  /**
+   * Hides the search box in the popover. Useful when the option count is
+   * small enough (e.g. 2–3) that searching adds no value.
+   *
+   * @default false
+   */
+  hideSearch?: boolean;
   /** Whether the options are loading. */
   isLoading?: boolean;
   /** Empty state message to display. */
@@ -154,6 +161,7 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
   options,
   renderOption,
   singleSelection = false,
+  hideSearch = false,
   isLoading,
   emptyMessage,
   noMatchesMessage,
@@ -305,20 +313,23 @@ export const SelectableFilterPopover = <T extends object = Record<string, unknow
           emptyMessage={emptyMessage}
           noMatchesMessage={noMatchesMessage}
           onChange={handleSelectChange}
-          searchable
-          searchProps={{ compressed: true }}
+          {...(hideSearch
+            ? { searchable: false as const }
+            : { searchable: true as const, searchProps: { compressed: true } })}
           data-test-subj={`${dataTestSubj}-list`}
           aria-label={title}
         >
           {(list, search) => (
             <>
               {singleSelection ? (
-                <EuiPanel hasShadow={false} paddingSize="s">
-                  {search}
-                </EuiPanel>
+                !hideSearch && (
+                  <EuiPanel hasShadow={false} paddingSize="s">
+                    {search}
+                  </EuiPanel>
+                )
               ) : (
                 <FilterPopoverHeader
-                  search={search}
+                  search={hideSearch ? undefined : search}
                   activeCount={activeCount}
                   onClear={clearAll}
                   data-test-subj={`${dataTestSubj}-clear`}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/components/action_policies_table_content.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/components/action_policies_table_content.tsx
@@ -422,6 +422,7 @@ const EnabledFilterComponent = ({
       <StandardFilterOption isActive={isActive}>{option.label}</StandardFilterOption>
     )}
     singleSelection
+    hideSearch
     data-test-subj="actionPoliciesEnabledFilter"
   />
 );

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/components/action_policies_table_content.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_action_policies_page/components/action_policies_table_content.tsx
@@ -160,7 +160,11 @@ export const ActionPoliciesTableContent = ({
         scrollableInline
         responsiveBreakpoint={false}
       >
-        <Column.Name showDescription onClick={(item) => setPolicyToViewId(toPolicy(item).id)} />
+        <Column.Name
+          showDescription
+          onClick={(item) => setPolicyToViewId(toPolicy(item).id)}
+          maxWidth="400px"
+        />
         <DestinationsColumn />
         <Column
           id="tags"
@@ -185,7 +189,6 @@ export const ActionPoliciesTableContent = ({
         <Column
           id="updatedBy"
           name={UPDATED_BY_COLUMN_NAME}
-          width="150px"
           render={(item) => {
             const { updatedBy } = toPolicy(item);
             if (!updatedBy) return null;
@@ -248,7 +251,7 @@ export const ActionPoliciesTableContent = ({
           name={i18n.translate('xpack.alertingV2.actionPoliciesList.column.notify', {
             defaultMessage: 'Notify',
           })}
-          width="50px"
+          width="60px"
           render={(item) => {
             const policy = toPolicy(item);
             if (!policy.enabled || !canWrite) return null;
@@ -270,6 +273,7 @@ export const ActionPoliciesTableContent = ({
           name={i18n.translate('xpack.alertingV2.actionPoliciesList.column.actions', {
             defaultMessage: 'Actions',
           })}
+          width="80px"
           render={(item) => {
             const policy = toPolicy(item);
             return (


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/rna-program/issues/798, two follow-up improvements after the Action Policy list moved to the content list component (#279317):

- Hide the search box in the enabled/disabled state filter — it only has 2 fixed options (Enabled/Disabled), so search adds no value. The tags filter keeps its search box.
- Balance column widths in the table — the name column was too wide, forcing other columns to wrap content unnecessarily.

To support hiding the search box generically, `SelectableFilterPopover` (`@kbn/content-list-toolbar`) gained a new `hideSearch` prop, useful for any filter with a small, finite option set.

Before | After
-- | --
<img width="585" height="311" alt="image" src="https://github.com/user-attachments/assets/902d2608-8dcf-4e8b-a043-dcd6e833f7a4" /> | <img width="395" height="341" alt="image" src="https://github.com/user-attachments/assets/433e100b-6111-4447-9407-4d42b4553abd" />



## Test plan

- [ ] Open the Action Policies list, confirm the state filter popover has no search box while the tags filter still does.
- [ ] Confirm the name/tags/updated/state/notify/actions columns are balanced and no longer wrap unnecessarily.

Made with [Cursor](https://cursor.com)