### PR TITLE
[OAS Docs] Fix Dashboards & Visualizations placeholder operationIds and summaries

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -11388,8 +11388,8 @@ paths:
     get:
       tags:
         - Dashboards
-      summary: Get dashboards
-      operationId: get-dashboards-redirect
+      summary: Search dashboards
+      operationId: search-dashboards
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -11401,7 +11401,7 @@ paths:
       tags:
         - Dashboards
       summary: Create a dashboard
-      operationId: create-dashboard-redirect
+      operationId: create-dashboard
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -11414,7 +11414,7 @@ paths:
       tags:
         - Dashboards
       summary: Get a dashboard
-      operationId: get-dashboard-redirect
+      operationId: get-dashboard
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -11425,8 +11425,8 @@ paths:
     put:
       tags:
         - Dashboards
-      summary: Update a dashboard
-      operationId: update-dashboard-redirect
+      summary: Upsert a dashboard
+      operationId: upsert-dashboard
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -11438,7 +11438,7 @@ paths:
       tags:
         - Dashboards
       summary: Delete a dashboard
-      operationId: delete-dashboard-redirect
+      operationId: delete-dashboard
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -65459,8 +65459,8 @@ paths:
     get:
       tags:
         - Visualizations
-      summary: Get visualizations
-      operationId: get-visualizations-redirect
+      summary: Search visualizations
+      operationId: search-visualizations
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -65471,8 +65471,8 @@ paths:
     post:
       tags:
         - Visualizations
-      summary: Create a visualization
-      operationId: create-visualization-redirect
+      summary: Create visualization
+      operationId: create-visualization
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -65484,8 +65484,8 @@ paths:
     get:
       tags:
         - Visualizations
-      summary: Get a visualization
-      operationId: get-visualization-redirect
+      summary: Get visualization
+      operationId: get-visualization
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -65496,8 +65496,8 @@ paths:
     put:
       tags:
         - Visualizations
-      summary: Update a visualization
-      operationId: update-visualization-redirect
+      summary: Upsert visualization
+      operationId: upsert-visualization
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -65508,8 +65508,8 @@ paths:
     delete:
       tags:
         - Visualizations
-      summary: Delete a visualization
-      operationId: delete-visualization-redirect
+      summary: Delete visualization
+      operationId: delete-visualization
       description: |
         > This documentation is temporarily hosted at a separate location.
         >

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -14051,8 +14051,8 @@ paths:
     get:
       tags:
         - Dashboards
-      summary: Get dashboards
-      operationId: get-dashboards-redirect
+      summary: Search dashboards
+      operationId: search-dashboards
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -14064,7 +14064,7 @@ paths:
       tags:
         - Dashboards
       summary: Create a dashboard
-      operationId: create-dashboard-redirect
+      operationId: create-dashboard
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -14077,7 +14077,7 @@ paths:
       tags:
         - Dashboards
       summary: Get a dashboard
-      operationId: get-dashboard-redirect
+      operationId: get-dashboard
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -14088,8 +14088,8 @@ paths:
     put:
       tags:
         - Dashboards
-      summary: Update a dashboard
-      operationId: update-dashboard-redirect
+      summary: Upsert a dashboard
+      operationId: upsert-dashboard
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -14101,7 +14101,7 @@ paths:
       tags:
         - Dashboards
       summary: Delete a dashboard
-      operationId: delete-dashboard-redirect
+      operationId: delete-dashboard
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -73485,8 +73485,8 @@ paths:
     get:
       tags:
         - Visualizations
-      summary: Get visualizations
-      operationId: get-visualizations-redirect
+      summary: Search visualizations
+      operationId: search-visualizations
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -73497,8 +73497,8 @@ paths:
     post:
       tags:
         - Visualizations
-      summary: Create a visualization
-      operationId: create-visualization-redirect
+      summary: Create visualization
+      operationId: create-visualization
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -73510,8 +73510,8 @@ paths:
     get:
       tags:
         - Visualizations
-      summary: Get a visualization
-      operationId: get-visualization-redirect
+      summary: Get visualization
+      operationId: get-visualization
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -73522,8 +73522,8 @@ paths:
     put:
       tags:
         - Visualizations
-      summary: Update a visualization
-      operationId: update-visualization-redirect
+      summary: Upsert visualization
+      operationId: upsert-visualization
       description: |
         > This documentation is temporarily hosted at a separate location.
         >
@@ -73534,8 +73534,8 @@ paths:
     delete:
       tags:
         - Visualizations
