### PR TITLE
[metrics_experience] Fix authz bypass on dimensions and fields GET ro…

### DIFF
--- a/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr-manifests/ftr_platform_stateful_configs.yml
@@ -52,6 +52,7 @@ enabled:
   - src/platform/test/analytics/config.ts
   - src/platform/test/api_integration/config.js
   - src/platform/test/api_integration/apis/unused_urls_task/config.ts
+  - src/platform/test/api_integration/apis/metrics_experience/authorization.config.ts
   - src/platform/test/examples/config.js
   - src/platform/test/functional/apps/bundles/config.ts
   - src/platform/test/functional/apps/console/config.ts

--- a/src/platform/plugins/shared/metrics_experience/server/routes/dimensions/route.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/routes/dimensions/route.ts
@@ -18,7 +18,7 @@ import { throwNotFoundIfMetricsExperienceDisabled } from '../../lib/utils';
 
 export const getDimensionsRoute = createRoute({
   endpoint: 'GET /internal/metrics_experience/dimensions',
-  security: { authz: { enabled: false, reason: 'Authorization provided by Elasticsearch' } },
+  security: { authz: { requiredPrivileges: ['read'] } },
   params: z.object({
     query: z.object({
       dimensions: z

--- a/src/platform/plugins/shared/metrics_experience/server/routes/fields/route.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/routes/fields/route.ts
@@ -18,7 +18,7 @@ import { throwNotFoundIfMetricsExperienceDisabled } from '../../lib/utils';
 
 export const getFieldsRoute = createRoute({
   endpoint: 'GET /internal/metrics_experience/fields',
-  security: { authz: { enabled: false, reason: 'Authorization provided by Elasticsearch' } },
+  security: { authz: { requiredPrivileges: ['read'] } },
   params: z.object({
     query: z.object({
       index: z.string().default('metrics-*'),

--- a/src/platform/test/api_integration/apis/metrics_experience/authorization.config.ts
+++ b/src/platform/test/api_integration/apis/metrics_experience/authorization.config.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
+import type { FtrConfigProviderContext } from '@kbn/test';
+import { services } from '../../services';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const apiIntegrationConfig = await readConfigFile(require.resolve('../../config.js'));
+
+  return {
+    ...apiIntegrationConfig.getAll(),
+    rootTags: ['runOutsideOfCiGroups'],
+    testFiles: [require.resolve('./authorization')],
+    services,
+    testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
+    junit: {
+      reportName: 'Metrics Experience Authorization API Integration Tests',
+    },
+    esTestCluster: {
+      ...apiIntegrationConfig.get('esTestCluster'),
+      // Security must be enabled to test Kibana privilege enforcement
+      serverArgs: ['xpack.security.enabled=true'],
+    },
+    kbnTestServer: {
+      ...apiIntegrationConfig.get('kbnTestServer'),
+      serverArgs: [...apiIntegrationConfig.get('kbnTestServer.serverArgs')],
+    },
+  };
+}

--- a/src/platform/test/api_integration/apis/metrics_experience/authorization.ts
+++ b/src/platform/test/api_integration/apis/metrics_experience/authorization.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import expect from '@kbn/expect';
+import { X_ELASTIC_INTERNAL_ORIGIN_REQUEST } from '@kbn/core-http-common';
+import type { FtrProviderContext } from '../../ftr_provider_context';
+import { timerange } from './timerange';
+import { toggleMetricsExperienceFeature } from './utils/helpers';
+
+const ROLE_NAME = 'metrics_experience_no_kibana_priv';
+const USERNAME = 'metrics_experience_no_kibana_user';
+const PASSWORD = 'metrics_experience_no_kibana_user_pwd';
+
+export default function ({ getService }: FtrProviderContext) {
+  const security = getService('security');
+  const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const esArchiver = getService('esArchiver');
+
+  describe('Authorization', () => {
+    before(async () => {
+      await esArchiver.load(
+        'src/platform/test/api_integration/fixtures/es_archiver/metrics_experience'
+      );
+      await toggleMetricsExperienceFeature(supertest, true);
+
+      await security.role.create(ROLE_NAME, {
+        elasticsearch: {
+          indices: [{ names: ['*'], privileges: ['read'] }],
+        },
+        // intentionally no kibana privileges
+      });
+
+      await security.user.create(USERNAME, {
+        password: PASSWORD,
+        roles: [ROLE_NAME],
+        full_name: 'Metrics No Kibana User',
+      });
+    });
+
+    after(async () => {
+      await esArchiver.unload(
+        'src/platform/test/api_integration/fixtures/es_archiver/metrics_experience'
+      );
+      await toggleMetricsExperienceFeature(supertest, false);
+      await security.user.delete(USERNAME);
+      await security.role.delete(ROLE_NAME);
+    });
+
+    describe('GET /internal/metrics_experience/dimensions', () => {
+      const query = {
+        indices: JSON.stringify(['fieldsense-station-metrics']),
+        dimensions: JSON.stringify(['station.name']),
+        from: timerange.min,
+        to: timerange.max,
+      };
+
+      it('returns 403 for a user with no Kibana privileges', async () => {
+        const { status } = await supertestWithoutAuth
+          .get('/internal/metrics_experience/dimensions')
+          .auth(USERNAME, PASSWORD)
+          .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+          .query(query);
+
+        expect(status).to.be(403);
+      });
+
+      it('returns 200 for an authenticated admin user', async () => {
+        const { status } = await supertest
+          .get('/internal/metrics_experience/dimensions')
+          .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+          .query(query);
+
+        expect(status).to.be(200);
+      });
+    });
+
+    describe('GET /internal/metrics_experience/fields', () => {
+      const query = {
+        index: 'fieldsense-station-metrics',
+        from: timerange.min,
+        to: timerange.max,
+      };
+
+      it('returns 403 for a user with no Kibana privileges', async () => {
+        const { status } = await supertestWithoutAuth
+          .get('/internal/metrics_experience/fields')
+          .auth(USERNAME, PASSWORD)
+          .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+          .query(query);
+
+        expect(status).to.be(403);
+      });
+
+      it('returns 200 for an authenticated admin user', async () => {
+        const { status } = await supertest
+          .get('/internal/metrics_experience/fields')
+          .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+          .query(query);
+
+        expect(status).to.be(200);
+      });
+    });
+
+    describe('POST /internal/metrics_experience/fields/_search', () => {
+      const body = {
+        index: 'fieldsense-station-metrics',
+        from: timerange.min,
+        to: timerange.max,
+      };
+
+      it('returns 403 for a user with no Kibana privileges', async () => {
+        const { status } = await supertestWithoutAuth
+          .post('/internal/metrics_experience/fields/_search')
+          .auth(USERNAME, PASSWORD)
+          .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+          .send(body);
+
+        expect(status).to.be(403);
+      });
+
+      it('returns 200 for an authenticated admin user', async () => {
+        const { status } = await supertest
+          .post('/internal/metrics_experience/fields/_search')
+          .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+          .send(body);
+
+        expect(status).to.be(200);
+      });
+    });
+  });
+}


### PR DESCRIPTION
closes https://github.com/elastic/security/issues/12231

## Summary

`GET /internal/metrics_experience/dimensions` and `GET /internal/metrics_experience/fields` were registered with `security.authz.enabled: false`, delegating all access control to Elasticsearch. This allowed a user with **no Kibana privileges** (but with ES index-level read access) to query real metric data through Kibana by supplying the `x-elastic-internal-origin` header — bypassing the Kibana privilege check that the sibling `POST /internal/metrics_experience/fields/_search` route correctly enforces.

### Root cause

Both routes used:
```ts
security: { authz: { enabled: false, reason: 'Authorization provided by Elasticsearch' } },
```

While the POST sibling already had:
```ts
security: { authz: { requiredPrivileges: ['read'] } },
```

### Fix

Replace `authz.enabled: false` with `requiredPrivileges: ['read']` on both affected GET routes, matching the existing pattern of the sibling route.

### Tests

Added a dedicated FTR authorization test suite (`authorization.config.ts` / `authorization.ts`) that runs with security enabled and asserts:
- A user with ES read access but **no Kibana privileges** receives `403` on all three routes (`GET /dimensions`, `GET /fields`, `POST /fields/_search`)
- An admin user receives `200` on all three routes