### PR TITLE
Fix flaky ES client tests when they run in parallel

### DIFF
--- a/src/core/server/integration_tests/elasticsearch/client.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/client.test.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { esTestConfig } from '@kbn/test';
 import * as http from 'http';
+import type { AddressInfo } from 'net';
 import { ReplaySubject, firstValueFrom } from 'rxjs';
 
 import type { Root } from '@kbn/core-root-server-internal';
@@ -21,8 +21,7 @@ import {
 import type { ServiceStatus } from '@kbn/core-status-common';
 import type { ElasticsearchStatusMeta } from '@kbn/core-elasticsearch-server-internal';
 
-// Failing: See https://github.com/elastic/kibana/issues/171294
-describe.skip('elasticsearch clients', () => {
+describe('elasticsearch clients', () => {
   let esServer: TestElasticsearchUtils;
   let kibanaServer: TestKibanaUtils;
 
@@ -69,24 +68,24 @@ function createFakeElasticsearchServer(): Promise<http.Server> {
       res.end();
     });
     server.on('error', reject);
-    server.listen(esTestConfig.getPort(), () => resolve(server));
+    server.listen(0, '127.0.0.1', () => resolve(server));
   });
 }
 
-// Failing: See https://github.com/elastic/kibana/issues/171295
-describe.skip('fake elasticsearch', () => {
+describe('fake elasticsearch', () => {
   let esServer: http.Server;
   let kibanaServer: Root;
   let esStatus$: ReplaySubject<ServiceStatus<ElasticsearchStatusMeta>>;
 
   beforeAll(async () => {
+    esServer = await createFakeElasticsearchServer();
     kibanaServer = createRootWithCorePlugins({
       elasticsearch: {
+        hosts: [`http://127.0.0.1:${(esServer.address() as AddressInfo).port}`],
         healthCheck: { retry: 1 },
       },
       status: { allowAnonymous: true },
     });
-    esServer = await createFakeElasticsearchServer();
 
     await kibanaServer.preboot();
     const { elasticsearch } = await kibanaServer.setup();


### PR DESCRIPTION
## Summary

Fixes #171294.
Fixes #171295.


<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->