### PR TITLE
[Inference] Inject dummy tool when history has tool use but tools are empty

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/providers/apply_provider_transforms.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/providers/apply_provider_transforms.test.ts
@@ -15,6 +15,49 @@ import { applyProviderTransforms } from './apply_provider_transforms';
 import { createInferenceConnectorMock } from '../../../../test_utils';
 
 describe('applyProviderTransforms', () => {
+  it('injects a dummy tool when history has tool use and tools are omitted', () => {
+    const connector = createInferenceConnectorMock({
+      type: InferenceConnectorType.Inference,
+      config: {
+        provider: InferenceEndpointProvider.OpenAI,
+      },
+    });
+
+    const request = applyProviderTransforms({
+      connector,
+      messages: [
+        { role: MessageRole.User, content: 'question' },
+        {
+          role: MessageRole.Assistant,
+          content: '',
+          toolCalls: [
+            {
+              toolCallId: '1',
+              function: { name: 'myTool', arguments: {} },
+            },
+          ],
+        },
+        {
+          role: MessageRole.Tool,
+          name: 'myTool',
+          toolCallId: '1',
+          response: { ok: true },
+        },
+      ],
+      simulatedFunctionCalling: false,
+    });
+
+    expect(request.tools).toEqual({
+      doNotCallThisTool: {
+        description: 'Do not call this tool, it is strictly forbidden',
+        schema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    });
+  });
+
   it('fixes array schema definition for rainbow-sprinkles', () => {
     const connector = createInferenceConnectorMock({
       type: InferenceConnectorType.Inference,

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/providers/apply_provider_transforms.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/providers/apply_provider_transforms.ts
@@ -6,8 +6,9 @@
  */
 
 import type { ToolOptions } from '@kbn/inference-common';
-import { InferenceEndpointProvider, MessageRole } from '@kbn/inference-common';
+import { InferenceEndpointProvider } from '@kbn/inference-common';
 import { fixSchemaArrayProperties } from '../../bedrock/convert_tools';
+import { ensureToolsWhenHistoryHasToolUse } from '../../../utils/ensure_tools_when_history_has_tool_use';
 import type { CreateOpenAIRequestOptions } from '../types';
 import { getProvider, getElasticModelProvider } from '../utils';
 
@@ -24,6 +25,11 @@ export const applyProviderTransforms = (
     options = applyBedrockTransforms(options);
   }
 
+  options.tools = ensureToolsWhenHistoryHasToolUse({
+    tools: options.tools,
+    messages: options.messages,
+  });
+
   return options;
 };
 
@@ -39,26 +45,6 @@ const applyBedrockTransforms = (
 
       return tools;
     }, {} as Required<ToolOptions>['tools']);
-  }
-
-  const hasToolUse = options.messages.some(
-    (message) =>
-      message.role === MessageRole.Tool ||
-      (message.role === MessageRole.Assistant && message.toolCalls?.length)
-  );
-
-  // bedrock does not accept tool calls in conversation history
-  // if no tools are present in the request.
-  if (hasToolUse && Object.keys(options.tools ?? {}).length === 0) {
-    options.tools = {
-      doNotCallThisTool: {
-        description: 'Do not call this tool, it is strictly forbidden',
-        schema: {
-          type: 'object',
-          properties: {},
-        },
-      },
-    };
   }
 
   return options;

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.test.ts
@@ -575,6 +575,66 @@ describe('inferenceEndpointAdapter', () => {
       );
     });
 
+    it('injects a dummy tool when history has tool use and tools are omitted', () => {
+      executorMock.invoke.mockResolvedValue(
+        observableIntoEventSourceStream(
+          of({
+            choices: [{ finish_reason: null, index: 0, delta: { content: '' } }],
+            created: Date.now(),
+            id: 'test-chunk',
+            model: 'gpt-4o',
+            object: 'chat.completion.chunk',
+          }),
+          logger
+        )
+      );
+
+      inferenceEndpointAdapter
+        .chatComplete({
+          ...defaultArgs,
+          messages: [
+            { role: MessageRole.User, content: 'question' },
+            {
+              role: MessageRole.Assistant,
+              content: '',
+              toolCalls: [
+                {
+                  toolCallId: '1',
+                  function: { name: 'myTool', arguments: {} },
+                },
+              ],
+            },
+            {
+              role: MessageRole.Tool,
+              name: 'myTool',
+              toolCallId: '1',
+              response: { ok: true },
+            },
+          ],
+        })
+        .subscribe(noop);
+
+      expect(executorMock.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            tools: [
+              {
+                type: 'function',
+                function: {
+                  name: 'doNotCallThisTool',
+                  description: 'Do not call this tool, it is strictly forbidden',
+                  parameters: {
+                    type: 'object',
+                    properties: {},
+                  },
+                },
+              },
+            ],
+          }),
+        })
+      );
+    });
+
     it('uses simulated function calling when functionCalling is "simulated"', () => {
       executorMock.invoke.mockResolvedValue(
         observableIntoEventSourceStream(of(createOpenAIChunk({ delta: { content: '' } })), logger)

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.ts
@@ -30,6 +30,7 @@ import {
 } from '../../simulated_function_calling';
 import { getTemperatureIfValid } from '../../utils/get_temperature';
 import type { InferenceEndpointExecutor } from '../../utils/inference_endpoint_executor';
+import { ensureToolsWhenHistoryHasToolUse } from '../../utils/ensure_tools_when_history_has_tool_use';
 import type { OpenAIRequest } from '../openai/types';
 
 export interface InferenceEndpointAdapterChatCompleteOptions {
@@ -137,7 +138,8 @@ const createEndpointRequest = ({
     };
   }
 
-  const openAiTools = toolsToOpenAI(tools);
+  const toolsForRequest = ensureToolsWhenHistoryHasToolUse({ tools, messages });
+  const openAiTools = toolsToOpenAI(toolsForRequest);
   const hasTools = Array.isArray(openAiTools) && openAiTools.length > 0;
 
   return {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.test.ts
@@ -288,6 +288,59 @@ describe('openAIAdapter', () => {
       ]);
     });
 
+    it('injects a dummy tool when history has tool use and tools are omitted', () => {
+      openAIAdapter
+        .chatComplete({
+          ...defaultArgs,
+          messages: [
+            {
+              role: MessageRole.User,
+              content: 'question',
+            },
+            {
+              role: MessageRole.Assistant,
+              content: 'answer',
+              toolCalls: [
+                {
+                  function: {
+                    name: 'my_function',
+                    arguments: {
+                      foo: 'bar',
+                    },
+                  },
+                  toolCallId: '0',
+                },
+              ],
+            },
+            {
+              name: 'my_function',
+              role: MessageRole.Tool,
+              toolCallId: '0',
+              response: {
+                bar: 'foo',
+              },
+            },
+          ],
+        })
+        .subscribe(noop);
+
+      expect(pick(getRequest().body, 'tools')).toEqual({
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'doNotCallThisTool',
+              description: 'Do not call this tool, it is strictly forbidden',
+              parameters: {
+                type: 'object',
+                properties: {},
+              },
+            },
+          },
+        ],
+      });
+    });
+
     it('correctly formats tools and tool choice', () => {
       openAIAdapter
         .chatComplete({

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/openai_adapter.ts
@@ -22,6 +22,7 @@ import {
   isNativeFunctionCallingSupported,
   handleConnectorStreamResponse,
   handleConnectorDataResponse,
+  ensureToolsWhenHistoryHasToolUse,
 } from '../../utils';
 import type { OpenAIRequest } from './types';
 import { messagesToOpenAI, toolsToOpenAI, toolChoiceToOpenAI } from './to_openai';
@@ -70,7 +71,8 @@ export const openAIAdapter: InferenceConnectorAdapter = {
         messages: messagesToOpenAI({ system: wrapped.system, messages: wrapped.messages }),
       };
     } else {
-      const openAiTools = toolsToOpenAI(tools);
+      const toolsForRequest = ensureToolsWhenHistoryHasToolUse({ tools, messages });
+      const openAiTools = toolsToOpenAI(toolsForRequest);
       const hasTools = Array.isArray(openAiTools) && openAiTools.length > 0;
 
       request = {
@@ -78,11 +80,12 @@ export const openAIAdapter: InferenceConnectorAdapter = {
         ...getTemperatureIfValid(temperature, { connector, modelName }),
         model: modelName,
         messages: messagesToOpenAI({ system, messages }),
-        // Some OpenAI-compatible gateways (notably for Anthropic models) reject tool calling
-        // params when the tools list is empty. Only forward tools/tool_choice when tools exist.
         ...(hasTools
           ? {
-              tool_choice: toolChoiceToOpenAI(toolChoice, { connector, tools }),
+              tool_choice: toolChoiceToOpenAI(toolChoice, {
+                connector,
+                tools: toolsForRequest,
+              }),
               tools: openAiTools,
             }
           : {}),

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/ensure_tools_when_history_has_tool_use.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/ensure_tools_when_history_has_tool_use.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Message } from '@kbn/inference-common';
+import { MessageRole } from '@kbn/inference-common';
+import { ensureToolsWhenHistoryHasToolUse } from './ensure_tools_when_history_has_tool_use';
+
+describe('ensureToolsWhenHistoryHasToolUse', () => {
+  const toolHistoryMessages: Message[] = [
+    { role: MessageRole.User, content: 'question' },
+    {
+      role: MessageRole.Assistant,
+      content: '',
+      toolCalls: [
+        {
+          toolCallId: '1',
+          function: { name: 'list_indices', arguments: {} },
+        },
+      ],
+    },
+    {
+      role: MessageRole.Tool,
+      name: 'list_indices',
+      toolCallId: '1',
+      response: { indices: [] },
+    },
+  ];
+
+  it('returns existing tools unchanged', () => {
+    const tools = {
+      list_indices: { description: 'List indices' },
+    };
+
+    expect(
+      ensureToolsWhenHistoryHasToolUse({
+        tools,
+        messages: toolHistoryMessages,
+      })
+    ).toBe(tools);
+  });
+
+  it('returns tools unchanged when history has no tool use', () => {
+    expect(
+      ensureToolsWhenHistoryHasToolUse({
+        messages: [{ role: MessageRole.User, content: 'hello' }],
+      })
+    ).toBeUndefined();
+  });
+
+  it('injects a dummy tool when history has tool use and tools are empty', () => {
+    expect(
+      ensureToolsWhenHistoryHasToolUse({
+        tools: {},
+        messages: toolHistoryMessages,
+      })
+    ).toEqual({
+      doNotCallThisTool: {
+        description: 'Do not call this tool, it is strictly forbidden',
+        schema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    });
+  });
+
+  it('injects a dummy tool when history has tool use and tools are omitted', () => {
+    expect(
+      ensureToolsWhenHistoryHasToolUse({
+        messages: toolHistoryMessages,
+      })
+    ).toEqual({
+      doNotCallThisTool: {
+        description: 'Do not call this tool, it is strictly forbidden',
+        schema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/ensure_tools_when_history_has_tool_use.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/ensure_tools_when_history_has_tool_use.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Message, ToolOptions } from '@kbn/inference-common';
+import { MessageRole } from '@kbn/inference-common';
+
+const DO_NOT_CALL_THIS_TOOL = {
+  doNotCallThisTool: {
+    description: 'Do not call this tool, it is strictly forbidden',
+    schema: {
+      type: 'object' as const,
+      properties: {},
+    },
+  },
+};
+
+export const ensureToolsWhenHistoryHasToolUse = ({
+  tools,
+  messages,
+}: {
+  tools?: ToolOptions['tools'];
+  messages: Message[];
+}): ToolOptions['tools'] | undefined => {
+  const hasExistingTools = Object.keys(tools ?? {}).length > 0;
+  if (hasExistingTools) {
+    return tools;
+  }
+
+  const hasToolUse = messages.some(
+    (message) =>
+      message.role === MessageRole.Tool ||
+      (message.role === MessageRole.Assistant && Boolean(message.toolCalls?.length))
+  );
+
+  if (!hasToolUse) {
+    return tools;
+  }
+
+  return DO_NOT_CALL_THIS_TOOL;
+};

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/index.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/index.ts
@@ -28,3 +28,4 @@ export {
   handleConnectorDataResponse,
 } from './handle_connector_response';
 export { handleLifecycleCallbacks } from './handle_lifecycle_callbacks';
+export { ensureToolsWhenHistoryHasToolUse } from './ensure_tools_when_history_has_tool_use';


### PR DESCRIPTION
## Summary

Some OpenAI-compatible gateways reject chat requests that include prior tool calls in the message history but omit the tools parameter. This left Agent Builder and similar callers failing against LiteLLM-backed Anthropic models after a tool had already run. The inference plugin now injects the same forbidden dummy tool used for Bedrock in that edge case, so those requests stay valid without changing normal tool-calling behavior.

### Screen Recording

https://github.com/user-attachments/assets/e66b9778-138a-45e9-b3d7-145cb650d33f




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

## Release note

Fixes chat completions through OpenAI-compatible gateways that reject tool history when the tools parameter is omitted.
