### PR TITLE
[Cases] Fix assignee user action

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/mocks.ts
@@ -95,6 +95,24 @@ const originalCasesWithAssignee = [
   { ...createCaseSavedObjectResponse({ overrides: { assignees: [{ uid: '1' }] } }), id: '1' },
 ].map((so) => transformSavedObjectToExternalModel(so));
 
+const originalCasesWithEnrichedAssignee = [
+  {
+    ...createCaseSavedObjectResponse({
+      overrides: {
+        assignees: [
+          {
+            uid: '1',
+            username: 'user_one',
+            full_name: 'User One',
+            email: 'user_one@example.com',
+          },
+        ],
+      },
+    }),
+    id: '1',
+  },
+].map((so) => transformSavedObjectToExternalModel(so));
+
 export const patchAssigneesCasesRequest = {
   cases: [
     {
@@ -130,6 +148,24 @@ export const patchAddRemoveAssigneesCasesRequest = {
         assignees: [{ uid: '2' }],
       },
       originalCase: originalCasesWithAssignee[0],
+    },
+  ],
+};
+
+/**
+ * Retains an identity-enriched assignee and adds a uid-only one. Used to assert that
+ * user-action diffs compare by uid (not deep equality), otherwise the retained assignee
+ * is incorrectly recorded as delete+add.
+ */
+export const patchAddAssigneeWithEnrichedOriginalRequest = {
+  cases: [
+    {
+      ...createCaseSavedObjectResponse(),
+      caseId: '1',
+      updatedAttributes: {
+        assignees: [{ uid: '1' }, { uid: '2' }],
+      },
+      originalCase: originalCasesWithEnrichedAssignee[0],
     },
   ],
 };

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.test.ts
@@ -29,6 +29,7 @@ import {
   getBuiltUserActions,
   getTagsAddedRemovedUserActions,
   patchAddRemoveAssigneesCasesRequest,
+  patchAddAssigneeWithEnrichedOriginalRequest,
   patchAssigneesCasesRequest,
   patchCasesRequest,
   patchAddCustomFieldsToOriginalCasesRequest,
@@ -352,6 +353,52 @@ describe('UserActionPersister', () => {
           isMock: false,
         })
       );
+    });
+
+    it('diffs assignees by uid when the original has assigneeIdentity fields', () => {
+      // Without uid-only normalization, deep equality treats the retained enriched
+      // assignee as deleted and re-added alongside the newly assigned uid.
+      expect(
+        persister.buildUserActions({
+          updatedCases: patchAddAssigneeWithEnrichedOriginalRequest,
+          user: testUser,
+        })
+      ).toEqual({
+        '1': [
+          {
+            eventDetails: {
+              action: 'add',
+              descriptiveAction: 'case_user_action_add_case_assignees',
+              getMessage: expect.any(Function),
+              savedObjectId: '1',
+              savedObjectType: 'cases',
+            },
+            parameters: {
+              attributes: {
+                action: 'add',
+                created_at: '2022-01-09T22:00:00.000Z',
+                created_by: {
+                  email: 'elastic@elastic.co',
+                  full_name: 'Elastic User',
+                  username: 'elastic',
+                },
+                owner: 'securitySolution',
+                payload: {
+                  assignees: [{ uid: '2' }],
+                },
+                type: 'assignees',
+              },
+              references: [
+                {
+                  id: '1',
+                  name: 'associated-cases',
+                  type: 'cases',
+                },
+              ],
+            },
+          },
+        ],
+      });
     });
 
     it('creates the correct user actions when tags are added and removed', async () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/operations/create.ts
@@ -9,6 +9,7 @@ import type { SavedObject, SavedObjectsBulkResponse } from '@kbn/core/server';
 import { isSavedObjectErrorResult } from '@kbn/core/server';
 import { get, isEmpty, pickBy } from 'lodash';
 import type {
+  CaseAssignee,
   CaseAssignees,
   CaseCustomField,
   CaseCustomFields,
@@ -289,13 +290,26 @@ export class UserActionPersister {
     return fieldUserAction ? [fieldUserAction] : [];
   }
 
-  private buildAssigneesUserActions(params: TypedUserActionDiffedItems<CaseUserProfile>) {
+  private buildAssigneesUserActions(params: TypedUserActionDiffedItems<CaseAssignee>) {
     const createPayload: CreatePayloadFunction<
       CaseUserProfile,
       typeof UserActionTypes.assignees
     > = (items: CaseAssignees) => ({ assignees: items });
 
-    return this.buildAddDeleteUserActions(params, createPayload, UserActionTypes.assignees);
+    // assigneeIdentity persists username/full_name/email on the SO; client PATCHes uid-only.
+    // Diff by uid so retained assignees are not recorded as delete+add.
+    const toUidOnly = (assignees: CaseAssignee[]): CaseUserProfile[] =>
+      assignees.map(({ uid }) => ({ uid }));
+
+    return this.buildAddDeleteUserActions(
+      {
+        ...params,
+        originalValue: toUidOnly(params.originalValue),
+        newValue: toUidOnly(params.newValue),
+      },
+      createPayload,
+      UserActionTypes.assignees
+    );
   }
 
   private buildTagsUserActions(params: TypedUserActionDiffedItems<string>) {


### PR DESCRIPTION
## Summary

Fixed a bug introduced by expanding assignee attributes

Before - assigning another user creates 2 user actions
<img width="1027" height="245" alt="image" src="https://github.com/user-attachments/assets/beb116c5-ddab-4c6c-b683-abbd815ce296" />

After 

<img width="855" height="146" alt="image" src="https://github.com/user-attachments/assets/2dac5e4f-d65d-482a-83b5-1ff82a19e4ad" />

How to test
1. Create a case
2. Make sure the environment has >1 users
3. Assign 2 users and observe user actions in the case

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->