### PR TITLE
[Context Engine] add core verifier framework code

### DIFF
--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type {
+  KnowledgeIndicator,
+  KiVerifierContext,
+  KiVerificationContext,
+  KiVerifierResult,
+  KiVerifier,
+  KiVerificationSummary,
+} from './types';
+export { KiVerifierRegistry } from './registry';
+export { KiVerificationService } from './service';

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
@@ -9,6 +9,7 @@ export type {
   KnowledgeIndicator,
   KiVerifierContext,
   KiVerificationContext,
+  KiVerifierOutcome,
   KiVerifierResult,
   KiVerifier,
   KiVerificationSummary,

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.test.ts
@@ -6,11 +6,11 @@
  */
 
 import { KiVerifierRegistry } from './registry';
-import type { KiVerifier, KnowledgeIndicator } from './types';
+import type { KiVerifier } from './types';
 
 const makeVerifier = (overrides: Partial<KiVerifier> & { id: string }): KiVerifier => ({
   applies: () => true,
-  verify: jest.fn(async () => ({ verifier: overrides.id, passed: true })),
+  verify: jest.fn(async () => ({ passed: true as const })),
   ...overrides,
 });
 
@@ -38,22 +38,7 @@ describe('KiVerifierRegistry', () => {
     );
   });
 
