### PR TITLE
[Security Solution][Take Actions] Add attack action menus

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/attack_discovery_action_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/attack_discovery_action_menu.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiContextMenu } from '@elastic/eui';
+import type {
+  EuiContextMenuPanelDescriptor,
+  EuiContextMenuPanelItemDescriptor,
+} from '@elastic/eui';
+import React, { useMemo } from 'react';
+import {
+  getActionMenuGroupSeparator,
+  withActionIcons,
+} from '../../../../common/utils/action_menu_items';
+import { RUN_ATTACK_WORKFLOW_ACTION_ID } from '../../../../detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_run_workflow_items';
+
+interface AttackDiscoveryActionMenuProps {
+  aiItems: EuiContextMenuPanelItemDescriptor[];
+  caseItems: EuiContextMenuPanelItemDescriptor[];
+  datasetItems: EuiContextMenuPanelItemDescriptor[];
+  panels: EuiContextMenuPanelDescriptor[];
+  statusItems: EuiContextMenuPanelItemDescriptor[];
+  workflowItems: EuiContextMenuPanelItemDescriptor[];
+}
+
+const ACTION_ICONS_BY_ID = {
+  [RUN_ATTACK_WORKFLOW_ACTION_ID]: 'workflow',
+} as const;
+
+export const AttackDiscoveryActionMenu = ({
+  aiItems,
+  caseItems,
+  datasetItems,
+  panels,
+  statusItems,
+  workflowItems,
+}: AttackDiscoveryActionMenuProps) => {
+  const items = useMemo(() => {
+    const actionGroups = [statusItems, workflowItems, caseItems, aiItems, datasetItems].filter(
+      (group) => group.length > 0
+    );
+
+    return withActionIcons(
+      actionGroups.flatMap((group, index) => [
+        ...group,
+        ...(index < actionGroups.length - 1
+          ? [getActionMenuGroupSeparator(`separator-${index}`)]
+          : []),
+      ]),
+      ACTION_ICONS_BY_ID
+    );
+  }, [aiItems, caseItems, datasetItems, statusItems, workflowItems]);
+
+  return <EuiContextMenu initialPanelId={0} panels={[{ id: 0, items }, ...panels]} />;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.test.tsx
@@ -150,7 +150,7 @@ describe('TakeAction', () => {
     mockUseAlertsPrivileges.mockReturnValue({ hasAlertsUpdate: true });
   });
 
-  it('renders the Add to new case action', () => {
+  it('renders the Add to case action', () => {
     render(
       <TestProviders>
         <TakeAction {...defaultProps} />
@@ -162,7 +162,7 @@ describe('TakeAction', () => {
     expect(screen.getByTestId('addToCase')).toBeInTheDocument();
   });
 
-  it('renders the Add to existing case action', () => {
+  it('renders the Add to existing case action', async () => {
     render(
       <TestProviders>
         <TakeAction {...defaultProps} />
@@ -171,7 +171,8 @@ describe('TakeAction', () => {
 
     openPopover();
 
-    expect(screen.getByTestId('addToExistingCase')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('addToCase'));
+    expect(await screen.findByTestId('addToExistingCase')).toBeInTheDocument();
   });
 
   it('renders the View in AI Assistant action', () => {
@@ -184,6 +185,29 @@ describe('TakeAction', () => {
     openPopover();
 
     expect(screen.getByTestId('viewInAiAssistant')).toBeInTheDocument();
+  });
+
+  it('renders explicitly ordered action groups with icons and separators', () => {
+    render(
+      <TestProviders>
+        <TakeAction {...defaultProps} />
+      </TestProviders>
+    );
+    openPopover();
+
+    expect(
+      screen.getAllByRole('menuitem').map((item) => item.getAttribute('data-test-subj'))
+    ).toEqual([
+      'markAsOpen',
+      'markAsAcknowledged',
+      'markAsClosed',
+      'addToCase',
+      'viewInAiAssistant',
+    ]);
+    expect(screen.getAllByTestId('securityActionMenuGroupSeparator')).toHaveLength(2);
+    screen.getAllByRole('menuitem').forEach((item) => {
+      expect(item.querySelector('[data-euiicon-type]')).not.toBeNull();
+    });
   });
 
   it('renders the Add to chat action disabled when license is invalid', () => {
@@ -511,6 +535,9 @@ describe('TakeAction', () => {
 
       openPopover();
       fireEvent.click(screen.getByTestId('addToCase'));
+      expect(await screen.findByTestId('add-to-case-submit')).toBeDisabled();
+      fireEvent.click(await screen.findByTestId('addToNewCase'));
+      fireEvent.click(await screen.findByTestId('add-to-case-submit'));
 
       await waitFor(() => {
         expect(mockOnAddToNewCase).toHaveBeenCalledWith({
@@ -521,7 +548,7 @@ describe('TakeAction', () => {
       });
     });
 
-    it('calls onAddToExistingCase when clicking add to existing case', () => {
+    it('calls onAddToExistingCase when clicking add to existing case', async () => {
       render(
         <TestProviders>
           <TakeAction {...defaultProps} />
@@ -529,7 +556,9 @@ describe('TakeAction', () => {
       );
 
       openPopover();
-      fireEvent.click(screen.getByTestId('addToExistingCase'));
+      fireEvent.click(screen.getByTestId('addToCase'));
+      fireEvent.click(await screen.findByTestId('addToExistingCase'));
+      fireEvent.click(await screen.findByTestId('add-to-case-submit'));
 
       expect(mockOnAddToExistingCase).toHaveBeenCalledWith({
         alertIds: expect.any(Array),
@@ -597,7 +626,6 @@ describe('TakeAction', () => {
       openPopover();
 
       expect(screen.queryByTestId('addToCase')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('addToExistingCase')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/index.tsx
@@ -13,13 +13,8 @@ import {
   type Replacements,
 } from '@kbn/elastic-assistant-common';
 import { i18n as i18nTranslate } from '@kbn/i18n';
-import {
-  EuiButtonEmpty,
-  EuiContextMenu,
-  type EuiContextMenuPanelDescriptor,
-  EuiPopover,
-  useGeneratedHtmlId,
-} from '@elastic/eui';
+import { EuiButtonEmpty, EuiIcon, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
+import { AddToCaseActionPanel, ADD_TO_CASE, CASE_TYPE } from '@kbn/response-ops-alerts-table';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { useReportAddToChat } from '../../../../agent_builder/hooks/use_report_add_to_chat';
@@ -32,6 +27,8 @@ import { APP_ID } from '../../../../../common';
 import { useKibana } from '../../../../common/lib/kibana';
 import * as i18n from './translations';
 import { UpdateAlertsModal } from './update_alerts_modal';
+import { AttackDiscoveryActionMenu } from './attack_discovery_action_menu';
+
 import { useAttackDiscoveryBulk } from '../../use_attack_discovery_bulk';
 import { useUpdateAlertsStatus } from './use_update_alerts_status';
 import { isAttackDiscoveryAlert } from '../../utils/is_attack_discovery_alert';
@@ -39,6 +36,20 @@ import { useAgentBuilderAvailability } from '../../../../agent_builder/hooks/use
 import { useAttackDiscoveryAttachment } from '../use_attack_discovery_attachment';
 import { useAlertsPrivileges } from '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { useAttackRunWorkflowContextMenuItems } from '../../../../detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_run_workflow_context_menu_items';
+
+const ATTACK_DISCOVERY_ACTION_IDS = {
+  addToCase: 'addToCase',
+  addToChat: 'viewInAgentBuilder',
+  addToDataset: 'addToDataset',
+  addToExistingCase: 'addToExistingCase',
+  addToNewCase: 'addToNewCase',
+  markAsAcknowledged: 'markAsAcknowledged',
+  markAsClosed: 'markAsClosed',
+  markAsOpen: 'markAsOpen',
+  viewInAiAssistant: 'viewInAiAssistant',
+} as const;
+
+const ATTACK_DISCOVERY_CASE_PANEL_ID = 'attack-discovery-add-to-case-panel';
 
 interface Props {
   attackDiscoveries: AttackDiscovery[] | AttackDiscoveryAlert[];
@@ -308,7 +319,7 @@ const TakeActionComponent: React.FC<Props> = ({
     [buttonSize, buttonText, onButtonClick]
   );
 
-  const allItems = useMemo(() => {
+  const actionMenuItems = useMemo(() => {
     const isSingleAttackDiscovery = attackDiscoveries.length === 1;
 
     const isOpen = attackDiscoveries.every(
@@ -328,7 +339,8 @@ const TakeActionComponent: React.FC<Props> = ({
         ? [
             {
               'data-test-subj': 'markAsOpen',
-              key: 'markAsOpen',
+              key: ATTACK_DISCOVERY_ACTION_IDS.markAsOpen,
+              icon: <EuiIcon type="dot" color="danger" aria-hidden />,
               name: i18n.MARK_AS_OPEN,
               onClick: () => onUpdateWorkflowStatus('open'),
             },
@@ -340,7 +352,8 @@ const TakeActionComponent: React.FC<Props> = ({
         ? [
             {
               'data-test-subj': 'markAsAcknowledged',
-              key: 'markAsAcknowledged',
+              key: ATTACK_DISCOVERY_ACTION_IDS.markAsAcknowledged,
+              icon: <EuiIcon type="dot" color="primary" aria-hidden />,
               name: i18n.MARK_AS_ACKNOWLEDGED,
               onClick: () => onUpdateWorkflowStatus('acknowledged'),
             },
@@ -352,7 +365,8 @@ const TakeActionComponent: React.FC<Props> = ({
         ? [
             {
               'data-test-subj': 'markAsClosed',
-              key: 'markAsClosed',
+              key: ATTACK_DISCOVERY_ACTION_IDS.markAsClosed,
+              icon: <EuiIcon type="dot" color="subdued" aria-hidden />,
               name: i18n.MARK_AS_CLOSED,
               onClick: () => onUpdateWorkflowStatus('closed'),
             },
@@ -363,15 +377,10 @@ const TakeActionComponent: React.FC<Props> = ({
       ? [
           {
             'data-test-subj': 'addToCase',
-            key: 'addToCase',
-            name: i18n.ADD_TO_NEW_CASE,
-            onClick: onClickAddToNewCase,
-          },
-          {
-            'data-test-subj': 'addToExistingCase',
-            key: 'addToExistingCase',
-            name: i18n.ADD_TO_EXISTING_CASE,
-            onClick: onClickAddToExistingCase,
+            key: ATTACK_DISCOVERY_ACTION_IDS.addToCase,
+            icon: 'briefcase',
+            name: ADD_TO_CASE,
+            panel: ATTACK_DISCOVERY_CASE_PANEL_ID,
           },
         ]
       : [];
@@ -383,7 +392,8 @@ const TakeActionComponent: React.FC<Props> = ({
               {
                 'data-test-subj': 'viewInAgentBuilder',
                 disabled: isAddToChatDisabled,
-                key: 'viewInAgentBuilder',
+                key: ATTACK_DISCOVERY_ACTION_IDS.addToChat,
+                icon: 'comment',
                 name: i18n.ADD_TO_CHAT,
                 onClick: onViewInAgentBuilder,
                 toolTipContent: isAddToChatDisabled
@@ -397,7 +407,8 @@ const TakeActionComponent: React.FC<Props> = ({
             {
               'data-test-subj': 'viewInAiAssistant',
               disabled: viewInAiAssistantDisabled,
-              key: 'viewInAiAssistant',
+              key: ATTACK_DISCOVERY_ACTION_IDS.viewInAiAssistant,
+              icon: 'sparkles',
               name: i18n.VIEW_IN_AI_ASSISTANT,
               onClick: onViewInAiAssistant,
             },
@@ -410,28 +421,24 @@ const TakeActionComponent: React.FC<Props> = ({
         ? [
             {
               'data-test-subj': 'addToDataset',
-              key: 'addToDataset',
+              key: ATTACK_DISCOVERY_ACTION_IDS.addToDataset,
+              icon: 'database',
               name: addToDatasetAction.label,
               onClick: addToDatasetAction.onClick,
             },
           ]
         : [];
 
-    return [
-      ...markAsOpenItem,
-      ...markAsAcknowledgedItem,
-      ...markAsClosedItem,
-      ...runWorkflowItems,
-      ...caseItems,
-      ...aiItems,
-      ...datasetItems,
-    ];
+    return {
+      aiItems,
+      caseItems,
+      datasetItems,
+      statusItems: [...markAsOpenItem, ...markAsAcknowledgedItem, ...markAsClosedItem],
+    };
   }, [
     attackDiscoveries,
     hasAlertsUpdate,
     addToCaseDisabled,
-    onClickAddToNewCase,
-    onClickAddToExistingCase,
     isAgentChatExperienceEnabled,
     hasAgentBuilderPrivilege,
     isAddToChatDisabled,
@@ -440,13 +447,38 @@ const TakeActionComponent: React.FC<Props> = ({
     viewInAiAssistantDisabled,
     onViewInAiAssistant,
     onUpdateWorkflowStatus,
-    runWorkflowItems,
     addToDatasetAction,
   ]);
 
-  const panels: EuiContextMenuPanelDescriptor[] = useMemo(
-    () => [{ id: 0, items: allItems }, ...runWorkflowPanels],
-    [allItems, runWorkflowPanels]
+  const casePanels = useMemo(
+    () =>
+      !addToCaseDisabled
+        ? [
+            {
+              id: ATTACK_DISCOVERY_CASE_PANEL_ID,
+              title: CASE_TYPE,
+              content: (
+                <AddToCaseActionPanel
+                  actions={[
+                    {
+                      id: ATTACK_DISCOVERY_ACTION_IDS.addToNewCase,
+                      label: i18n.ADD_TO_NEW_CASE,
+                      dataTestSubj: ATTACK_DISCOVERY_ACTION_IDS.addToNewCase,
+                      onClick: onClickAddToNewCase,
+                    },
+                    {
+                      id: ATTACK_DISCOVERY_ACTION_IDS.addToExistingCase,
+                      label: i18n.ADD_TO_EXISTING_CASE,
+                      dataTestSubj: 'addToExistingCase',
+                      onClick: onClickAddToExistingCase,
+                    },
+                  ]}
+                />
+              ),
+            },
+          ]
+        : [],
+    [addToCaseDisabled, onClickAddToExistingCase, onClickAddToNewCase]
   );
 
   const onCloseOrCancel = useCallback(() => {
@@ -465,7 +497,14 @@ const TakeActionComponent: React.FC<Props> = ({
         isOpen={isPopoverOpen}
         panelPaddingSize="none"
       >
-        <EuiContextMenu initialPanelId={0} panels={panels} />
+        <AttackDiscoveryActionMenu
+          aiItems={actionMenuItems.aiItems}
+          caseItems={actionMenuItems.caseItems}
+          datasetItems={actionMenuItems.datasetItems}
+          panels={[...casePanels, ...runWorkflowPanels]}
+          statusItems={actionMenuItems.statusItems}
+          workflowItems={runWorkflowItems}
+        />
       </EuiPopover>
 
       {pendingAction != null && !hasSearchAILakeConfigurations && (

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_action_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_action_menu.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiContextMenu } from '@elastic/eui';
+import type {
+  EuiContextMenuPanelDescriptor,
+  EuiContextMenuPanelItemDescriptor,
+} from '@elastic/eui';
+import React, { useMemo } from 'react';
+import {
+  getActionMenuGroupSeparator,
+  withActionIcon,
+  withActionIcons,
+  withStatusDotIcons,
+} from '../../../../common/utils/action_menu_items';
+import { ATTACK_CASE_ACTION_IDS } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items';
+import { ATTACK_TAG_ACTION_ID } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_tags_items';
+import { ATTACK_ASSIGNEE_ACTION_IDS } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_assignees_items';
+import { RUN_ATTACK_WORKFLOW_ACTION_ID } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_run_workflow_items';
+import { ATTACK_INVESTIGATE_IN_TIMELINE_ACTION_ID } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items';
+import { ATTACK_AI_ACTION_IDS } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_view_in_ai_assistant_context_menu_items';
+import { EXPLORE_IN_ATTACKS_ACTION_ID } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_explore_in_attacks_context_menu_items';
+
+interface AttacksActionMenuProps {
+  assigneeItems: EuiContextMenuPanelItemDescriptor[];
+  assigneePanels: EuiContextMenuPanelDescriptor[];
+  caseItems: EuiContextMenuPanelItemDescriptor[];
+  casePanels: EuiContextMenuPanelDescriptor[];
+  datasetItems: EuiContextMenuPanelItemDescriptor[];
+  isRemoteDocument: boolean;
+  navigationItems: EuiContextMenuPanelItemDescriptor[];
+  runWorkflowItems: EuiContextMenuPanelItemDescriptor[];
+  runWorkflowPanels: EuiContextMenuPanelDescriptor[];
+  showAiAssistantAction: boolean;
+  statusItems: EuiContextMenuPanelItemDescriptor[];
+  statusPanels: EuiContextMenuPanelDescriptor[];
+  tagItems: EuiContextMenuPanelItemDescriptor[];
+  tagPanels: EuiContextMenuPanelDescriptor[];
+  viewInAiAssistantItems: EuiContextMenuPanelItemDescriptor[];
+}
+
+const ATTACK_STATUS_ICON_COLORS = {
+  'acknowledged-attack-status': 'primary',
+  'open-attack-status': 'danger',
+} as const;
+
+const ACTION_ICONS_BY_ID = {
+  [ATTACK_AI_ACTION_IDS.addToChat]: 'comment',
+  [ATTACK_AI_ACTION_IDS.viewInAiAssistant]: 'sparkles',
+  [ATTACK_ASSIGNEE_ACTION_IDS.assign]: 'users',
+  [ATTACK_ASSIGNEE_ACTION_IDS.unassignAll]: 'users',
+  [ATTACK_CASE_ACTION_IDS.addToCase]: 'briefcase',
+  [ATTACK_INVESTIGATE_IN_TIMELINE_ACTION_ID]: 'timeline',
+  [ATTACK_TAG_ACTION_ID]: 'tag',
+  [EXPLORE_IN_ATTACKS_ACTION_ID]: 'external',
+  [RUN_ATTACK_WORKFLOW_ACTION_ID]: 'workflow',
+} as const;
+
+export const AttacksActionMenu = ({
+  assigneeItems,
+  assigneePanels,
+  caseItems,
+  casePanels,
+  datasetItems,
+  isRemoteDocument,
+  navigationItems,
+  runWorkflowItems,
+  runWorkflowPanels,
+  showAiAssistantAction,
+  statusItems,
+  statusPanels,
+  tagItems,
+  tagPanels,
+  viewInAiAssistantItems,
+}: AttacksActionMenuProps) => {
+  const items = useMemo(() => {
+    const navigationActionItems = withActionIcons(navigationItems, ACTION_ICONS_BY_ID);
+
+    if (isRemoteDocument) {
+      return navigationActionItems;
+    }
+
+    const attackManagementItems = [...assigneeItems, ...caseItems, ...tagItems];
+    const actionGroups = [
+      withStatusDotIcons(statusItems, ATTACK_STATUS_ICON_COLORS, 'subdued'),
+      attackManagementItems,
+      runWorkflowItems,
+      showAiAssistantAction ? viewInAiAssistantItems : [],
+      withActionIcon(datasetItems, 'database'),
+      navigationActionItems,
+    ].filter((group) => group.length > 0);
+
+    return withActionIcons(
+      actionGroups.flatMap((group, index) => [
+        ...group,
+        ...(index < actionGroups.length - 1
+          ? [getActionMenuGroupSeparator(`separator-${index}`)]
+          : []),
+      ]),
+      ACTION_ICONS_BY_ID
+    );
+  }, [
+    assigneeItems,
+    caseItems,
+    datasetItems,
+    isRemoteDocument,
+    navigationItems,
+    runWorkflowItems,
+    showAiAssistantAction,
+    statusItems,
+    tagItems,
+    viewInAiAssistantItems,
+  ]);
+
+  const panels = useMemo(
+    () =>
+      isRemoteDocument
+        ? []
+        : [...casePanels, ...runWorkflowPanels, ...statusPanels, ...assigneePanels, ...tagPanels],
+    [assigneePanels, casePanels, isRemoteDocument, runWorkflowPanels, statusPanels, tagPanels]
+  );
+
+  return <EuiContextMenu initialPanelId={0} panels={[{ id: 0, items }, ...panels]} />;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.test.tsx
@@ -20,6 +20,11 @@ import { useAttackCaseContextMenuItems } from '../../../hooks/attacks/bulk_actio
 import { useAttackRunWorkflowContextMenuItems } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_run_workflow_context_menu_items';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
+import { ATTACK_STATUS_ACTION_IDS } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_workflow_status_items';
+import { ATTACK_ASSIGNEE_ACTION_IDS } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_assignees_items';
+import { ATTACK_TAG_ACTION_ID } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_tags_items';
+import { ATTACK_INVESTIGATE_IN_TIMELINE_ACTION_ID } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items';
+import { ATTACK_CASE_ACTION_IDS } from '../../../hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items';
 
 jest.mock(
   '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_view_in_ai_assistant_context_menu_items'
@@ -110,25 +115,30 @@ describe('AttacksGroupTakeActionItems', () => {
     });
     mockUseAttackWorkflowStatusContextMenuItems.mockReturnValue({
       items: [
-        { name: 'Mark as acknowledged', key: 'markAsAcknowledged' },
-        { name: 'Mark as closed', key: 'markAsClosed' },
-        { name: 'Mark as open', key: 'markAsOpen' },
+        { name: 'Mark as acknowledged', key: ATTACK_STATUS_ACTION_IDS.markAsAcknowledged },
+        { name: 'Mark as closed', key: ATTACK_STATUS_ACTION_IDS.markAsClosed },
+        { name: 'Mark as open', key: ATTACK_STATUS_ACTION_IDS.markAsOpen },
       ],
       panels: [],
     });
     mockUseAttackAssigneesContextMenuItems.mockReturnValue({
       items: [
-        { name: 'Assign alert', key: 'assignAlert' },
-        { name: 'Unassign alert', key: 'unassignAlert' },
+        { name: 'Assign alert', key: ATTACK_ASSIGNEE_ACTION_IDS.assign },
+        { name: 'Unassign alert', key: ATTACK_ASSIGNEE_ACTION_IDS.unassignAll },
       ],
       panels: [],
     });
     mockUseAttackTagsContextMenuItems.mockReturnValue({
-      items: [{ name: 'Apply alert tags', key: 'applyAlertTags' }],
+      items: [{ name: 'Apply alert tags', key: ATTACK_TAG_ACTION_ID }],
       panels: [],
     });
     mockUseAttackInvestigateInTimelineContextMenuItems.mockReturnValue({
-      items: [{ name: 'Investigate in Timeline', key: 'investigateInTimeline' }],
+      items: [
+        {
+          name: 'Investigate in Timeline',
+          key: ATTACK_INVESTIGATE_IN_TIMELINE_ACTION_ID,
+        },
+      ],
       panels: [],
     });
     mockUseAttackExploreInAttacksContextMenuItems.mockReturnValue({
@@ -136,7 +146,7 @@ describe('AttacksGroupTakeActionItems', () => {
     });
     mockUseIsInSecurityApp.mockReturnValue(true);
     mockUseAttackCaseContextMenuItems.mockReturnValue({
-      items: [],
+      items: [{ name: 'Add to case', key: ATTACK_CASE_ACTION_IDS.addToCase }],
       panels: [],
     });
     mockUseAttackRunWorkflowContextMenuItems.mockReturnValue({
@@ -149,6 +159,27 @@ describe('AttacksGroupTakeActionItems', () => {
         },
       ],
       panels: [],
+    });
+  });
+
+  it('renders explicitly ordered action groups with icons and separators', () => {
+    const { getAllByRole, getAllByTestId } = renderAttack(mockAttack);
+
+    expect(getAllByRole('menuitem').map(({ textContent }) => textContent)).toEqual([
+      'Mark as acknowledged',
+      'Mark as closed',
+      'Mark as open',
+      'Assign alert',
+      'Unassign alert',
+      'Add to case',
+      'Apply alert tags',
+      'Run workflow',
+      'View in AI Assistant',
+      'Investigate in Timeline',
+    ]);
+    expect(getAllByTestId('securityActionMenuGroupSeparator')).toHaveLength(4);
+    getAllByRole('menuitem').forEach((item) => {
+      expect(item.querySelector('[data-euiicon-type]')).not.toBeNull();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
-import { EuiContextMenu } from '@elastic/eui';
 import {
   type AttackDiscoveryAlert,
   getAttackDiscoveryMarkdown,
@@ -30,6 +28,7 @@ import { useAttackViewInAiAssistantContextMenuItems } from '../../../hooks/attac
 import type { AttacksActionTelemetrySource } from '../../../../common/lib/telemetry/events/attacks/types';
 import { useAttackRunWorkflowContextMenuItems } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_run_workflow_context_menu_items';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
+import { AttacksActionMenu } from './attacks_action_menu';
 
 interface AttacksGroupTakeActionItemsProps {
   attack: AttackDiscoveryAlert;
@@ -52,6 +51,7 @@ const ADD_TO_DATASET = i18n.translate(
   'xpack.securitySolution.attacks.table.takeAction.addToDatasetButtonLabel',
   { defaultMessage: 'Add to dataset' }
 );
+const ADD_TO_DATASET_ACTION_ID = 'addToDataset';
 
 export function AttacksGroupTakeActionItems({
   attack,
@@ -157,7 +157,7 @@ export function AttacksGroupTakeActionItems({
     [attack, baseAttackProps]
   );
 
-  const { items: casesItems } = useAttackCaseContextMenuItems({
+  const { items: casesItems, panels: casePanels } = useAttackCaseContextMenuItems({
     closePopover,
     title: attack.title,
     attacksWithCase,
@@ -204,7 +204,7 @@ export function AttacksGroupTakeActionItems({
         ? [
             {
               'data-test-subj': 'addToDataset',
-              key: 'addToDataset',
+              key: ADD_TO_DATASET_ACTION_ID,
               name: addToDatasetAction.label,
               onClick: addToDatasetAction.onClick,
             },
@@ -213,43 +213,23 @@ export function AttacksGroupTakeActionItems({
     [addToDatasetAction]
   );
 
-  const defaultPanel: EuiContextMenuPanelDescriptor = useMemo(
-    () => ({
-      id: 0,
-      items: isRemoteDocument
-        ? [...navigationItems]
-        : [
-            ...casesItems,
-            ...workflowItems,
-            ...tagsItems,
-            ...assignItems,
-            ...runWorkflowItems,
-            ...(showAiAssistantAction ? viewInAiAssistantItems : []),
-            ...datasetItems,
-            ...navigationItems,
-          ],
-    }),
-    [
-      isRemoteDocument,
-      runWorkflowItems,
-      workflowItems,
-      assignItems,
-      tagsItems,
-      navigationItems,
-      casesItems,
-      showAiAssistantAction,
-      viewInAiAssistantItems,
-      datasetItems,
-    ]
+  return (
+    <AttacksActionMenu
+      assigneeItems={assignItems}
+      assigneePanels={assignPanels}
+      caseItems={casesItems}
+      casePanels={casePanels}
+      datasetItems={datasetItems}
+      isRemoteDocument={isRemoteDocument}
+      navigationItems={navigationItems}
+      runWorkflowItems={runWorkflowItems}
+      runWorkflowPanels={runWorkflowPanels}
+      showAiAssistantAction={showAiAssistantAction}
+      statusItems={workflowItems}
+      statusPanels={workflowPanels}
+      tagItems={tagsItems}
+      tagPanels={tagsPanels}
+      viewInAiAssistantItems={viewInAiAssistantItems}
+    />
   );
-
-  const panels: EuiContextMenuPanelDescriptor[] = useMemo(
-    () =>
-      isRemoteDocument
-        ? [defaultPanel]
-        : [defaultPanel, ...runWorkflowPanels, ...workflowPanels, ...assignPanels, ...tagsPanels],
-    [isRemoteDocument, runWorkflowPanels, workflowPanels, assignPanels, defaultPanel, tagsPanels]
-  );
-
-  return <EuiContextMenu initialPanelId={defaultPanel.id} panels={panels} />;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_assignees_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_assignees_items.tsx
@@ -26,6 +26,11 @@ import * as i18n from '../translations';
 import { useApplyAttackAssignees } from '../apply_actions/use_apply_attack_assignees';
 import type { AttackContentPanelConfig, BulkAttackActionItems } from '../types';
 
+export const ATTACK_ASSIGNEE_ACTION_IDS = {
+  assign: 'manage-attack-assignees',
+  unassignAll: 'remove-all-attack-assignees',
+} as const;
+
 export interface UseBulkAttackAssigneesItemsProps {
   /** Callback when assignees are updated */
   onAssigneesUpdate?: () => void;
@@ -89,7 +94,7 @@ export const useBulkAttackAssigneesItems = ({
 
     return [
       {
-        key: 'manage-attack-assignees',
+        key: ATTACK_ASSIGNEE_ACTION_IDS.assign,
         'data-test-subj': 'attack-assignees-context-menu-item',
         name: i18n.ATTACK_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE,
         panel: 2,
@@ -98,7 +103,7 @@ export const useBulkAttackAssigneesItems = ({
         disable: false,
       },
       {
-        key: 'remove-all-attack-assignees',
+        key: ATTACK_ASSIGNEE_ACTION_IDS.unassignAll,
         'data-test-subj': 'remove-attack-assignees-menu-item',
         name: i18n.REMOVE_ATTACK_ASSIGNEES_CONTEXT_MENU_TITLE,
         label: i18n.REMOVE_ATTACK_ASSIGNEES_CONTEXT_MENU_TITLE,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.test.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { TimelineItem } from '@kbn/response-ops-alerts-table/types';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import React from 'react';
 import { useBulkAttackCaseItems } from './use_bulk_attack_case_items';
@@ -14,6 +16,27 @@ import {
   ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT,
 } from '../constants';
 import { AttacksEventTypes } from '../../../../../common/lib/telemetry';
+
+const submitCaseAction = async ({
+  panel,
+  alertItems,
+  actionTestSubj = 'attack-add-to-new-case',
+}: {
+  panel: NonNullable<ReturnType<typeof useBulkAttackCaseItems>['panels'][number]>;
+  alertItems: TimelineItem[];
+  actionTestSubj?: string;
+}) => {
+  render(
+    panel.renderContent({
+      alertItems,
+      setIsBulkActionsLoading: jest.fn(),
+      closePopoverMenu: jest.fn(),
+    })
+  );
+  expect(screen.getByTestId('add-to-case-submit')).toBeDisabled();
+  await userEvent.click(screen.getByTestId(actionTestSubj));
+  await userEvent.click(screen.getByTestId('add-to-case-submit'));
+};
 
 jest.mock('../../../../../common/lib/kibana', () => ({
   useKibana: jest.fn(),
@@ -81,12 +104,13 @@ describe('useBulkAttackCaseItems', () => {
     });
   });
 
-  it('should return two case items when user has permissions', () => {
+  it('should return an add-to-case item and case type panel when user has permissions', () => {
     const { result } = renderHook(() => useBulkAttackCaseItems({ title: 'attack title' }), {
       wrapper,
     });
 
-    expect(result.current.items).toHaveLength(2);
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.panels).toHaveLength(1);
   });
 
   it('should return empty items when user lacks cases permissions', () => {
@@ -122,8 +146,9 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[1]?.onClick?.(
-      [
+    await submitCaseAction({
+      panel: result.current.panels[0],
+      alertItems: [
         {
           _id: 'attack-1',
           data: [
@@ -141,11 +166,7 @@ describe('useBulkAttackCaseItems', () => {
           ecs: { _id: 'attack-2' },
         },
       ],
-      false,
-      jest.fn(),
-      jest.fn(),
-      jest.fn()
-    );
+    });
 
     expect(onAddToNewCase).toHaveBeenCalledWith({
       alertIds: ['alert-1', 'alert-2', 'alert-3'],
@@ -166,19 +187,16 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[1]?.onClick?.(
-      [
+    await submitCaseAction({
+      panel: result.current.panels[0],
+      alertItems: [
         {
           _id: 'attack-1',
           data: [],
           ecs: { _id: 'attack-1' },
         },
       ],
-      false,
-      jest.fn(),
-      jest.fn(),
-      jest.fn()
-    );
+    });
 
     expect(reportEventMock).toHaveBeenCalledWith(AttacksEventTypes.ActionAddedToCase, {
       source: 'attacks_page_group_take_action',
@@ -195,8 +213,10 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[0]?.onClick?.(
-      [
+    await submitCaseAction({
+      panel: result.current.panels[0],
+      actionTestSubj: 'attack-add-to-existing-case',
+      alertItems: [
         {
           _id: 'attack-1',
           data: [
@@ -214,11 +234,7 @@ describe('useBulkAttackCaseItems', () => {
           ecs: { _id: 'attack-2' },
         },
       ],
-      false,
-      jest.fn(),
-      jest.fn(),
-      jest.fn()
-    );
+    });
 
     expect(onAddToExistingCase).toHaveBeenCalledWith({
       alertIds: ['alert-1', 'alert-2'],
@@ -239,19 +255,17 @@ describe('useBulkAttackCaseItems', () => {
       }
     );
 
-    await result.current.items[0]?.onClick?.(
-      [
+    await submitCaseAction({
+      panel: result.current.panels[0],
+      actionTestSubj: 'attack-add-to-existing-case',
+      alertItems: [
         {
           _id: 'attack-1',
           data: [],
           ecs: { _id: 'attack-1' },
         },
       ],
-      false,
-      jest.fn(),
-      jest.fn(),
-      jest.fn()
-    );
+    });
 
     expect(reportEventMock).toHaveBeenCalledWith(AttacksEventTypes.ActionAddedToCase, {
       source: 'attacks_page_group_take_action',
@@ -259,11 +273,11 @@ describe('useBulkAttackCaseItems', () => {
     });
   });
 
-  it('should return empty panels', () => {
+  it('should return the case type panel', () => {
     const { result } = renderHook(() => useBulkAttackCaseItems({ title: 'attack title' }), {
       wrapper,
     });
 
-    expect(result.current.panels).toEqual([]);
+    expect(result.current.panels).toHaveLength(1);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_case_items.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { useCallback, useMemo } from 'react';
+import { AddToCaseActionPanel, ADD_TO_CASE, CASE_TYPE } from '@kbn/response-ops-alerts-table';
+import React, { useCallback, useMemo } from 'react';
 import type { BulkActionsConfig } from '@kbn/response-ops-alerts-table/types';
 
 import { useAddToExistingCase } from '../../../../../attack_discovery/pages/results/take_action/use_add_to_existing_case';
@@ -18,6 +19,14 @@ import { ADD_TO_EXISTING_CASE, ADD_TO_NEW_CASE } from '../translations';
 import { ALERT_ATTACK_DISCOVERY_MARKDOWN_COMMENT } from '../constants';
 import type { BulkAttackActionItems } from '../types';
 import { extractRelatedDetectionAlertIds } from '../utils/extract_related_detection_alert_ids';
+
+export const ATTACK_CASE_ACTION_IDS = {
+  addToCase: 'attack-add-to-case',
+  addToExistingCase: 'attack-add-to-existing-case',
+  addToNewCase: 'attack-add-to-new-case',
+} as const;
+
+const ATTACK_CASE_PANEL_ID = 'attack-add-to-case-panel';
 
 export interface UseBulkAttackCaseItemsProps {
   /** Title used to initialize "create case" flyout */
@@ -121,22 +130,68 @@ export const useBulkAttackCaseItems = ({
       canCreateAndReadCases
         ? [
             {
-              name: ADD_TO_EXISTING_CASE,
-              label: ADD_TO_EXISTING_CASE,
-              key: 'attack-add-to-existing-case',
-              'data-test-subj': 'attack-add-to-existing-case',
+              name: ADD_TO_CASE,
+              label: ADD_TO_CASE,
+              key: ATTACK_CASE_ACTION_IDS.addToCase,
+              'data-test-subj': ATTACK_CASE_ACTION_IDS.addToCase,
               disableOnQuery: true,
-              disable: isAddToExistingCaseDisabled,
-              onClick: onAddToExistingCaseClick,
+              disable: isAddToExistingCaseDisabled && isAddToNewCaseDisabled,
+              groupId: 'cases',
+              icon: 'briefcase',
+              panel: ATTACK_CASE_PANEL_ID,
             },
+          ]
+        : [],
+    [canCreateAndReadCases, isAddToExistingCaseDisabled, isAddToNewCaseDisabled]
+  );
+
+  const panels = useMemo<BulkAttackActionItems['panels']>(
+    () =>
+      canCreateAndReadCases
+        ? [
             {
-              name: ADD_TO_NEW_CASE,
-              label: ADD_TO_NEW_CASE,
-              key: 'attack-add-to-new-case',
-              'data-test-subj': 'attack-add-to-new-case',
-              disableOnQuery: true,
-              disable: isAddToNewCaseDisabled,
-              onClick: onAddToNewCaseClick,
+              id: ATTACK_CASE_PANEL_ID,
+              title: CASE_TYPE,
+              renderContent: ({
+                alertItems,
+                isAllSelected = false,
+                setIsBulkActionsLoading,
+                clearSelection = () => undefined,
+                refresh = () => undefined,
+              }) => (
+                <AddToCaseActionPanel
+                  actions={[
+                    {
+                      id: ATTACK_CASE_ACTION_IDS.addToNewCase,
+                      label: ADD_TO_NEW_CASE,
+                      dataTestSubj: ATTACK_CASE_ACTION_IDS.addToNewCase,
+                      disabled: isAddToNewCaseDisabled,
+                      onClick: () =>
+                        onAddToNewCaseClick(
+                          alertItems,
+                          isAllSelected,
+                          setIsBulkActionsLoading,
+                          clearSelection,
+                          refresh
+                        ),
+                    },
+                    {
+                      id: ATTACK_CASE_ACTION_IDS.addToExistingCase,
+                      label: ADD_TO_EXISTING_CASE,
+                      dataTestSubj: ATTACK_CASE_ACTION_IDS.addToExistingCase,
+                      disabled: isAddToExistingCaseDisabled,
+                      onClick: () =>
+                        onAddToExistingCaseClick(
+                          alertItems,
+                          isAllSelected,
+                          setIsBulkActionsLoading,
+                          clearSelection,
+                          refresh
+                        ),
+                    },
+                  ]}
+                />
+              ),
             },
           ]
         : [],
@@ -149,11 +204,5 @@ export const useBulkAttackCaseItems = ({
     ]
   );
 
-  return useMemo(
-    () => ({
-      items,
-      panels: [],
-    }),
-    [items]
-  );
+  return useMemo(() => ({ items, panels }), [items, panels]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_investigate_in_timeline_items.tsx
@@ -17,6 +17,9 @@ import { extractRelatedDetectionAlertIds } from '../utils/extract_related_detect
 import { AttacksEventTypes } from '../../../../../common/lib/telemetry';
 import type { AttacksActionTelemetrySource } from '../../../../../common/lib/telemetry';
 
+export const ATTACK_INVESTIGATE_IN_TIMELINE_ACTION_ID =
+  'attack-investigate-in-timeline-action-item';
+
 export interface UseBulkAttackInvestigateInTimelineItemsProps {
   /** Optional callback to close the popover after triggering action */
   closePopover?: () => void;
@@ -65,7 +68,7 @@ export const useBulkAttackInvestigateInTimelineItems = ({
             {
               name: ACTION_INVESTIGATE_IN_TIMELINE,
               label: ACTION_INVESTIGATE_IN_TIMELINE,
-              key: 'attack-investigate-in-timeline-action-item',
+              key: ATTACK_INVESTIGATE_IN_TIMELINE_ACTION_ID,
               'data-test-subj': 'attack-investigate-in-timeline-action-item',
               disableOnQuery: true,
               onClick: onInvestigateInTimelineClick,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_run_workflow_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_run_workflow_items.tsx
@@ -21,6 +21,8 @@ import { useKibana } from '../../../../../common/lib/kibana';
 import type { AttacksActionTelemetrySource } from '../../../../../common/lib/telemetry';
 import { AttacksEventTypes } from '../../../../../common/lib/telemetry';
 
+export const RUN_ATTACK_WORKFLOW_ACTION_ID = 'run-attack-workflow-action';
+
 export interface UseBulkAttackRunWorkflowItemsProps {
   /** Source of the action for telemetry */
   telemetrySource?: AttacksActionTelemetrySource;
@@ -72,7 +74,7 @@ export const useBulkAttackRunWorkflowItems = ({
       canRunWorkflow
         ? [
             {
-              key: 'run-attack-workflow-action',
+              key: RUN_ATTACK_WORKFLOW_ACTION_ID,
               name: alertsTableI18n.CONTEXT_MENU_RUN_WORKFLOW,
               label: alertsTableI18n.CONTEXT_MENU_RUN_WORKFLOW,
               panel: RUN_WORKFLOW_BULK_PANEL_ID,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_tags_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_tags_items.tsx
@@ -20,6 +20,8 @@ import { useApplyAttackTags } from '../apply_actions/use_apply_attack_tags';
 import * as i18n from '../translations';
 import type { AttackContentPanelConfig, BulkAttackActionItems } from '../types';
 
+export const ATTACK_TAG_ACTION_ID = 'manage-attack-tags';
+
 export interface UseBulkAttackTagsItemsProps {
   /** Optional callback when tags are updated */
   onTagsUpdate?: () => void;
@@ -47,7 +49,7 @@ export const useBulkAttackTagsItems = ({
 
     return [
       {
-        key: 'manage-attack-tags',
+        key: ATTACK_TAG_ACTION_ID,
         'data-test-subj': 'attack-tags-context-menu-item',
         name: i18n.ATTACK_TAGS_CONTEXT_MENU_ITEM_TITLE,
         panel: 1,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_workflow_status_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_workflow_status_items.tsx
@@ -20,6 +20,12 @@ import { useApplyAttackWorkflowStatus } from '../apply_actions/use_apply_attack_
 import * as i18n from '../translations';
 import type { AttackContentPanelConfig, BulkAttackActionItems } from '../types';
 
+export const ATTACK_STATUS_ACTION_IDS = {
+  markAsAcknowledged: 'acknowledge-attack-status',
+  markAsClosed: 'closed-attack-status',
+  markAsOpen: 'open-attack-status',
+} as const;
+
 export interface UseBulkAttackWorkflowStatusItemsProps {
   /** Callback when workflow status is updated */
   onWorkflowStatusUpdate?: () => void;
@@ -111,7 +117,7 @@ export const useBulkAttackWorkflowStatusItems = ({
     if (currentStatus !== FILTER_OPEN) {
       items.push({
         label: i18n.BULK_ACTION_OPEN_SELECTED,
-        key: 'open-attack-status',
+        key: ATTACK_STATUS_ACTION_IDS.markAsOpen,
         'data-test-subj': 'open-attack-status',
         onClick: handleStatusUpdate(FILTER_OPEN as AlertWorkflowStatus),
         disableOnQuery: true,
@@ -122,7 +128,7 @@ export const useBulkAttackWorkflowStatusItems = ({
     if (currentStatus !== FILTER_ACKNOWLEDGED) {
       items.push({
         label: i18n.BULK_ACTION_ACKNOWLEDGED_SELECTED,
-        key: 'acknowledge-attack-status',
+        key: ATTACK_STATUS_ACTION_IDS.markAsAcknowledged,
         'data-test-subj': 'acknowledged-attack-status',
         onClick: handleStatusUpdate(FILTER_ACKNOWLEDGED as AlertWorkflowStatus),
         disableOnQuery: true,
@@ -133,7 +139,7 @@ export const useBulkAttackWorkflowStatusItems = ({
     if (currentStatus !== FILTER_CLOSED) {
       items.push({
         label: alertClosingReasonItem?.label ?? i18n.BULK_ACTION_CLOSE_SELECTED,
-        key: alertClosingReasonItem?.key ?? 'closed-attack-status',
+        key: alertClosingReasonItem?.key ?? ATTACK_STATUS_ACTION_IDS.markAsClosed,
         'data-test-subj': alertClosingReasonItem?.['data-test-subj'],
         panel: alertClosingReasonItem?.panel,
         disableOnQuery: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_explore_in_attacks_context_menu_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_explore_in_attacks_context_menu_items.tsx
@@ -16,6 +16,7 @@ import { useIsNewFlyoutEnabled } from '../../../../../common/hooks/use_is_new_fl
 import { buildExploreInAttacksUrl } from '../../../../../flyout_v2/attack/main/utils/get_explore_in_attacks_url';
 
 export const EXPLORE_IN_ATTACKS_TEST_ID = 'exploreInAttacksContextMenuItem';
+export const EXPLORE_IN_ATTACKS_ACTION_ID = 'exploreInAttacks';
 export const EXPLORE_IN_ATTACKS_LABEL = i18n.translate(
   'xpack.securitySolution.attacks.exploreInAttacks',
   { defaultMessage: 'Explore in Attacks' }
@@ -64,7 +65,7 @@ export const useAttackExploreInAttacksContextMenuItems = ({
     () => [
       {
         'data-test-subj': EXPLORE_IN_ATTACKS_TEST_ID,
-        key: 'exploreInAttacks',
+        key: EXPLORE_IN_ATTACKS_ACTION_ID,
         name: (
           <EuiFlexGroup alignItems="center" gutterSize="xs" justifyContent="flexStart">
             <EuiFlexItem grow={false}>{EXPLORE_IN_ATTACKS_LABEL}</EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_view_in_ai_assistant_context_menu_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/context_menu_items/use_attack_view_in_ai_assistant_context_menu_items.tsx
@@ -22,6 +22,11 @@ import { useKibana } from '../../../../../common/lib/kibana';
 import { AttacksEventTypes } from '../../../../../common/lib/telemetry';
 import type { AttacksActionTelemetrySource } from '../../../../../common/lib/telemetry';
 
+export const ATTACK_AI_ACTION_IDS = {
+  addToChat: 'viewInAgentBuilder',
+  viewInAiAssistant: 'viewInAiAssistant',
+} as const;
+
 export interface UseAttackViewInAiAssistantContextMenuItemsProps {
   /** The attack discovery object */
   attack: AttackDiscoveryAlert;
@@ -114,7 +119,7 @@ export const useAttackViewInAiAssistantContextMenuItems = ({
       return [
         {
           name: i18n.ADD_TO_CHAT,
-          key: 'viewInAgentBuilder',
+          key: ATTACK_AI_ACTION_IDS.addToChat,
           'data-test-subj': 'viewInAgentBuilder',
           disabled: isAddToChatDisabled,
           onClick: () => {
@@ -132,7 +137,7 @@ export const useAttackViewInAiAssistantContextMenuItems = ({
     return [
       {
         name: i18n.VIEW_IN_AI_ASSISTANT,
-        key: 'viewInAiAssistant',
+        key: ATTACK_AI_ACTION_IDS.viewInAiAssistant,
         'data-test-subj': 'viewInAiAssistant',
         disabled: viewInAiAssistantDisabled,
         onClick: () => {


### PR DESCRIPTION
## Summary

- adds named menus for attack and Attack Discovery actions
- adopts the shared two-layer case action flow
- keeps management and workflow actions in consistent groups

Stack layer 3 of 7. Depends on the shared action-menu utilities and case menu below it.

Addresses #278607

### Checklist

- [x] Added text follows EUI writing and i18n guidelines
- [x] Documentation is not required for this internal menu composition change
- [x] Unit tests cover action ordering and case selection
- [x] No plugin configuration or HTTP API changes were introduced
- [x] Validation from the original PR is preserved because the stacked branch chain reproduces its final tree exactly

### Identify risks

Low risk. Existing attack actions and telemetry callbacks remain unchanged.

## Release note

Improves the consistency and readability of attack action menus.

Made with [Cursor](https://cursor.com)

## Stack

1. [#284116 — Two-layer case action menu](https://github.com/elastic/kibana/pull/284116)
2. [#284117 — Alert action menus](https://github.com/elastic/kibana/pull/284117)
3. [#284118 — Attack action menus](https://github.com/elastic/kibana/pull/284118)
4. [#284119 — Document action menus](https://github.com/elastic/kibana/pull/284119)
5. [#284120 — Events table bulk action menu](https://github.com/elastic/kibana/pull/284120)
6. [#284121 — Entity analytics action menus](https://github.com/elastic/kibana/pull/284121)
7. [#284122 — ML case action menu](https://github.com/elastic/kibana/pull/284122)