### PR TITLE
[Security Solution][Take Actions] Add entity analytics action menus

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/add_to_existing_case.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/add_to_existing_case.tsx
@@ -8,7 +8,7 @@
 import type { FC } from 'react';
 import React, { useCallback } from 'react';
 import { EuiContextMenuItem } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import type { EntityToAttach } from '..';
 import { generateEntityAttachmentsWithoutOwner } from '..';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -28,6 +28,23 @@ export interface AddToExistingCaseProps {
   ['data-test-subj']?: string;
 }
 
+export const ADD_TO_EXISTING_CASE = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.cases.addToExistingCase',
+  {
+    defaultMessage: 'Add to existing case',
+  }
+);
+
+export const useAddToExistingCase = ({ entity, onClick }: AddToExistingCaseProps) => {
+  const { cases } = useKibana().services;
+  const selectCaseModal = cases.hooks.useCasesAddToExistingCaseModal();
+
+  return useCallback(() => {
+    onClick();
+    selectCaseModal.open({ getAttachments: () => generateEntityAttachmentsWithoutOwner(entity) });
+  }, [entity, onClick, selectCaseModal]);
+};
+
 /**
  * Leverages the cases plugin api to display a modal listing all the existing cases.
  * Once a case is selected, an entity attachment is added to it and a confirmation
@@ -43,20 +60,11 @@ export const AddToExistingCase: FC<AddToExistingCaseProps> = ({
   onClick,
   'data-test-subj': dataTestSubj,
 }) => {
-  const { cases } = useKibana().services;
-  const selectCaseModal = cases.hooks.useCasesAddToExistingCaseModal();
-
-  const menuItemClicked = useCallback(() => {
-    onClick();
-    selectCaseModal.open({ getAttachments: () => generateEntityAttachmentsWithoutOwner(entity) });
-  }, [entity, onClick, selectCaseModal]);
+  const menuItemClicked = useAddToExistingCase({ entity, onClick });
 
   return (
     <EuiContextMenuItem onClick={menuItemClicked} data-test-subj={dataTestSubj}>
-      <FormattedMessage
-        defaultMessage="Add to existing case"
-        id="xpack.securitySolution.entityAnalytics.cases.addToExistingCase"
-      />
+      {ADD_TO_EXISTING_CASE}
     </EuiContextMenuItem>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/add_to_new_case.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/add_to_new_case.tsx
@@ -8,7 +8,7 @@
 import type { FC } from 'react';
 import React, { useCallback } from 'react';
 import { EuiContextMenuItem } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import type { EntityToAttach } from '..';
 import { generateEntityAttachmentsWithoutOwner } from '..';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -28,6 +28,23 @@ export interface AddToNewCaseProps {
   ['data-test-subj']?: string;
 }
 
+export const ADD_TO_NEW_CASE = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.cases.addToNewCase',
+  {
+    defaultMessage: 'Add to new case',
+  }
+);
+
+export const useAddToNewCase = ({ entity, onClick }: AddToNewCaseProps) => {
+  const { cases } = useKibana().services;
+  const createCaseFlyout = cases.hooks.useCasesAddToNewCaseFlyout();
+
+  return useCallback(() => {
+    onClick();
+    createCaseFlyout.open({ attachments: generateEntityAttachmentsWithoutOwner(entity) });
+  }, [createCaseFlyout, entity, onClick]);
+};
+
 /**
  * Leverages the cases plugin api to display a flyout to create a new case.
  * Once a case is created, an entity attachment is added to it and a confirmation
@@ -43,20 +60,11 @@ export const AddToNewCase: FC<AddToNewCaseProps> = ({
   onClick,
   'data-test-subj': dataTestSubj,
 }) => {
-  const { cases } = useKibana().services;
-  const createCaseFlyout = cases.hooks.useCasesAddToNewCaseFlyout();
-
-  const menuItemClicked = useCallback(() => {
-    onClick();
-    createCaseFlyout.open({ attachments: generateEntityAttachmentsWithoutOwner(entity) });
-  }, [createCaseFlyout, entity, onClick]);
+  const menuItemClicked = useAddToNewCase({ entity, onClick });
 
   return (
     <EuiContextMenuItem onClick={menuItemClicked} data-test-subj={dataTestSubj}>
-      <FormattedMessage
-        defaultMessage="Add to new case"
-        id="xpack.securitySolution.entityAnalytics.cases.addToNewCase"
-      />
+      {ADD_TO_NEW_CASE}
     </EuiContextMenuItem>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/hooks/use_entity_case_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/hooks/use_entity_case_take_action_items.test.tsx
@@ -43,26 +43,26 @@ describe('useEntityCaseTakeActionItems', () => {
     mockUseKibana().services.cases.config = { attachmentsEnabled: true };
   });
 
-  it('returns both items when the user can add to new and existing cases', () => {
-    expect(renderItemKeys()).toEqual(['addToNewCase', 'addToExistingCase']);
+  it('returns the case submenu when the user can add to new and existing cases', () => {
+    expect(renderItemKeys()).toEqual(['addToCase']);
   });
 
-  it('hides "add to new case" when the user cannot create a new case', () => {
+  it('keeps the case submenu when the user can only add to an existing case', () => {
     mockUseEntityCasePermissions.mockReturnValue({
       canAddToNewCase: false,
       canAddToExistingCase: true,
     });
 
-    expect(renderItemKeys()).toEqual(['addToExistingCase']);
+    expect(renderItemKeys()).toEqual(['addToCase']);
   });
 
-  it('hides "add to existing case" when the user cannot update a case', () => {
+  it('keeps the case submenu when the user can only add to a new case', () => {
     mockUseEntityCasePermissions.mockReturnValue({
       canAddToNewCase: true,
       canAddToExistingCase: false,
     });
 
-    expect(renderItemKeys()).toEqual(['addToNewCase']);
+    expect(renderItemKeys()).toEqual(['addToCase']);
   });
 
   it('returns no items when the user has neither case permission', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/hooks/use_entity_case_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/hooks/use_entity_case_take_action_items.tsx
@@ -6,16 +6,61 @@
  */
 
 import React, { useCallback } from 'react';
