### PR TITLE
[Context Engine] execute_esql now filters by space

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/esql/execute_esql.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/esql/execute_esql.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { errors } from '@elastic/elasticsearch';
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { executeEsql } from './execute_esql';
+
+describe('executeEsql', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+
+  const getRequest = () => esClient.esql.query.mock.calls[0][0];
+
+  beforeEach(() => {
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.esql.query.mockResolvedValue({
+      columns: [{ name: 'title', type: 'keyword' }],
+      values: [['a title']],
+    } as never);
+  });
+
+  it('returns the columns and values from the response', async () => {
+    const result = await executeEsql({ query: 'FROM idx', esClient });
+
+    expect(result).toEqual({
+      columns: [{ name: 'title', type: 'keyword' }],
+      values: [['a title']],
+    });
+  });
+
+  it('passes the filter through to the ES|QL request', async () => {
+    const filter: QueryDslQueryContainer = { terms: { spaces: ['marketing', '*'] } };
+
+    await executeEsql({ query: 'FROM idx', filter, esClient });
+
+    expect(getRequest()).toEqual(expect.objectContaining({ filter }));
+  });
+
+  it('omits the filter key entirely when no filter is provided', async () => {
+    await executeEsql({ query: 'FROM idx', esClient });
+
+    expect(getRequest()).not.toHaveProperty('filter');
+  });
+
+  it('sends both params and filter when both are provided', async () => {
+    const filter: QueryDslQueryContainer = { term: { spaces: 'marketing' } };
+
+    await executeEsql({
+      query: 'FROM idx | WHERE title == ?title',
+      params: [{ title: 'a title' }],
+      filter,
+      esClient,
+    });
+
+    expect(getRequest()).toEqual(
+      expect.objectContaining({ params: [{ title: 'a title' }], filter })
+    );
+  });
+
+  it('omits the params key entirely when the params array is empty', async () => {
+    await executeEsql({ query: 'FROM idx', params: [], esClient });
+
+    expect(getRequest()).not.toHaveProperty('params');
+  });
+
+  it('applies the limit to the query when one is provided', async () => {
+    await executeEsql({ query: 'FROM idx', limit: 10, esClient });
+
+    expect(getRequest().query).toBe('FROM idx | LIMIT 10');
+  });
+
+  it('leaves the query untouched when no limit is provided', async () => {
+    await executeEsql({ query: 'FROM idx', esClient });
+
+    expect(getRequest().query).toBe('FROM idx');
+  });
+
+  it('rethrows a maximum-response-size error with actionable guidance', async () => {
+    esClient.esql.query.mockRejectedValue(
+      new errors.RequestAbortedError('Response content length exceeded')
+    );
+
+    await expect(executeEsql({ query: 'FROM idx', esClient })).rejects.toThrow(
+      /exceeded the maximum allowed size of 20MB/
+    );
+  });
+
+  it('rethrows any other error unchanged', async () => {
+    const original = new Error('verification_exception');
+    esClient.esql.query.mockRejectedValue(original);
+
+    await expect(executeEsql({ query: 'FROM idx', esClient })).rejects.toBe(original);
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/esql/execute_esql.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/esql/execute_esql.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import type { EsqlEsqlColumnInfo, FieldValue } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  EsqlEsqlColumnInfo,
+  FieldValue,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { isMaximumResponseSizeExceededError } from '@kbn/es-errors';
 import { MAX_ES_RESPONSE_SIZE_BYTES } from '../../constants';
@@ -25,16 +29,25 @@ export interface EsqlResponse {
  * When `limit` is provided, the query is rewritten so the ES|QL engine enforces the cap. If the
  * query already ends with a `LIMIT N`, the trailing limit becomes `min(N, limit)`; otherwise a
  * new `| LIMIT <limit>` pipe is appended. See `applyLimit` for full semantics.
+ *
+ * `filter` is a Query DSL container applied by Elasticsearch before any ES|QL pipeline operator
+ * runs, across every `FORK` branch. It is not equivalent to a `WHERE` clause: Elasticsearch also
+ * uses it as the `index_filter` during field resolution, so an index that cannot match is skipped
+ * entirely and its exclusive columns disappear from the response with no error. Build the clause so
+ * every targeted index can still match it. `params` placeholders are not substituted into `filter`,
+ * and the filter does not reach `LOOKUP JOIN` or `ENRICH` sources.
  */
 export const executeEsql = async ({
   query,
   params,
   limit,
+  filter,
   esClient,
 }: {
   query: string;
   params?: Array<Record<string, FieldValue>>;
   limit?: number;
+  filter?: QueryDslQueryContainer;
   esClient: ElasticsearchClient;
 }): Promise<EsqlResponse> => {
   const effectiveQuery = limit !== undefined ? applyLimit(query, limit) : query;
@@ -46,6 +59,7 @@ export const executeEsql = async ({
         drop_null_columns: true,
         allow_partial_results: true,
         ...(params && params.length > 0 ? { params: params as unknown as FieldValue[] } : {}),
+        ...(filter ? { filter } : {}),
       },
       { maxResponseSize: MAX_ES_RESPONSE_SIZE_BYTES }
     );

--- a/x-pack/platform/plugins/shared/agent_builder_platform/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/moon.yml
@@ -26,6 +26,7 @@ dependsOn:
   - '@kbn/zod'
   - '@kbn/core-lifecycle-server'
   - '@kbn/esql-language'
+  - '@kbn/esql-utils'
   - '@kbn/product-doc-common'
   - '@kbn/llm-tasks-plugin'
   - '@kbn/i18n'
@@ -47,6 +48,8 @@ dependsOn:
   - '@kbn/logging-mocks'
   - '@kbn/triggers-actions-ui-plugin'
   - '@kbn/agent-builder-plugin'
+  - '@kbn/context-engine-plugin'
+  - '@kbn/core-elasticsearch-server'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/esql_scope_filter.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/esql_scope_filter.test.ts
@@ -1,0 +1,227 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { mergeScopeClauses, resolveEsqlScopeFilter } from './esql_scope_filter';
+
+const SML_INDEX = 'ai-index-idx-sml-data';
+
+const spaceClauseFor = (spaceId: string): QueryDslQueryContainer => ({
+  bool: {
+    minimum_should_match: 1,
+    should: [
+      { terms: { spaces: [spaceId, '*'] } },
+      { bool: { must_not: { exists: { field: 'spaces' } } } },
+    ],
+  },
+});
+
+const keywordField = {
+  spaces: { keyword: { type: 'keyword', searchable: true, aggregatable: true } },
+};
+
+describe('mergeScopeClauses', () => {
+  it('returns undefined when there are no clauses', () => {
+    expect(mergeScopeClauses([])).toBeUndefined();
+  });
+
+  it('returns the clause itself when there is exactly one', () => {
+    const clause = { term: { spaces: 'marketing' } };
+
+    expect(mergeScopeClauses([clause])).toBe(clause);
+  });
+
+  it('ANDs the clauses under bool.must when there are several', () => {
+    const first = { term: { spaces: 'marketing' } };
+    const second = { term: { type: 'dashboard' } };
+
+    expect(mergeScopeClauses([first, second])).toEqual({ bool: { must: [first, second] } });
+  });
+});
+
+describe('resolveEsqlScopeFilter', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+
+  /** Stub one `field_caps` response: which concrete indices resolved, and whether they map `spaces`. */
+  const mockProbe = (indices: string[], spacesMapped: boolean) =>
+    esClient.fieldCaps.mockResolvedValue({
+      indices,
+      fields: spacesMapped ? keywordField : {},
+    } as never);
+
+  /** Resolve and assert success, returning the filter (which may be undefined). */
+  const resolve = async (query: string, spaceId = 'marketing') => {
+    const result = await resolveEsqlScopeFilter({ query, spaceId, esClient, logger });
+
+    if (!result.ok) {
+      throw new Error(`expected a scope filter but the query was refused: ${result.error}`);
+    }
+    return result.filter;
+  };
+
+  /** Resolve and assert refusal, returning the message the tool surfaces to the model. */
+  const resolveRefusal = async (query: string, spaceId = 'marketing') => {
+    const result = await resolveEsqlScopeFilter({ query, spaceId, esClient, logger });
+
+    if (result.ok) {
+      throw new Error('expected the query to be refused, but it resolved');
+    }
+    return result.error;
+  };
+
+  beforeEach(() => {
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
+    logger = loggingSystemMock.createLogger();
+  });
+
+  describe('when the query targets AI indices', () => {
+    it('scopes to the current space', async () => {
+      mockProbe([SML_INDEX], true);
+
+      expect(await resolve('FROM ai-index-* | LIMIT 10')).toEqual(spaceClauseFor('marketing'));
+    });
+
+    it('scopes the default space the same way as a named space', async () => {
+      mockProbe([SML_INDEX], true);
+
+      expect(await resolve('FROM ai-index-*', 'default')).toEqual(spaceClauseFor('default'));
+    });
+
+    it('lets documents with no spaces field through, so AI indices without the mapping survive field resolution', async () => {
+      mockProbe([SML_INDEX, 'ai-index-other'], true);
+
+      const filter = await resolve('FROM ai-index-*');
+
+      expect(filter?.bool?.should).toContainEqual({
+        bool: { must_not: { exists: { field: 'spaces' } } },
+      });
+    });
+
+    it('sends no filter when the AI indices do not map the spaces field', async () => {
+      mockProbe(['ai-index-other'], false);
+
+      expect(await resolve('FROM ai-index-other')).toBeUndefined();
+    });
+
+    it('recognises a rolled-over write index behind an alias', async () => {
+      mockProbe([`${SML_INDEX}-000001`], true);
+
+      expect(await resolve(`FROM ${SML_INDEX}`)).toEqual(spaceClauseFor('marketing'));
+    });
+
+    it('recognises a data stream backing index', async () => {
+      mockProbe(['.ds-ai-index-ds-events-2026.08.07-000001'], true);
+
+      expect(await resolve('FROM ai-index-ds-events')).toEqual(spaceClauseFor('marketing'));
+    });
+
+    it('recognises a remote index under cross-cluster search', async () => {
+      mockProbe([`remote:${SML_INDEX}`], true);
+
+      expect(await resolve(`FROM remote:${SML_INDEX}`)).toEqual(spaceClauseFor('marketing'));
+    });
+  });
+
+  describe('when the query targets no AI index', () => {
+    it('sends no filter for an ordinary index', async () => {
+      mockProbe(['logs-000001'], false);
+
+      expect(await resolve('FROM logs-* | LIMIT 10')).toBeUndefined();
+    });
+
+    it('sends no filter for an unrelated index that happens to map a spaces field', async () => {
+      // `spaces` is an ordinary word. Filtering a meeting-room index by Kibana space ids would
+      // silently drop the caller's rows, so the namespace gate has to win over the field probe.
+      mockProbe(['meeting-rooms'], true);
+
+      expect(await resolve('FROM meeting-rooms')).toBeUndefined();
+    });
+
+    it('sends no filter when the pattern matches nothing at all', async () => {
+      mockProbe([], false);
+
+      expect(await resolve('FROM does-not-exist-*')).toBeUndefined();
+    });
+
+    it('returns no filter for a query with no source command', async () => {
+      expect(await resolve('ROW a = 1')).toBeUndefined();
+      expect(esClient.fieldCaps).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the query mixes AI indices with other indices', () => {
+    it('fails closed rather than scoping or skipping', async () => {
+      mockProbe([SML_INDEX, 'logs-000001'], true);
+
+      await expect(resolveRefusal('FROM ai-index-*,logs-*')).resolves.toMatch(
+        /reads from AI indices .* and from other indices .* query them separately/s
+      );
+    });
+
+    it('names both sides so the caller can split the query', async () => {
+      mockProbe([SML_INDEX, 'logs-000001'], true);
+
+      await expect(resolveRefusal('FROM ai-index-*,logs-*')).resolves.toMatch(
+        new RegExp(`${SML_INDEX}[\\s\\S]*logs-000001`)
+      );
+    });
+
+    it('catches a broad wildcard that happens to span both', async () => {
+      mockProbe(['logs-000001', SML_INDEX, 'metrics-000001'], true);
+
+      await expect(resolveRefusal('FROM *')).resolves.toMatch(/cannot be scoped together/);
+    });
+  });
+
+  describe('field probe', () => {
+    it('probes only the scoped fields, tolerating missing indices', async () => {
+      mockProbe([SML_INDEX], true);
+
+      await resolve('FROM ai-index-* | LIMIT 10');
+
+      expect(esClient.fieldCaps).toHaveBeenCalledTimes(1);
+      expect(esClient.fieldCaps).toHaveBeenCalledWith({
+        index: 'ai-index-*',
+        fields: ['spaces'],
+        ignore_unavailable: true,
+        allow_no_indices: true,
+      });
+    });
+
+    it('probes every source of a multi-source query in one call', async () => {
+      mockProbe([SML_INDEX], true);
+
+      await resolve('FROM ai-index-*, remote:ai-index-*');
+
+      expect(esClient.fieldCaps).toHaveBeenCalledTimes(1);
+      expect(esClient.fieldCaps).toHaveBeenCalledWith(
+        expect.objectContaining({ index: 'ai-index-*,remote:ai-index-*' })
+      );
+    });
+
+    it('strips the quoting ES|QL allows around a source name', async () => {
+      mockProbe([SML_INDEX], true);
+
+      await resolve('FROM "ai-index-*"');
+
+      expect(esClient.fieldCaps).toHaveBeenCalledWith(
+        expect.objectContaining({ index: 'ai-index-*' })
+      );
+    });
+
+    it('fails closed when the probe errors, rather than dropping the space scope', async () => {
+      esClient.fieldCaps.mockRejectedValue(new Error('cluster_block_exception'));
+
+      await expect(resolveRefusal('FROM ai-index-*')).resolves.toMatch(
+        /Could not determine the space scope/
+      );
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('failing closed'));
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/esql_scope_filter.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/esql_scope_filter.ts
@@ -1,0 +1,259 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
+import { getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
+import { AI_INDEX_DEST_PREFIX } from '@kbn/context-engine-plugin/common/constants';
+
+/** Keyword field carrying the space ids a document belongs to. See `sml_storage.ts`. */
+const SPACES_FIELD = 'spaces';
+
+/** Space id meaning "every space", the convention `checkItemsAccess` and `autocompleteSml` use. */
+const ALL_SPACES = '*';
+
+/** Every field a scope clause may reference. Probed in a single `field_caps` call. */
+const SCOPED_FIELDS = [SPACES_FIELD] as const;
+
+/** Elasticsearch's own prefix for the backing indices of a data stream. */
+const DATA_STREAM_BACKING_PREFIX = '.ds-';
+
+/**
+ * Decide whether a concrete index sits in the AI index namespace.
+ *
+ * `context_engine` owns this namespace: it derives every destination name from
+ * `AI_INDEX_DEST_PREFIX`, either as `ai-index-ds-<id>` for a data stream or `ai-index-idx-<id>` for
+ * an index (see `getAiIndexDest`). `smlIndexName` in `sml_storage.ts` is one such destination. The
+ * base prefix covers both forms, so it is the right thing to test.
+ *
+ * Field names alone cannot gate the scope clause. `spaces` is an ordinary English word, so an
+ * unrelated index may well map a `spaces` field meaning something else entirely, and filtering it
+ * by Kibana space ids would silently drop the caller's rows. The namespace is the real signal.
+ *
+ * `field_caps` reports concrete indices, so the name we see may not be the destination name itself:
+ * a data stream's backing index is `.ds-<destination>-<date>-<generation>`, a rolled-over write
+ * index behind an alias is `<destination>-000001` (what `StorageIndexAdapter` creates), and
+ * cross-cluster search prefixes the cluster (`remote:<destination>`). All three have to be
+ * recognised.
+ */
+const isAiIndex = (index: string): boolean => {
+  const withoutCluster = index.slice(index.lastIndexOf(':') + 1);
+  const destination = withoutCluster.startsWith(DATA_STREAM_BACKING_PREFIX)
+    ? withoutCluster.slice(DATA_STREAM_BACKING_PREFIX.length)
+    : withoutCluster;
+  return destination.startsWith(AI_INDEX_DEST_PREFIX);
+};
+
+/**
+ * Restrict results to documents belonging to the current space.
+ *
+ * The `must_not exists` arm is not a convenience. Elasticsearch also applies the ES|QL `filter` as
+ * the `index_filter` during field resolution, so an index that cannot match the filter is dropped
+ * from the query and its exclusive columns disappear from the response with no error. A query such
+ * as `FROM ai-index-*` spans the SML index and other AI indices that do not map `spaces`; without
+ * this arm those other indices would silently return nothing.
+ *
+ * The arm is also a fail-open for any individual document that lacks the field, which is why the
+ * clause is only worth having while SML documents keep `spaces` mapped and populated.
+ *
+ * `terms` is the Query DSL equivalent of the `MV_CONTAINS(spaces, ?)` call in `buildSmlEsqlQuery`:
+ * on a `keyword` array it matches when any value matches.
+ */
+const buildSpaceClause = (spaceId: string): QueryDslQueryContainer => ({
+  bool: {
+    minimum_should_match: 1,
+    should: [
+      { terms: { [SPACES_FIELD]: [spaceId, ALL_SPACES] } },
+      { bool: { must_not: { exists: { field: SPACES_FIELD } } } },
+    ],
+  },
+});
+
+/**
+ * Combine scope clauses into a single filter, collapsing the zero and one clause cases.
+ *
+ * Mirrors `mergeUserFilterWithNamespacesBool` in the Saved Objects ES|QL API and the same collapse
+ * in `buildConstraintsFilter`. Clauses are ANDed: a document must satisfy every dimension.
+ */
+export const mergeScopeClauses = (
+  clauses: QueryDslQueryContainer[]
+): QueryDslQueryContainer | undefined => {
+  if (clauses.length === 0) {
+    return undefined;
+  }
+  if (clauses.length === 1) {
+    return clauses[0];
+  }
+  return { bool: { must: clauses } };
+};
+
+/** Strip the quoting ES|QL allows around source names (`FROM "ai-index-*"`). */
+const normalizeSource = (source: string): string => source.trim().replace(/^["'`]+|["'`]+$/g, '');
+
+const parseSources = (indexPattern: string): string[] =>
+  indexPattern.split(',').map(normalizeSource).filter(Boolean);
+
+interface TargetProbe {
+  /** Every concrete index the pattern resolved to, whether or not it maps a probed field. */
+  indices: string[];
+  /** The subset of the probed fields that is mapped somewhere in those indices. */
+  presentFields: Set<string>;
+}
+
+type ProbeOutcome = { ok: true; probe: TargetProbe } | { ok: false; error: string };
+
+/**
+ * Outcome of resolving the scope filter.
+ *
+ * A refusal is reported rather than thrown so the tool can return it as a `ToolResultType.error`,
+ * which is how the rest of the builtin tools surface a problem the model can act on. `ok: true` with
+ * no `filter` means no scope applies, which is not the same as a refusal.
+ */
+export type EsqlScopeFilterResult =
+  | { ok: true; filter?: QueryDslQueryContainer }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the concrete indices behind a pattern and report which probed fields they map.
+ *
+ * One call answers both questions, so a future dimension adds a name to `SCOPED_FIELDS` rather than
+ * a round trip. The result is deliberately not cached: an index or mapping created between two
+ * agent turns must take effect immediately, because what it gates is a security control.
+ *
+ * Fails closed. A clause that was never built cannot be told apart from one that was not needed, so
+ * a `field_caps` error must not silently drop the space scope.
+ */
+const probeTargets = async ({
+  index,
+  fields,
+  esClient,
+  logger,
+}: {
+  index: string;
+  fields: readonly string[];
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}): Promise<ProbeOutcome> => {
+  try {
+    const response = await esClient.fieldCaps({
+      index,
+      fields: [...fields],
+      ignore_unavailable: true,
+      allow_no_indices: true,
+    });
+    const { indices } = response;
+    return {
+      ok: true,
+      probe: {
+        indices: Array.isArray(indices) ? indices : [indices].filter(Boolean),
+        presentFields: new Set(Object.keys(response.fields)),
+      },
+    };
+  } catch (error) {
+    logger.warn(
+      `Could not resolve scope targets for index pattern "${index}"; failing closed: ${
+        (error as Error).message
+      }`
+    );
+    return {
+      ok: false,
+      error: `Could not determine the space scope for this ES|QL query against "${index}"; please retry.`,
+    };
+  }
+};
+
+/**
+ * Build the server-imposed scope filter for an ES|QL query, to be sent as the Elasticsearch
+ * `filter` parameter.
+ *
+ * This filter is never exposed to the model. The agent must not be able to read, set, or remove a
+ * security boundary, so it is resolved from the handler context rather than from tool arguments.
+ *
+ * Two gates have to pass before a clause is applied. The target indices must all sit in the AI index
+ * namespace, and they must map the field the clause references. The namespace gate keeps the clause
+ * away from unrelated indices that happen to map a same-named field; the field gate avoids
+ * eliminating AI indices that do not carry the field at all.
+ *
+ * A query mixing AI indices with other indices is rejected rather than guessed at. Scoping the whole
+ * query could silently drop the caller's unrelated rows, and scoping none of it would leave the AI
+ * indices unprotected.
+ *
+ * Elasticsearch ANDs its own document-level security query on top of whatever we send. Space and
+ * privilege enforcement for documents that carry permission tokens belongs there. This filter
+ * covers what document-level security cannot see: documents with no tokens, which it treats as
+ * public to every space, and Kibana agent configuration such as runtime constraints.
+ *
+ * Known gap: `filter` does not reach `LOOKUP JOIN` or `ENRICH` sources. `getIndexPatternFromESQLQuery`
+ * does not extract those sources either, so the two behaviors agree, but a knowledge index used as
+ * a lookup target is not scoped by this clause. Elasticsearch document-level security does cover
+ * those sources.
+ */
+export const resolveEsqlScopeFilter = async ({
+  query,
+  spaceId,
+  esClient,
+  logger,
+}: {
+  query: string;
+  spaceId: string;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}): Promise<EsqlScopeFilterResult> => {
+  const sources = parseSources(getIndexPatternFromESQLQuery(query));
+
+  // No source command to scope, for example a `ROW` or `SHOW` query.
+  if (sources.length === 0) {
+    return { ok: true };
+  }
+
+  const index = sources.join(',');
+  const probed = await probeTargets({ index, fields: SCOPED_FIELDS, esClient, logger });
+  if (!probed.ok) {
+    return probed;
+  }
+
+  const { indices, presentFields } = probed.probe;
+  const aiIndices = indices.filter(isAiIndex);
+
+  // Nothing in the AI index namespace, so there is no Kibana-managed scope metadata to enforce.
+  if (aiIndices.length === 0) {
+    logger.debug(`No AI index in the ES|QL query against "${index}"; sending no scope filter`);
+    return { ok: true };
+  }
+
+  if (aiIndices.length !== indices.length) {
+    const others = indices.filter((candidate) => !isAiIndex(candidate));
+    logger.warn(
+      `Refusing to scope an ES|QL query that mixes AI indices with other indices: "${index}"`
+    );
+    return {
+      ok: false,
+      error:
+        `This ES|QL query reads from AI indices (${aiIndices.join(', ')}) and from other indices ` +
+        `(${others.join(', ')}) at the same time. They cannot be scoped together — ` +
+        `query them separately.`,
+    };
+  }
+
+  const clauses: QueryDslQueryContainer[] = [];
+  if (presentFields.has(SPACES_FIELD)) {
+    clauses.push(buildSpaceClause(spaceId));
+  }
+  // A runtime-constraints clause pushes here next. `buildConstraintsFilter` in `sml_service.ts`
+  // already emits the right shape.
+
+  const filter = mergeScopeClauses(clauses);
+
+  logger.debug(
+    filter
+      ? `Scoping ES|QL query against "${index}" to space "${spaceId}"`
+      : `No scope filter applies to the ES|QL query against "${index}"`
+  );
+
+  return { ok: true, filter };
+};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import type { ToolHandlerContext } from '@kbn/agent-builder-server/tools';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import { executeEsql } from '@kbn/agent-builder-genai-utils/tools/utils/esql';
+import { executeEsqlTool } from './execute_esql';
+
+jest.mock('@kbn/agent-builder-genai-utils/tools/utils/esql', () => {
+  const actual = jest.requireActual('@kbn/agent-builder-genai-utils/tools/utils/esql');
+  return { ...actual, executeEsql: jest.fn() };
+});
+
+const executeEsqlMock = executeEsql as jest.MockedFunction<typeof executeEsql>;
+
+describe('executeEsqlTool', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createScopedClusterClient>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+
+  const createContext = (spaceId = 'marketing') =>
+    ({
+      esClient,
+      logger,
+      spaceId,
+      attachments: { getActive: () => [] },
+    } as unknown as ToolHandlerContext);
+
+  const run = (query: string, spaceId?: string) =>
+    executeEsqlTool().handler({ query, limit: 100 }, createContext(spaceId));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    esClient = elasticsearchServiceMock.createScopedClusterClient();
+    logger = loggingSystemMock.createLogger();
+    executeEsqlMock.mockResolvedValue({ columns: [], values: [] });
+  });
+
+  it('sends a space filter when the target indices map the spaces field', async () => {
+    esClient.asCurrentUser.fieldCaps.mockResolvedValue({
+      indices: ['ai-index-idx-sml-data'],
+      fields: { spaces: { keyword: { type: 'keyword', searchable: true, aggregatable: true } } },
+    } as never);
+
+    await run('FROM ai-index-*');
+
+    expect(executeEsqlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          bool: {
+            minimum_should_match: 1,
+            should: [
+              { terms: { spaces: ['marketing', '*'] } },
+              { bool: { must_not: { exists: { field: 'spaces' } } } },
+            ],
+          },
+        },
+      })
+    );
+  });
+
+  it('sends no filter when the target indices do not map the spaces field', async () => {
+    esClient.asCurrentUser.fieldCaps.mockResolvedValue({
+      indices: ['logs-000001'],
+      fields: {},
+    } as never);
+
+    await run('FROM logs-*');
+
+    expect(executeEsqlMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filter: undefined, query: 'FROM logs-*' })
+    );
+  });
+
+  it('leaves an unrelated index that maps a spaces field completely alone', async () => {
+    esClient.asCurrentUser.fieldCaps.mockResolvedValue({
+      indices: ['meeting-rooms'],
+      fields: { spaces: { keyword: { type: 'keyword', searchable: true, aggregatable: true } } },
+    } as never);
+
+    await run('FROM meeting-rooms');
+
+    expect(executeEsqlMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filter: undefined, query: 'FROM meeting-rooms' })
+    );
+  });
+
+  it('refuses a query that mixes AI indices with other indices', async () => {
+    esClient.asCurrentUser.fieldCaps.mockResolvedValue({
+      indices: ['ai-index-idx-sml-data', 'logs-000001'],
+      fields: { spaces: { keyword: { type: 'keyword', searchable: true, aggregatable: true } } },
+    } as never);
+
+    const result = await run('FROM ai-index-*,logs-*');
+
+    expect(result).toEqual({
+      results: [
+        expect.objectContaining({
+          type: ToolResultType.error,
+          data: { message: expect.stringMatching(/query them separately/) },
+        }),
+      ],
+    });
+    expect(executeEsqlMock).not.toHaveBeenCalled();
+  });
+
+  it('reads the space from the handler context rather than from tool arguments', async () => {
+    esClient.asCurrentUser.fieldCaps.mockResolvedValue({
+      indices: ['ai-index-idx-sml-data'],
+      fields: { spaces: { keyword: { type: 'keyword', searchable: true, aggregatable: true } } },
+    } as never);
+
+    await run('FROM ai-index-*', 'engineering');
+
+    const { filter } = executeEsqlMock.mock.calls[0][0];
+    expect(filter?.bool?.should).toContainEqual({ terms: { spaces: ['engineering', '*'] } });
+  });
+
+  it('does not expose the filter as a tool parameter', () => {
+    expect(Object.keys(executeEsqlTool().schema.shape)).toEqual([
+      'query',
+      'params',
+      'time_range',
+      'limit',
+    ]);
+  });
+
+  it('reports a fail-closed scope resolution error instead of running the query', async () => {
+    esClient.asCurrentUser.fieldCaps.mockRejectedValue(new Error('cluster_block_exception'));
+
+    const result = await run('FROM ai-index-*');
+
+    expect(result).toEqual({
+      results: [
+        expect.objectContaining({
+          type: ToolResultType.error,
+          data: { message: expect.stringMatching(/Could not determine the space scope/) },
+        }),
+      ],
+    });
+    expect(executeEsqlMock).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.ts
@@ -15,8 +15,9 @@ import {
 } from '@kbn/agent-builder-genai-utils/tools/utils/esql';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
-import { getToolResultId } from '@kbn/agent-builder-server/tools';
+import { createErrorResult, getToolResultId } from '@kbn/agent-builder-server/tools';
 import { resolveTimeRange } from './screen_context_utils';
+import { resolveEsqlScopeFilter } from './esql_scope_filter';
 
 const executeEsqlToolSchema = z.object({
   query: z.string().describe('The ES|QL query to execute'),
@@ -68,7 +69,7 @@ Note that this option can't be used to increase the number of results if the que
     schema: executeEsqlToolSchema,
     handler: async (
       { query: esqlQuery, params: esqlParams = {}, time_range: explicitTimeRange, limit = 100 },
-      { esClient, attachments }
+      { esClient, attachments, spaceId, logger }
     ) => {
       const timeRange = resolveTimeRange(attachments, explicitTimeRange);
 
@@ -79,9 +80,24 @@ Note that this option can't be used to increase the number of results if the que
         ...(buildTimeRangeParams(timeRange) ?? []),
       ];
 
+      // Server-imposed scope, not visible to the model. `params` placeholders are not substituted
+      // into the filter, so it has to be built as Query DSL here.
+      const scope = await resolveEsqlScopeFilter({
+        query: esqlQuery,
+        spaceId,
+        esClient: esClient.asCurrentUser,
+        logger,
+      });
+
+      // The query cannot be scoped safely, so it is not run at all.
+      if (!scope.ok) {
+        return { results: [createErrorResult(scope.error)] };
+      }
+
       const result = await executeEsql({
         query: esqlQuery,
         params,
+        filter: scope.filter,
         esClient: esClient.asCurrentUser,
         limit,
       });

--- a/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
@@ -15,6 +15,7 @@
     "@kbn/zod",
     "@kbn/core-lifecycle-server",
     "@kbn/esql-language",
+    "@kbn/esql-utils",
     "@kbn/product-doc-common",
     "@kbn/llm-tasks-plugin",
     "@kbn/i18n",
@@ -36,5 +37,7 @@
     "@kbn/logging-mocks",
     "@kbn/triggers-actions-ui-plugin",
     "@kbn/agent-builder-plugin",
+    "@kbn/context-engine-plugin",
+    "@kbn/core-elasticsearch-server",
   ]
 }


### PR DESCRIPTION
## Summary

### Closes https://github.com/elastic/search-team/issues/15630

Adds a server-imposed scope filter to the `execute_esql` builtin tool so queries against AI indices (`ai-index-*`) only return documents belonging to the caller's current Kibana space.

**Changes**

1. `@kbn/agent-builder-genai-utils` — `executeEsql` accepts an optional `filter?: QueryDslQueryContainer` and forwards it to `esClient.esql.query` as the ES|QL [`filter`](https://www.elastic.co/docs/reference/query-languages/esql/esql-rest#esql-rest-filtering) parameter.
2. New `agent_builder_platform/server/tools/esql_scope_filter.ts` — `resolveEsqlScopeFilter` derives the filter from the query's source indices and the handler context.
3. `execute_esql.ts` — resolves the filter from `spaceId` on the handler context and passes it down.

The filter is **not** part of the tool schema. It is resolved from the handler context, so the model cannot read, set, or remove it. No prompt or schema changes.

**Emitted clause**

```json
{
  "bool": {
    "minimum_should_match": 1,
    "should": [
      { "terms": { "spaces": ["<current-space-id>", "*"] } },
      { "bool": { "must_not": { "exists": { "field": "spaces" } } } }
    ]
  }
}
```

The `must_not exists` arm is required, not a convenience: Elasticsearch also applies `filter` as the `index_filter` during field-caps resolution, so an index that cannot match the clause is dropped from the query and its exclusive columns vanish from the response with no error. Without that arm, `FROM ai-index-*` would silently return nothing for AI indices that do not map `spaces`.

**Gating**

Two gates must pass before the clause is applied, resolved from one `field_caps` call:

- **Namespace** — every resolved concrete index must sit under `AI_INDEX_DEST_PREFIX` (sourced from `@kbn/context-engine-plugin/common/constants`, which owns the AI index namespace). Field presence alone is insufficient: `spaces` is an ordinary word, and filtering an unrelated customer index by Kibana space ids would silently drop rows. Recognises data stream backing indices (`.ds-…`), rolled-over write indices behind an alias (`…-000001`), and CCS cluster prefixes (`remote:…`).
- **Field presence** — the indices must map `spaces`, otherwise no clause is emitted.

Queries are refused (returning `ToolResultType.error`, not executed) in two cases:

- **Mixed sources.** A query spanning both AI and non-AI indices cannot be scoped coherently — scoping all of it would drop the caller's unrelated rows, scoping none would leave the AI indices unprotected. The error names both sets so the caller can split the query.
- **`field_caps` failure.** Fails closed; a clause that was never built is indistinguishable from one that was not needed.

## Security model / dependency on Elasticsearch

**This PR does not implement permission filtering, only space filtering.** Per-document privilege enforcement is deferred to `AiIndexImplicitPrivilegesProvider` in [elastic/elasticsearch#155197](https://github.com/elastic/elasticsearch/pull/155197), which applies DLS in Elasticsearch.

Consequences until that lands:

- The tool executes as `asCurrentUser`, so Elasticsearch index privileges still apply and this filter can only **remove** rows — it cannot grant access to anything the caller could not already read. Safe to merge independently.
- Because most users are not granted raw ES read privileges on `ai-index-*` today, the tool returns little or nothing for AI indices regardless of this filter.
- Where a user *does* hold broad read privileges, `execute_esql` returns space-correct but **permission-unfiltered** rows. `sml_search` filters by permission and remains the correct tool for SML access.

**`sml_search` must not be deprecated or de-prioritised in prompts as a result of this PR.**

## Known limits

- `filter` does not reach `LOOKUP JOIN` or `ENRICH` sources. `getIndexPatternFromESQLQuery` does not extract them either, so the two behaviours agree, but a knowledge index used as a lookup target is unscoped here. ES DLS will cover it.
- Documents with no `spaces` field are visible in every space (the fail-open arm above). This is the gap ES DLS also has for token-less documents.
- One additional `field_caps` round trip per execution. Deliberately uncached: an index or mapping created between agent turns must take effect immediately, since it gates a security control.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- **Mixed-source queries are now refused.** An agent issuing `FROM *` or `FROM ai-index-*,logs-*` previously succeeded and now receives an error result. Severity: low–medium. Mitigation: the message names both index sets and instructs splitting the query; the model can recover within the same turn.
- **Fail-closed on `field_caps` failure.** Cluster instability turns AI index queries into errors rather than unscoped results. Severity: low, and the deliberate trade-off — the alternative silently drops the space boundary.
- **Added latency.** One `field_caps` call per `execute_esql` invocation. Severity: low.
- **Namespace coupling.** An AI index provisioned outside `ai-index-*` would not be scoped. Severity: low; the prefix is sourced from `context_engine`'s own constant rather than duplicated.