### PR TITLE
[ML][Take Actions] Add two-layer case action menu

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/alerting/anomaly_detection_alerts_table/alert_actions.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/alerting/anomaly_detection_alerts_table/alert_actions.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiContextMenuItem, EuiPopover, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public';
@@ -15,6 +15,7 @@ import type { GetAlertsTableProp } from '@kbn/response-ops-alerts-table/types';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { DefaultAlertActions } from '@kbn/response-ops-alerts-table/components/default_alert_actions';
 import { ExpandableContextMenuPanel } from '@kbn/response-ops-alerts-table/components/expandable_context_menu_panel';
+import { AddToCaseContextMenuItem } from '@kbn/response-ops-alerts-table';
 import { STACK_MANAGEMENT_RULE_PAGE_URL_PREFIX } from '@kbn/response-ops-alerts-table/constants';
 import { PLUGIN_ID } from '../../../common/constants/app';
 import { useMlKibana } from '../../application/contexts/kibana';
@@ -96,24 +97,27 @@ export const AlertActions: GetAlertsTableProp<'renderActionsCell'> = (props) => 
   const actionsMenuItems = [
     ...(casesPrivileges && casesPrivileges?.create && casesPrivileges.read
       ? [
-          <EuiContextMenuItem
-            data-test-subj="add-to-existing-case-action"
-            key="addToExistingCase"
-            onClick={handleAddToExistingCaseClick}
-          >
-            {i18n.translate('xpack.ml.alerts.actions.addToCase', {
-              defaultMessage: 'Add to existing case',
-            })}
-          </EuiContextMenuItem>,
-          <EuiContextMenuItem
-            data-test-subj="add-to-new-case-action"
-            key="addToNewCase"
-            onClick={handleAddToNewCaseClick}
-          >
-            {i18n.translate('xpack.ml.alerts.actions.addToNewCase', {
-              defaultMessage: 'Add to new case',
-            })}
-          </EuiContextMenuItem>,
+          <AddToCaseContextMenuItem
+            key="addToCase"
+            actions={[
+              {
+                id: 'addToNewCase',
+                label: i18n.translate('xpack.ml.alerts.actions.addToNewCase', {
+                  defaultMessage: 'Add to new case',
+                }),
+                dataTestSubj: 'add-to-new-case-action',
+                onClick: handleAddToNewCaseClick,
+              },
+              {
+                id: 'addToExistingCase',
+                label: i18n.translate('xpack.ml.alerts.actions.addToCase', {
+                  defaultMessage: 'Add to existing case',
+                }),
+                dataTestSubj: 'add-to-existing-case-action',
+                onClick: handleAddToExistingCaseClick,
+              },
+            ]}
+          />,
         ]
       : []),
   ];


### PR DESCRIPTION
## Summary

- adopts the shared two-layer case action selector in anomaly detection alert actions
- preserves the existing new-case and existing-case callbacks

Stack layer 7 of 7. This is the top of the action-menu stack.

Addresses #278607

### Checklist

- [x] Added text follows EUI writing and i18n guidelines
- [x] Documentation is not required for this internal menu composition change
- [x] Existing shared case-menu tests cover the selection behavior
- [x] No plugin configuration or HTTP API changes were introduced
- [x] Validation from the original PR is preserved because the stacked branch chain reproduces its final tree exactly

### Identify risks

Low risk. This layer only replaces two sibling menu items with the shared case selector.

## Release note

Improves case actions in the anomaly detection alerts table.

Made with [Cursor](https://cursor.com)

## Stack

1. [#284116 — Two-layer case action menu](https://github.com/elastic/kibana/pull/284116)
2. [#284117 — Alert action menus](https://github.com/elastic/kibana/pull/284117)
3. [#284118 — Attack action menus](https://github.com/elastic/kibana/pull/284118)
4. [#284119 — Document action menus](https://github.com/elastic/kibana/pull/284119)
5. [#284120 — Events table bulk action menu](https://github.com/elastic/kibana/pull/284120)
6. [#284121 — Entity analytics action menus](https://github.com/elastic/kibana/pull/284121)
7. [#284122 — ML case action menu](https://github.com/elastic/kibana/pull/284122)