### PR TITLE
[Entity Analytics] Fix flaky watchlist index sync API-key race

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/watchlists/trial_license_complete_tier/index_source_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/watchlists/trial_license_complete_tier/index_source_sync.ts
@@ -117,10 +117,14 @@ export default ({ getService }: FtrProviderContext) => {
         user: { name: 'alice' },
         entity: { id: userEuid('alice'), type: 'user' },
       });
-      await utils.addUsersToSourceIndex(['alice'], sourceIndexName);
 
       // Simulate a source that has no API key stored
       await utils.clearEntitySourceApiKey(entitySourceId);
+
+      // Add the user only after the key is cleared, so the fire-and-forget background
+      // sync triggered at source creation (which still holds the valid key) cannot
+      // populate the watchlist index and race this assertion.
+      await utils.addUsersToSourceIndex(['alice'], sourceIndexName);
 
       await utils.syncWatchlist(watchlistId);
 
@@ -138,10 +142,14 @@ export default ({ getService }: FtrProviderContext) => {
         user: { name: 'alice' },
         entity: { id: userEuid('alice'), type: 'user' },
       });
-      await utils.addUsersToSourceIndex(['alice'], sourceIndexName);
 
       // Simulate a source that has no API key stored
       await utils.clearEntitySourceApiKey(entitySourceId);
+
+      // Add the user only after the key is cleared, so the fire-and-forget background
+      // sync triggered at source creation (which still holds the valid key) cannot
+      // populate the watchlist index and race this assertion.
+      await utils.addUsersToSourceIndex(['alice'], sourceIndexName);
 
       await utils.syncWatchlist(watchlistId);
       expect(await utils.queryWatchlistIndex(watchlistId)).toHaveLength(0);


### PR DESCRIPTION
## Summary

Closes #274072
Closes #274411

- **Issue:** create-time fire-and-forget sync could populate `alice` while the API key was still valid, so the post-clear empty-watchlist assertion failed intermittently
- **Fix:** adds users to the source index only after clearing the API key

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->