-  it('getApplicable returns only verifiers that apply, in registration order', () => {
-    const ki: KnowledgeIndicator = { type: 'esql' };
-    const applies = makeVerifier({ id: 'applies', applies: () => true });
-    const skips = makeVerifier({ id: 'skips', applies: () => false });
-    const alsoApplies = makeVerifier({
-      id: 'also',
-      applies: (candidate) => candidate.type === 'esql',
-    });
-    registry.register(applies);
-    registry.register(skips);
-    registry.register(alsoApplies);
-
-    expect(registry.getApplicable(ki)).toEqual([applies, alsoApplies]);
-  });
-
-  it('getApplicable is empty when nothing is registered', () => {
-    expect(registry.getApplicable({})).toEqual([]);
+  it('getAll is empty when nothing is registered', () => {
+    expect(registry.getAll()).toEqual([]);
   });
 });

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { KiVerifierRegistry } from './registry';
+import type { KiVerifier, KnowledgeIndicator } from './types';
+
+const makeVerifier = (overrides: Partial<KiVerifier> & { id: string }): KiVerifier => ({
+  applies: () => true,
+  verify: jest.fn(async () => ({ verifier: overrides.id, passed: true })),
+  ...overrides,
+});
+
+describe('KiVerifierRegistry', () => {
+  let registry: KiVerifierRegistry;
+
+  beforeEach(() => {
+    registry = new KiVerifierRegistry();
+  });
+
+  it('registers and returns verifiers in registration order', () => {
+    const a = makeVerifier({ id: 'a' });
+    const b = makeVerifier({ id: 'b' });
+    registry.register(a);
+    registry.register(b);
+
+    expect(registry.getAll()).toEqual([a, b]);
+  });
+
+  it('throws when a verifier id is registered twice', () => {
+    registry.register(makeVerifier({ id: 'dup' }));
+
+    expect(() => registry.register(makeVerifier({ id: 'dup' }))).toThrow(
+      "KI verifier 'dup' is already registered"
+    );
+  });
+
+  it('getApplicable returns only verifiers that apply, in registration order', () => {
+    const ki: KnowledgeIndicator = { type: 'esql' };
+    const applies = makeVerifier({ id: 'applies', applies: () => true });
+    const skips = makeVerifier({ id: 'skips', applies: () => false });
+    const alsoApplies = makeVerifier({
+      id: 'also',
+      applies: (candidate) => candidate.type === 'esql',
+    });
+    registry.register(applies);
+    registry.register(skips);
+    registry.register(alsoApplies);
+
+    expect(registry.getApplicable(ki)).toEqual([applies, alsoApplies]);
+  });
+
+  it('getApplicable is empty when nothing is registered', () => {
+    expect(registry.getApplicable({})).toEqual([]);
+  });
+});

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KiVerifier, KnowledgeIndicator } from './types';
+
+export class KiVerifierRegistry {
+  private readonly verifiers = new Map<string, KiVerifier>();
+
+  register(verifier: KiVerifier): void {
+    if (this.verifiers.has(verifier.id)) {
+      throw new Error(`KI verifier '${verifier.id}' is already registered`);
+    }
+    this.verifiers.set(verifier.id, verifier);
+  }
+
+  getAll(): KiVerifier[] {
+    return [...this.verifiers.values()];
+  }
+
+  /** Verifiers that apply to the given KI, preserving registration order. */
+  getApplicable(ki: KnowledgeIndicator): KiVerifier[] {
+    return this.getAll().filter((verifier) => verifier.applies(ki));
+  }
+}

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/registry.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { KiVerifier, KnowledgeIndicator } from './types';
+import type { KiVerifier } from './types';
 
 export class KiVerifierRegistry {
   private readonly verifiers = new Map<string, KiVerifier>();
@@ -19,10 +19,5 @@ export class KiVerifierRegistry {
 
   getAll(): KiVerifier[] {
     return [...this.verifiers.values()];
-  }
-
-  /** Verifiers that apply to the given KI, preserving registration order. */
-  getApplicable(ki: KnowledgeIndicator): KiVerifier[] {
-    return this.getAll().filter((verifier) => verifier.applies(ki));
   }
 }

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { KiVerifierRegistry } from './registry';
+import { KiVerificationService } from './service';
+import type { KiVerificationContext, KiVerifier, KiVerifierResult } from './types';
+
+const makeVerifier = (
+  id: string,
+  result: Omit<KiVerifierResult, 'verifier'>,
+  applies = true
+): KiVerifier => ({
+  id,
+  applies: () => applies,
+  verify: jest.fn(async () => ({ verifier: id, ...result })),
+});
+
+describe('KiVerificationService', () => {
+  let registry: KiVerifierRegistry;
+  let service: KiVerificationService;
+  let context: KiVerificationContext;
+
+  beforeEach(() => {
+    registry = new KiVerifierRegistry();
+    service = new KiVerificationService(registry);
+    context = {
+      isEnabled: true,
+      esClient: elasticsearchServiceMock.createElasticsearchClient(),
+      logger: loggingSystemMock.createLogger(),
+    };
+  });
+
+  it('passes when every applicable verifier passes', async () => {
+    registry.register(makeVerifier('a', { passed: true }));
+    registry.register(makeVerifier('b', { passed: true }));
+
+    const summary = await service.verifyKi({}, context);
+
+    expect(summary.passed).toBe(true);
+    expect(summary.results).toEqual([
+      { verifier: 'a', passed: true },
+      { verifier: 'b', passed: true },
+    ]);
+  });
+
+  it('runs all verifiers even after a failure, aggregating every reason (run-all, not first-fail)', async () => {
+    const first = makeVerifier('first', { passed: false, reason: 'first failed' });
+    const second = makeVerifier('second', { passed: false, reason: 'second failed' });
+    registry.register(first);
+    registry.register(second);
+
+    const summary = await service.verifyKi({}, context);
+
+    expect(second.verify).toHaveBeenCalledTimes(1);
+    expect(summary.passed).toBe(false);
+    expect(summary.results).toEqual([
+      { verifier: 'first', passed: false, reason: 'first failed' },
+      { verifier: 'second', passed: false, reason: 'second failed' },
+    ]);
+  });
+
+  it('fails overall when any applicable verifier fails', async () => {
+    registry.register(makeVerifier('pass', { passed: true }));
+    registry.register(makeVerifier('fail', { passed: false, reason: 'nope' }));
+
+    const summary = await service.verifyKi({}, context);
+
+    expect(summary.passed).toBe(false);
+  });
+
+  it('runs only applicable verifiers', async () => {
+    const applies = makeVerifier('applies', { passed: true }, true);
+    const skips = makeVerifier('skips', { passed: false, reason: 'should not run' }, false);
+    registry.register(applies);
+    registry.register(skips);
+
+    const summary = await service.verifyKi({}, context);
+
+    expect(applies.verify).toHaveBeenCalledTimes(1);
+    expect(skips.verify).not.toHaveBeenCalled();
+    expect(summary.passed).toBe(true);
+    expect(summary.results).toEqual([{ verifier: 'applies', passed: true }]);
+  });
+
+  it('records a throwing verifier as a failure, logs it, and continues the run', async () => {
+    const thrower: KiVerifier = {
+      id: 'thrower',
+      applies: () => true,
+      verify: jest.fn(async () => {
+        throw new Error('boom');
+      }),
+    };
+    const after = makeVerifier('after', { passed: true });
+    registry.register(thrower);
+    registry.register(after);
+
+    const summary = await service.verifyKi({}, context);
+
+    expect(after.verify).toHaveBeenCalledTimes(1);
+    expect(summary.passed).toBe(false);
+    expect(summary.results).toEqual([
+      { verifier: 'thrower', passed: false, reason: 'boom' },
+      { verifier: 'after', passed: true },
+    ]);
+    expect(context.logger.warn).toHaveBeenCalledWith("KI verifier 'thrower' threw: boom");
+  });
+
+  it('passes with no results when no verifier applies', async () => {
+    registry.register(makeVerifier('skips', { passed: false, reason: 'x' }, false));
+
+    const summary = await service.verifyKi({}, context);
+
+    expect(summary).toEqual({ passed: true, results: [] });
+  });
+
+  it('is a no-op that passes with no results when the feature flag is disabled', async () => {
+    const verifier = makeVerifier('a', { passed: false, reason: 'x' });
+    registry.register(verifier);
+
+    const summary = await service.verifyKi({}, { ...context, isEnabled: false });
+
+    expect(verifier.verify).not.toHaveBeenCalled();
+    expect(summary).toEqual({ passed: true, results: [] });
+  });
+});

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.test.ts
@@ -8,16 +8,12 @@
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { KiVerifierRegistry } from './registry';
 import { KiVerificationService } from './service';
-import type { KiVerificationContext, KiVerifier, KiVerifierResult } from './types';
+import type { KiVerificationContext, KiVerifier, KiVerifierOutcome } from './types';
 
-const makeVerifier = (
-  id: string,
-  result: Omit<KiVerifierResult, 'verifier'>,
-  applies = true
-): KiVerifier => ({
+const makeVerifier = (id: string, outcome: KiVerifierOutcome, applies = true): KiVerifier => ({
   id,
   applies: () => applies,
-  verify: jest.fn(async () => ({ verifier: id, ...result })),
+  verify: jest.fn(async () => outcome),
 });
 
 describe('KiVerificationService', () => {
@@ -108,6 +104,40 @@ describe('KiVerificationService', () => {
       { verifier: 'after', passed: true },
     ]);
     expect(context.logger.warn).toHaveBeenCalledWith("KI verifier 'thrower' threw: boom");
+  });
+
+  it('records a verifier whose applies() throws as a failure and continues the run', async () => {
+    const thrower: KiVerifier = {
+      id: 'applies-thrower',
+      applies: () => {
+        throw new Error('applies boom');
+      },
+      verify: jest.fn(async () => ({ passed: true as const })),
+    };
+    const after = makeVerifier('after', { passed: true });
+    registry.register(thrower);
+    registry.register(after);
+
+    const summary = await service.verifyKi({}, context);
+
+    expect(thrower.verify).not.toHaveBeenCalled();
+    expect(after.verify).toHaveBeenCalledTimes(1);
+    expect(summary.passed).toBe(false);
+    expect(summary.results).toEqual([
+      { verifier: 'applies-thrower', passed: false, reason: 'applies boom' },
+      { verifier: 'after', passed: true },
+    ]);
+    expect(context.logger.warn).toHaveBeenCalledWith(
+      "KI verifier 'applies-thrower' threw: applies boom"
+    );
+  });
+
+  it('stamps the result with the verifier id from the registry', async () => {
+    registry.register(makeVerifier('real-id', { passed: true }));
+
+    const summary = await service.verifyKi({}, context);
+
+    expect(summary.results).toEqual([{ verifier: 'real-id', passed: true }]);
   });
 
   it('passes with no results when no verifier applies', async () => {

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KiVerifierRegistry } from './registry';
+import type {
+  KiVerificationContext,
+  KiVerificationSummary,
+  KiVerifierResult,
+  KnowledgeIndicator,
+} from './types';
+
+export class KiVerificationService {
+  constructor(private readonly registry: KiVerifierRegistry) {}
+
+  /**
+   * Runs all applicable verifiers and aggregates their results. A verifier that
+   * throws is recorded as a failure and does not abort the run. No-op when the
+   * feature flag is off.
+   */
+  async verifyKi(
+    ki: KnowledgeIndicator,
+    { isEnabled, ...verifierContext }: KiVerificationContext
+  ): Promise<KiVerificationSummary> {
+    if (!isEnabled) {
+      return { passed: true, results: [] };
+    }
+
+    const results: KiVerifierResult[] = [];
+
+    for (const verifier of this.registry.getApplicable(ki)) {
+      try {
+        results.push(await verifier.verify(ki, verifierContext));
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        verifierContext.logger.warn(`KI verifier '${verifier.id}' threw: ${reason}`);
+        results.push({ verifier: verifier.id, passed: false, reason });
+      }
+    }
+
+    return { passed: results.every((result) => result.passed), results };
+  }
+}

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/service.ts
@@ -9,6 +9,7 @@ import type { KiVerifierRegistry } from './registry';
 import type {
   KiVerificationContext,
   KiVerificationSummary,
+  KiVerifierContext,
   KiVerifierResult,
   KnowledgeIndicator,
 } from './types';
@@ -17,8 +18,9 @@ export class KiVerificationService {
   constructor(private readonly registry: KiVerifierRegistry) {}
 
   /**
-   * Runs all applicable verifiers and aggregates their results. A verifier that
-   * throws is recorded as a failure and does not abort the run. No-op when the
+   * Runs all applicable verifiers and aggregates their results, stamping each
+   * result with its verifier id. A verifier that throws from `applies` or
+   * `verify` is recorded as a failure and does not abort the run. No-op when the
    * feature flag is off.
    */
   async verifyKi(
@@ -31,16 +33,32 @@ export class KiVerificationService {
 
     const results: KiVerifierResult[] = [];
 
-    for (const verifier of this.registry.getApplicable(ki)) {
+    for (const verifier of this.registry.getAll()) {
+      let applies: boolean;
       try {
-        results.push(await verifier.verify(ki, verifierContext));
+        applies = verifier.applies(ki);
       } catch (error) {
-        const reason = error instanceof Error ? error.message : String(error);
-        verifierContext.logger.warn(`KI verifier '${verifier.id}' threw: ${reason}`);
-        results.push({ verifier: verifier.id, passed: false, reason });
+        results.push(this.toFailure(verifier.id, error, verifierContext));
+        continue;
+      }
+      if (!applies) {
+        continue;
+      }
+
+      try {
+        const outcome = await verifier.verify(ki, verifierContext);
+        results.push({ ...outcome, verifier: verifier.id });
+      } catch (error) {
+        results.push(this.toFailure(verifier.id, error, verifierContext));
       }
     }
 
     return { passed: results.every((result) => result.passed), results };
+  }
+
+  private toFailure(id: string, error: unknown, { logger }: KiVerifierContext): KiVerifierResult {
+    const reason = error instanceof Error ? error.message : String(error);
+    logger.warn(`KI verifier '${id}' threw: ${reason}`);
+    return { verifier: id, passed: false, reason };
   }
 }

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/types.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/types.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+
+/**
+ * A Knowledge Indicator (KI) to verify. Fields mirror the base AI index
+ * mappings (`ai-index@mappings`).
+ */
+export interface KnowledgeIndicator {
+  type?: string;
+  title?: string;
+  description?: string;
+  content?: string;
+  tags?: string[];
+  attributes?: Record<string, unknown>;
+}
+
+/** Context passed to each verifier when it runs. */
+export interface KiVerifierContext {
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Context for {@link KiVerificationService.verifyKi}. `isEnabled` gates the run
+ * on the `contextEngine:enabled` feature flag.
+ */
+export interface KiVerificationContext extends KiVerifierContext {
+  isEnabled: boolean;
+}
+
+/** Outcome of a single verifier for one KI. */
+export interface KiVerifierResult {
+  /** Id of the verifier that produced this result. */
+  verifier: string;
+  passed: boolean;
+  /** Explanation, set when a check fails. */
+  reason?: string;
+}
+
+export interface KiVerifier {
+  readonly id: string;
+  /** Whether this verifier has anything to check for the given KI. */
+  applies(ki: KnowledgeIndicator): boolean;
+  verify(ki: KnowledgeIndicator, context: KiVerifierContext): Promise<KiVerifierResult>;
+}
+
+/**
+ * Aggregated outcome. `passed` is true only when all applicable verifiers
+ * passed.
+ */
+export interface KiVerificationSummary {
+  passed: boolean;
+  results: KiVerifierResult[];
+}

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/types.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/types.ts
@@ -35,20 +35,17 @@ export interface KiVerificationContext extends KiVerifierContext {
   isEnabled: boolean;
 }
 
-/** Outcome of a single verifier for one KI. */
-export interface KiVerifierResult {
-  /** Id of the verifier that produced this result. */
-  verifier: string;
-  passed: boolean;
-  /** Explanation, set when a check fails. */
-  reason?: string;
-}
+/** Outcome a verifier reports for one KI. A failure must carry a reason. */
+export type KiVerifierOutcome = { passed: true } | { passed: false; reason: string };
+
+/** A {@link KiVerifierOutcome} attributed to a verifier by the framework. */
+export type KiVerifierResult = KiVerifierOutcome & { verifier: string };
 
 export interface KiVerifier {
   readonly id: string;
   /** Whether this verifier has anything to check for the given KI. */
   applies(ki: KnowledgeIndicator): boolean;
-  verify(ki: KnowledgeIndicator, context: KiVerifierContext): Promise<KiVerifierResult>;
+  verify(ki: KnowledgeIndicator, context: KiVerifierContext): Promise<KiVerifierOutcome>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds the core KI verifier framework at `x-pack/platform/plugins/shared/context_engine/server/ki_verification/`:

- `KiVerifier interface`
- `KiVerifierRegistry`
- `KiVerificationService.verifyKi()` that runs all applicable verifiers and aggregates the results

This PR only provides the framework, no verifiers are introduced yet. 

Notes
- We run all verifiers today, so the summary carries the reason from every failing verifier. A verifier that throws is recorded as a failure and does not abort the run. If we want to fail fast we can add that in the future as a followup. 
- Gated behind the `contextEngine:enabled` feature flag; when the feature flag is not enabled verification is a no-op.

### Checklist

- [x] Unit tests added

### Identify risks

No risks, this resides behind a feature flag.



