### PR TITLE
[Security Solution][Take Actions] Add events table bulk action menu

### DIFF
--- a/x-pack/solutions/security/packages/data-table/components/toolbar/bulk_actions/types.ts
+++ b/x-pack/solutions/security/packages/data-table/components/toolbar/bulk_actions/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { IconType } from '@elastic/eui';
 import type { TimelineItem } from '@kbn/timelines-plugin/common';
 
 export type AlertWorkflowStatus = 'open' | 'closed' | 'acknowledged';
@@ -12,6 +13,7 @@ export type AlertWorkflowStatus = 'open' | 'closed' | 'acknowledged';
 export interface CustomBulkAction {
   key: string;
   label: string;
+  icon?: IconType;
   disableOnQuery?: boolean;
   disabledLabel?: string;
   onClick: (items?: TimelineItem[]) => void;

--- a/x-pack/solutions/security/plugins/security_solution/common/types/bulk_actions/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/types/bulk_actions/index.ts
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
+import type { IconType } from '@elastic/eui';
 import type { TimelineItem } from '../../search_strategy';
+
 export interface CustomBulkAction {
   key: string;
   label: string;
+  icon?: IconType;
   disableOnQuery?: boolean;
   disabledLabel?: string;
   onClick: (items?: TimelineItem[]) => void;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EventsTableBulkActionMenu } from './events_table_bulk_action_menu';
+
+describe('EventsTableBulkActionMenu', () => {
+  it('groups new and existing case actions in a case type panel', async () => {
+    const onAddToNewCase = jest.fn();
+    const onAddToExistingCase = jest.fn();
+
+    render(
+      <EventsTableBulkActionMenu
+        items={[
+          {
+            key: 'add-to-timeline',
+            name: 'Add to timeline',
+            'data-test-subj': 'add-to-timeline',
+            icon: 'timeline',
+          },
+          {
+            key: 'run-document-workflow-action',
+            name: 'Run workflow',
+            'data-test-subj': 'run-document-workflow-action',
+            icon: 'workflow',
+          },
+          {
+            key: 'attach-new-case',
+            name: 'Add to new case',
+            'data-test-subj': 'attach-new-case',
+            onActionClick: onAddToNewCase,
+          },
+          {
+            key: 'attach-existing-case',
+            name: 'Add to existing case',
+            'data-test-subj': 'attach-existing-case',
+            onActionClick: onAddToExistingCase,
+          },
+        ]}
+        panels={[]}
+      />
+    );
+
+    expect(
+      screen.getByTestId('add-to-timeline').querySelector('[data-euiicon-type="timeline"]')
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId('run-document-workflow-action')
+        .querySelector('[data-euiicon-type="workflow"]')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('add-to-case')).toBeInTheDocument();
+    expect(screen.queryByTestId('attach-new-case')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('attach-existing-case')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('add-to-case'));
+
+    expect(await screen.findByText('Case type')).toBeInTheDocument();
+    const submitButton = await screen.findByTestId('add-to-case-submit');
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.click(await screen.findByTestId('attach-existing-case'));
+    expect(submitButton).toBeEnabled();
+    fireEvent.click(submitButton);
+
+    expect(onAddToExistingCase).toHaveBeenCalledTimes(1);
+    expect(onAddToNewCase).not.toHaveBeenCalled();
+  });
+
+  it('leaves an individual case action in the initial panel', () => {
+    render(
+      <EventsTableBulkActionMenu
+        items={[
+          {
+            key: 'attach-new-case',
+            name: 'Add to new case',
+            'data-test-subj': 'attach-new-case',
+          },
+        ]}
+        panels={[]}
+      />
+    );
+
+    expect(screen.getByTestId('attach-new-case')).toBeInTheDocument();
+    expect(screen.queryByTestId('add-to-case')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import { EuiContextMenu } from '@elastic/eui';
+import { AddToCaseActionPanel, ADD_TO_CASE, CASE_TYPE } from '@kbn/response-ops-alerts-table';
+import React, { useMemo } from 'react';
+import {
+  ADD_TO_EXISTING_CASE,
+  ADD_TO_NEW_CASE,
+} from '../../../../cases/attachments/event/translations';
+import type { BulkActionMenuItem } from './use_bulk_action_items';
+
+const ADD_TO_NEW_CASE_ACTION_ID = 'attach-new-case';
+const ADD_TO_EXISTING_CASE_ACTION_ID = 'attach-existing-case';
+const ADD_TO_CASE_ACTION_ID = 'add-to-case';
+const ADD_TO_CASE_PANEL_ID = 'events-table-add-to-case-panel';
+
+interface EventsTableBulkActionMenuProps {
+  items: BulkActionMenuItem[];
+  panels: EuiContextMenuPanelDescriptor[];
+}
+
+export const EventsTableBulkActionMenu = ({ items, panels }: EventsTableBulkActionMenuProps) => {
+  const menuPanels = useMemo<EuiContextMenuPanelDescriptor[]>(() => {
+    const addToNewCase = items.find(({ key }) => key === ADD_TO_NEW_CASE_ACTION_ID);
+    const addToExistingCase = items.find(({ key }) => key === ADD_TO_EXISTING_CASE_ACTION_ID);
+
+    if (!addToNewCase?.onActionClick || !addToExistingCase?.onActionClick) {
+      return [{ id: 0, items }, ...panels];
+    }
+
+    const firstCaseActionIndex = items.findIndex(
+      ({ key }) => key === ADD_TO_NEW_CASE_ACTION_ID || key === ADD_TO_EXISTING_CASE_ACTION_ID
+    );
+    const initialItems = items.filter(
+      ({ key }) => key !== ADD_TO_NEW_CASE_ACTION_ID && key !== ADD_TO_EXISTING_CASE_ACTION_ID
+    );
+    initialItems.splice(firstCaseActionIndex, 0, {
+      key: ADD_TO_CASE_ACTION_ID,
+      'data-test-subj': ADD_TO_CASE_ACTION_ID,
+      disabled: Boolean(addToNewCase.disabled && addToExistingCase.disabled),
+      icon: 'briefcase',
+      name: ADD_TO_CASE,
+      panel: ADD_TO_CASE_PANEL_ID,
+    });
+
+    return [
+      { id: 0, items: initialItems },
+      {
+        id: ADD_TO_CASE_PANEL_ID,
+        title: CASE_TYPE,
+        content: (
+          <AddToCaseActionPanel
+            actions={[
+              {
+                id: ADD_TO_NEW_CASE_ACTION_ID,
+                label: ADD_TO_NEW_CASE,
+                dataTestSubj: addToNewCase['data-test-subj'],
+                disabled: addToNewCase.disabled,
+                onClick: addToNewCase.onActionClick,
+              },
+              {
+                id: ADD_TO_EXISTING_CASE_ACTION_ID,
+                label: ADD_TO_EXISTING_CASE,
+                dataTestSubj: addToExistingCase['data-test-subj'],
+                disabled: addToExistingCase.disabled,
+                onClick: addToExistingCase.onActionClick,
+              },
+            ]}
+          />
+        ),
+      },
+      ...panels,
+    ];
+  }, [items, panels]);
+
+  return <EuiContextMenu panels={menuPanels} initialPanelId={0} />;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/index.tsx
@@ -6,10 +6,11 @@
  */
 
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
-import { EuiPopover, EuiButtonEmpty, EuiContextMenu } from '@elastic/eui';
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import { EuiPopover, EuiButtonEmpty } from '@elastic/eui';
+import React, { useState, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
-import type { AlertTableContextMenuItem } from '../../../../detections/components/alerts_table/types';
+import { EventsTableBulkActionMenu } from './events_table_bulk_action_menu';
+import type { BulkActionMenuItem } from './use_bulk_action_items';
 
 interface OwnProps {
   selectText: string;
@@ -17,7 +18,7 @@ interface OwnProps {
   showClearSelection: boolean;
   onSelectAll: () => void;
   onClearSelection: () => void;
-  bulkActionItems: AlertTableContextMenuItem[];
+  bulkActionItems: BulkActionMenuItem[];
   bulkActionPanels: EuiContextMenuPanelDescriptor[];
   closePopoverRef?: React.MutableRefObject<() => void>;
 }
@@ -66,17 +67,6 @@ const BulkActionsComponent: React.FC<OwnProps> = ({
     }
   }, [onClearSelection, onSelectAll, showClearSelection]);
 
-  const panels = useMemo(
-    () => [
-      {
-        id: 0,
-        items: bulkActionItems,
-      },
-      ...bulkActionPanels,
-    ],
-    [bulkActionItems, bulkActionPanels]
-  );
-
   return (
     <BulkActionsContainer data-test-subj="bulk-actions-button-container">
       <EuiPopover
@@ -99,7 +89,7 @@ const BulkActionsComponent: React.FC<OwnProps> = ({
         }
         closePopover={closeActionPopover}
       >
-        <EuiContextMenu panels={panels} initialPanelId={0} />
+        <EventsTableBulkActionMenu items={bulkActionItems} panels={bulkActionPanels} />
       </EuiPopover>
 
       <EuiButtonEmpty

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.test.tsx
@@ -94,6 +94,26 @@ describe('useBulkActionItems', () => {
     ).toBeUndefined();
   });
 
+  it('exposes custom actions for composed bulk action menus', () => {
+    const onClick = jest.fn();
+    const { result } = renderUseBulkActionItems({
+      customBulkActions: [
+        {
+          key: 'attach-new-case',
+          label: 'Add to new case',
+          icon: 'briefcase',
+          onClick,
+        },
+      ],
+    });
+
+    const customAction = result.current.items.find(({ key }) => key === 'attach-new-case');
+    customAction?.onActionClick?.();
+
+    expect(onClick).toHaveBeenCalledWith(['mockEventId']);
+    expect(customAction?.icon).toBe('briefcase');
+  });
+
   describe('workflow actions', () => {
     it('should include workflow menu items when useRunDocumentWorkflowPanel returns items', () => {
       const mockMenuItem = {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.tsx
@@ -29,6 +29,15 @@ import { useAlertCloseInfoModal } from '../../../../detections/hooks/use_alert_c
 import { useAlertsPrivileges } from '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { useRunDocumentWorkflowPanel } from '../../../../detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel';
 
+export type BulkActionMenuItem = AlertTableContextMenuItem & {
+  onActionClick?: () => void;
+};
+
+export const ALERT_STATUS_ACTION_IDS = {
+  markAsAcknowledged: 'acknowledge',
+  markAsOpen: 'open',
+} as const;
+
 export interface BulkActionsProps {
   eventIds: string[];
   currentStatus?: AlertWorkflowStatus;
@@ -194,12 +203,12 @@ export const useBulkActionItems = ({
     closePopover: closePopover ?? noop,
   });
 
-  const items = useMemo(() => {
-    const actionItems: AlertTableContextMenuItem[] = [];
+  const items = useMemo<BulkActionMenuItem[]>(() => {
+    const actionItems: BulkActionMenuItem[] = [];
     if (showAlertStatusActions && hasAlertsUpdate) {
       if (currentStatus !== FILTER_OPEN) {
         actionItems.push({
-          key: 'open',
+          key: ALERT_STATUS_ACTION_IDS.markAsOpen,
           'data-test-subj': 'open-alert-status',
           onClick: () => {
             closePopover?.();
@@ -210,7 +219,7 @@ export const useBulkActionItems = ({
       }
       if (currentStatus !== FILTER_ACKNOWLEDGED) {
         actionItems.push({
-          key: 'acknowledge',
+          key: ALERT_STATUS_ACTION_IDS.markAsAcknowledged,
           'data-test-subj': 'acknowledged-alert-status',
           onClick: () => {
             closePopover?.();
@@ -230,17 +239,20 @@ export const useBulkActionItems = ({
     }
 
     const additionalItems = customBulkActions
-      ? customBulkActions.reduce<AlertTableContextMenuItem[]>((acc, action) => {
+      ? customBulkActions.reduce<BulkActionMenuItem[]>((acc, action) => {
           const isDisabled = !!(query && action.disableOnQuery);
+          const onActionClick = () => {
+            closePopover?.();
+            action.onClick(eventIds);
+          };
           acc.push({
             key: action.key,
             disabled: isDisabled,
             'data-test-subj': action['data-test-subj'],
+            icon: action.icon,
             toolTipContent: isDisabled ? action.disabledLabel : null,
-            onClick: () => {
-              closePopover?.();
-              action.onClick(eventIds);
-            },
+            onClick: onActionClick,
+            onActionClick,
             name: action.label,
           });
           return acc;

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/bulk_actions/bulk_actions.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/bulk_actions/bulk_actions.cy.ts
@@ -7,6 +7,7 @@
 
 import { getNewRule } from '../../../../../objects/rule';
 import {
+  ADD_TO_CASE_BUTTON,
   ADD_TO_EXISTING_CASE_BUTTON,
   ADD_TO_NEW_CASE_BUTTON,
   SELECTED_ALERTS,
@@ -42,6 +43,7 @@ describe('Alerts table bulk actions', { tags: ['@ess', '@serverless'] }, () => {
     cy.get(SELECTED_ALERTS).should('have.text', `Selected 2 alerts`);
     cy.get(TAKE_ACTION_POPOVER_BTN).first().click();
     cy.get(TAKE_ACTION_POPOVER_BTN).should('be.visible');
+    cy.get(ADD_TO_CASE_BUTTON).click();
     cy.get(ADD_TO_NEW_CASE_BUTTON).should('be.visible');
     cy.get(ADD_TO_EXISTING_CASE_BUTTON).should('be.visible');
   });


### PR DESCRIPTION
## Summary

- adds a dedicated bulk action menu for event selections
- groups new and existing case actions behind the shared case selector
- preserves investigate and workflow icons

Stack layer 5 of 7. Depends on the shared case menu below it.

Addresses #278607

### Checklist

- [x] Added text follows EUI writing and i18n guidelines
- [x] Documentation is not required for this internal menu composition change
- [x] Unit and Cypress tests cover the event bulk menu
- [x] No plugin configuration or HTTP API changes were introduced
- [x] Validation from the original PR is preserved because the stacked branch chain reproduces its final tree exactly

### Identify risks

Low risk. Existing event bulk callbacks are reused and icon propagation is tested.

## Release note

Improves case and workflow actions in event table bulk menus.

Made with [Cursor](https://cursor.com)

## Stack

1. [#284116 — Two-layer case action menu](https://github.com/elastic/kibana/pull/284116)
2. [#284117 — Alert action menus](https://github.com/elastic/kibana/pull/284117)
3. [#284118 — Attack action menus](https://github.com/elastic/kibana/pull/284118)
4. [#284119 — Document action menus](https://github.com/elastic/kibana/pull/284119)
5. [#284120 — Events table bulk action menu](https://github.com/elastic/kibana/pull/284120)
6. [#284121 — Entity analytics action menus](https://github.com/elastic/kibana/pull/284121)
7. [#284122 — ML case action menu](https://github.com/elastic/kibana/pull/284122)