-      summary: Delete a visualization
-      operationId: delete-visualization-redirect
+      summary: Delete visualization
+      operationId: delete-visualization
       description: |
         > This documentation is temporarily hosted at a separate location.
         >

--- a/oas_docs/overlays/kibana.overlays.bump_slim.yaml
+++ b/oas_docs/overlays/kibana.overlays.bump_slim.yaml
@@ -37,7 +37,7 @@ actions:
         tags:
           - Dashboards
         summary: "Get dashboards"
-        operationId: get-dashboards-redirect
+        operationId: get-dashboards
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -49,7 +49,7 @@ actions:
         tags:
           - Dashboards
         summary: "Create a dashboard"
-        operationId: create-dashboard-redirect
+        operationId: create-dashboard
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -74,7 +74,7 @@ actions:
         tags:
           - Dashboards
         summary: "Get a dashboard"
-        operationId: get-dashboard-redirect
+        operationId: get-dashboard
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -86,7 +86,7 @@ actions:
         tags:
           - Dashboards
         summary: "Update a dashboard"
-        operationId: update-dashboard-redirect
+        operationId: update-dashboard
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -98,7 +98,7 @@ actions:
         tags:
           - Dashboards
         summary: "Delete a dashboard"
-        operationId: delete-dashboard-redirect
+        operationId: delete-dashboard
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -125,7 +125,7 @@ actions:
         tags:
           - Visualizations
         summary: "Get visualizations"
-        operationId: get-visualizations-redirect
+        operationId: get-visualizations
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -137,7 +137,7 @@ actions:
         tags:
           - Visualizations
         summary: "Create a visualization"
-        operationId: create-visualization-redirect
+        operationId: create-visualization
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -162,7 +162,7 @@ actions:
         tags:
           - Visualizations
         summary: "Get a visualization"
-        operationId: get-visualization-redirect
+        operationId: get-visualization
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -174,7 +174,7 @@ actions:
         tags:
           - Visualizations
         summary: "Update a visualization"
-        operationId: update-visualization-redirect
+        operationId: update-visualization
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -186,7 +186,7 @@ actions:
         tags:
           - Visualizations
         summary: "Delete a visualization"
-        operationId: delete-visualization-redirect
+        operationId: delete-visualization
         description: |
           > This documentation is temporarily hosted at a separate location.
           >

--- a/oas_docs/overlays/kibana.overlays.bump_slim.yaml
+++ b/oas_docs/overlays/kibana.overlays.bump_slim.yaml
@@ -36,8 +36,8 @@ actions:
       get:
         tags:
           - Dashboards
-        summary: "Get dashboards"
-        operationId: get-dashboards
+        summary: "Search dashboards"
+        operationId: search-dashboards
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -85,8 +85,8 @@ actions:
       put:
         tags:
           - Dashboards
-        summary: "Update a dashboard"
-        operationId: update-dashboard
+        summary: "Upsert a dashboard"
+        operationId: upsert-dashboard
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -124,8 +124,8 @@ actions:
       get:
         tags:
           - Visualizations
-        summary: "Get visualizations"
-        operationId: get-visualizations
+        summary: "Search visualizations"
+        operationId: search-visualizations
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -136,7 +136,7 @@ actions:
       post:
         tags:
           - Visualizations
-        summary: "Create a visualization"
+        summary: "Create visualization"
         operationId: create-visualization
         description: |
           > This documentation is temporarily hosted at a separate location.
@@ -161,7 +161,7 @@ actions:
       get:
         tags:
           - Visualizations
-        summary: "Get a visualization"
+        summary: "Get visualization"
         operationId: get-visualization
         description: |
           > This documentation is temporarily hosted at a separate location.
@@ -173,8 +173,8 @@ actions:
       put:
         tags:
           - Visualizations
-        summary: "Update a visualization"
-        operationId: update-visualization
+        summary: "Upsert visualization"
+        operationId: upsert-visualization
         description: |
           > This documentation is temporarily hosted at a separate location.
           >
@@ -185,7 +185,7 @@ actions:
       delete:
         tags:
           - Visualizations
-        summary: "Delete a visualization"
+        summary: "Delete visualization"
         operationId: delete-visualization
         description: |
           > This documentation is temporarily hosted at a separate location.


### PR DESCRIPTION
## Summary

Fixes the `operationId` and `summary` values of the 10 Dashboards and Visualizations placeholder operations in the bump-slim overlay.

The bump-slim overlay strips those operations down to placeholder shells that link to the externally hosted reference. See #266195 for the retirement checklist. Two problems crept into the shells.

