### PR TITLE
[Security Solution][Take Actions] Add alert action menus

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action.tsx
@@ -19,6 +19,7 @@ import type { AlertTableContextMenuItem } from '../../../../../detections/compon
 import { useGetAgentStatus } from '../../../../../management/hooks/agents/use_get_agent_status';
 
 export type HostIsolationAction = 'isolateHost' | 'unisolateHost';
+export const ISOLATE_HOST_ACTION_ID = 'isolate-host-action-item';
 
 export interface UseHostIsolationActionProps {
   closePopover: () => void;
@@ -83,7 +84,7 @@ export const useHostIsolationAction = ({
     }
 
     const menuItem: AlertTableContextMenuItem = {
-      key: 'isolate-host-action-item',
+      key: ISOLATE_HOST_ACTION_ID,
       'data-test-subj': 'isolate-host-action-item',
       disabled: isHostAgentUnEnrolled,
       onClick: isolateHostHandler,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_item.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_item.tsx
@@ -12,6 +12,8 @@ import { useUserPrivileges } from '../../../user_privileges';
 import type { AlertTableContextMenuItem } from '../../../../../detections/components/alerts_table/types';
 import { useWithResponderActionDataFromAlert } from './use_responder_action_data';
 
+export const RESPOND_ACTION_ID = 'endpointResponseActions-action-item';
+
 export const useResponderActionItem = (
   eventDetailsData: TimelineEventsDetailsItem[] | null,
   onClick: () => void
@@ -28,7 +30,7 @@ export const useResponderActionItem = (
 
     if (!isAuthzLoading && canAccessResponseConsole) {
       actions.push({
-        key: 'endpointResponseActions-action-item',
+        key: RESPOND_ACTION_ID,
         'data-test-subj': 'endpointResponseActions-action-item',
         disabled: isDisabled,
         toolTipContent: tooltip,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.test.tsx
@@ -95,6 +95,12 @@ describe('useBulkAlertAssigneesItems', () => {
     expect(result.current.alertAssigneesItems[1]['data-test-subj']).toEqual(
       'remove-alert-assignees-menu-item'
     );
+    expect(result.current.alertAssigneesItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ icon: 'users', groupId: 'assignees' }),
+        expect.objectContaining({ icon: 'users', groupId: 'assignees' }),
+      ])
+    );
     expect(result.current.alertAssigneesPanels[0]['data-test-subj']).toEqual(
       'alert-assignees-context-menu-panel'
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.tsx
@@ -24,6 +24,11 @@ import { BulkAlertAssigneesPanel } from './alert_bulk_assignees';
 import * as i18n from './translations';
 import { useSetAlertAssignees } from './use_set_alert_assignees';
 
+export const ALERT_ASSIGNEE_ACTION_IDS = {
+  assign: 'manage-alert-assignees',
+  unassignAll: 'remove-all-alert-assignees',
+} as const;
+
 export interface UseBulkAlertAssigneesItemsProps {
   onAssigneesUpdate?: () => void;
   alertAssignments?: string[];
@@ -89,22 +94,26 @@ export const useBulkAlertAssigneesItems = ({
       hasAlertsUpdate && isPlatinumPlus
         ? [
             {
-              key: 'manage-alert-assignees',
+              key: ALERT_ASSIGNEE_ACTION_IDS.assign,
               'data-test-subj': 'alert-assignees-context-menu-item',
               name: i18n.ALERT_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE,
               panel: 2,
               label: i18n.ALERT_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE,
               disableOnQuery: true,
               disable: false,
+              icon: 'users' as const,
+              groupId: 'assignees',
             },
             {
-              key: 'remove-all-alert-assignees',
+              key: ALERT_ASSIGNEE_ACTION_IDS.unassignAll,
               'data-test-subj': 'remove-alert-assignees-menu-item',
               name: i18n.REMOVE_ALERT_ASSIGNEES_CONTEXT_MENU_TITLE,
               label: i18n.REMOVE_ALERT_ASSIGNEES_CONTEXT_MENU_TITLE,
               disableOnQuery: true,
               onClick: onRemoveAllAssignees,
               disable: alertAssignments ? isEmpty(alertAssignments) : false,
+              icon: 'users' as const,
+              groupId: 'assignees',
             },
           ]
         : [],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_tags_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_tags_items.test.tsx
@@ -61,6 +61,10 @@ describe('useBulkAlertTagsItems', () => {
     expect(result.current.alertTagsItems[0]['data-test-subj']).toEqual(
       'alert-tags-context-menu-item'
     );
+    expect(result.current.alertTagsItems[0]).toMatchObject({
+      icon: 'tag',
+      groupId: 'tags',
+    });
     expect(result.current.alertTagsPanels[0]['data-test-subj']).toEqual(
       'alert-tags-context-menu-panel'
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_tags_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_tags_items.tsx
@@ -14,6 +14,8 @@ import { BulkAlertTagsPanel } from './alert_bulk_tags';
 import * as i18n from './translations';
 import { useSetAlertTags } from './use_set_alert_tags';
 
+export const ALERT_TAG_ACTION_ID = 'manage-alert-tags';
+
 export interface UseBulkAlertTagsItemsProps {
   refetch?: () => void;
 }
@@ -42,12 +44,14 @@ export const useBulkAlertTagsItems = ({ refetch }: UseBulkAlertTagsItemsProps) =
       hasAlertsUpdate
         ? [
             {
-              key: 'manage-alert-tags',
+              key: ALERT_TAG_ACTION_ID,
               'data-test-subj': 'alert-tags-context-menu-item',
               name: i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE,
               panel: 1,
               label: i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE,
               disableOnQuery: true,
+              icon: 'tag' as const,
+              groupId: 'tags',
             },
           ]
         : [],

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_actions.test.tsx
@@ -9,6 +9,7 @@ import { renderHook } from '@testing-library/react';
 import React from 'react';
 import { mockAttributes } from './mocks';
 import { DEFAULT_ACTIONS, useActions } from './use_actions';
+import { VisualizationContextMenuActions } from './types';
 import { TestProviders } from '../../mock';
 
 jest.mock('./use_add_to_existing_case', () => {
@@ -83,12 +84,29 @@ describe(`useActions`, () => {
     expect(result.current[0].order).toEqual(4);
     expect(result.current[1].id).toEqual('addToNewCase');
     expect(result.current[1].order).toEqual(3);
+    expect(result.current[1].grouping?.[0].id).toEqual('addToCase');
     expect(result.current[2].id).toEqual('addToExistingCase');
     expect(result.current[2].order).toEqual(2);
+    expect(result.current[2].grouping?.[0].id).toEqual('addToCase');
     expect(result.current[3].id).toEqual('saveToLibrary');
     expect(result.current[3].order).toEqual(1);
     expect(result.current[4].id).toEqual('openInLens');
     expect(result.current[4].order).toEqual(0);
+  });
+
+  it('does not group a single case action', () => {
+    const { result } = renderHook(
+      () =>
+        useActions({
+          ...props,
+          withActions: [VisualizationContextMenuActions.addToNewCase],
+        }),
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    expect(result.current.find(({ id }) => id === 'addToNewCase')?.grouping).toBeUndefined();
   });
 
   it('should render extra actions if available', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_actions.ts
@@ -11,6 +11,7 @@ import type { Action, Trigger } from '@kbn/ui-actions-plugin/public';
 import { createAction } from '@kbn/ui-actions-plugin/public';
 import type { ActionDefinition } from '@kbn/ui-actions-plugin/public/actions';
 import type { LensProps } from '@kbn/cases-plugin/public/types';
+import { ADD_TO_CASE } from '@kbn/response-ops-alerts-table';
 import { useKibana } from '../../lib/kibana/kibana_react';
 import { useAddToExistingCase } from './use_add_to_existing_case';
 import { useAddToNewCase } from './use_add_to_new_case';
@@ -41,6 +42,15 @@ export const INSPECT_ACTION: VisualizationContextMenuActions[] = [
 export const VISUALIZATION_CONTEXT_MENU_TRIGGER: Trigger = {
   id: 'VISUALIZATION_CONTEXT_MENU_TRIGGER',
 };
+
+const ADD_TO_CASE_GROUP = [
+  {
+    id: 'addToCase',
+    getDisplayName: () => ADD_TO_CASE,
+    getIconType: () => 'casesApp' as const,
+    order: 3,
+  },
+];
 
 const ACTION_DEFINITION: Record<
   VisualizationContextMenuActions,
@@ -137,6 +147,9 @@ export const useActions = ({
   });
 
   const { openSaveVisualizationFlyout, disableVisualizations } = useSaveToLibrary({ attributes });
+  const groupCaseActions =
+    withActions.includes(VisualizationContextMenuActions.addToNewCase) &&
+    withActions.includes(VisualizationContextMenuActions.addToExistingCase);
 
   const allActions: Action[] = useMemo(
     () =>
@@ -151,6 +164,7 @@ export const useActions = ({
         }),
         createAction({
           ...ACTION_DEFINITION[VisualizationContextMenuActions.addToNewCase],
+          grouping: groupCaseActions ? ADD_TO_CASE_GROUP : undefined,
           execute: async () => {
             onAddToNewCaseClicked();
             topValuesPopover.closePopover();
@@ -161,6 +175,7 @@ export const useActions = ({
         }),
         createAction({
           ...ACTION_DEFINITION[VisualizationContextMenuActions.addToExistingCase],
+          grouping: groupCaseActions ? ADD_TO_CASE_GROUP : undefined,
           execute: async () => {
             onAddToExistingCaseClicked();
           },
@@ -200,6 +215,7 @@ export const useActions = ({
       canUseEditor,
       disableVisualizations,
       extraActions,
+      groupCaseActions,
       inspectActionProps,
       isAddToExistingCaseDisabled,
       isAddToNewCaseDisabled,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/action_menu_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/action_menu_items.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiIcon } from '@elastic/eui';
+import type { EuiContextMenuPanelItemDescriptor, EuiIconProps, IconType } from '@elastic/eui';
+import type { ReactNode } from 'react';
+import React from 'react';
+
+export const ACTION_MENU_GROUP_SEPARATOR_TEST_ID = 'securityActionMenuGroupSeparator';
+
+interface ActionMenuGroupSeparator {
+  key: string;
+  isSeparator: true;
+  'data-test-subj': typeof ACTION_MENU_GROUP_SEPARATOR_TEST_ID;
+}
+
+export const isActionMenuItem = (
+  item: EuiContextMenuPanelItemDescriptor
+): item is Extract<EuiContextMenuPanelItemDescriptor, { name: ReactNode }> => 'name' in item;
+
+export const withActionIcon = (
+  items: readonly EuiContextMenuPanelItemDescriptor[],
+  icon: IconType
+): EuiContextMenuPanelItemDescriptor[] =>
+  items.map((item) => (isActionMenuItem(item) ? { ...item, icon } : item));
+
+export const withActionIcons = (
+  items: readonly EuiContextMenuPanelItemDescriptor[],
+  iconsByActionId: Readonly<Record<string, IconType>>
+): EuiContextMenuPanelItemDescriptor[] =>
+  items.map((item) => {
+    if (!isActionMenuItem(item) || typeof item.key !== 'string') {
+      return item;
+    }
+
+    const icon = iconsByActionId[item.key];
+
+    return icon ? { ...item, icon } : item;
+  });
+
+export const withStatusDotIcons = (
+  items: readonly EuiContextMenuPanelItemDescriptor[],
+  colorsByTestSubject: Readonly<Record<string, EuiIconProps['color']>>,
+  defaultColor?: EuiIconProps['color']
+): EuiContextMenuPanelItemDescriptor[] =>
+  items.map((item) => {
+    if (!isActionMenuItem(item)) {
+      return item;
+    }
+
+    const testSubject = item['data-test-subj'];
+    const color =
+      (typeof testSubject === 'string' ? colorsByTestSubject[testSubject] : undefined) ??
+      defaultColor;
+
+    if (!color) {
+      return item;
+    }
+
+    return {
+      ...item,
+      icon: <EuiIcon type="dot" color={color} aria-hidden />,
+    };
+  });
+
+export const getActionMenuGroupSeparator = (key: string): ActionMenuGroupSeparator => ({
+  key,
+  isSeparator: true,
+  'data-test-subj': ACTION_MENU_GROUP_SEPARATOR_TEST_ID,
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/action_menu/alert_summary_action_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/action_menu/alert_summary_action_menu.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiContextMenu } from '@elastic/eui';
+import type {
+  EuiContextMenuPanelDescriptor,
+  EuiContextMenuPanelItemDescriptor,
+} from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { withActionIcons } from '../../../../common/utils/action_menu_items';
+import { ALERT_TAG_ACTION_ID } from '../../../../common/components/toolbar/bulk_actions/use_bulk_alert_tags_items';
+import { ADD_TO_CASE_ACTION_IDS } from '../../alerts_table/timeline_actions/use_add_to_case_actions';
+
+interface AlertSummaryActionMenuProps {
+  addToCaseItems: EuiContextMenuPanelItemDescriptor[];
+  alertTagsItems: EuiContextMenuPanelItemDescriptor[];
+  panels: EuiContextMenuPanelDescriptor[];
+}
+
+const ACTION_ICONS_BY_ID = {
+  [ADD_TO_CASE_ACTION_IDS.addToCase]: 'briefcase',
+  [ALERT_TAG_ACTION_ID]: 'tag',
+} as const;
+
+export const AlertSummaryActionMenu = ({
+  addToCaseItems,
+  alertTagsItems,
+  panels,
+}: AlertSummaryActionMenuProps) => {
+  const items = useMemo(
+    () => withActionIcons([...addToCaseItems, ...alertTagsItems], ACTION_ICONS_BY_ID),
+    [addToCaseItems, alertTagsItems]
+  );
+
+  return <EuiContextMenu initialPanelId={0} panels={[{ id: 0, items }, ...panels]} />;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import {
   MORE_ACTIONS_BUTTON_TEST_ID,
   MoreActionsRowControlColumn,
@@ -45,15 +45,16 @@ describe('MoreActionsRowControlColumn', () => {
       'kibana.alert.workflow_tags': [],
     };
 
-    const { getByTestId } = render(<MoreActionsRowControlColumn alert={mockAlert} />);
+    const { findByTestId, getByTestId } = render(<MoreActionsRowControlColumn alert={mockAlert} />);
 
     const button = getByTestId(MORE_ACTIONS_BUTTON_TEST_ID);
     expect(button).toBeInTheDocument();
 
     await userEvent.click(button);
 
-    expect(getByTestId('add-to-existing-case-action')).toBeInTheDocument();
-    expect(getByTestId('add-to-new-case-action')).toBeInTheDocument();
+    fireEvent.click(getByTestId('add-to-case-action'));
+    expect(await findByTestId('add-to-existing-case-action')).toBeInTheDocument();
+    expect(await findByTestId('add-to-new-case-action')).toBeInTheDocument();
     expect(getByTestId('alert-tags-context-menu-item')).toBeInTheDocument();
   });
 
@@ -90,8 +91,7 @@ describe('MoreActionsRowControlColumn', () => {
 
     await userEvent.click(button);
 
-    expect(queryByTestId('add-to-existing-case-action')).not.toBeInTheDocument();
-    expect(queryByTestId('add-to-new-case-action')).not.toBeInTheDocument();
+    expect(queryByTestId('add-to-case-action')).not.toBeInTheDocument();
   });
 
   it('should not show tags actions if user is not authorized', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.tsx
@@ -6,13 +6,14 @@
  */
 
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
 import type { EcsSecurityExtension } from '@kbn/securitysolution-ecs';
 import type { Alert } from '@kbn/alerting-types';
 import { i18n } from '@kbn/i18n';
 import { expandDottedObject } from '../../../../../common/utils/expand_dotted';
 import { useAlertTagsActions } from '../../alerts_table/timeline_actions/use_alert_tags_actions';
 import { useAddToCaseActions } from '../../alerts_table/timeline_actions/use_add_to_case_actions';
+import { AlertSummaryActionMenu } from '../action_menu/alert_summary_action_menu';
 
 export const MORE_ACTIONS_BUTTON_TEST_ID = 'alert-summary-table-row-action-more-actions';
 
@@ -72,7 +73,7 @@ export const MoreActionsRowControlColumn = memo(({ alert }: MoreActionsRowContro
     [alert]
   );
 
-  const { addToCaseActionItems } = useAddToCaseActions({
+  const { addToCaseActionItems, addToCaseActionPanels = [] } = useAddToCaseActions({
     ecsData: ecsAlert,
     nonEcsData,
     onMenuItemClick: closePopover,
@@ -84,17 +85,6 @@ export const MoreActionsRowControlColumn = memo(({ alert }: MoreActionsRowContro
     ecsRowData: ecsAlert,
   });
 
-  const panels = useMemo(
-    () => [
-      {
-        id: 0,
-        items: [...addToCaseActionItems, ...alertTagsItems],
-      },
-      ...alertTagsPanels,
-    ],
-    [addToCaseActionItems, alertTagsItems, alertTagsPanels]
-  );
-
   return (
     <EuiPopover
       aria-label={MORE_ACTIONS_BUTTON_ARIA_LABEL}
@@ -103,7 +93,11 @@ export const MoreActionsRowControlColumn = memo(({ alert }: MoreActionsRowContro
       isOpen={isPopoverOpen}
       panelPaddingSize="none"
     >
-      <EuiContextMenu initialPanelId={0} panels={panels} />
+      <AlertSummaryActionMenu
+        addToCaseItems={addToCaseActionItems}
+        alertTagsItems={alertTagsItems}
+        panels={[...addToCaseActionPanels, ...alertTagsPanels]}
+      />
     </EuiPopover>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/action_menu/alert_row_action_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/action_menu/alert_row_action_menu.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { AlertRowActionMenu } from './alert_row_action_menu';
+
+const createItem = (name: string): EuiContextMenuPanelItemDescriptor => ({
+  key: name,
+  name,
+});
+
+describe('AlertRowActionMenu', () => {
+  it('orders alert action groups consistently', () => {
+    render(
+      <AlertRowActionMenu
+        addToCaseItems={[createItem('Add to case')]}
+        addToChatItems={[createItem('Add to chat')]}
+        alertAssigneeItems={[createItem('Assign alert')]}
+        alertTagItems={[createItem('Apply alert tags')]}
+        canCreateEndpointEventFilters={false}
+        eventFilterItems={[]}
+        exceptionItems={[createItem('Add endpoint exception')]}
+        hasAgent
+        isAlert
+        osqueryItems={[createItem('Run Osquery')]}
+        panels={[]}
+        runAlertWorkflowItems={[createItem('Run workflow')]}
+        runDocumentWorkflowItems={[]}
+        statusItems={[createItem('Mark as open')]}
+      />
+    );
+
+    expect(screen.getAllByRole('menuitem').map(({ textContent }) => textContent)).toEqual([
+      'Mark as open',
+      'Assign alert',
+      'Add to case',
+      'Apply alert tags',
+      'Add endpoint exception',
+      'Run workflow',
+      'Run Osquery',
+      'Add to chat',
+    ]);
+    expect(screen.getAllByTestId('securityActionMenuGroupSeparator')).toHaveLength(4);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/action_menu/alert_row_action_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/action_menu/alert_row_action_menu.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiContextMenu } from '@elastic/eui';
+import type {
+  EuiContextMenuPanelDescriptor,
+  EuiContextMenuPanelItemDescriptor,
+} from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { ALERT_EXCEPTION_ACTION_IDS } from '../use_add_exception_actions';
+import {
+  getActionMenuGroupSeparator,
+  withActionIcons,
+  withStatusDotIcons,
+} from '../../../../../common/utils/action_menu_items';
+import { ALERT_TAG_ACTION_ID } from '../../../../../common/components/toolbar/bulk_actions/use_bulk_alert_tags_items';
+import { ALERT_ASSIGNEE_ACTION_IDS } from '../../../../../common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items';
+import { OSQUERY_ACTION_ID } from '../../../osquery/osquery_action_item';
+import { ADD_TO_CASE_ACTION_IDS } from '../use_add_to_case_actions';
+import { ADD_TO_CHAT_ACTION_ID } from '../use_add_to_chat_action';
+import { EVENT_FILTER_ACTION_ID } from '../use_event_filter_action';
+import { RUN_ALERT_WORKFLOW_ACTION_ID } from '../use_run_alert_workflow_panel';
+import { RUN_DOCUMENT_WORKFLOW_ACTION_ID } from '../use_run_document_workflow_panel';
+
+interface AlertRowActionMenuProps {
+  addToCaseItems: EuiContextMenuPanelItemDescriptor[];
+  addToChatItems: EuiContextMenuPanelItemDescriptor[];
+  alertAssigneeItems: EuiContextMenuPanelItemDescriptor[];
+  alertTagItems: EuiContextMenuPanelItemDescriptor[];
+  canCreateEndpointEventFilters: boolean;
+  eventFilterItems: EuiContextMenuPanelItemDescriptor[];
+  exceptionItems: EuiContextMenuPanelItemDescriptor[];
+  hasAgent: boolean;
+  isAlert: boolean;
+  osqueryItems: EuiContextMenuPanelItemDescriptor[];
+  panels: EuiContextMenuPanelDescriptor[];
+  runAlertWorkflowItems: EuiContextMenuPanelItemDescriptor[];
+  runDocumentWorkflowItems: EuiContextMenuPanelItemDescriptor[];
+  statusItems: EuiContextMenuPanelItemDescriptor[];
+}
+
+const ALERT_STATUS_ICON_COLORS = {
+  'acknowledged-alert-status': 'primary',
+  'alert-close-context-menu-item': 'subdued',
+  'open-alert-status': 'danger',
+} as const;
+
+const ACTION_ICONS_BY_ID = {
+  [ADD_TO_CASE_ACTION_IDS.addToCase]: 'briefcase',
+  [ADD_TO_CHAT_ACTION_ID]: 'comment',
+  [ALERT_ASSIGNEE_ACTION_IDS.assign]: 'users',
+  [ALERT_ASSIGNEE_ACTION_IDS.unassignAll]: 'users',
+  [ALERT_EXCEPTION_ACTION_IDS.addEndpointException]: 'bullseye',
+  [ALERT_EXCEPTION_ACTION_IDS.addRuleException]: 'filter',
+  [ALERT_TAG_ACTION_ID]: 'tag',
+  [EVENT_FILTER_ACTION_ID]: 'filter',
+  [OSQUERY_ACTION_ID]: 'console',
+  [RUN_ALERT_WORKFLOW_ACTION_ID]: 'workflow',
+  [RUN_DOCUMENT_WORKFLOW_ACTION_ID]: 'workflow',
+} as const;
+
+export const AlertRowActionMenu = ({
+  addToCaseItems,
+  addToChatItems,
+  alertAssigneeItems,
+  alertTagItems,
+  canCreateEndpointEventFilters,
+  eventFilterItems,
+  exceptionItems,
+  hasAgent,
+  isAlert,
+  osqueryItems,
+  panels,
+  runAlertWorkflowItems,
+  runDocumentWorkflowItems,
+  statusItems,
+}: AlertRowActionMenuProps) => {
+  const items = useMemo(() => {
+    const alertManagementItems = [...alertAssigneeItems, ...addToCaseItems, ...alertTagItems];
+    const responseActionItems = [
+      ...(isAlert ? runAlertWorkflowItems : runDocumentWorkflowItems),
+      ...(hasAgent ? osqueryItems : []),
+    ];
+    const actionGroups = isAlert
+      ? [statusItems, alertManagementItems, exceptionItems, responseActionItems, addToChatItems]
+      : [
+          addToCaseItems,
+          canCreateEndpointEventFilters ? eventFilterItems : [],
+          responseActionItems,
+        ];
+    const visibleActionGroups = actionGroups.filter((group) => group.length > 0);
+
+    const orderedItems = visibleActionGroups.flatMap((group, index) => [
+      ...group,
+      ...(index < visibleActionGroups.length - 1
+        ? [getActionMenuGroupSeparator(`separator-${index}`)]
+        : []),
+    ]);
+
+    return withStatusDotIcons(
+      withActionIcons(orderedItems, ACTION_ICONS_BY_ID),
+      ALERT_STATUS_ICON_COLORS
+    );
+  }, [
+    addToCaseItems,
+    addToChatItems,
+    alertAssigneeItems,
+    alertTagItems,
+    canCreateEndpointEventFilters,
+    eventFilterItems,
+    exceptionItems,
+    hasAgent,
+    isAlert,
+    osqueryItems,
+    runAlertWorkflowItems,
+    runDocumentWorkflowItems,
+    statusItems,
+  ]);
+
+  return (
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={[{ id: 0, items }, ...panels]}
+      data-test-subj="actions-context-menu"
+    />
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.test.tsx
@@ -131,6 +131,7 @@ jest.mock('./use_add_to_chat_action', () => ({
 }));
 
 const actionMenuButton = 'timeline-context-menu-button';
+const addToCaseButton = 'add-to-case-action';
 const addToExistingCaseButton = 'add-to-existing-case-action';
 const addToNewCaseButton = 'add-to-new-case-action';
 const markAsOpenButton = 'open-alert-status';
@@ -182,7 +183,7 @@ jest.mock(
 
 describe('Alert table context menu', () => {
   describe('Case actions', () => {
-    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsPage', () => {
+    test('it render AddToCase context menu item if timelineId === TimelineId.detectionsPage', async () => {
       const wrapper = render(
         <TestProviders>
           <AlertContextMenu {...props} scopeId={TableId.alertsOnAlertsPage} />
@@ -191,8 +192,9 @@ describe('Alert table context menu', () => {
 
       fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
-      expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
-      expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
+      fireEvent.click(wrapper.getByTestId(addToCaseButton));
+      expect(await wrapper.findByTestId(addToExistingCaseButton)).toBeTruthy();
+      expect(await wrapper.findByTestId(addToNewCaseButton)).toBeTruthy();
     });
 
     test('it render AddToCase context menu item if timelineId === TimelineId.detectionsRulesDetailsPage', () => {
@@ -204,8 +206,7 @@ describe('Alert table context menu', () => {
 
       fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
-      expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
-      expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
+      expect(wrapper.getByTestId(addToCaseButton)).toBeTruthy();
     });
 
     test('it render AddToCase context menu item if timelineId === TimelineId.active', () => {
@@ -217,8 +218,7 @@ describe('Alert table context menu', () => {
 
       fireEvent.click(wrapper.getByTestId(actionMenuButton));
 
-      expect(wrapper.getByTestId(addToExistingCaseButton)).toBeTruthy();
-      expect(wrapper.getByTestId(addToNewCaseButton)).toBeTruthy();
+      expect(wrapper.getByTestId(addToCaseButton)).toBeTruthy();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 
-import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { indexOf } from 'lodash';
 import { useSelector } from 'react-redux-v7';
 import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
@@ -50,11 +50,12 @@ import { ATTACH_ALERT_TO_CASE_FOR_ROW } from '../../../../timelines/components/t
 import { selectTimelineById } from '../../../../timelines/store/selectors';
 import { useEventFilterAction } from './use_event_filter_action';
 import { useAddToCaseActions } from './use_add_to_case_actions';
-import type { AlertTableContextMenuItem } from '../types';
 import { useAlertTagsActions } from './use_alert_tags_actions';
 import { useAlertAssigneesActions } from './use_alert_assignees_actions';
 import { useAddToChatAction } from './use_add_to_chat_action';
 import { timelineDefaults } from '../../../../timelines/store/defaults';
+import { AlertRowActionMenu } from './action_menu/alert_row_action_menu';
+
 interface AlertContextMenuProps {
   ariaLabel?: string;
   ariaRowindex: number;
@@ -104,7 +105,7 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
     }));
   }, [ecsRowData]);
 
-  const { addToCaseActionItems } = useAddToCaseActions({
+  const { addToCaseActionItems, addToCaseActionPanels = [] } = useAddToCaseActions({
     ecsData: ecsRowData,
     nonEcsData: flattenedEcsData,
     onMenuItemClick,
@@ -262,49 +263,30 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
     alertId: ecsRowData._id,
   });
 
-  const items: AlertTableContextMenuItem[] = useMemo(
-    () =>
-      !isEvent && ruleId
-        ? [
-            ...addToCaseActionItems,
-            ...statusActionItems,
-            ...runWorkflowMenuItem,
-            ...alertTagsItems,
-            ...alertAssigneesItems,
-            ...exceptionActionItems,
-            ...(agentId ? osqueryActionItems : []),
-            ...addToChatActionItems,
-          ]
-        : [
-            ...addToCaseActionItems,
-            ...runDocumentWorkflowMenuItem,
-            ...(canCreateEndpointEventFilters ? eventFilterActionItems : []),
-            ...(agentId ? osqueryActionItems : []),
-          ],
-    [
-      runWorkflowMenuItem,
-      runDocumentWorkflowMenuItem,
-      isEvent,
-      ruleId,
-      addToCaseActionItems,
-      statusActionItems,
-      exceptionActionItems,
-      agentId,
-      osqueryActionItems,
-      eventFilterActionItems,
-      canCreateEndpointEventFilters,
-      alertTagsItems,
-      alertAssigneesItems,
-      addToChatActionItems,
-    ]
-  );
+  const isAlertActionMenu = !isEvent && Boolean(ruleId);
+  const hasItems = (
+    isAlertActionMenu
+      ? [
+          addToCaseActionItems,
+          statusActionItems,
+          runWorkflowMenuItem,
+          alertTagsItems,
+          alertAssigneesItems,
+          exceptionActionItems,
+          agentId ? osqueryActionItems : [],
+          addToChatActionItems,
+        ]
+      : [
+          addToCaseActionItems,
+          runDocumentWorkflowMenuItem,
+          canCreateEndpointEventFilters ? eventFilterActionItems : [],
+          agentId ? osqueryActionItems : [],
+        ]
+  ).some((actionItems) => actionItems.length > 0);
 
   const panels = useMemo(
     () => [
-      {
-        id: 0,
-        items,
-      },
+      ...addToCaseActionPanels,
       ...alertTagsPanels,
       ...alertAssigneesPanels,
       ...statusActionPanels,
@@ -312,7 +294,7 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
       ...runDocumentWorkflowPanels,
     ],
     [
-      items,
+      addToCaseActionPanels,
       alertTagsPanels,
       alertAssigneesPanels,
       statusActionPanels,
@@ -322,7 +304,6 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
   );
 
   const button = useMemo(() => {
-    const hasItems = !!items.length;
     const tooltipContent = hasItems ? i18n.MORE_ACTIONS : i18n.INSUFFICIENT_PRIVILEGES;
 
     return (
@@ -339,7 +320,7 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
         />
       </EuiToolTip>
     );
-  }, [ariaLabel, isPopoverOpen, onButtonClick, disabled, items.length]);
+  }, [ariaLabel, disabled, hasItems, isPopoverOpen, onButtonClick]);
 
   const osqueryFlyout = useMemo(() => {
     return (
@@ -366,10 +347,21 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps> = ({
             anchorPosition="downLeft"
             repositionOnScroll
           >
-            <EuiContextMenu
-              initialPanelId={0}
+            <AlertRowActionMenu
+              addToCaseItems={addToCaseActionItems}
+              addToChatItems={addToChatActionItems}
+              alertAssigneeItems={alertAssigneesItems}
+              alertTagItems={alertTagsItems}
+              canCreateEndpointEventFilters={canCreateEndpointEventFilters}
+              eventFilterItems={eventFilterActionItems}
+              exceptionItems={exceptionActionItems}
+              hasAgent={Boolean(agentId)}
+              isAlert={isAlertActionMenu}
+              osqueryItems={osqueryActionItems}
               panels={panels}
-              data-test-subj="actions-context-menu"
+              runAlertWorkflowItems={runWorkflowMenuItem}
+              runDocumentWorkflowItems={runDocumentWorkflowMenuItem}
+              statusItems={statusActionItems}
             />
           </EuiPopover>
         </EventsTdContent>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.test.tsx
@@ -74,6 +74,8 @@ describe('useAddBulkToTimelineAction', () => {
         onClick: expect.any(Function),
         key: 'add-bulk-to-timeline',
         'data-test-subj': 'investigate-bulk-in-timeline',
+        icon: 'timeline',
+        groupId: 'timeline',
       });
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
@@ -36,6 +36,8 @@ import { useSendBulkToTimeline } from './use_send_bulk_to_timeline';
 
 const { setEventsLoading } = dataTableActions;
 
+export const BULK_INVESTIGATE_IN_TIMELINE_ACTION_ID = 'add-bulk-to-timeline';
+
 export interface UseAddBulkToTimelineActionProps {
   /* filters being passed to the Alert/events table */
   localFilters: Filter[];
@@ -208,10 +210,12 @@ export const useAddBulkToTimelineAction = ({
         ? [
             {
               label: investigateInTimelineTitle,
-              key: 'add-bulk-to-timeline',
+              key: BULK_INVESTIGATE_IN_TIMELINE_ACTION_ID,
               'data-test-subj': 'investigate-bulk-in-timeline',
               disableOnQuery: disableActionOnSelectAll,
               onClick: onActionClick,
+              icon: 'timeline' as const,
+              groupId: 'timeline',
             },
           ]
         : [],

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_exception_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_exception_actions.tsx
@@ -14,6 +14,11 @@ import type { AlertTableContextMenuItem } from '../types';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useAlertsPrivileges } from '../../../containers/detection_engine/alerts/use_alerts_privileges';
 
+export const ALERT_EXCEPTION_ACTION_IDS = {
+  addEndpointException: 'add-endpoint-exception-menu-item',
+  addRuleException: 'add-exception-menu-item',
+} as const;
+
 export interface UseExceptionActionProps {
   isEndpointAlert: boolean;
   onAddExceptionTypeClick: (type?: ExceptionListTypeEnum) => void;
@@ -44,14 +49,14 @@ export const useAlertExceptionActions = ({
         ? []
         : [
             {
-              key: 'add-endpoint-exception-menu-item',
+              key: ALERT_EXCEPTION_ACTION_IDS.addEndpointException,
               'data-test-subj': 'add-endpoint-exception-menu-item',
               disabled: disabledAddEndpointException,
               onClick: handleEndpointExceptionModal,
               name: ACTION_ADD_ENDPOINT_EXCEPTION,
             },
             {
-              key: 'add-exception-menu-item',
+              key: ALERT_EXCEPTION_ACTION_IDS.addRuleException,
               'data-test-subj': 'add-exception-menu-item',
               disabled: disabledAddException,
               onClick: handleDetectionExceptionModal,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
@@ -7,7 +7,8 @@
 
 import React from 'react';
 import { EuiContextMenu, EuiPopover } from '@elastic/eui';
-import { render, screen, renderHook, act } from '@testing-library/react';
+import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useAddToCaseActions } from './use_add_to_case_actions';
 import { TestProviders } from '../../../../common/mock';
@@ -54,8 +55,11 @@ const addToNewCase = jest.fn().mockReturnValue(caseHooksReturnedValue);
 const addToExistingCase = jest.fn().mockReturnValue(caseHooksReturnedValue);
 const useKibanaMock = useKibana as jest.Mock;
 
-const renderContextMenu = (items: AlertTableContextMenuItem[]) => {
-  const panels = [{ id: 0, items }];
+const renderContextMenu = (
+  items: AlertTableContextMenuItem[],
+  actionPanels: EuiContextMenuPanelDescriptor[]
+) => {
+  const panels = [{ id: 0, items }, ...actionPanels];
   render(
     <EuiPopover
       aria-label="Context menu"
@@ -93,13 +97,9 @@ describe('useAddToCaseActions', () => {
     const { result } = renderHook(() => useAddToCaseActions(defaultProps), {
       wrapper: TestProviders,
     });
-    expect(result.current.addToCaseActionItems.length).toEqual(2);
-    expect(result.current.addToCaseActionItems[0]['data-test-subj']).toEqual(
-      'add-to-existing-case-action'
-    );
-    expect(result.current.addToCaseActionItems[1]['data-test-subj']).toEqual(
-      'add-to-new-case-action'
-    );
+    expect(result.current.addToCaseActionItems.length).toEqual(1);
+    expect(result.current.addToCaseActionItems[0]['data-test-subj']).toEqual('add-to-case-action');
+    expect(result.current.addToCaseActionPanels).toHaveLength(1);
   });
 
   it('should render case options when event is not alert ', () => {
@@ -109,7 +109,7 @@ describe('useAddToCaseActions', () => {
         wrapper: TestProviders,
       }
     );
-    expect(result.current.addToCaseActionItems.length).toEqual(2);
+    expect(result.current.addToCaseActionItems.length).toEqual(1);
   });
 
   it('should call useCasesAddToNewCaseFlyout with attachments only when step is not active', () => {
@@ -145,12 +145,15 @@ describe('useAddToCaseActions', () => {
       wrapper: TestProviders,
     });
 
-    expect(result.current.addToCaseActionItems.length).toEqual(2);
+    expect(result.current.addToCaseActionItems.length).toEqual(1);
 
-    renderContextMenu(result.current.addToCaseActionItems);
+    renderContextMenu(result.current.addToCaseActionItems, result.current.addToCaseActionPanels);
 
-    expect(screen.getByTestId('add-to-new-case-action')).toBeInTheDocument();
-    await userEvent.click(screen.getByTestId('add-to-new-case-action'));
+    await userEvent.click(screen.getByTestId('add-to-case-action'));
+    expect(await screen.findByTestId('add-to-new-case-action')).toBeInTheDocument();
+    expect(await screen.findByTestId('add-to-case-submit')).toBeDisabled();
+    fireEvent.click(await screen.findByTestId('add-to-new-case-action'));
+    fireEvent.click(await screen.findByTestId('add-to-case-submit'));
 
     expect(refetch).toHaveBeenCalled();
   });
@@ -160,7 +163,7 @@ describe('useAddToCaseActions', () => {
       wrapper: TestProviders,
     });
 
-    expect(result.current.addToCaseActionItems.length).toEqual(2);
+    expect(result.current.addToCaseActionItems.length).toEqual(1);
 
     addToNewCase.mock.calls[0][0].onSuccess();
 
@@ -172,12 +175,14 @@ describe('useAddToCaseActions', () => {
       wrapper: TestProviders,
     });
 
-    expect(result.current.addToCaseActionItems.length).toEqual(2);
+    expect(result.current.addToCaseActionItems.length).toEqual(1);
 
-    renderContextMenu(result.current.addToCaseActionItems);
+    renderContextMenu(result.current.addToCaseActionItems, result.current.addToCaseActionPanels);
 
-    expect(screen.getByTestId('add-to-existing-case-action')).toBeInTheDocument();
-    await userEvent.click(screen.getByTestId('add-to-existing-case-action'));
+    await userEvent.click(screen.getByTestId('add-to-case-action'));
+    expect(await screen.findByTestId('add-to-existing-case-action')).toBeInTheDocument();
+    fireEvent.click(await screen.findByTestId('add-to-existing-case-action'));
+    fireEvent.click(await screen.findByTestId('add-to-case-submit'));
 
     expect(refetch).toHaveBeenCalled();
   });
@@ -187,7 +192,7 @@ describe('useAddToCaseActions', () => {
       wrapper: TestProviders,
     });
 
-    expect(result.current.addToCaseActionItems.length).toEqual(2);
+    expect(result.current.addToCaseActionItems.length).toEqual(1);
 
     addToExistingCase.mock.calls[0][0].onSuccess();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import { useCallback, useMemo } from 'react';
+import { AddToCaseActionPanel, ADD_TO_CASE, CASE_TYPE } from '@kbn/response-ops-alerts-table';
+import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import React, { useCallback, useMemo } from 'react';
 import { SECURITY_ALERT_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common';
 import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
@@ -16,12 +18,25 @@ import { ADD_TO_EXISTING_CASE, ADD_TO_NEW_CASE } from '../translations';
 import type { AlertTableContextMenuItem } from '../types';
 import { generateEventAttachmentWithoutOwner } from '../../../../cases/attachments/event/utils';
 
+export const ADD_TO_CASE_ACTION_IDS = {
+  addToCase: 'add-to-case-action',
+  addToExistingCase: 'add-to-existing-case-action',
+  addToNewCase: 'add-to-new-case-action',
+} as const;
+
+const ADD_TO_CASE_PANEL_ID = 'add-to-case-panel';
+
 export interface UseAddToCaseActions {
   onMenuItemClick: () => void;
   ariaLabel?: string;
   ecsData: Ecs;
   nonEcsData: TimelineNonEcsData[];
   onSuccess?: () => Promise<void>;
+  onActionClick?: (
+    actionId:
+      | typeof ADD_TO_CASE_ACTION_IDS.addToNewCase
+      | typeof ADD_TO_CASE_ACTION_IDS.addToExistingCase
+  ) => void;
   refetch?: (() => void) | undefined;
 }
 
@@ -31,6 +46,7 @@ export const useAddToCaseActions = ({
   ecsData,
   nonEcsData,
   onSuccess,
+  onActionClick,
   refetch,
 }: UseAddToCaseActions) => {
   const { cases: casesUi } = useKibana().services;
@@ -94,51 +110,74 @@ export const useAddToCaseActions = ({
   const handleAddToNewCaseClick = useCallback(() => {
     // TODO rename this, this is really `closePopover()`
     onMenuItemClick();
+    onActionClick?.(ADD_TO_CASE_ACTION_IDS.addToNewCase);
     createCaseFlyout.open({
       attachments: caseAttachments,
     });
-  }, [onMenuItemClick, createCaseFlyout, caseAttachments]);
+  }, [onMenuItemClick, onActionClick, createCaseFlyout, caseAttachments]);
 
   const handleAddToExistingCaseClick = useCallback(() => {
     // TODO rename this, this is really `closePopover()`
     onMenuItemClick();
+    onActionClick?.(ADD_TO_CASE_ACTION_IDS.addToExistingCase);
     selectCaseModal.open({
       getAttachments: () => caseAttachments,
     });
-  }, [caseAttachments, onMenuItemClick, selectCaseModal]);
+  }, [caseAttachments, onActionClick, onMenuItemClick, selectCaseModal]);
 
   const addToCaseActionItems: AlertTableContextMenuItem[] = useMemo(() => {
     if (userCasesPermissions.createComment && userCasesPermissions.read) {
       return [
-        // add to existing case menu item
         {
           'aria-label': ariaLabel,
-          'data-test-subj': 'add-to-existing-case-action',
-          key: 'add-to-existing-case-action',
-          onClick: handleAddToExistingCaseClick,
-          name: ADD_TO_EXISTING_CASE,
-        },
-        // add to new case menu item
-        {
-          'aria-label': ariaLabel,
-          'data-test-subj': 'add-to-new-case-action',
-          key: 'add-to-new-case-action',
-          onClick: handleAddToNewCaseClick,
-          name: ADD_TO_NEW_CASE,
+          'data-test-subj': ADD_TO_CASE_ACTION_IDS.addToCase,
+          key: ADD_TO_CASE_ACTION_IDS.addToCase,
+          name: ADD_TO_CASE,
+          panel: ADD_TO_CASE_PANEL_ID,
         },
       ];
     }
     return [];
-  }, [
-    userCasesPermissions.createComment,
-    userCasesPermissions.read,
-    ariaLabel,
-    handleAddToExistingCaseClick,
-    handleAddToNewCaseClick,
-  ]);
+  }, [userCasesPermissions.createComment, userCasesPermissions.read, ariaLabel]);
+  const addToCaseActionPanels: EuiContextMenuPanelDescriptor[] = useMemo(
+    () =>
+      userCasesPermissions.createComment && userCasesPermissions.read
+        ? [
+            {
+              id: ADD_TO_CASE_PANEL_ID,
+              title: CASE_TYPE,
+              content: (
+                <AddToCaseActionPanel
+                  actions={[
+                    {
+                      id: ADD_TO_CASE_ACTION_IDS.addToNewCase,
+                      label: ADD_TO_NEW_CASE,
+                      dataTestSubj: ADD_TO_CASE_ACTION_IDS.addToNewCase,
+                      onClick: handleAddToNewCaseClick,
+                    },
+                    {
+                      id: ADD_TO_CASE_ACTION_IDS.addToExistingCase,
+                      label: ADD_TO_EXISTING_CASE,
+                      dataTestSubj: ADD_TO_CASE_ACTION_IDS.addToExistingCase,
+                      onClick: handleAddToExistingCaseClick,
+                    },
+                  ]}
+                />
+              ),
+            },
+          ]
+        : [],
+    [
+      handleAddToExistingCaseClick,
+      handleAddToNewCaseClick,
+      userCasesPermissions.createComment,
+      userCasesPermissions.read,
+    ]
+  );
 
   return {
     addToCaseActionItems,
+    addToCaseActionPanels,
     handleAddToNewCaseClick,
     handleAddToExistingCaseClick,
   };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_chat_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_chat_action.tsx
@@ -16,6 +16,8 @@ import { SecurityAgentBuilderAttachments } from '../../../../../common/constants
 import type { AlertTableContextMenuItem } from '../types';
 import * as i18n from '../../../../agent_builder/components/translations';
 
+export const ADD_TO_CHAT_ACTION_ID = 'add-to-chat-action';
+
 export interface UseAddToChatActionParams {
   /**
    * ECS row data as field/value pairs (already available in alert_context_menu).
@@ -70,6 +72,7 @@ export const useAddToChatAction = ({
 
     return [
       {
+        key: ADD_TO_CHAT_ACTION_ID,
         name: i18n.ADD_TO_CHAT,
         'data-test-subj': 'add-to-chat-action',
         disabled: !hasValidAgentBuilderLicense,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_event_filter_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_event_filter_action.tsx
@@ -9,6 +9,8 @@ import { useMemo } from 'react';
 import { ACTION_ADD_EVENT_FILTER } from '../translations';
 import type { AlertTableContextMenuItem } from '../types';
 
+export const EVENT_FILTER_ACTION_ID = 'add-event-filter-menu-item';
+
 export const useEventFilterAction = ({
   onAddEventFilterClick,
   disabled = false,
@@ -21,7 +23,7 @@ export const useEventFilterAction = ({
   const eventFilterActionItems = useMemo(
     (): AlertTableContextMenuItem[] => [
       {
-        key: 'add-event-filter-menu-item',
+        key: EVENT_FILTER_ACTION_ID,
         'data-test-subj': 'add-event-filter-menu-item',
         onClick: onAddEventFilterClick,
         disabled,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
@@ -34,6 +34,8 @@ import { ALERTS_ACTIONS } from '../../../../common/lib/apm/user_actions';
 import { defaultUdtHeaders } from '../../../../timelines/components/timeline/body/column_headers/default_headers';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 
+export const INVESTIGATE_IN_TIMELINE_ACTION_ID = 'investigate-in-timeline-action-item';
+
 interface UseInvestigateInTimelineActionProps {
   ecsRowData?: Ecs | Ecs[] | null;
   onInvestigateInTimelineAlertClick?: () => void;
@@ -205,7 +207,7 @@ export const useInvestigateInTimeline = ({
       canInvestigateInTimeline
         ? [
             {
-              key: 'investigate-in-timeline-action-item',
+              key: INVESTIGATE_IN_TIMELINE_ACTION_ID,
               'data-test-subj': 'investigate-in-timeline-action-item',
               disabled: ecsRowData == null,
               onClick: investigateInTimelineAlertClick,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel.tsx
@@ -59,6 +59,7 @@ export const AlertWorkflowsPanel = ({ alertIds, onClose, onExecute }: AlertWorkf
 export const RUN_WORKFLOW_PANEL_ID = 'RUN_WORKFLOW_PANEL_ID';
 export const RUN_WORKFLOW_BULK_PANEL_ID = 'BULK_RUN_WORKFLOW_PANEL_ID';
 export const RUN_WORKFLOWS_PANEL_WIDTH = 400;
+export const RUN_ALERT_WORKFLOW_ACTION_ID = 'run-workflow-action';
 
 export interface UseRunAlertWorkflowPanelProps {
   /** ECS document for the selected alert row. */
@@ -90,7 +91,7 @@ export const useRunAlertWorkflowPanel = ({
       {
         'aria-label': i18n.CONTEXT_MENU_RUN_WORKFLOW,
         'data-test-subj': 'run-workflow-action',
-        key: 'run-workflow-action',
+        key: RUN_ALERT_WORKFLOW_ACTION_ID,
         name: i18n.CONTEXT_MENU_RUN_WORKFLOW,
         panel: RUN_WORKFLOW_PANEL_ID,
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel.test.tsx
@@ -143,6 +143,7 @@ describe('useRunDocumentWorkflowPanel', () => {
       );
       expect(result.current.runWorkflowMenuItem[0].key).toBe('run-document-workflow-action');
       expect(result.current.runWorkflowMenuItem[0].name).toBe(i18n.CONTEXT_MENU_RUN_WORKFLOW);
+      expect(result.current.runWorkflowMenuItem[0].icon).toBe('workflow');
       expect(result.current.runWorkflowMenuItem[0].panel).toBe(RUN_DOCUMENT_WORKFLOW_PANEL_ID);
 
       expect(result.current.runDocumentWorkflowPanel).toHaveLength(1);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel.tsx
@@ -54,6 +54,7 @@ export const DocumentWorkflowsPanel = ({
 
 export const RUN_DOCUMENT_WORKFLOW_PANEL_ID = 'RUN_DOCUMENT_WORKFLOW_PANEL_ID';
 export const RUN_DOCUMENT_WORKFLOWS_PANEL_WIDTH = 400;
+export const RUN_DOCUMENT_WORKFLOW_ACTION_ID = 'run-document-workflow-action';
 
 export interface UseRunDocumentWorkflowPanelProps {
   /** Full documents including _id, _index, and all source fields */
@@ -85,7 +86,8 @@ export const useRunDocumentWorkflowPanel = ({
       {
         'aria-label': i18n.CONTEXT_MENU_RUN_WORKFLOW,
         'data-test-subj': 'run-document-workflow-action',
-        key: 'run-document-workflow-action',
+        icon: 'workflow',
+        key: RUN_DOCUMENT_WORKFLOW_ACTION_ID,
         name: i18n.CONTEXT_MENU_RUN_WORKFLOW,
         panel: RUN_DOCUMENT_WORKFLOW_PANEL_ID,
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/osquery/osquery_action_item.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/osquery/osquery_action_item.tsx
@@ -12,8 +12,10 @@ interface IProps {
   handleClick: () => void;
 }
 
+export const OSQUERY_ACTION_ID = 'osquery-action-item';
+
 export const getOsqueryActionItem = ({ handleClick }: IProps): AlertTableContextMenuItem => ({
-  key: 'osquery-action-item',
+  key: OSQUERY_ACTION_ID,
   'data-test-subj': 'osquery-action-item',
   onClick: handleClick,
   name: ACTION_OSQUERY,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.test.tsx
@@ -52,5 +52,15 @@ describe('useBulkAlertActionItems', () => {
     it('should include "Mark as closed"', () => {
       expect(items.find((item) => item.key === 'close-alert-with-reason')).not.toBeUndefined();
     });
+    it('should add status group metadata and icons', () => {
+      items.forEach((item) => {
+        expect(item).toEqual(
+          expect.objectContaining({
+            groupId: 'status',
+            icon: expect.anything(),
+          })
+        );
+      });
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.tsx
@@ -9,9 +9,10 @@ import type {
   BulkActionsConfig,
   BulkActionsPanelConfig,
 } from '@kbn/response-ops-alerts-table/types';
-import { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { Filter } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
+import { EuiIcon } from '@elastic/eui';
 import type { TableId } from '@kbn/securitysolution-data-table';
 import { useBulkClosingReasonItems } from '@kbn/response-ops-detections-close-reason';
 import type { AlertClosingReason } from '../../../../common/types';
@@ -25,6 +26,11 @@ import * as i18n from '../translations';
 import { buildTimeRangeFilter } from '../../components/alerts_table/helpers';
 import { useAlertsPrivileges } from '../../containers/detection_engine/alerts/use_alerts_privileges';
 import { useAlertCloseInfoModal } from '../use_alert_close_info_modal';
+
+export const BULK_ALERT_STATUS_ACTION_IDS = {
+  markAsAcknowledged: 'acknowledged-alert-status',
+  markAsOpen: 'open-alert-status',
+} as const;
 
 export interface UseBulkAlertActionItemsArgs {
   /* Table ID for which this hook is being used */
@@ -199,17 +205,37 @@ export const useBulkAlertActionItems = ({
           : status === FILTER_CLOSED
           ? i18n.BULK_ACTION_CLOSE_SELECTED
           : i18n.BULK_ACTION_ACKNOWLEDGED_SELECTED;
+      const icon = (
+        <EuiIcon
+          type="dot"
+          color={
+            status === FILTER_OPEN
+              ? 'danger'
+              : status === FILTER_ACKNOWLEDGED
+              ? 'primary'
+              : 'subdued'
+          }
+          aria-hidden
+        />
+      );
 
       if (status === FILTER_CLOSED) {
-        return alertClosingReasonItem;
+        return alertClosingReasonItem
+          ? { ...alertClosingReasonItem, icon, groupId: 'status' }
+          : undefined;
       }
 
       return {
         label,
-        key: `${status}-alert-status`,
+        key:
+          status === FILTER_OPEN
+            ? BULK_ALERT_STATUS_ACTION_IDS.markAsOpen
+            : BULK_ALERT_STATUS_ACTION_IDS.markAsAcknowledged,
         'data-test-subj': `${status}-alert-status`,
         disableOnQuery: false,
         onClick: getOnAction(status),
+        icon,
+        groupId: 'status',
       };
     },
     [alertClosingReasonItem, getOnAction]

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_run_alert_workflow_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_run_alert_workflow_panel.test.tsx
@@ -90,6 +90,8 @@ describe('useBulkRunAlertWorkflowPanel', () => {
       expect(result.current.runWorkflowItems[0].label).toBe(i18n.CONTEXT_MENU_RUN_WORKFLOW);
       expect(result.current.runWorkflowItems[0].panel).toBe(RUN_WORKFLOW_BULK_PANEL_ID);
       expect(result.current.runWorkflowItems[0].disableOnQuery).toBe(false);
+      expect(result.current.runWorkflowItems[0].icon).toBe('workflow');
+      expect(result.current.runWorkflowItems[0].groupId).toBe('workflow');
 
       expect(result.current.runWorkflowPanels).toHaveLength(1);
       expect(result.current.runWorkflowPanels[0].id).toBe(RUN_WORKFLOW_BULK_PANEL_ID);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_run_alert_workflow_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_run_alert_workflow_panel.tsx
@@ -25,6 +25,8 @@ export interface UseBulkRunAlertWorkflowPanelResult {
   runWorkflowPanels: ContentPanelConfig[];
 }
 
+export const BULK_RUN_ALERT_WORKFLOW_ACTION_ID = 'bulk-run-alert-workflow';
+
 export const useBulkRunAlertWorkflowPanel = (): UseBulkRunAlertWorkflowPanelResult => {
   const { canExecuteWorkflow } = useWorkflowsCapabilities();
   const workflowUIEnabled = useWorkflowsUIEnabledSetting();
@@ -47,12 +49,14 @@ export const useBulkRunAlertWorkflowPanel = (): UseBulkRunAlertWorkflowPanelResu
       canRunWorkflow
         ? [
             {
-              key: 'bulk-run-alert-workflow',
+              key: BULK_RUN_ALERT_WORKFLOW_ACTION_ID,
               'data-test-subj': 'bulk-run-alert-workflow-action',
               label: i18n.CONTEXT_MENU_RUN_WORKFLOW,
               name: i18n.CONTEXT_MENU_RUN_WORKFLOW,
               panel: RUN_WORKFLOW_BULK_PANEL_ID,
               disableOnQuery: false,
+              icon: 'workflow' as const,
+              groupId: 'workflow',
             },
           ]
         : [],

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/alerts.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/alerts.ts
@@ -253,6 +253,8 @@ export const ADD_TO_NEW_CASE_BUTTON = '[data-test-subj="attach-new-case"]';
 
 export const ADD_TO_EXISTING_CASE_BUTTON = '[data-test-subj="attach-existing-case"]';
 
+export const ADD_TO_CASE_BUTTON = '[data-test-subj="alerts-table-add-to-case"]';
+
 export const GROUP_ALERTS_BY_BTN = '[data-test-subj="alerts-table-group-selector"]';
 
 export const TAKE_ACTION_GROUPED_ALERTS_BTN = '[data-test-subj="take-action-button"]';


### PR DESCRIPTION
## Summary

- adds named action menus for alert rows and alert summaries
- makes action ordering, icons, and separators explicit
- preserves case, workflow, response-action, and telemetry behavior

Stack layer 2 of 7. Depends on the shared case menu in the previous layer.

Addresses #278607

### Checklist

- [x] Added text follows EUI writing and i18n guidelines
- [x] Documentation is not required for this internal menu composition change
- [x] Unit tests cover action ordering, icons, and separators
- [x] No plugin configuration or HTTP API changes were introduced
- [x] Validation from the original PR is preserved because the stacked branch chain reproduces its final tree exactly

### Identify risks

Low risk. The change reorganizes existing actions without replacing their callbacks or telemetry.

## Release note

Improves the consistency and readability of alert action menus.

Made with [Cursor](https://cursor.com)

## Stack

1. [#284116 — Two-layer case action menu](https://github.com/elastic/kibana/pull/284116)
2. [#284117 — Alert action menus](https://github.com/elastic/kibana/pull/284117)
3. [#284118 — Attack action menus](https://github.com/elastic/kibana/pull/284118)
4. [#284119 — Document action menus](https://github.com/elastic/kibana/pull/284119)
5. [#284120 — Events table bulk action menu](https://github.com/elastic/kibana/pull/284120)
6. [#284121 — Entity analytics action menus](https://github.com/elastic/kibana/pull/284121)
7. [#284122 — ML case action menu](https://github.com/elastic/kibana/pull/284122)