### PR TITLE
[9.3] [Security Solution] Drop transient progress-panel assertion in flaky rule-migration onboarding test

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/siem_migrations/rules/onboarding.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/siem_migrations/rules/onboarding.cy.ts
@@ -9,7 +9,6 @@ import {
   ONBOARDING_SIEM_MIGRATIONS_LIST,
   ONBOARDING_TRANSLATIONS_RESULT_TABLE,
   RULE_MIGRATIONS_GROUP_PANEL,
-  RULE_MIGRATION_PROGRESS_BAR,
 } from '../../../../screens/siem_migrations';
 import { deleteConnectors } from '../../../../tasks/api_calls/common';
 import { createBedrockConnector } from '../../../../tasks/api_calls/connectors';
@@ -126,7 +125,6 @@ describe(
           .should('have.property', 'skip_prebuilt_rules_matching', false);
         cy.get(RULE_MIGRATIONS_GROUP_PANEL).within(() => {
           cy.get(ONBOARDING_SIEM_MIGRATIONS_LIST).should('have.length', 1);
-          cy.get(RULE_MIGRATION_PROGRESS_BAR).should('have.length', 1);
         });
       });
     });


### PR DESCRIPTION
## Backport

This is a backport of PR #282993 to the `9.3` branch.

See the original PR for details: https://github.com/elastic/kibana/pull/282993