### PR TITLE
[Security Solution] Stub RuleActionsField in flaky CreateFlyout schedule test

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.test.tsx
@@ -32,6 +32,15 @@ jest.mock('../../../../../data_view_manager/hooks/use_data_view', () => ({
     status: 'ready',
   }),
 }));
+// Stub the heavy RuleActionsField subtree. It renders the triggers_actions_ui
+// `ActionForm` via `React.lazy`/`Suspense` (`getActionFormLazy`), whose first
+// mount pays a large one-time lazy-import cost and whose connector/action-type
+// loads never settle under jsdom. That subtree — not `AlertSelection` — is the
+// dominant cost and the source of the "not wrapped in act(...)" churn that
+// tripped Jest's 5s per-test timeout in CI.
+jest.mock('../../../../../common/components/rule_actions_field', () => ({
+  RuleActionsField: () => <div data-test-subj="mockRuleActionsField" />,
+}));
 // Stub the heavy AlertSelection subtree (lens embeddable, unified-search bar,
 // alert-preview tabs) that otherwise blows the 5s render budget under jsdom. The
 // stub keeps the `alertSelection` marker and an `alertsRange` control wired to
@@ -285,7 +294,7 @@ describe('CreateFlyout', () => {
       await renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Select a connector type')).toBeInTheDocument();
+        expect(screen.getByTestId('mockRuleActionsField')).toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #283073. Related to #220116.

#283073 stubbed the `AlertSelection` subtree in the `CreateFlyout` schedule Jest suite, but the first test was still slow (~1.1–1.9s) and the suite still emitted `ActionForm` "not wrapped in `act(...)`" warnings — the never-settling async surface that trips Jest's 5s per-test timeout under CI contention.

The dominant remaining cost is a **different** heavy subtree that the previous fix left fully live: the real `triggers_actions_ui` `ActionForm`, mounted via the actions field:

```
CreateFlyout → useEditForm → EditForm → RuleActionsField
  → triggersActionsUi.getActionForm() → getActionFormLazy (React.lazy + Suspense)
```

Two things make it expensive/flaky under jsdom:
1. **First-time lazy mount** — `getActionFormLazy` dynamically imports a large module subtree; the first render in the file pays that one-time cost, which Jest attributes to the first `it()` (hence "first test slow, rest fast").
2. **Never-settling async** — `ActionForm` fires `setIsLoadingActionTypes` / `setIsLoadingConnectors` that never settle in jsdom (the `act()` warnings), which under CI worker contention pushed the render past the 5s per-test timeout.

This PR stubs `RuleActionsField` the same way #283073 stubbed `AlertSelection`.

## Results (local, `--no-cache`, Node 24.19)

| Config | First test | `act()` warnings |
|---|---|---|
| main (`AlertSelection` stub only, post-#283073) | ~1386 ms | 8 |
| this PR (`+ RuleActionsField` stub) | ~160 ms | 0 |

Warm-cache first test drops from ~313 ms → ~120 ms (under the 300 ms slow-test threshold); the slow-test flag disappears and all 14 tests pass.

## Notes

- The assertion in `should render actions component` previously matched the real form's "Select a connector type" text; it now asserts the stub's `data-test-subj`. The test only ever verified that the actions section rendered — the connector-form behavior is covered by `triggers_actions_ui`'s own tests.
- The sibling `edit_form.test.tsx` mounts the same real `ActionForm` and already trips the slow-test flag (~320 ms), but it is **not** currently reported flaky and has a test that asserts `getActionForm` is called with specific props (so a blanket `RuleActionsField` stub would break it). Left out of this focused PR; can be handled separately with a lighter `getActionForm` stub if it becomes a problem.

## Verification

- ✅ `node scripts/jest .../schedule/create_flyout/index.test.tsx` — 14/14 pass, 0 `act()` warnings, no slow-test flag
- ✅ `node scripts/eslint .../schedule/create_flyout/index.test.tsx` — no errors
- ⚠️ `node scripts/type_check` for `security_solution` OOMs locally (as noted in #283073); change is test-only and the stub shape mirrors the existing `AlertSelection` stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
