### PR TITLE
[9.5] [Alerting V2][ResponseOps] Update API allows a signal rule to be persisted with query.format: composed (#283754)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/README.md
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/README.md
@@ -57,6 +57,7 @@ backwards compatible. Renaming or removing a code is a breaking change.
 | `RULE_VERSION_CONFLICT`       | 409    | An update / delete races another writer (`if_seq_no` mismatch)       | `{ rule_id }`                              |
 | `INVALID_RULE_DATA`           | 400    | The submitted body fails the domain-level schema check               | `{ context, errors }` (tree-shaped errors) |
 | `INVALID_STATE_TRANSITION`    | 400    | `state_transition` is incompatible with the rule's `kind`            | `{ rule_id, kind, transition }`            |
+| `INVALID_SIGNAL_RULE`               | 400    | An update would leave a signal rule in an invalid shape | `{ rule_id, rule_kind }`               |
 | `INVALID_BULK_PARAMS`         | 400    | Bulk operation combines `ids` with `filter` / `search` / `match_all` | `{ params }`                               |
 | `IMMUTABLE_FIELDS_CHANGED`    | 400    | PUT (upsert) request changes a field flagged as immutable            | `{ fields }`                               |
 | `INVALID_FILTER_FIELD`        | 400    | The `filter` references a field that is not in the allow-list        | `{ field, allowed_fields }`                |

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
@@ -35,6 +35,8 @@ export const ALERTING_V2_ERROR_CODES = {
   INVALID_STATE_TRANSITION: 'INVALID_STATE_TRANSITION',
   /** Bulk rule operation params combine `ids` with `filter` / `search`. */
   INVALID_BULK_PARAMS: 'INVALID_BULK_PARAMS',
+  /** A signal rule's merged shape violates signal constraints. */
+  INVALID_SIGNAL_RULE: 'INVALID_SIGNAL_RULE',
   /** PUT body changed a field flagged as immutable. */
   IMMUTABLE_FIELDS_CHANGED: 'IMMUTABLE_FIELDS_CHANGED',
   /** Filter expression referenced an unknown field. */

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -428,12 +428,126 @@ describe('RulesClient', () => {
       ).resolves.not.toThrow();
     });
 
-    it('allows setting stateTransition to null on a signal rule (removing it)', async () => {
+    it('throws 400 when updating a signal rule query to composed format', async () => {
       const client = createClient();
 
       const existingAttributes: RuleSavedObjectAttributes = {
         ...baseSoAttrs,
         kind: 'signal',
+      };
+
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-signal-composed',
+        attributes: existingAttributes,
+        version: 'WzEsMV0=',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-signal-composed',
+          data: {
+            query: {
+              format: 'composed',
+              base: 'FROM logs-*',
+              breach: { segment: 'WHERE error' },
+            },
+          },
+        })
+      ).rejects.toMatchObject({
+        output: { statusCode: 400 },
+        message: 'kind "signal" requires query.format "standalone".',
+      });
+
+      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 when setting recovery_strategy or no_data_strategy on a signal rule', async () => {
+      const client = createClient();
+
+      const existingAttributes: RuleSavedObjectAttributes = {
+        ...baseSoAttrs,
+        kind: 'signal',
+      };
+
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-signal-recovery',
+        attributes: existingAttributes,
+        version: 'WzEsMV0=',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-signal-recovery',
+          data: { recovery_strategy: 'no_breach' },
+        })
+      ).rejects.toMatchObject({
+        output: { statusCode: 400 },
+        message: 'Signal rules cannot set recovery_strategy or no_data_strategy.',
+      });
+
+      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+    });
+
+    it('allows updating an alert rule query to composed format', async () => {
+      const client = createClient();
+
+      const existingAttributes: RuleSavedObjectAttributes = {
+        ...baseSoAttrs,
+        kind: 'alert',
+      };
+
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-alert-composed',
+        attributes: existingAttributes,
+        version: 'WzEsMV0=',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-alert-composed',
+          data: {
+            query: {
+              format: 'composed',
+              base: 'FROM logs-*',
+              breach: { segment: 'WHERE error' },
+            },
+          },
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('allows a metadata-only update on a signal rule (query omitted stays standalone)', async () => {
+      const client = createClient();
+
+      const existingAttributes: RuleSavedObjectAttributes = {
+        ...baseSoAttrs,
+        kind: 'signal',
+        recovery_strategy: undefined,
+      };
+
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-signal-metadata',
+        attributes: existingAttributes,
+        version: 'WzEsMV0=',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-signal-metadata',
+          data: { metadata: { name: 'renamed signal' } },
+        })
+      ).resolves.not.toThrow();
+
+      expect(rulesSavedObjectService.update).toHaveBeenCalled();
+    });
+
+    it('allows setting state_transition to null on a signal rule (removing it)', async () => {
+      const client = createClient();
+
+      const existingAttributes: RuleSavedObjectAttributes = {
+        ...baseSoAttrs,
+        kind: 'signal',
+        recovery_strategy: undefined,
       };
 
       mockSavedObjectsClient.get.mockResolvedValueOnce({
@@ -2456,6 +2570,34 @@ describe('RulesClient', () => {
         data: {
           code: 'INVALID_STATE_TRANSITION',
           details: { rule_id: 'rule-id-y', rule_kind: 'signal' },
+        },
+      });
+    });
+
+    it('attaches INVALID_SIGNAL_RULE code when a signal rule is updated to a composed query', async () => {
+      const client = createClient();
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-signal-z',
+        attributes: { ...baseSoAttrs, kind: 'signal' },
+        version: 'v1',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-signal-z',
+          data: {
+            query: {
+              format: 'composed',
+              base: 'FROM logs-*',
+              breach: { segment: 'WHERE error' },
+            },
+          },
+        })
+      ).rejects.toMatchObject({
+        output: { statusCode: 400 },
+        data: {
+          code: 'INVALID_SIGNAL_RULE',
+          details: { rule_id: 'rule-id-signal-z', rule_kind: 'signal' },
         },
       });
     });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -436,10 +436,12 @@ describe('RulesClient', () => {
         kind: 'signal',
       };
 
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-signal-composed',
         attributes: existingAttributes,
         version: 'WzEsMV0=',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(
@@ -458,7 +460,7 @@ describe('RulesClient', () => {
         message: 'kind "signal" requires query.format "standalone".',
       });
 
-      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+      expect(mockSavedObjectsClient.update).not.toHaveBeenCalled();
     });
 
     it('throws 400 when setting recovery_strategy or no_data_strategy on a signal rule', async () => {
@@ -469,10 +471,12 @@ describe('RulesClient', () => {
         kind: 'signal',
       };
 
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-signal-recovery',
         attributes: existingAttributes,
         version: 'WzEsMV0=',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(
@@ -485,7 +489,7 @@ describe('RulesClient', () => {
         message: 'Signal rules cannot set recovery_strategy or no_data_strategy.',
       });
 
-      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+      expect(mockSavedObjectsClient.update).not.toHaveBeenCalled();
     });
 
     it('allows updating an alert rule query to composed format', async () => {
@@ -496,10 +500,12 @@ describe('RulesClient', () => {
         kind: 'alert',
       };
 
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-alert-composed',
         attributes: existingAttributes,
         version: 'WzEsMV0=',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(
@@ -525,10 +531,12 @@ describe('RulesClient', () => {
         recovery_strategy: undefined,
       };
 
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-signal-metadata',
         attributes: existingAttributes,
         version: 'WzEsMV0=',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(
@@ -538,7 +546,7 @@ describe('RulesClient', () => {
         })
       ).resolves.not.toThrow();
 
-      expect(rulesSavedObjectService.update).toHaveBeenCalled();
+      expect(mockSavedObjectsClient.update).toHaveBeenCalled();
     });
 
     it('allows setting state_transition to null on a signal rule (removing it)', async () => {
@@ -2576,10 +2584,12 @@ describe('RulesClient', () => {
 
     it('attaches INVALID_SIGNAL_RULE code when a signal rule is updated to a composed query', async () => {
       const client = createClient();
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-signal-z',
         attributes: { ...baseSoAttrs, kind: 'signal' },
         version: 'v1',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
@@ -9,6 +9,8 @@ import Boom from '@hapi/boom';
 import {
   BULK_FILTER_MAX_RULES,
   createRuleDataSchema,
+  isSignalQueryBreachOnly,
+  isSignalUsingStandaloneFormat,
   isStateTransitionAllowed,
   updateRuleDataSchema,
 } from '@kbn/alerting-v2-schemas';
@@ -363,6 +365,19 @@ export class RulesClient {
       updatedBy: userProfileUid,
       updatedAt: nowIso,
     });
+
+    if (!isSignalUsingStandaloneFormat(nextAttrs)) {
+      throw Boom.badRequest('kind "signal" requires query.format "standalone".', {
+        code: ALERTING_V2_ERROR_CODES.INVALID_SIGNAL_RULE,
+        details: { rule_id: id, rule_kind: existingAttrs.kind },
+      });
+    }
+    if (!isSignalQueryBreachOnly(nextAttrs)) {
+      throw Boom.badRequest('Signal rules cannot set recovery_strategy or no_data_strategy.', {
+        code: ALERTING_V2_ERROR_CODES.INVALID_SIGNAL_RULE,
+        details: { rule_id: id, rule_kind: existingAttrs.kind },
+      });
+    }
 
     await this.validateSchedule({
       updatedEvery: nextAttrs.schedule.every,

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/update_rule.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/update_rule.spec.ts
@@ -430,6 +430,57 @@ apiTest.describe('Update rule API', { tag: '@local-stateful-classic' }, () => {
     }
   );
 
+  const buildSignalRuleData = (name: string) =>
+    buildCreateRuleData({
+      kind: 'signal',
+      state_transition: undefined,
+      recovery_strategy: undefined,
+      query: {
+        format: 'standalone',
+        breach: { query: 'FROM logs-* | LIMIT 10' },
+      },
+      metadata: { name },
+    });
+
+  apiTest(
+    'validation: should reject updating a signal rule query to composed format',
+    async ({ apiClient, apiServices }) => {
+      const created = await apiServices.alertingV2.rules.create(
+        buildSignalRuleData('signal-to-composed')
+      );
+      const response = await apiClient.patch(getRuleUrl(created.id), {
+        headers: writerHeaders,
+        body: {
+          query: {
+            format: 'composed',
+            base: 'FROM logs-* | STATS count = COUNT(*) BY host.name',
+            breach: { segment: 'WHERE count >= 10' },
+          },
+        },
+      });
+      expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_SIGNAL_RULE');
+      // The rejected update must not have persisted: the query stays standalone.
+      const stored = await apiServices.alertingV2.rules.get(created.id);
+      expect(stored.query.format).toBe('standalone');
+    }
+  );
+
+  apiTest(
+    'validation: should reject setting recovery_strategy on a signal rule',
+    async ({ apiClient, apiServices }) => {
+      const created = await apiServices.alertingV2.rules.create(
+        buildSignalRuleData('signal-with-recovery')
+      );
+      const response = await apiClient.patch(getRuleUrl(created.id), {
+        headers: writerHeaders,
+        body: { recovery_strategy: 'no_breach' },
+      });
+      expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_SIGNAL_RULE');
+    }
+  );
+
   apiTest(
     'authorization: should return 200 for a user with full alerting_v2 privileges',
     async ({ apiClient, apiServices }) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Alerting V2][ResponseOps] Update API allows a signal rule to be persisted with query.format: composed (#283754)](https://github.com/elastic/kibana/pull/283754)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-07T22:18:31Z","message":"[Alerting V2][ResponseOps] Update API allows a signal rule to be persisted with query.format: composed (#283754)\n\nResolves https://github.com/elastic/kibana/issues/283716\n\n## Summary\n\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n### To verify\n\n1. Enabled alerting v2\n2. Go to dev tools and create a signal rule\n```\n\nPOST kbn:/api/alerting/v2/rules\n{\n  \"kind\": \"signal\",\n  \"metadata\": { \"name\": \"manual-signal-test\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"1m\", \"lookback\": \"5m\" },\n  \"query\": {\n    \"format\": \"standalone\",\n    \"breach\": { \"query\": \"FROM kibana_sample_data_flights | LIMIT 10\" }\n  }\n}\n```\n3. Try to update the rule by setting `query.format` to `composed`,\nverify that you get an error\n\n```\nPATCH kbn:/api/alerting/v2/rules/<id>\n{\n  \"query\": {\n    \"format\": \"composed\",\n    \"base\": \"FROM kibana_sample_data_flights\",\n    \"breach\": { \"segment\": \"WHERE Cancelled == true\" }\n  }\n}\n```\n\n4. Try to the update the rule by setting a recovery query for `format:\nstandalone`, verify that you get an error\n```\nPATCH kbn:/api/alerting/v2/rules/<id>\n{ \"recovery_strategy\": \"no_breach\" }\n```","sha":"6dd80a7db9c73017f8fa36f32a13ecf7812cee87","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:ResponseOps","backport:version","reviewer:scout","v9.6.0","v9.5.1"],"title":"[Alerting V2][ResponseOps] Update API allows a signal rule to be persisted with query.format: composed","number":283754,"url":"https://github.com/elastic/kibana/pull/283754","mergeCommit":{"message":"[Alerting V2][ResponseOps] Update API allows a signal rule to be persisted with query.format: composed (#283754)\n\nResolves https://github.com/elastic/kibana/issues/283716\n\n## Summary\n\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n### To verify\n\n1. Enabled alerting v2\n2. Go to dev tools and create a signal rule\n```\n\nPOST kbn:/api/alerting/v2/rules\n{\n  \"kind\": \"signal\",\n  \"metadata\": { \"name\": \"manual-signal-test\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"1m\", \"lookback\": \"5m\" },\n  \"query\": {\n    \"format\": \"standalone\",\n    \"breach\": { \"query\": \"FROM kibana_sample_data_flights | LIMIT 10\" }\n  }\n}\n```\n3. Try to update the rule by setting `query.format` to `composed`,\nverify that you get an error\n\n```\nPATCH kbn:/api/alerting/v2/rules/<id>\n{\n  \"query\": {\n    \"format\": \"composed\",\n    \"base\": \"FROM kibana_sample_data_flights\",\n    \"breach\": { \"segment\": \"WHERE Cancelled == true\" }\n  }\n}\n```\n\n4. Try to the update the rule by setting a recovery query for `format:\nstandalone`, verify that you get an error\n```\nPATCH kbn:/api/alerting/v2/rules/<id>\n{ \"recovery_strategy\": \"no_breach\" }\n```","sha":"6dd80a7db9c73017f8fa36f32a13ecf7812cee87"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283754","number":283754,"mergeCommit":{"message":"[Alerting V2][ResponseOps] Update API allows a signal rule to be persisted with query.format: composed (#283754)\n\nResolves https://github.com/elastic/kibana/issues/283716\n\n## Summary\n\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n### To verify\n\n1. Enabled alerting v2\n2. Go to dev tools and create a signal rule\n```\n\nPOST kbn:/api/alerting/v2/rules\n{\n  \"kind\": \"signal\",\n  \"metadata\": { \"name\": \"manual-signal-test\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"1m\", \"lookback\": \"5m\" },\n  \"query\": {\n    \"format\": \"standalone\",\n    \"breach\": { \"query\": \"FROM kibana_sample_data_flights | LIMIT 10\" }\n  }\n}\n```\n3. Try to update the rule by setting `query.format` to `composed`,\nverify that you get an error\n\n```\nPATCH kbn:/api/alerting/v2/rules/<id>\n{\n  \"query\": {\n    \"format\": \"composed\",\n    \"base\": \"FROM kibana_sample_data_flights\",\n    \"breach\": { \"segment\": \"WHERE Cancelled == true\" }\n  }\n}\n```\n\n4. Try to the update the rule by setting a recovery query for `format:\nstandalone`, verify that you get an error\n```\nPATCH kbn:/api/alerting/v2/rules/<id>\n{ \"recovery_strategy\": \"no_breach\" }\n```","sha":"6dd80a7db9c73017f8fa36f32a13ecf7812cee87"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->