+import { AddToCaseContextMenuItem } from '@kbn/response-ops-alerts-table';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useKibana } from '../../../../common/lib/kibana';
 import type { EntityToAttach } from '..';
-import { AddToNewCase } from '../components/add_to_new_case';
-import { AddToExistingCase } from '../components/add_to_existing_case';
+import { ADD_TO_NEW_CASE, useAddToNewCase } from '../components/add_to_new_case';
+import { ADD_TO_EXISTING_CASE, useAddToExistingCase } from '../components/add_to_existing_case';
 import {
   ADD_TO_NEW_CASE_TEST_ID,
   ADD_TO_EXISTING_CASE_TEST_ID,
 } from '../../../../../common/cases/attachments/entity/test_ids';
 import { useEntityCasePermissions } from './use_case_permission';
+
+interface EntityAddToCaseContextMenuItemProps {
+  entity: EntityToAttach;
+  closePopover: () => void;
+  canAddToNewCase: boolean;
+  canAddToExistingCase: boolean;
+}
+
+const EntityAddToCaseContextMenuItem = ({
+  entity,
+  closePopover,
+  canAddToNewCase,
+  canAddToExistingCase,
+}: EntityAddToCaseContextMenuItemProps) => {
+  const addToNewCase = useAddToNewCase({ entity, onClick: closePopover });
+  const addToExistingCase = useAddToExistingCase({ entity, onClick: closePopover });
+
+  return (
+    <AddToCaseContextMenuItem
+      actions={[
+        ...(canAddToNewCase
+          ? [
+              {
+                id: 'addToNewCase',
+                label: ADD_TO_NEW_CASE,
+                dataTestSubj: ADD_TO_NEW_CASE_TEST_ID,
+                onClick: addToNewCase,
+              },
+            ]
+          : []),
+        ...(canAddToExistingCase
+          ? [
+              {
+                id: 'addToExistingCase',
+                label: ADD_TO_EXISTING_CASE,
+                dataTestSubj: ADD_TO_EXISTING_CASE_TEST_ID,
+                onClick: addToExistingCase,
+              },
+            ]
+          : []),
+      ]}
+    />
+  );
+};
 
 /**
  * Builds the "add to case" menu items for an entity's flyout "Take action" popover.
@@ -38,33 +83,24 @@ export const useEntityCaseTakeActionItems = (
 
   return useCallback(
     (closePopover: () => void) => {
-      if (!entityAttachmentsEnabled || !attachmentsEnabled || !entity.name || !entity.id) {
+      if (
+        !entityAttachmentsEnabled ||
+        !attachmentsEnabled ||
+        !entity.name ||
+        !entity.id ||
+        (!canAddToNewCase && !canAddToExistingCase)
+      ) {
         return [];
       }
 
-      // Only surface the actions the user can actually perform; the rest are hidden
-      // rather than shown disabled, matching the alerts "add to case" convention.
       return [
-        ...(canAddToNewCase
-          ? [
-              <AddToNewCase
-                key="addToNewCase"
-                entity={entity}
-                onClick={closePopover}
-                data-test-subj={ADD_TO_NEW_CASE_TEST_ID}
-              />,
-            ]
-          : []),
-        ...(canAddToExistingCase
-          ? [
-              <AddToExistingCase
-                key="addToExistingCase"
-                entity={entity}
-                onClick={closePopover}
-                data-test-subj={ADD_TO_EXISTING_CASE_TEST_ID}
-              />,
-            ]
-          : []),
+        <EntityAddToCaseContextMenuItem
+          key="addToCase"
+          entity={entity}
+          closePopover={closePopover}
+          canAddToNewCase={canAddToNewCase}
+          canAddToExistingCase={canAddToExistingCase}
+        />,
       ];
     },
     [entityAttachmentsEnabled, attachmentsEnabled, entity, canAddToNewCase, canAddToExistingCase]

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_table_row_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_anomaly_table_row_actions.ts
@@ -23,8 +23,14 @@ import {
   ENTITY_ANOMALY_TABLE_ROW_ACTION_VIEW_IN_SMV,
 } from '../../components/anomalies/translations';
 
+export const ANOMALY_ACTION_IDS = {
+  addToTimeline: 'add-to-timeline',
+  viewInDiscover: 'view-in-discover',
+  viewInSingleMetricViewer: 'view-in-single-metric-viewer',
+} as const;
+
 export interface AnomalyTableRowAction {
-  key: string;
+  key: (typeof ANOMALY_ACTION_IDS)[keyof typeof ANOMALY_ACTION_IDS];
   label: string;
   icon: IconType;
   onClick: () => void;
@@ -242,7 +248,7 @@ export const useAnomalyTableRowActions = ({
 
     if (canReadTimeline) {
       items.push({
-        key: 'add-to-timeline',
+        key: ANOMALY_ACTION_IDS.addToTimeline,
         label: ENTITY_ANOMALY_TABLE_ROW_ACTION_ADD_TO_TIMELINE,
         icon: 'timeline',
         onClick: handleAddToTimeline,
@@ -250,7 +256,7 @@ export const useAnomalyTableRowActions = ({
     }
 
     items.push({
-      key: 'view-in-discover',
+      key: ANOMALY_ACTION_IDS.viewInDiscover,
       label: ENTITY_ANOMALY_TABLE_ROW_ACTION_VIEW_IN_DISCOVER,
       icon: 'productDiscover',
       onClick: handleViewInDiscover,
@@ -258,7 +264,7 @@ export const useAnomalyTableRowActions = ({
 
     if (getUrl) {
       items.push({
-        key: 'view-in-single-metric-viewer',
+        key: ANOMALY_ACTION_IDS.viewInSingleMetricViewer,
         label: ENTITY_ANOMALY_TABLE_ROW_ACTION_VIEW_IN_SMV,
         icon: 'singleMetricViewer',
         onClick: handleViewInSingleMetricViewer,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_action_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_action_menu.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiContextMenu } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import type { AnomalyTableRowAction } from '../../../api/hooks/use_anomaly_table_row_actions';
+import { ANOMALIES_TABLE_ROW_ACTION_TEST_ID_PREFIX } from '../test_ids';
+
+interface AnomalyActionMenuProps {
+  actions: AnomalyTableRowAction[];
+}
+
+export const AnomalyActionMenu = ({ actions }: AnomalyActionMenuProps) => {
+  const items = useMemo(
+    () =>
+      actions.map((action) => ({
+        key: action.key,
+        name: action.label,
+        icon: action.icon,
+        onClick: action.onClick,
+        'data-test-subj': `${ANOMALIES_TABLE_ROW_ACTION_TEST_ID_PREFIX}${action.key}`,
+      })),
+    [actions]
+  );
+
+  return <EuiContextMenu initialPanelId={0} panels={[{ id: 0, items }]} />;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_row_actions_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_row_actions_menu.test.tsx
@@ -99,6 +99,11 @@ describe('AnomalyRowActionsMenu', () => {
     expect(screen.getByTestId(ADD_TO_TIMELINE)).toBeInTheDocument();
     expect(screen.getByTestId(VIEW_IN_DISCOVER)).toBeInTheDocument();
     expect(screen.getByTestId(VIEW_IN_SMV)).toBeInTheDocument();
+    expect(screen.getAllByRole('menuitem').map(({ textContent }) => textContent)).toEqual([
+      'Add to timeline',
+      'View in Discover',
+      'View in Single metric viewer',
+    ]);
   });
 
   it('labels each investigation action', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_row_actions_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/anomalies/table/anomaly_row_actions_menu.tsx
@@ -5,16 +5,13 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
-import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
-import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import React, { useCallback, useState } from 'react';
+import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { ENTITY_ANOMALY_TABLE_ACTIONS_COLUMN_TOOLTIP } from '../translations';
 import type { TableRow } from './types';
+import { AnomalyActionMenu } from './anomaly_action_menu';
 import { useAnomalyTableRowActions } from '../../../api/hooks/use_anomaly_table_row_actions';
-import {
-  ANOMALIES_TABLE_ROW_ACTIONS_BUTTON_TEST_ID,
-  ANOMALIES_TABLE_ROW_ACTION_TEST_ID_PREFIX,
-} from '../test_ids';
+import { ANOMALIES_TABLE_ROW_ACTIONS_BUTTON_TEST_ID } from '../test_ids';
 
 interface AnomalyRowActionsMenuProps {
   row: TableRow;
@@ -27,21 +24,6 @@ export const AnomalyRowActionsMenu: React.FC<AnomalyRowActionsMenuProps> = ({ ro
   const togglePopover = useCallback(() => setIsOpen((value) => !value), []);
 
   const { actions } = useAnomalyTableRowActions({ row, timeRange, closePopover });
-
-  const panels = useMemo<EuiContextMenuPanelDescriptor[]>(
-    () => [
-      {
-        id: 0,
-        items: actions.map((action) => ({
-          name: action.label,
-          icon: action.icon,
-          onClick: action.onClick,
-          'data-test-subj': `${ANOMALIES_TABLE_ROW_ACTION_TEST_ID_PREFIX}${action.key}`,
-        })),
-      },
-    ],
-    [actions]
-  );
 
   const button = (
     <EuiToolTip content={ENTITY_ANOMALY_TABLE_ACTIONS_COLUMN_TOOLTIP} disableScreenReaderOutput>
@@ -64,7 +46,7 @@ export const AnomalyRowActionsMenu: React.FC<AnomalyRowActionsMenuProps> = ({ ro
       panelPaddingSize="none"
       anchorPosition="downRight"
     >
-      <EuiContextMenu initialPanelId={0} panels={panels} />
+      <AnomalyActionMenu actions={actions} />
     </EuiPopover>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/action_column.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/action_column.tsx
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useState } from 'react';
 import type { InputAlert } from '../../../hooks/use_risk_contributing_alerts';
-
-import { useRiskInputActionsPanels } from '../hooks/use_risk_input_actions_panels';
+import { RiskInputActionMenu } from './risk_input_action_menu';
 
 interface ActionColumnProps {
   input: InputAlert;
@@ -20,7 +19,6 @@ export const ActionColumn: React.FC<ActionColumnProps> = ({ input }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
   const togglePopover = useCallback(() => setIsPopoverOpen((isOpen) => !isOpen), []);
-  const panels = useRiskInputActionsPanels([input], closePopover);
 
   return (
     <EuiPopover
@@ -59,7 +57,7 @@ export const ActionColumn: React.FC<ActionColumnProps> = ({ input }) => {
       panelPaddingSize="none"
       anchorPosition="downLeft"
     >
-      <EuiContextMenu initialPanelId={0} panels={panels} />
+      <RiskInputActionMenu closePopover={closePopover} inputs={[input]} />
     </EuiPopover>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/risk_input_action_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/risk_input_action_menu.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiContextMenu } from '@elastic/eui';
+import React from 'react';
+import type { InputAlert } from '../../../hooks/use_risk_contributing_alerts';
+import { useRiskInputActionsPanels } from '../hooks/use_risk_input_actions_panels';
+
+interface RiskInputActionMenuProps {
+  closePopover: () => void;
+  inputs: InputAlert[];
+}
+
+export const RiskInputActionMenu = ({ closePopover, inputs }: RiskInputActionMenuProps) => {
+  const panels = useRiskInputActionsPanels(inputs, closePopover);
+
+  return <EuiContextMenu initialPanelId={0} panels={panels} />;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/utility_bar.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/utility_bar.tsx
@@ -10,7 +10,6 @@ import React, { useCallback, useState } from 'react';
 
 import {
   EuiButtonEmpty,
-  EuiContextMenu,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPopover,
@@ -20,8 +19,8 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
-import { useRiskInputActionsPanels } from '../hooks/use_risk_input_actions_panels';
 import type { InputAlert } from '../../../hooks/use_risk_contributing_alerts';
+import { RiskInputActionMenu } from './risk_input_action_menu';
 
 interface Props {
   riskInputs: InputAlert[];
@@ -32,7 +31,6 @@ export const RiskInputsUtilityBar: FunctionComponent<Props> = React.memo(({ risk
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const togglePopover = useCallback(() => setIsPopoverOpen(!isPopoverOpen), [isPopoverOpen]);
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
-  const panels = useRiskInputActionsPanels(riskInputs, closePopover);
 
   if (riskInputs.length === 0) {
     return null;
@@ -80,7 +78,7 @@ export const RiskInputsUtilityBar: FunctionComponent<Props> = React.memo(({ risk
               </EuiButtonEmpty>
             }
           >
-            <EuiContextMenu panels={panels} initialPanelId={0} />
+            <RiskInputActionMenu closePopover={closePopover} inputs={riskInputs} />
           </EuiPopover>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_risk_input_actions_panels.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_risk_input_actions_panels.test.tsx
@@ -8,7 +8,7 @@
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiContextMenu } from '@elastic/eui';
 import { casesPluginMock } from '@kbn/cases-plugin/public/mocks';
-import { render, renderHook } from '@testing-library/react';
+import { fireEvent, render, renderHook } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { alertInputDataMock } from '../mocks';
@@ -101,11 +101,32 @@ describe('useRiskInputActionsPanels', () => {
     expect(getByTestId('contextMenuPanelTitle')).toHaveTextContent('2 selected');
   });
 
-  it('displays cases actions when user has cases permissions', () => {
-    const { container } = customRender();
+  it('displays cases actions when user has cases permissions', async () => {
+    const { findByTestId, getByTestId } = customRender();
 
-    expect(container).toHaveTextContent('Add to existing case');
-    expect(container).toHaveTextContent('Add to new case');
+    fireEvent.click(getByTestId('add-to-case'));
+
+    expect(await findByTestId('add-to-new-case')).toBeInTheDocument();
+    expect(await findByTestId('add-to-existing-case')).toBeInTheDocument();
+  });
+
+  it('keeps action order, icons, and the explicit group separator visible', () => {
+    mockUseUserPrivileges.mockReturnValue({
+      timelinePrivileges: { read: true },
+    });
+    const { getAllByRole, getByTestId } = customRender();
+
+    expect(getAllByRole('menuitem').map(({ textContent }) => textContent)).toEqual([
+      'Add to new timeline',
+      'Add to case',
+    ]);
+    expect(getByTestId('securityActionMenuGroupSeparator')).toBeInTheDocument();
+    expect(
+      getByTestId('add-to-new-timeline').querySelector('[data-euiicon-type="timeline"]')
+    ).not.toBeNull();
+    expect(
+      getByTestId('add-to-case').querySelector('[data-euiicon-type="briefcase"]')
+    ).not.toBeNull();
   });
 
   it('does NOT display cases actions when user has NO cases permissions', () => {
@@ -158,11 +179,12 @@ describe('useRiskInputActionsPanels', () => {
     );
 
     const timelineAction = result.current[0].items?.find(
-      (item: Partial<{ name: React.JSX.Element }>) =>
-        item.name?.props?.defaultMessage === 'Add to new timeline'
+      ({ key }) => key === 'add-to-new-timeline'
     );
 
-    timelineAction?.onClick?.();
+    if (timelineAction && 'onClick' in timelineAction) {
+      timelineAction.onClick?.();
+    }
 
     expect(mockSendBulkEvents).toHaveBeenCalledWith([
       {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_risk_input_actions_panels.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_risk_input_actions_panels.tsx
@@ -11,6 +11,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
 import { TableId } from '@kbn/securitysolution-data-table';
 import { i18n } from '@kbn/i18n';
+import { AddToCaseActionPanel, ADD_TO_CASE, CASE_TYPE } from '@kbn/response-ops-alerts-table';
 import { get } from 'lodash/fp';
 import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { useRiskInputActions } from './use_risk_input_actions';
@@ -21,6 +22,29 @@ import { useUserPrivileges } from '../../../../common/components/user_privileges
 import { EntityEventTypes } from '../../../../common/lib/telemetry';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import { useIsInSecurityApp } from '../../../../common/hooks/is_in_security_app';
+
+export const RISK_INPUT_ACTION_IDS = {
+  addToNewTimeline: 'add-to-new-timeline',
+  addToCase: 'add-to-case',
+  addToNewCase: 'add-to-new-case',
+  addToExistingCase: 'add-to-existing-case',
+} as const;
+
+const ADD_TO_NEW_CASE = i18n.translate(
+  'xpack.securitySolution.flyout.entityDetails.riskInputs.actions.addToNewCase',
+  {
+    defaultMessage: 'Add to new case',
+  }
+);
+
+const ADD_TO_EXISTING_CASE = i18n.translate(
+  'xpack.securitySolution.flyout.entityDetails.riskInputs.actions.addToExistingCase',
+  {
+    defaultMessage: 'Add to existing case',
+  }
+);
+
+const ADD_TO_CASE_PANEL_ID = 1;
 
 export const useRiskInputActionsPanels = (inputs: InputAlert[], closePopover: () => void) => {
   const { cases: casesService, telemetry } = useKibana().services;
@@ -45,6 +69,9 @@ export const useRiskInputActionsPanels = (inputs: InputAlert[], closePopover: ()
 
     return [
       {
+        key: RISK_INPUT_ACTION_IDS.addToNewTimeline,
+        icon: 'timeline',
+        'data-test-subj': RISK_INPUT_ACTION_IDS.addToNewTimeline,
         name: (
           <FormattedMessage
             id="xpack.securitySolution.flyout.entityDetails.riskInputs.actions.addToNewTimeline"
@@ -116,33 +143,54 @@ export const useRiskInputActionsPanels = (inputs: InputAlert[], closePopover: ()
         id: 0,
         items: [
           ...timelineActions,
+          ...(timelineActions.length > 0 && hasCasesPermissions
+            ? [
+                {
+                  key: 'separator-before-cases',
+                  isSeparator: true as const,
+                  'data-test-subj': 'securityActionMenuGroupSeparator',
+                },
+              ]
+            : []),
           ...(hasCasesPermissions
             ? [
                 {
-                  name: (
-                    <FormattedMessage
-                      id="xpack.securitySolution.flyout.entityDetails.riskInputs.actions.addToNewCase"
-                      defaultMessage="Add to new case"
-                    />
-                  ),
-
-                  onClick: addToNewCaseClick,
-                },
-
-                {
-                  name: (
-                    <FormattedMessage
-                      id="xpack.securitySolution.flyout.entityDetails.riskInputs.actions.addToExistingCase"
-                      defaultMessage="Add to existing case"
-                    />
-                  ),
-
-                  onClick: addToExistingCase,
+                  key: RISK_INPUT_ACTION_IDS.addToCase,
+                  icon: 'briefcase' as const,
+                  'data-test-subj': RISK_INPUT_ACTION_IDS.addToCase,
+                  name: ADD_TO_CASE,
+                  panel: ADD_TO_CASE_PANEL_ID,
                 },
               ]
             : []),
         ],
       },
+      ...(hasCasesPermissions
+        ? [
+            {
+              id: ADD_TO_CASE_PANEL_ID,
+              title: CASE_TYPE,
+              content: (
+                <AddToCaseActionPanel
+                  actions={[
+                    {
+                      id: RISK_INPUT_ACTION_IDS.addToNewCase,
+                      label: ADD_TO_NEW_CASE,
+                      dataTestSubj: RISK_INPUT_ACTION_IDS.addToNewCase,
+                      onClick: addToNewCaseClick,
+                    },
+                    {
+                      id: RISK_INPUT_ACTION_IDS.addToExistingCase,
+                      label: ADD_TO_EXISTING_CASE,
+                      dataTestSubj: RISK_INPUT_ACTION_IDS.addToExistingCase,
+                      onClick: addToExistingCase,
+                    },
+                  ]}
+                />
+              ),
+            },
+          ]
+        : []),
     ];
   }, [addToExistingCase, addToNewCaseClick, inputs, hasCasesPermissions, timelineActions]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/service_right/footer.test.tsx
@@ -9,11 +9,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { TestProviders } from '../../../common/mock';
 import { ServicePanelFooter } from './footer';
-import {
-  ADD_TO_NEW_CASE_TEST_ID,
-  ADD_TO_EXISTING_CASE_TEST_ID,
-} from '../../../../common/cases/attachments/entity/test_ids';
 import type { EntityStoreRecord } from '../shared/hooks/use_entity_from_store';
+
+const ADD_TO_CASE_TEST_ID = 'add-to-case-action';
+
+jest.mock('@kbn/response-ops-alerts-table', () => ({
+  ...jest.requireActual('@kbn/response-ops-alerts-table'),
+  AddToCaseContextMenuItem: () => <div data-test-subj="add-to-case-action" />,
+}));
 
 jest.mock('@kbn/entity-store/public', () => ({
   useEntityStoreEuidApi: jest.fn(() => null),
@@ -44,16 +47,13 @@ jest.mock('../../../entity_analytics/components/ai_assistant_button/ai_assistant
   ),
 }));
 
-// Render the real menu items but with minimal markup — footer tests only care about presence.
 jest.mock('../../../cases/attachments/entity/components/add_to_new_case', () => ({
-  AddToNewCase: ({ 'data-test-subj': testSubj }: { 'data-test-subj'?: string }) => (
-    <div data-test-subj={testSubj} />
-  ),
+  ADD_TO_NEW_CASE: 'Add to new case',
+  useAddToNewCase: () => jest.fn(),
 }));
 jest.mock('../../../cases/attachments/entity/components/add_to_existing_case', () => ({
-  AddToExistingCase: ({ 'data-test-subj': testSubj }: { 'data-test-subj'?: string }) => (
-    <div data-test-subj={testSubj} />
-  ),
+  ADD_TO_EXISTING_CASE: 'Add to existing case',
+  useAddToExistingCase: () => jest.fn(),
 }));
 
 const SERVICE_IDENTITY_FIELDS = { 'service.name': 'service-alice' };
@@ -94,39 +94,34 @@ const renderFooter = (
 describe('ServicePanelFooter – entity attachment actions', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('renders Add to new case and Add to existing case when all conditions are met', () => {
+  it('renders the Add to case submenu when all conditions are met', () => {
     renderFooter(true, true, ENTITY_STORE_RECORD);
 
-    expect(screen.getByTestId(ADD_TO_NEW_CASE_TEST_ID)).toBeInTheDocument();
-    expect(screen.getByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(ADD_TO_CASE_TEST_ID)).toBeInTheDocument();
   });
 
   it('renders no case actions when entityAttachmentsEnabled is false', () => {
     renderFooter(false, true, ENTITY_STORE_RECORD);
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders no case actions when cases attachmentsEnabled config is false', () => {
     renderFooter(true, false, ENTITY_STORE_RECORD);
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders no case actions when there is no entity store record (entityStoreId is undefined)', () => {
     renderFooter(true, true, undefined);
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders no case actions when serviceName resolves to an empty string', () => {
     renderFooter(true, true, ENTITY_STORE_RECORD, { 'service.name': '' });
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/take_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/shared/components/take_action.tsx
@@ -6,13 +6,8 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import {
-  EuiButton,
-  EuiContextMenuItem,
-  EuiContextMenuPanel,
-  EuiPopover,
-  useGeneratedHtmlId,
-} from '@elastic/eui';
+import { EuiButton, EuiContextMenuItem, EuiPopover, useGeneratedHtmlId } from '@elastic/eui';
+import { ExpandableContextMenuPanel } from '@kbn/response-ops-alerts-table/components/expandable_context_menu_panel';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
@@ -120,7 +115,7 @@ export const TakeAction = ({ kqlQuery, isDisabled, additionalItems }: TakeAction
       anchorPosition="downLeft"
       data-test-subj="take-action-button"
     >
-      <EuiContextMenuPanel items={actionsItems} />
+      <ExpandableContextMenuPanel items={actionsItems} />
     </EuiPopover>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/host/main/footer.test.tsx
@@ -9,11 +9,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import { Footer } from './footer';
-import {
-  ADD_TO_NEW_CASE_TEST_ID,
-  ADD_TO_EXISTING_CASE_TEST_ID,
-} from '../../../../../common/cases/attachments/entity/test_ids';
 import type { EntityStoreRecord } from '../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
+
+const ADD_TO_CASE_TEST_ID = 'add-to-case-action';
+
+jest.mock('@kbn/response-ops-alerts-table', () => ({
+  ...jest.requireActual('@kbn/response-ops-alerts-table'),
+  AddToCaseContextMenuItem: () => <div data-test-subj="add-to-case-action" />,
+}));
 
 jest.mock('@kbn/entity-store/public', () => ({
   useEntityStoreEuidApi: jest.fn(() => null),
@@ -51,16 +54,13 @@ jest.mock(
   })
 );
 
-// Render the real menu items but with minimal markup — footer tests only care about presence.
 jest.mock('../../../../cases/attachments/entity/components/add_to_new_case', () => ({
-  AddToNewCase: ({ 'data-test-subj': testSubj }: { 'data-test-subj'?: string }) => (
-    <div data-test-subj={testSubj} />
-  ),
+  ADD_TO_NEW_CASE: 'Add to new case',
+  useAddToNewCase: () => jest.fn(),
 }));
 jest.mock('../../../../cases/attachments/entity/components/add_to_existing_case', () => ({
-  AddToExistingCase: ({ 'data-test-subj': testSubj }: { 'data-test-subj'?: string }) => (
-    <div data-test-subj={testSubj} />
-  ),
+  ADD_TO_EXISTING_CASE: 'Add to existing case',
+  useAddToExistingCase: () => jest.fn(),
 }));
 
 const HOST_IDENTITY_FIELDS = { 'host.name': 'host-alice' };
@@ -97,39 +97,34 @@ const renderFooter = (
 describe('Footer – entity attachment actions', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('renders Add to new case and Add to existing case when all conditions are met', () => {
+  it('renders the Add to case submenu when all conditions are met', () => {
     renderFooter(true, true, ENTITY_STORE_RECORD);
 
-    expect(screen.getByTestId(ADD_TO_NEW_CASE_TEST_ID)).toBeInTheDocument();
-    expect(screen.getByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(ADD_TO_CASE_TEST_ID)).toBeInTheDocument();
   });
 
   it('renders no case actions when entityAttachmentsEnabled is false', () => {
     renderFooter(false, true, ENTITY_STORE_RECORD);
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders no case actions when cases attachmentsEnabled config is false', () => {
     renderFooter(true, false, ENTITY_STORE_RECORD);
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders no case actions when there is no entity store record (entityStoreId is undefined)', () => {
     renderFooter(true, true, undefined);
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders no case actions when hostName resolves to an empty string', () => {
     renderFooter(true, true, ENTITY_STORE_RECORD, { 'host.name': '' });
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/entity/user/main/footer.test.tsx
@@ -9,11 +9,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import { Footer } from './footer';
-import {
-  ADD_TO_NEW_CASE_TEST_ID,
-  ADD_TO_EXISTING_CASE_TEST_ID,
-} from '../../../../../common/cases/attachments/entity/test_ids';
 import type { EntityStoreRecord } from '../../../../flyout/entity_details/shared/hooks/use_entity_from_store';
+
+const ADD_TO_CASE_TEST_ID = 'add-to-case-action';
+
+jest.mock('@kbn/response-ops-alerts-table', () => ({
+  ...jest.requireActual('@kbn/response-ops-alerts-table'),
+  AddToCaseContextMenuItem: () => <div data-test-subj="add-to-case-action" />,
+}));
 
 jest.mock('@kbn/entity-store/public', () => ({
   useEntityStoreEuidApi: jest.fn(() => null),
@@ -51,16 +54,13 @@ jest.mock(
   })
 );
 
-// Render the real menu items but with minimal markup — footer tests only care about presence.
 jest.mock('../../../../cases/attachments/entity/components/add_to_new_case', () => ({
-  AddToNewCase: ({ 'data-test-subj': testSubj }: { 'data-test-subj'?: string }) => (
-    <div data-test-subj={testSubj} />
-  ),
+  ADD_TO_NEW_CASE: 'Add to new case',
+  useAddToNewCase: () => jest.fn(),
 }));
 jest.mock('../../../../cases/attachments/entity/components/add_to_existing_case', () => ({
-  AddToExistingCase: ({ 'data-test-subj': testSubj }: { 'data-test-subj'?: string }) => (
-    <div data-test-subj={testSubj} />
-  ),
+  ADD_TO_EXISTING_CASE: 'Add to existing case',
+  useAddToExistingCase: () => jest.fn(),
 }));
 
 const USER_IDENTITY_FIELDS = { 'user.name': 'alice' };
@@ -97,39 +97,34 @@ const renderFooter = (
 describe('Footer – entity attachment actions', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('renders Add to new case and Add to existing case when all conditions are met', () => {
+  it('renders the Add to case submenu when all conditions are met', () => {
     renderFooter(true, true, ENTITY_STORE_RECORD);
 
-    expect(screen.getByTestId(ADD_TO_NEW_CASE_TEST_ID)).toBeInTheDocument();
-    expect(screen.getByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(ADD_TO_CASE_TEST_ID)).toBeInTheDocument();
   });
 
   it('renders no case actions when entityAttachmentsEnabled is false', () => {
     renderFooter(false, true, ENTITY_STORE_RECORD);
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders no case actions when cases attachmentsEnabled config is false', () => {
     renderFooter(true, false, ENTITY_STORE_RECORD);
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders no case actions when there is no entity store record (entityStoreId is undefined)', () => {
     renderFooter(true, true, undefined);
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('renders no case actions when userName resolves to an empty string', () => {
     renderFooter(true, true, ENTITY_STORE_RECORD, { 'user.name': '' });
 
-    expect(screen.queryByTestId(ADD_TO_NEW_CASE_TEST_ID)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ADD_TO_EXISTING_CASE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ADD_TO_CASE_TEST_ID)).not.toBeInTheDocument();
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/entity_analytics/ui/fixtures/page_objects/entity_cases_page.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/entity_analytics/ui/fixtures/page_objects/entity_cases_page.ts
@@ -34,8 +34,10 @@ import {
 export class EntityCasesPage {
   // Entity flyout – Take Action popover
   public readonly takeActionButton: Locator;
+  public readonly addToCaseItem: Locator;
   public readonly addToNewCaseItem: Locator;
   public readonly addToExistingCaseItem: Locator;
+  public readonly addToCaseSubmitButton: Locator;
 
   // Case view – Attachments tab + Entities accordion
   public readonly attachmentsTab: Locator;
@@ -53,8 +55,10 @@ export class EntityCasesPage {
 
   constructor(private readonly page: ScoutPage) {
     this.takeActionButton = page.testSubj.locator('take-action-button');
+    this.addToCaseItem = page.testSubj.locator('add-to-case-action');
     this.addToNewCaseItem = page.testSubj.locator(ADD_TO_NEW_CASE_TEST_ID);
     this.addToExistingCaseItem = page.testSubj.locator(ADD_TO_EXISTING_CASE_TEST_ID);
+    this.addToCaseSubmitButton = page.testSubj.locator('add-to-case-submit');
 
     this.attachmentsTab = page.testSubj.locator('case-view-tab-title-attachments');
     this.attachmentsContainer = page.testSubj.locator('case-view-attachments');
@@ -104,11 +108,15 @@ export class EntityCasesPage {
   }
 
   async clickAddToNewCase() {
+    await this.addToCaseItem.click();
     await this.addToNewCaseItem.click();
+    await this.addToCaseSubmitButton.click();
   }
 
   async clickAddToExistingCase() {
+    await this.addToCaseItem.click();
     await this.addToExistingCaseItem.click();
+    await this.addToCaseSubmitButton.click();
   }
 
   async fillCaseName(name: string) {


### PR DESCRIPTION
## Summary

- adds named anomaly and risk-input action menus
- adopts the shared two-layer case flow for entity attachments
- keeps entity action composition explicit at each surface

Stack layer 6 of 7. Depends on the shared action-menu utilities and case menu below it.

Addresses #278607

### Checklist

- [x] Added text follows EUI writing and i18n guidelines
- [x] Documentation is not required for this internal menu composition change
- [x] Unit and Scout coverage was updated for entity case actions
- [x] No plugin configuration or HTTP API changes were introduced
- [x] Validation from the original PR is preserved because the stacked branch chain reproduces its final tree exactly

### Identify risks

Low risk. Existing entity action callbacks remain unchanged and case selection is covered by tests.

## Release note

Improves the consistency and readability of entity analytics action menus.

Made with [Cursor](https://cursor.com)

## Stack

1. [#284116 — Two-layer case action menu](https://github.com/elastic/kibana/pull/284116)
2. [#284117 — Alert action menus](https://github.com/elastic/kibana/pull/284117)
3. [#284118 — Attack action menus](https://github.com/elastic/kibana/pull/284118)
4. [#284119 — Document action menus](https://github.com/elastic/kibana/pull/284119)
5. [#284120 — Events table bulk action menu](https://github.com/elastic/kibana/pull/284120)
6. [#284121 — Entity analytics action menus](https://github.com/elastic/kibana/pull/284121)
7. [#284122 — ML case action menu](https://github.com/elastic/kibana/pull/284122)