### PR TITLE
[8.19] chore(security, axios): migrate ui_capabilities FTR services to fetch (phase 6) (#281823)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -352,7 +352,6 @@ const AXIOS_LEGACY_CONSUMERS = [
   'x-pack/platform/test/fleet_cypress/artifact_manager.ts',
   'x-pack/platform/test/fleet_cypress/fleet_server.ts',
   'x-pack/platform/test/serverless/api_integration/test_suites/telemetry/telemetry_config.ts',
-  'x-pack/platform/test/ui_capabilities/common/services/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/packages/alerting-test-data/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/plugins/apm/scripts/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/observability/plugins/apm/server/test_helpers/**/*.{js,mjs,ts,tsx}',
@@ -367,7 +366,6 @@ const AXIOS_LEGACY_CONSUMERS = [
   'x-pack/solutions/security/packages/kbn-securitysolution-utils/src/axios/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/common/endpoint/format_axios_error.ts',
-  'x-pack/solutions/security/plugins/security_solution/common/endpoint/utils/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/scripts/endpoint/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/server/integration_tests/**/*.{js,mjs,ts,tsx}',
   'x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/**/*.{js,mjs,ts,tsx}',
@@ -2549,10 +2547,12 @@ module.exports = {
       // globally by RESTRICTED_IMPORTS; this allowlist should only ever shrink
       // as consumers migrate to the native `fetch` API. Placed last so it wins
       // over any earlier override that re-applies RESTRICTED_IMPORTS (e.g. the
-      // security_solution and workflows_management blocks). The trade-off: the
-      // allowlisted files that overlap with those blocks lose their `*legacy*`
-      // pattern check; verified that none of them currently import any path
-      // matching `*legacy*`. The js-yaml freeze is handled separately via
+      // security_solution block). The trade-off: the allowlisted files that
+      // overlap with that block lose their `*legacy*` pattern check; verified
+      // that none of them currently import any path matching `*legacy*`. The
+      // workflows_management overlap is gone, and this comment can be dropped
+      // entirely once the remaining security_solution consumers migrate. The
+      // js-yaml freeze is handled separately via
       // @kbn/eslint/module_migration in packages/kbn-eslint-config/.eslintrc.js
       // so it does not interact with this override.
       files: AXIOS_LEGACY_CONSUMERS,

--- a/x-pack/platform/test/ui_capabilities/common/services/features.ts
+++ b/x-pack/platform/test/ui_capabilities/common/services/features.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import axios, { AxiosInstance } from 'axios';
 import { format as formatUrl } from 'url';
 import util from 'util';
 import { ToolingLog } from '@kbn/tooling-log';
@@ -13,49 +12,51 @@ import { FtrProviderContext } from '../ftr_provider_context';
 import { Features } from '../features';
 
 export class FeaturesService {
-  private readonly axios: AxiosInstance;
-
-  constructor(url: string, private readonly log: ToolingLog) {
-    this.axios = axios.create({
-      headers: { 'kbn-xsrf': 'x-pack/ftr/services/features' },
-      baseURL: url,
-      allowAbsoluteUrls: false,
-      maxRedirects: 0,
-      validateStatus: () => true, // we'll handle our own statusCodes and throw informative errors
-    });
-  }
+  constructor(
+    private readonly url: string,
+    private readonly credentials: { username: string; password: string },
+    private readonly log: ToolingLog
+  ) {}
 
   public async get({ ignoreValidLicenses } = { ignoreValidLicenses: false }): Promise<Features> {
     this.log.debug('requesting /api/features to get the features');
-    const response = await this.axios.get(
-      `/api/features?ignoreValidLicenses=${ignoreValidLicenses}`
+    const { username, password } = this.credentials;
+    const response = await fetch(
+      `${this.url}/api/features?ignoreValidLicenses=${ignoreValidLicenses}`,
+      {
+        headers: {
+          'kbn-xsrf': 'x-pack/ftr/services/features',
+          authorization: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+        },
+        redirect: 'manual', // we'll handle our own statusCodes and throw informative errors
+      }
     );
 
     if (response.status !== 200) {
       throw new Error(
         `Expected status code of 200, received ${response.status} ${
           response.statusText
-        }: ${util.inspect(response.data)}`
+        }: ${util.inspect(await response.text())}`
       );
     }
 
-    const features = response.data.reduce(
-      (acc: Features, feature: any) => ({
+    return ((await response.json()) as Array<{ id: string; app: string[] }>).reduce<Features>(
+      (acc, feature) => ({
         ...acc,
-        [feature.id]: {
-          app: feature.app,
-        },
+        [feature.id]: { app: feature.app },
       }),
       {}
     );
-    return features;
   }
 }
 
 export function FeaturesProvider({ getService }: FtrProviderContext) {
   const log = getService('log');
   const config = getService('config');
-  const url = formatUrl(config.get('servers.kibana'));
+  // `fetch` rejects URLs that embed credentials, so keep them out of the URL
+  // and send them as a Basic auth header instead.
+  const { username, password } = config.get('servers.kibana');
+  const url = formatUrl({ ...config.get('servers.kibana'), auth: undefined });
 
-  return new FeaturesService(url, log);
+  return new FeaturesService(url, { username, password }, log);
 }

--- a/x-pack/platform/test/ui_capabilities/common/services/ui_capabilities.ts
+++ b/x-pack/platform/test/ui_capabilities/common/services/ui_capabilities.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import axios, { AxiosInstance } from 'axios';
 import type { Capabilities as UICapabilities } from '@kbn/core/types';
 import { format as formatUrl } from 'url';
 import util from 'util';
@@ -31,18 +30,12 @@ interface GetUICapabilitiesResult {
 
 export class UICapabilitiesService {
   private readonly log: ToolingLog;
-  private readonly axios: AxiosInstance;
+  private readonly url: string;
   private readonly featureService: FeaturesService;
 
   constructor(url: string, log: ToolingLog, featureService: FeaturesService) {
     this.log = log;
-    this.axios = axios.create({
-      headers: { 'kbn-xsrf': 'x-pack/ftr/services/ui_capabilities' },
-      baseURL: url,
-      allowAbsoluteUrls: false,
-      maxRedirects: 0,
-      validateStatus: () => true, // we'll handle our own statusCodes and throw informative errors
-    });
+    this.url = url;
     this.featureService = featureService;
   }
 
@@ -69,15 +62,18 @@ export class UICapabilitiesService {
           ).toString('base64')}`,
         }
       : {};
-    const response = await this.axios.post(
-      `${spaceUrlPrefix}/api/core/capabilities`,
-      { applications: [...applications, 'kibana:stack_management'] },
-      {
-        headers: requestHeaders,
-      }
-    );
+    const response = await fetch(`${this.url}${spaceUrlPrefix}/api/core/capabilities`, {
+      method: 'POST',
+      headers: {
+        'kbn-xsrf': 'x-pack/ftr/services/ui_capabilities',
+        'content-type': 'application/json',
+        ...requestHeaders,
+      },
+      body: JSON.stringify({ applications: [...applications, 'kibana:stack_management'] }),
+      redirect: 'manual', // we'll handle our own statusCodes and throw informative errors
+    });
 
-    if (response.status === 302 && response.headers.location === '/spaces/space_selector') {
+    if (response.status === 302 && response.headers.get('location') === '/spaces/space_selector') {
       return {
         success: false,
         failureReason: GetUICapabilitiesFailureReason.RedirectedToSpaceSelector,
@@ -95,13 +91,13 @@ export class UICapabilitiesService {
       throw new Error(
         `Expected status code of 200, received ${response.status} ${
           response.statusText
-        }: ${util.inspect(response.data)}`
+        }: ${util.inspect(await response.text())}`
       );
     }
 
     return {
       success: true,
-      value: response.data,
+      value: (await response.json()) as UICapabilities,
     };
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(security, axios): migrate ui_capabilities FTR services to fetch (phase 6) (#281823)](https://github.com/elastic/kibana/pull/281823)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2026-08-07T11:42:55Z","message":"chore(security, axios): migrate ui_capabilities FTR services to fetch (phase 6) (#281823)\n\n## Summary\n\nPart of the incremental [`axios` to native `fetch`\nmigration](https://github.com/elastic/kibana/pull/266556) (the\nlint-freeze PR). Phase 6 drains the `@elastic/kibana-security` bucket:\nthe two `ui_capabilities` FTR services.\n\n**Tier: MEDIUM.** Both files used `axios.create(...)` instances (no\ninterceptors, no custom adapter).\n\nEach service now calls `fetch` directly at the call site, in place,\nmatching the earlier phases of this migration. The axios settings both\ninstances shared map over as:\n\n| axios config | fetch equivalent |\n| --- | --- |\n| `maxRedirects: 0` | `redirect: 'manual'` |\n| `validateStatus: () => true` | statuses are inspected and never thrown\non, so the existing 302/404 branches and error messages are unchanged |\n| implicit JSON `Content-Type` on POST | set explicitly |\n| `transformResponse` | `await response.json()` on success, `await\nresponse.text()` in the error path |\n\n### Behavior notes for reviewers\n\nTwo things worth a close look, both verified rather than assumed:\n\n1. **`features.ts` was authenticated via credentials embedded in its\nbase URL.** It built the URL with\n`formatUrl(config.get('servers.kibana'))`, which includes the `auth`\nfield, and axios silently converted that into a `Basic` header. Native\n`fetch` instead throws `TypeError: Request cannot be constructed from a\nURL that includes credentials`. Rather than parsing them back out of the\nURL, `FeaturesProvider` now strips `auth` and passes `{ username,\npassword }` to the service, which sends the header itself. That mirrors\nwhat `UICapabilitiesService` already did with its per-request\ncredentials, and keeps both services structurally parallel. Only the\nproviders construct these classes, so the constructor change is\ncontained.\n2. **The 302 space-selector detection still works.** In Node/undici,\n`redirect: 'manual'` returns the real response with status `302` and a\nreadable `location` header, unlike browsers, which return an opaque\nredirect with status `0` and no headers. `response.headers.location`\nbecame `response.headers.get('location')`.\n\n### eslint allowlist\n\n- Removed `x-pack/platform/test/ui_capabilities/common/services/**` from\n`AXIOS_LEGACY_CONSUMERS`, and confirmed the global ban now fires on\nthese files by temporarily re-adding an `axios` import.\n- Also pruned four globs whose files no longer import axios at all\n(`kbn-evals`, `observability_ai_assistant/server/functions`,\n`observability_onboarding/server/test_helpers`,\n`security_solution/common/endpoint/utils`), and trimmed the now-obsolete\n`workflows_management` half of the override's trade-off comment (that\noverlap is gone). `AXIOS_LEGACY_CONSUMERS` is now 54 globs covering all\n239 remaining consumers exactly: no leaks, no dead globs.\n\n### Testing\n\n- `node scripts/eslint` on the touched files: clean; the ban is verified\nto fire when axios is re-added.\n- `node scripts/type_check --project\nx-pack/platform/test/tsconfig.json`: green.\n- `node scripts/check_changes.ts`: all pre-commit checks passed.\n- Exercised both services against a mock Kibana covering every branch:\ncredentials to `Basic` header, `kbn-xsrf`, 200 + body parsing, `302` to\n`RedirectedToSpaceSelector`, `404` to `NotFound`, per-request\ncredentials, and a `503` producing the informative throw (status +\nstatusText + body).\n\nThe FTR configs that consume these services\n(`x-pack/platform/test/ui_capabilities/{security_and_spaces,spaces_only}`)\nare the real proof and run in CI.\n\n### Risk\n\nLow and contained. Every other reference to these classes is a type-only\nimport inside the same test tree that calls only `.get()`, so there is\nno contract change and no ripple outside\n`x-pack/platform/test/ui_capabilities/`.\n\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>","sha":"8e15f208e76c492d8a7c785e640116ecdfa91ebc","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport missing","backport:all-open","v9.6.0"],"title":"chore(security, axios): migrate ui_capabilities FTR services to fetch (phase 6)","number":281823,"url":"https://github.com/elastic/kibana/pull/281823","mergeCommit":{"message":"chore(security, axios): migrate ui_capabilities FTR services to fetch (phase 6) (#281823)\n\n## Summary\n\nPart of the incremental [`axios` to native `fetch`\nmigration](https://github.com/elastic/kibana/pull/266556) (the\nlint-freeze PR). Phase 6 drains the `@elastic/kibana-security` bucket:\nthe two `ui_capabilities` FTR services.\n\n**Tier: MEDIUM.** Both files used `axios.create(...)` instances (no\ninterceptors, no custom adapter).\n\nEach service now calls `fetch` directly at the call site, in place,\nmatching the earlier phases of this migration. The axios settings both\ninstances shared map over as:\n\n| axios config | fetch equivalent |\n| --- | --- |\n| `maxRedirects: 0` | `redirect: 'manual'` |\n| `validateStatus: () => true` | statuses are inspected and never thrown\non, so the existing 302/404 branches and error messages are unchanged |\n| implicit JSON `Content-Type` on POST | set explicitly |\n| `transformResponse` | `await response.json()` on success, `await\nresponse.text()` in the error path |\n\n### Behavior notes for reviewers\n\nTwo things worth a close look, both verified rather than assumed:\n\n1. **`features.ts` was authenticated via credentials embedded in its\nbase URL.** It built the URL with\n`formatUrl(config.get('servers.kibana'))`, which includes the `auth`\nfield, and axios silently converted that into a `Basic` header. Native\n`fetch` instead throws `TypeError: Request cannot be constructed from a\nURL that includes credentials`. Rather than parsing them back out of the\nURL, `FeaturesProvider` now strips `auth` and passes `{ username,\npassword }` to the service, which sends the header itself. That mirrors\nwhat `UICapabilitiesService` already did with its per-request\ncredentials, and keeps both services structurally parallel. Only the\nproviders construct these classes, so the constructor change is\ncontained.\n2. **The 302 space-selector detection still works.** In Node/undici,\n`redirect: 'manual'` returns the real response with status `302` and a\nreadable `location` header, unlike browsers, which return an opaque\nredirect with status `0` and no headers. `response.headers.location`\nbecame `response.headers.get('location')`.\n\n### eslint allowlist\n\n- Removed `x-pack/platform/test/ui_capabilities/common/services/**` from\n`AXIOS_LEGACY_CONSUMERS`, and confirmed the global ban now fires on\nthese files by temporarily re-adding an `axios` import.\n- Also pruned four globs whose files no longer import axios at all\n(`kbn-evals`, `observability_ai_assistant/server/functions`,\n`observability_onboarding/server/test_helpers`,\n`security_solution/common/endpoint/utils`), and trimmed the now-obsolete\n`workflows_management` half of the override's trade-off comment (that\noverlap is gone). `AXIOS_LEGACY_CONSUMERS` is now 54 globs covering all\n239 remaining consumers exactly: no leaks, no dead globs.\n\n### Testing\n\n- `node scripts/eslint` on the touched files: clean; the ban is verified\nto fire when axios is re-added.\n- `node scripts/type_check --project\nx-pack/platform/test/tsconfig.json`: green.\n- `node scripts/check_changes.ts`: all pre-commit checks passed.\n- Exercised both services against a mock Kibana covering every branch:\ncredentials to `Basic` header, `kbn-xsrf`, 200 + body parsing, `302` to\n`RedirectedToSpaceSelector`, `404` to `NotFound`, per-request\ncredentials, and a `503` producing the informative throw (status +\nstatusText + body).\n\nThe FTR configs that consume these services\n(`x-pack/platform/test/ui_capabilities/{security_and_spaces,spaces_only}`)\nare the real proof and run in CI.\n\n### Risk\n\nLow and contained. Every other reference to these classes is a type-only\nimport inside the same test tree that calls only `.get()`, so there is\nno contract change and no ripple outside\n`x-pack/platform/test/ui_capabilities/`.\n\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>","sha":"8e15f208e76c492d8a7c785e640116ecdfa91ebc"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281823","number":281823,"mergeCommit":{"message":"chore(security, axios): migrate ui_capabilities FTR services to fetch (phase 6) (#281823)\n\n## Summary\n\nPart of the incremental [`axios` to native `fetch`\nmigration](https://github.com/elastic/kibana/pull/266556) (the\nlint-freeze PR). Phase 6 drains the `@elastic/kibana-security` bucket:\nthe two `ui_capabilities` FTR services.\n\n**Tier: MEDIUM.** Both files used `axios.create(...)` instances (no\ninterceptors, no custom adapter).\n\nEach service now calls `fetch` directly at the call site, in place,\nmatching the earlier phases of this migration. The axios settings both\ninstances shared map over as:\n\n| axios config | fetch equivalent |\n| --- | --- |\n| `maxRedirects: 0` | `redirect: 'manual'` |\n| `validateStatus: () => true` | statuses are inspected and never thrown\non, so the existing 302/404 branches and error messages are unchanged |\n| implicit JSON `Content-Type` on POST | set explicitly |\n| `transformResponse` | `await response.json()` on success, `await\nresponse.text()` in the error path |\n\n### Behavior notes for reviewers\n\nTwo things worth a close look, both verified rather than assumed:\n\n1. **`features.ts` was authenticated via credentials embedded in its\nbase URL.** It built the URL with\n`formatUrl(config.get('servers.kibana'))`, which includes the `auth`\nfield, and axios silently converted that into a `Basic` header. Native\n`fetch` instead throws `TypeError: Request cannot be constructed from a\nURL that includes credentials`. Rather than parsing them back out of the\nURL, `FeaturesProvider` now strips `auth` and passes `{ username,\npassword }` to the service, which sends the header itself. That mirrors\nwhat `UICapabilitiesService` already did with its per-request\ncredentials, and keeps both services structurally parallel. Only the\nproviders construct these classes, so the constructor change is\ncontained.\n2. **The 302 space-selector detection still works.** In Node/undici,\n`redirect: 'manual'` returns the real response with status `302` and a\nreadable `location` header, unlike browsers, which return an opaque\nredirect with status `0` and no headers. `response.headers.location`\nbecame `response.headers.get('location')`.\n\n### eslint allowlist\n\n- Removed `x-pack/platform/test/ui_capabilities/common/services/**` from\n`AXIOS_LEGACY_CONSUMERS`, and confirmed the global ban now fires on\nthese files by temporarily re-adding an `axios` import.\n- Also pruned four globs whose files no longer import axios at all\n(`kbn-evals`, `observability_ai_assistant/server/functions`,\n`observability_onboarding/server/test_helpers`,\n`security_solution/common/endpoint/utils`), and trimmed the now-obsolete\n`workflows_management` half of the override's trade-off comment (that\noverlap is gone). `AXIOS_LEGACY_CONSUMERS` is now 54 globs covering all\n239 remaining consumers exactly: no leaks, no dead globs.\n\n### Testing\n\n- `node scripts/eslint` on the touched files: clean; the ban is verified\nto fire when axios is re-added.\n- `node scripts/type_check --project\nx-pack/platform/test/tsconfig.json`: green.\n- `node scripts/check_changes.ts`: all pre-commit checks passed.\n- Exercised both services against a mock Kibana covering every branch:\ncredentials to `Basic` header, `kbn-xsrf`, 200 + body parsing, `302` to\n`RedirectedToSpaceSelector`, `404` to `NotFound`, per-request\ncredentials, and a `503` producing the informative throw (status +\nstatusText + body).\n\nThe FTR configs that consume these services\n(`x-pack/platform/test/ui_capabilities/{security_and_spaces,spaces_only}`)\nare the real proof and run in CI.\n\n### Risk\n\nLow and contained. Every other reference to these classes is a type-only\nimport inside the same test tree that calls only `.get()`, so there is\nno contract change and no ripple outside\n`x-pack/platform/test/ui_capabilities/`.\n\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>","sha":"8e15f208e76c492d8a7c785e640116ecdfa91ebc"}},{"url":"https://github.com/elastic/kibana/pull/283653","number":283653,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/283654","number":283654,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->