**1. Every `operationId` ended in `-redirect`.** That suffix is not internal. It ships in the published `kibana.yaml` and `kibana.serverless.yaml` bundles, so every downstream consumer inherits it. Elastic CLI v0.3.0 generates command names from `operationId`, which produced this:

```
Commands:
  get-dashboards-redirect    Get dashboards
  create-dashboard-redirect  Create a dashboard
  get-dashboard-redirect     Get a dashboard
  update-dashboard-redirect  Update a dashboard
  delete-dashboard-redirect  Delete a dashboard
```

**2. The summaries had drifted from the route source.** The placeholder exists to mirror the real reference, so its nav labels should match. Three did not.

### What changed

Only `oas_docs/overlays/kibana.overlays.bump_slim.yaml`.

| Path | Summary before | Summary after | operationId after |
|---|---|---|---|
| `GET /api/dashboards` | Get dashboards | **Search dashboards** | `search-dashboards` |
| `POST /api/dashboards` | Create a dashboard | Create a dashboard | `create-dashboard` |
| `GET /api/dashboards/{id}` | Get a dashboard | Get a dashboard | `get-dashboard` |
| `PUT /api/dashboards/{id}` | Update a dashboard | **Upsert a dashboard** | `upsert-dashboard` |
| `DELETE /api/dashboards/{id}` | Delete a dashboard | Delete a dashboard | `delete-dashboard` |
| `GET /api/visualizations` | Get visualizations | **Search visualizations** | `search-visualizations` |
| `POST /api/visualizations` | Create a visualization | **Create visualization** | `create-visualization` |
| `GET /api/visualizations/{id}` | Get a visualization | **Get visualization** | `get-visualization` |
| `PUT /api/visualizations/{id}` | Update a visualization | **Upsert visualization** | `upsert-visualization` |
| `DELETE /api/visualizations/{id}` | Delete a visualization | **Delete visualization** | `delete-visualization` |

Every summary now matches its route source, with one deliberate exception described below. The Dashboards summaries keep the article, and the Visualizations summaries drop it, because the two route files differ that way.

The `-redirect` strings that remain in the file are overlay action `description` fields. Bump uses them to label the action. They never reach the output spec.

### One deliberate deviation from source

Both PUT routes upsert. Each one creates the object when the ID does not exist, and each returns 201.

The Dashboards route already says so. [`register_update_route.ts`](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/dashboard/server/api/update/register_update_route.ts) sets `summary: 'Upsert a dashboard'`.

The Visualizations route does not. [`update.ts`](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/lens/server/api/routes/visualizations/update.ts) sets `summary: 'Update visualization'`, even though its own description says "If no visualization exists with the specified ID, a new one is created". The internal Lens route for the same operation calls it "Create or update Lens visualization".

This overlay uses "Upsert visualization" so both tags describe the behavior consistently. That is a knowing deviation from the current Lens summary. The better fix is to correct the route summary itself, which needs a separate PR against Lens.

### Generated files

This PR does not touch generated output. Two jobs handle it:

- `make api-docs` regenerates `oas_docs/output/kibana.yaml` and `kibana.serverless.yaml`. CI runs it and auto-commits the result to this branch.
- `kibana_api_doc_links_sync` regenerates the Console doc-link map and opens its own PR.

### Verification

- All 10 new `operationId` values are free. Neither bundle on `main` already uses them.
- The overlay still parses. It has 16 actions and 10 unique `operationId` values.
- Every new summary was read from the route registration at `origin/main`.
- No page in `elastic/docs-content` links to the old `operation-*-redirect` anchors.

### Known gaps

Published anchors change. For example, `elastic.co/docs/api/doc/kibana/operation/operation-get-dashboards-redirect` becomes `operation-search-dashboards`. Nothing in `docs-content` links to the old form, but external bookmarks break.

Console's "Open API reference" links for these 10 endpoints break until `kibana_api_doc_links_sync` runs.

These names still differ from the auto-generated ones the routes produce today (`post-dashboards`, `get-dashboards-id`). When #266195 retires the bump-slim overlay, the published `operationId` values change again. To avoid that, set explicit `operationId` values on the Dashboards and Visualizations routes to match. That touches plugin code and belongs in a separate PR.

### Checklist

- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Remaining template items do not apply. This PR changes no UI text, no plugin config key, and no tests. It introduces no HTTP API change, because the routes themselves are untouched.

### Identify risks

Low. The change renames identifiers and labels in a documentation overlay. It does not alter any route, request shape, or response shape.

The one real risk is link rot on the two surfaces listed under Known gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->