### PR TITLE
[sigevents][ki] limit number of items in features array properties

### DIFF
--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/index.ts
@@ -60,6 +60,7 @@ export {
   isComputedFeature,
   isDuplicateFeature,
   isFeatureWithFilter,
+  MAX_FEATURE_ARRAY_ITEMS,
   mergeFeature,
   normalizeFeatureSlug,
   normalizeFeatureSlugForMatching,

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.test.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.test.ts
@@ -6,7 +6,12 @@
  */
 
 import type { BaseFeature } from './feature';
-import { computeFeatureUuid, MAX_FEATURE_ARRAY_ITEMS, mergeFeature, normalizeFeatureSlugForMatching } from './feature';
+import {
+  computeFeatureUuid,
+  MAX_FEATURE_ARRAY_ITEMS,
+  mergeFeature,
+  normalizeFeatureSlugForMatching,
+} from './feature';
 import { MAX_ID_LENGTH } from './significant_events/constants';
 
 const createFeature = ({
@@ -169,10 +174,10 @@ describe('mergeFeature version history', () => {
 it('evidence does not grow unbounded across repeated merges with distinct values', () => {
   let feature: BaseFeature = { ...createFeature(), evidence: [] };
   for (let iteration = 0; iteration < 20; iteration++) {
-    feature = mergeFeature(
-      feature,
-      { ...createFeature(), evidence: Array.from({ length: 5 }, (_, i) => `iter-${iteration}-${i}`) }
-    );
+    feature = mergeFeature(feature, {
+      ...createFeature(),
+      evidence: Array.from({ length: 5 }, (_, i) => `iter-${iteration}-${i}`),
+    });
   }
 
   expect(feature.evidence?.length ?? 0).toBeLessThanOrEqual(MAX_FEATURE_ARRAY_ITEMS);

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.test.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.test.ts
@@ -6,7 +6,7 @@
  */
 
 import type { BaseFeature } from './feature';
-import { computeFeatureUuid, mergeFeature, normalizeFeatureSlugForMatching } from './feature';
+import { computeFeatureUuid, MAX_FEATURE_ARRAY_ITEMS, mergeFeature, normalizeFeatureSlugForMatching } from './feature';
 import { MAX_ID_LENGTH } from './significant_events/constants';
 
 const createFeature = ({
@@ -164,4 +164,18 @@ describe('mergeFeature version history', () => {
 
     expect(merged.meta?.version_history).toEqual(['3.13.0']);
   });
+});
+
+it('evidence does not grow unbounded across repeated merges with distinct values', () => {
+  let feature: BaseFeature = { ...createFeature(), evidence: [] };
+  for (let iteration = 0; iteration < 20; iteration++) {
+    feature = mergeFeature(
+      feature,
+      { ...createFeature(), evidence: Array.from({ length: 5 }, (_, i) => `iter-${iteration}-${i}`) }
+    );
+  }
+
+  expect(feature.evidence?.length ?? 0).toBeLessThanOrEqual(MAX_FEATURE_ARRAY_ITEMS);
+  expect(feature.evidence).toContain('iter-19-4');
+  expect(feature.evidence).not.toContain('iter-0-0');
 });

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.ts
@@ -217,10 +217,10 @@ export function mergeFeature(existing: BaseFeature, incoming: BaseFeature): Base
   const versionHistory = getStringArray(existing.meta?.version_history);
   // Unioning incoming aliases is safe: model-written meta.aliases is stripped at the identify
   // boundary, so whatever arrives here was assigned by code after a verified reuse.
-  const aliases = uniq([
-    ...getStringArray(existing.meta?.aliases),
-    ...getStringArray(incoming.meta?.aliases),
-  ]).slice(-MAX_FEATURE_ARRAY_ITEMS);
+  const aliases = boundedUnion(
+    getStringArray(existing.meta?.aliases),
+    getStringArray(incoming.meta?.aliases)
+  ) ?? [];
 
   if (versionHistory.length > 0) {
     mergedMeta.version_history = versionHistory;

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.ts
@@ -176,8 +176,15 @@ export function isDuplicateFeature(feature: BaseFeature, other: BaseFeature): bo
   );
 }
 
-const mergeArrays = (a: string[] | undefined, b: string[] | undefined): string[] | undefined => {
-  const merged = uniq([...(a ?? []), ...(b ?? [])]);
+export const MAX_FEATURE_ARRAY_ITEMS = 10;
+
+// Keep the tail: incoming items are appended last, so the most recently emitted survive the cut.
+const boundedUnion = (
+  a: string[] | undefined,
+  b: string[] | undefined,
+  max: number = MAX_FEATURE_ARRAY_ITEMS
+): string[] | undefined => {
+  const merged = uniq([...(a ?? []), ...(b ?? [])]).slice(-max);
   return merged.length > 0 ? merged : undefined;
 };
 
@@ -213,7 +220,7 @@ export function mergeFeature(existing: BaseFeature, incoming: BaseFeature): Base
   const aliases = uniq([
     ...getStringArray(existing.meta?.aliases),
     ...getStringArray(incoming.meta?.aliases),
-  ]).slice(-10);
+  ]).slice(-MAX_FEATURE_ARRAY_ITEMS);
 
   if (versionHistory.length > 0) {
     mergedMeta.version_history = versionHistory;
@@ -233,7 +240,9 @@ export function mergeFeature(existing: BaseFeature, incoming: BaseFeature): Base
     incomingVersion.trim().length > 0 &&
     existingVersion !== incomingVersion
   ) {
-    mergedMeta.version_history = uniq([...versionHistory, existingVersion]).slice(-10);
+    mergedMeta.version_history = uniq([...versionHistory, existingVersion]).slice(
+      -MAX_FEATURE_ARRAY_ITEMS
+    );
   }
 
   return {
@@ -245,9 +254,9 @@ export function mergeFeature(existing: BaseFeature, incoming: BaseFeature): Base
     description: incoming.description,
     properties: mergedProperties,
     confidence: Math.round((existing.confidence + incoming.confidence) / 2),
-    evidence: mergeArrays(existing.evidence, incoming.evidence),
-    evidence_doc_ids: mergeArrays(existing.evidence_doc_ids, incoming.evidence_doc_ids),
-    tags: mergeArrays(existing.tags, incoming.tags),
+    evidence: boundedUnion(existing.evidence, incoming.evidence),
+    evidence_doc_ids: boundedUnion(existing.evidence_doc_ids, incoming.evidence_doc_ids),
+    tags: boundedUnion(existing.tags, incoming.tags),
     filter: incoming.filter ?? existing.filter,
     meta: Object.keys(mergedMeta).length > 0 ? mergedMeta : undefined,
   };

--- a/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.ts
+++ b/x-pack/platform/packages/shared/kbn-significant-events-schema/src/feature.ts
@@ -217,10 +217,9 @@ export function mergeFeature(existing: BaseFeature, incoming: BaseFeature): Base
   const versionHistory = getStringArray(existing.meta?.version_history);
   // Unioning incoming aliases is safe: model-written meta.aliases is stripped at the identify
   // boundary, so whatever arrives here was assigned by code after a verified reuse.
-  const aliases = boundedUnion(
-    getStringArray(existing.meta?.aliases),
-    getStringArray(incoming.meta?.aliases)
-  ) ?? [];
+  const aliases =
+    boundedUnion(getStringArray(existing.meta?.aliases), getStringArray(incoming.meta?.aliases)) ??
+    [];
 
   if (versionHistory.length > 0) {
     mergedMeta.version_history = versionHistory;


### PR DESCRIPTION
## Summary

Fix unbounded growth of feature evidence arrays across identification iterations





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->