### PR TITLE
[discover][scout] retry the data-view-editor fill→validate→submit

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/discover_app.ts
@@ -156,21 +156,48 @@ export class DiscoverApp {
     // FTR passes the base name and relies on the editor auto-appending `*` as the
     // user types. Scout sets the title verbatim (`fill`), so append the wildcard
     // here to preserve that contract (`name`, `* will be added automatically`).
-    await titleInput.fill(name.endsWith('*') ? name : `${name}*`);
-    // wait for async title validation to settle before continuing.
-    await form.and(this.page.locator('[data-validation-error="0"]')).waitFor({ state: 'visible' });
+    const title = name.endsWith('*') ? name : `${name}*`;
 
-    // wait for timestamp options; default @timestamp applies.
-    await timestampField
-      .and(this.page.locator('[data-is-loading="0"]'))
-      .waitFor({ state: 'visible', timeout: 30_000 });
+    // Retry: title validation can race its debounced index lookup and get stuck
+    // invalid even after a match is found (see FTR's `settings_page.ts` for the same fix).
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const isLastAttempt = attempt === maxAttempts;
 
-    if (adHoc) {
-      await this.page.testSubj.click('exploreIndexPatternButton');
-    } else {
-      await this.page.testSubj.click('saveIndexPatternButton');
+      if (attempt > 1) {
+        await titleInput.fill(''); // force a real value change to re-trigger validation
+      }
+      await titleInput.fill(title);
+      // wait for async title validation to settle before continuing.
+      await form
+        .and(this.page.locator('[data-validation-error="0"]'))
+        .waitFor({ state: 'visible' });
+
+      // wait for timestamp options; default @timestamp applies.
+      await timestampField
+        .and(this.page.locator('[data-is-loading="0"]'))
+        .waitFor({ state: 'visible', timeout: 30_000 });
+
+      if (adHoc) {
+        await this.page.testSubj.click('exploreIndexPatternButton');
+      } else {
+        await this.page.testSubj.click('saveIndexPatternButton');
+      }
+
+      const flyoutClosed = await flyout
+        .waitFor({ state: 'hidden', timeout: isLastAttempt ? 10_000 : 3_000 })
+        .then(() => true)
+        .catch(() => false);
+
+      if (flyoutClosed) {
+        break;
+      }
+      if (isLastAttempt) {
+        throw new Error(
+          `indexPatternEditorFlyout did not close after ${maxAttempts} attempts to submit "${title}"`
+        );
+      }
     }
-    await flyout.waitFor({ state: 'hidden' });
 
     await this.waitUntilTabIsLoaded();
   }

--- a/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/data_view_editor_page.ts
+++ b/src/platform/plugins/shared/data_view_editor/test/scout/ui/fixtures/page_objects/data_view_editor_page.ts
@@ -39,16 +39,33 @@ export class DataViewEditorPage {
   }
 
   // Fills the title field and waits for async validation to settle.
+  // Retries: title validation can race its debounced index lookup and get stuck invalid.
   async setTitle(title: string): Promise<void> {
-    await this.titleInput.fill(title);
-    await this.waitForValidTitle(title);
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const isLastAttempt = attempt === maxAttempts;
+
+      if (attempt > 1) {
+        await this.titleInput.fill(''); // force a real value change to re-trigger validation
+      }
+      await this.titleInput.fill(title);
+
+      try {
+        await this.waitForValidTitle(title, isLastAttempt ? 30_000 : 5_000);
+        return;
+      } catch (error) {
+        if (isLastAttempt) {
+          throw error;
+        }
+      }
+    }
   }
 
-  private async waitForValidTitle(title: string): Promise<void> {
+  private async waitForValidTitle(title: string, timeout = 30_000): Promise<void> {
     await expect(this.titleInput).toHaveValue(title);
-    await expect(this.titleInput).toHaveAttribute('data-is-validating', '0', { timeout: 30_000 });
-    await expect(this.titleInput).not.toHaveAttribute('aria-invalid', 'true');
-    await expect(this.form).toHaveAttribute('data-validation-error', '0', { timeout: 30_000 });
+    await expect(this.titleInput).toHaveAttribute('data-is-validating', '0', { timeout });
+    await expect(this.titleInput).not.toHaveAttribute('aria-invalid', 'true', { timeout });
+    await expect(this.form).toHaveAttribute('data-validation-error', '0', { timeout });
   }
 
   // Returns the timestamp field combo box value after the field finishes loading.

--- a/src/platform/plugins/shared/discover/test/scout/tabs/ui/parallel_tests/sharing.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/tabs/ui/parallel_tests/sharing.spec.ts
@@ -35,6 +35,8 @@ const openSharedPage = async (page: ScoutPage, sharedUrl: string, kbnUrl: Kibana
 };
 
 spaceTest.describe('Discover tabs - sharing', { tag: '@local-stateful-classic' }, () => {
+  spaceTest.setTimeout(90_000);
+
   spaceTest.beforeAll(async ({ discoverScoutSpace }) => {
     await discoverScoutSpace.setupDiscoverDefaults();
   });


### PR DESCRIPTION
## Summary

Fixes flaky Scout tests that create data views via the UI (e.g. `sharing.spec.ts`'s `"can share one unsaved tab from a persisted session"`), which intermittently timed out waiting for the `indexPatternEditorFlyout` to close.

Root cause: the data view editor's async title validation reads matched-index state from a separately debounced (250ms) lookup. When validation runs before that debounce fires, it can resolve using stale (e.g. empty) match data and mark the title permanently invalid — even though the preview panel already shows correct matches — because the form only re-validates fields that haven't already been validated. Clicking Save/Explore then silently no-ops, leaving the flyout open until the test times out. This is a known race also worked around in FTR (`settings_page.ts`).

Fix: retry `the fill → validate → submit` sequence (up to 3 attempts, re-filling the title to force fresh validation) instead of a single attempt, in the three Scout helpers that drive this flow:

- `kbn-scout`'s `fillAndSubmitDataViewEditor` (used by Discover's `createDataViewFromSearchBar`)
- `data_view_editor` plugin's own Scout page object (`setTitle`)
- Adds no overhead on the happy path (breaks out on first success); only spends extra time when the race actually occurs.



