### PR TITLE
[9.4] Add limit to cases alert API (#277291)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/cases/cases.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/cases/cases.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup } from '@kbn/core/server';
+import { casesTool } from './cases';
+import type { AgentBuilderPlatformPluginStart, PluginStartDependencies } from '../../types';
+
+const buildTool = () =>
+  casesTool({
+    getStartServices: jest.fn(),
+  } as unknown as CoreSetup<PluginStartDependencies, AgentBuilderPlatformPluginStart>);
+
+describe('casesTool schema', () => {
+  it('rejects more than 100 alertIds at the schema level', () => {
+    const tool = buildTool();
+
+    const tooMany = tool.schema.safeParse({
+      alertIds: Array.from({ length: 101 }, (_, i) => `alert-${i}`),
+    });
+    expect(tooMany.success).toBe(false);
+
+    const atLimit = tool.schema.safeParse({
+      alertIds: Array.from({ length: 100 }, (_, i) => `alert-${i}`),
+    });
+    expect(atLimit.success).toBe(true);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/cases/cases.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/cases/cases.ts
@@ -28,6 +28,10 @@ import {
   type EnhancedCaseData,
 } from './helpers';
 
+// Each alert ID fans out into a separate getCasesByAlertID request, so the
+// array must stay bounded to avoid resource exhaustion.
+const MAX_ALERT_IDS = 100;
+
 const casesSchema = z.object({
   // Get case by ID operation
   caseId: z
@@ -39,9 +43,10 @@ const casesSchema = z.object({
   // Find cases by alert IDs
   alertIds: z
     .array(z.string())
+    .max(MAX_ALERT_IDS)
     .optional()
     .describe(
-      'Array of alert IDs to find cases containing these alerts. If provided, cases containing any of these alert IDs will be returned. Alert IDs must be provided via this parameter.'
+      `Array of alert IDs to find cases containing these alerts (max ${MAX_ALERT_IDS}). If provided, cases containing any of these alert IDs will be returned. Alert IDs must be provided via this parameter.`
     ),
   // Owner filter
   owner: z


### PR DESCRIPTION
Manual backport of #277291 to `9.4`.

Adds a max bound (100) to the number of alert IDs accepted by the cases agent builder tool, preventing an unbounded array from fanning out into an excessive number of `getCasesByAlertID` requests.

The automated backport could not be applied cleanly: on `9.4` the cases tool lives in `x-pack/platform/plugins/shared/agent_builder_platform/server/tools/cases/cases.ts` (it was later moved to `cases/server/agent_builder/tools/search_cases.ts` on `main`/`9.5`). The fix is adapted to the `alertIds` schema in the `9.4` location, and a schema-level test was added.

### Checklist
- [x] Unit tests pass
- [x] Type check passes
- [x] Lint passes