### PR TITLE
[Workflows][Connectors] Add WHOIS connector

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2690,6 +2690,7 @@ src/platform/packages/shared/kbn-connector-specs/src/specs/sublime_security/** @
 src/platform/packages/shared/kbn-connector-specs/src/specs/tavily/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/urlvoid/** @elastic/workflows-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/virustotal/** @elastic/workflows-eng
+src/platform/packages/shared/kbn-connector-specs/src/specs/whois/** @elastic/workflows-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/workday/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/zendesk/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/zoom/** @elastic/workchat-eng

--- a/docs/reference/connectors-kibana/_snippets/data-context-sources-connectors-list.md
+++ b/docs/reference/connectors-kibana/_snippets/data-context-sources-connectors-list.md
@@ -74,3 +74,4 @@
 - [Shodan](/reference/connectors-kibana/shodan-action-type.md): Perform Internet-wide asset discovery and vulnerability scanning.
 - [URLVoid](/reference/connectors-kibana/urlvoid-action-type.md): Check domain and URL reputation using multi-engine scanning.
 - [VirusTotal](/reference/connectors-kibana/virustotal-action-type.md): Perform file scanning, URL and domain analysis, result retrieval, and threat intelligence lookups.
+- [WHOIS](/reference/connectors-kibana/whois-action-type.md): Look up domain, IP, ASN, nameserver, and contact registration records over RDAP.

--- a/docs/reference/connectors-kibana/whois-action-type.md
+++ b/docs/reference/connectors-kibana/whois-action-type.md
@@ -1,0 +1,88 @@
+---
+navigation_title: "WHOIS"
+type: reference
+description: "Use the WHOIS connector to enrich a domain or address indicator during triage: look up registration records for domains, IP addresses, ASNs, nameservers, and registry contacts over RDAP."
+applies_to:
+  stack: preview 9.6
+  serverless: preview
+---
+
+# WHOIS connector [whois-action-type]
+
+The WHOIS connector gives a workflow or agent registration facts about an indicator without a hand-built HTTP call. Point it at a domain and it returns the registrar, registration and expiry dates, nameservers, status codes, and whatever contacts the registry publishes. Point it at an IP address or ASN and it returns the owning organization, the netblock, the country, and the abuse contact. This is the enrichment step behind phishing and IOC triage, where a domain registered three days ago or a suspect netblock owner changes how an alert gets handled.
+
+## Overview
+
+This is a **custom connector** that speaks [RDAP](https://www.rfc-editor.org/rfc/rfc9083), the Registration Data Access Protocol, over HTTPS.
+
+RDAP is the IETF's replacement for the classic WHOIS protocol and returns structured JSON rather than free text. It is the only viable transport here: legacy WHOIS runs as a plain-text protocol on TCP port 43, which {{kib}} connectors cannot reach because they speak HTTP through an HTTP client only, and {{kib}} egress typically blocks raw TCP anyway.
+
+By default every lookup goes to `https://rdap.org`, an aggregating bootstrap service that redirects each query to the authoritative registry. You can point the connector at a single registry server instead, or at a commercial RDAP gateway that requires an API key.
+
+Every action is a read, so all of them are available both as workflow steps and as agent tools.
+
+### RDAP coverage [whois-rdap-coverage]
+
+RDAP coverage is broad but not universal, and this shapes what the connector can answer:
+
+* **Covered**: every gTLD (`.com`, `.net`, `.org`, `.dev`, `.xyz`, and roughly 1,200 others in the IANA bootstrap registry), and all five regional internet registries (ARIN, RIPE NCC, APNIC, LACNIC, AFRINIC) for IP addresses and ASNs.
+* **Not covered**: many country-code TLDs never adopted RDAP, including `.co`, `.io`, `.de`, `.ru`, and `.cn`. A lookup for one of these returns a not-found result rather than data.
+
+There is no fallback for an uncovered TLD, because port-43 WHOIS is unreachable from {{kib}}.
+
+## Create connectors in {{kib}} [define-whois-ui]
+
+You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.
+
+### Connector configuration [whois-connector-configuration]
+
+WHOIS connectors have the following configuration properties:
+
+RDAP server URL
+:   The base URL every lookup is sent to. Defaults to `https://rdap.org`. Must use HTTPS. Set it to a specific registry server, such as `https://rdap.verisign.com/com/v1` for `.com` domains or `https://rdap.arin.net/registry` for North American IP space, to skip the bootstrap redirect. Set it to your provider's URL to use a commercial RDAP gateway.
+
+Authentication
+:   Choose **No authentication (public RDAP)**, the default, since public RDAP requires no credential. Choose **API key header** only for a commercial or private RDAP gateway that requires one, and enter both the header name your gateway expects, for example `Authorization` or `X-Api-Key`, and the key itself. The key is stored encrypted.
+
+::::{note}
+The default `https://rdap.org` endpoint answers with an HTTP redirect to the authoritative registry host, so a lookup touches two hosts. If your deployment restricts outbound connections with the `xpack.actions.allowedHosts` setting, allow the registry hosts you expect to reach as well as `rdap.org`, or configure a single registry server as the RDAP server URL and allow just that host.
+::::
+
+## Connector actions [whois-connector-actions]
+
+`lookupDomain`
+:   Looks up a domain's registration record. Returns the registrar with its IANA ID, the registration, expiry, and last-changed dates, a precomputed age in days and days until expiry, EPP status codes, nameservers with any glue addresses, DNSSEC delegation state, and the registrant and abuse contacts the registry publishes. The primary enrichment step in phishing triage.
+
+`lookupIp`
+:   Looks up the registration record for an IPv4 or IPv6 address, or a CIDR block. Returns the owning organization, the netblock in CIDR form plus its start and end addresses, the allocation type, the AS numbers announcing it, and the abuse contact. Any address inside an allocation returns that whole allocation.
+
+`lookupAsn`
+:   Looks up an autonomous system number, with or without the `AS` prefix. Returns the AS name, the allocated range, the holding organization, country, and the abuse contact. Use it after `lookupIp` to identify the network announcing a suspect address.
+
+`lookupNameserver`
+:   Looks up a nameserver host object. Returns its registered glue IP addresses and status. Use it to pivot from a suspicious domain to the infrastructure behind its delegation.
+
+`lookupEntity`
+:   Looks up a contact or organization by its registry-assigned RDAP handle. Returns the name, organization, email, phone, address, country, roles, and any child contacts. Use it to expand a handle another lookup returned only as an identifier.
+
+## Usage notes [whois-usage-notes]
+
+* **A not-found result is data, not an error.** Every action returns a result with `found: false` instead of failing when the registry answers with HTTP 404, so a workflow can branch on "no record" without the run failing. RDAP cannot distinguish three cases behind that 404: the object is genuinely unregistered or unallocated, the registry operates no RDAP service, or the query was malformed. Check the `found` field rather than relying on an error.
+* **Responses are trimmed.** RDAP records are large and mostly boilerplate: terms-of-service notices, status-code glossaries, and self-referencing link arrays often make up half the payload, and a single IP record can exceed 6 KB. Each action returns only the triage-relevant fields. Set `includeRaw` to `true` to also receive the full unparsed record, but only when a field you need is genuinely missing, since the raw records will crowd out an agent's context.
+* **Query the registrable apex.** A subdomain is not registered, so `lookupDomain` on `mail.example.com` returns a not-found result. Query `example.com`.
+* **Punycode internationalized names first.** RDAP addresses an internationalized domain by its ASCII A-label, so pass `xn--80ak6aa92e.com` rather than the Unicode form.
+* **Registrant identity is usually redacted.** Most registries return `REDACTED FOR PRIVACY` in place of the registrant name and email while still publishing the registrar, dates, nameservers, and status. A missing registrant is normal and is not itself a suspicious signal.
+* **Handles are registry-scoped.** An entity handle returned by an IP lookup only resolves at the registry that issued it. Pass that registry as the per-call base URL when you look the handle up, for example `https://rdap.arin.net/registry` for an ARIN handle such as `GOGL`.
+* **Every action accepts a per-call base URL** that overrides the connector default, so one connector can query several registries directly. If you use the API key header authentication type, keep `xpack.actions.allowedHosts` restricted to your gateway: the key is sent to whichever host a call targets, and the default `https://rdap.org` configuration needs no credential at all.
+* **Registries differ on which fields they publish.** RIPE NCC and APNIC return a top-level ISO `country` code for an address; ARIN does not publish one, so for North American address space `country` is absent and the holder's location arrives as a postal address in `organization.address` instead. Do not read a missing `country` as a signal, and do not compare it across registries. Similarly, the `originAutnums` field naming the announcing AS is an ARIN extension and is often empty even at ARIN, so get the AS from `lookupAsn` or another tool rather than assuming an empty array means the address is unannounced.
+* **Respect registry rate limits.** Public RDAP servers rate-limit by IP address and return HTTP 429 under a burst of lookups. Space out a batch of enrichment calls.
+
+## Get API credentials [whois-api-credentials]
+
+The WHOIS connector needs **no credentials** in its default configuration. Public RDAP is an unauthenticated protocol, so you can create the connector with **No authentication** selected and every action works against public registry data.
+
+You only need a credential to route lookups through a commercial RDAP gateway for parsed extras or higher rate limits:
+
+1. Create an account with your RDAP provider and generate an API key.
+2. Check the provider's documentation for the header name it expects, for example `Authorization` or `X-Api-Key`.
+3. When you create the connector in {{kib}}, choose **API key header** as the authentication type, enter that header name and your key, and set the RDAP server URL to your provider's HTTPS endpoint.

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -136,6 +136,7 @@ toc:
           - file: connectors-kibana/tavily-action-type.md
           - file: connectors-kibana/urlvoid-action-type.md
           - file: connectors-kibana/virustotal-action-type.md
+          - file: connectors-kibana/whois-action-type.md
           - file: connectors-kibana/workday-action-type.md
           - file: connectors-kibana/zabbix-action-type.md
           - file: connectors-kibana/zendesk-action-type.md

--- a/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
@@ -73,3 +73,4 @@ export * from './specs/google_cloud_monitoring/google_cloud_monitoring';
 export * from './specs/opensearch_aws_opensearch_service/opensearch_aws_opensearch_service';
 export * from './specs/zabbix/zabbix';
 export * from './specs/gcp_iam/gcp_iam';
+export * from './specs/whois/whois';

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/whois/types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/whois/types.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z, lazySchema } from '@kbn/zod/v4';
+
+/**
+ * A DNS name in LDH (letter-digit-hyphen) form, i.e. already punycoded. Bounded to the DNS
+ * limit of 253 octets. The charset is constrained because the value becomes a URL path
+ * segment: RDAP rejects a malformed name with a 400, but an unconstrained value could also
+ * carry a `/` or `?` and reshape the request path.
+ *
+ * Unicode (IDN) names are deliberately rejected rather than silently mangled: RDAP addresses
+ * an IDN by its A-label (`xn--...`), so a caller must punycode first.
+ */
+const DOMAIN_PATTERN = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$/;
+
+/**
+ * An IPv4/IPv6 literal, optionally with a CIDR prefix length. RDAP accepts both an address
+ * and a CIDR block on the `/ip/` path, and both are useful during triage, so the schema
+ * allows either. Validated by regex rather than `z.ipv4()`/`z.ipv6()` because those reject
+ * the prefix-length suffix.
+ *
+ * The address part is matched structurally rather than as a charset, because the value is
+ * interpolated into the request path WITHOUT percent-encoding (an IPv6 colon and a CIDR slash
+ * are structural there, and encoding them makes registries 400). A bare charset bound is not
+ * sufficient protection on its own: `..` and `../12` are both made only of permitted
+ * characters, yet resolve away from the `/ip/` prefix and silently retarget the request. Each
+ * alternative below therefore requires at least one digit-or-hex group, which no dot-run can
+ * satisfy.
+ */
+const IPV4_PATTERN = '\\d{1,3}(\\.\\d{1,3}){3}';
+const IPV6_PATTERN = '[0-9A-Fa-f]{0,4}(:[0-9A-Fa-f]{0,4}){2,7}(\\.\\d{1,3}){0,3}';
+const IP_OR_CIDR_PATTERN = new RegExp(
+  `^(${IPV4_PATTERN}|${IPV6_PATTERN})(\\/(?:[0-9]|[1-9][0-9]|1[01][0-9]|12[0-8]))?$`
+);
+
+/** An AS number, with or without the conventional `AS` prefix. */
+const ASN_PATTERN = /^(AS|as)?\d{1,10}$/;
+
+/**
+ * An RDAP entity handle, e.g. `GOGL`, `ABUSE5250-ARIN`, or `133013863_DOMAIN_COM-VRSN`.
+ * Handles are registry-assigned and their charset varies, so this is deliberately permissive
+ * on characters while still excluding path-structural ones.
+ */
+const ENTITY_HANDLE_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+
+/**
+ * Any RDAP server URL an action may be pointed at. Constrained to HTTPS: RDAP over plain
+ * HTTP would leak the indicator being investigated, and an unconstrained scheme in a
+ * config-supplied base URL is an SSRF vector.
+ */
+export const RdapBaseUrlSchema = z
+  .string()
+  .min(8)
+  .max(512)
+  .regex(/^https:\/\/[A-Za-z0-9.-]+(:\d{1,5})?(\/[A-Za-z0-9._~\-/]*)?$/, {
+    message: 'Must be an https:// RDAP base URL, for example https://rdap.org',
+  });
+
+const rawRecord = () =>
+  z
+    .boolean()
+    .optional()
+    .describe(
+      'Set true to include the full unparsed RDAP object under a "raw" key alongside the trimmed fields. Off by default because RDAP records are large (a single IP record runs to several KB of nested vCard arrays, notices, and link boilerplate) and will crowd out an agent context window. Only turn it on when a needed field is missing from the parsed output.'
+    );
+
+/**
+ * A per-call server override. Note the interaction with the optional `api_key_header` auth
+ * mode: that key is installed as a default header on the connector's HTTP client, so it is
+ * sent to whichever host this override names. The Actions `allowedHosts` policy is enforced on
+ * every request target before dispatch, so an operator using a gateway key should keep
+ * `allowedHosts` restricted to their gateway rather than leaving it at `*`. Public RDAP needs
+ * no credential at all, so the default auth mode carries nothing to leak.
+ */
+const baseUrlOverride = () =>
+  RdapBaseUrlSchema.optional().describe(
+    'Optional RDAP server base URL for this one call, overriding the connector default. Use it to query an authoritative registry server directly, for example https://rdap.verisign.com/com/v1 for a .com domain, when the bootstrap service does not cover the target. Only ever point this at a real RDAP registry or gateway.'
+  );
+
+export const LookupDomainInputSchema = lazySchema(() =>
+  z.object({
+    domain: z
+      .string()
+      .min(3)
+      .max(253)
+      .regex(DOMAIN_PATTERN, {
+        message:
+          'Must be a bare domain name in ASCII/punycode form, for example example.com or xn--80ak6aa92e.com. Do not include a scheme, port, or path.',
+      })
+      .describe(
+        'The registrable domain name to look up, for example "example.com". Pass the bare domain: no scheme, no "www." unless it is genuinely part of the registration, no path. An internationalized name must already be punycoded to its xn-- A-label. Subdomains are not registrable, so query the apex ("example.com", not "mail.example.com").'
+      ),
+    baseUrl: baseUrlOverride(),
+    includeRaw: rawRecord(),
+  })
+);
+export type LookupDomainInput = z.infer<typeof LookupDomainInputSchema>;
+
+export const LookupIpInputSchema = lazySchema(() =>
+  z.object({
+    ip: z
+      .string()
+      .min(2)
+      .max(49)
+      .regex(IP_OR_CIDR_PATTERN, {
+        message:
+          'Must be an IPv4 or IPv6 address, optionally with a CIDR prefix, for example 8.8.8.8, 8.8.8.0/24, or 2001:4860:4860::8888.',
+      })
+      .describe(
+        'The IPv4 or IPv6 address to look up, for example "8.8.8.8" or "2001:4860:4860::8888". A CIDR block such as "8.8.8.0/24" also works. The registry answers with the netblock containing the address, so any address inside an allocation returns that allocation.'
+      ),
+    baseUrl: baseUrlOverride(),
+    includeRaw: rawRecord(),
+  })
+);
+export type LookupIpInput = z.infer<typeof LookupIpInputSchema>;
+
+export const LookupAsnInputSchema = lazySchema(() =>
+  z.object({
+    asn: z
+      .string()
+      .min(1)
+      .max(12)
+      .regex(ASN_PATTERN, {
+        message: 'Must be an AS number, for example 15169 or AS15169.',
+      })
+      .describe(
+        'The autonomous system number to look up, with or without the "AS" prefix, for example "15169" or "AS15169". An entry of the originAutnums array on a lookupIp result feeds this directly.'
+      ),
+    baseUrl: baseUrlOverride(),
+    includeRaw: rawRecord(),
+  })
+);
+export type LookupAsnInput = z.infer<typeof LookupAsnInputSchema>;
+
+export const LookupNameserverInputSchema = lazySchema(() =>
+  z.object({
+    nameserver: z
+      .string()
+      .min(3)
+      .max(253)
+      .regex(DOMAIN_PATTERN, {
+        message:
+          'Must be a nameserver host name in ASCII/punycode form, for example ns1.example.com.',
+      })
+      .describe(
+        'The nameserver host name to look up, for example "ns1.example.com". The nameservers array on a lookupDomain result feeds this directly. Only nameservers registered as host objects in a registry resolve; many registries do not publish them at all.'
+      ),
+    baseUrl: baseUrlOverride(),
+    includeRaw: rawRecord(),
+  })
+);
+export type LookupNameserverInput = z.infer<typeof LookupNameserverInputSchema>;
+
+export const LookupEntityInputSchema = lazySchema(() =>
+  z.object({
+    handle: z
+      .string()
+      .min(1)
+      .max(128)
+      .regex(ENTITY_HANDLE_PATTERN, {
+        message: 'Must be an RDAP entity handle, for example GOGL or ABUSE5250-ARIN.',
+      })
+      .describe(
+        'The registry-assigned entity handle, for example "GOGL" or "ABUSE5250-ARIN". Read it from the entities[].handle field of a lookupIp, lookupAsn, or lookupDomain result. A handle is only resolvable at the registry that issued it, so pass baseUrl when the handle came from a different registry than the connector default.'
+      ),
+    baseUrl: baseUrlOverride(),
+    includeRaw: rawRecord(),
+  })
+);
+export type LookupEntityInput = z.infer<typeof LookupEntityInputSchema>;
+
+// --- RDAP response shapes (RFC 9083) -----------------------------------------------------
+// Only the members this connector reads are modelled. RDAP is extensible and every member is
+// optional in practice, so everything here is optional: the "Certain JSON properties might
+// occasionally be missing" caveat applies to registry servers as much as to any vendor API.
+
+/** A jCard (RFC 7095) property row: [name, params, valueType, value]. */
+export type VcardEntry = [string, Record<string, unknown>, string, unknown];
+
+export interface RdapEvent {
+  eventAction?: string;
+  eventDate?: string;
+  eventActor?: string;
+}
+
+export interface RdapEntity {
+  objectClassName?: string;
+  handle?: string;
+  roles?: string[];
+  vcardArray?: [string, VcardEntry[]];
+  publicIds?: Array<{ type?: string; identifier?: string }>;
+  entities?: RdapEntity[];
+  events?: RdapEvent[];
+  remarks?: Array<{ title?: string; description?: string[] }>;
+  links?: Array<{ rel?: string; href?: string; type?: string; value?: string }>;
+  status?: string[];
+}
+
+export interface RdapNameserver {
+  objectClassName?: string;
+  ldhName?: string;
+  unicodeName?: string;
+  handle?: string;
+  ipAddresses?: { v4?: string[]; v6?: string[] };
+  events?: RdapEvent[];
+  status?: string[];
+}
+
+export interface RdapDomainResponse {
+  objectClassName?: string;
+  handle?: string;
+  ldhName?: string;
+  unicodeName?: string;
+  status?: string[];
+  events?: RdapEvent[];
+  entities?: RdapEntity[];
+  nameservers?: RdapNameserver[];
+  secureDNS?: { delegationSigned?: boolean; zoneSigned?: boolean };
+  port43?: string;
+  rdapConformance?: string[];
+}
+
+export interface RdapIpResponse {
+  objectClassName?: string;
+  handle?: string;
+  startAddress?: string;
+  endAddress?: string;
+  ipVersion?: string;
+  name?: string;
+  type?: string;
+  country?: string;
+  parentHandle?: string;
+  status?: string[];
+  events?: RdapEvent[];
+  entities?: RdapEntity[];
+  remarks?: Array<{ title?: string; description?: string[] }>;
+  port43?: string;
+  /** RFC 9083 cidr0 extension: the netblock in CIDR form rather than a start/end pair. */
+  cidr0_cidrs?: Array<{ v4prefix?: string; v6prefix?: string; length?: number }>;
+  /** ARIN originas0 extension: the AS numbers that originate this netblock. */
+  arin_originas0_originautnums?: number[];
+}
+
+export interface RdapAutnumResponse {
+  objectClassName?: string;
+  handle?: string;
+  startAutnum?: number;
+  endAutnum?: number;
+  name?: string;
+  type?: string;
+  country?: string;
+  status?: string[];
+  events?: RdapEvent[];
+  entities?: RdapEntity[];
+  port43?: string;
+}

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/whois/whois.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/whois/whois.test.ts
@@ -1,0 +1,1146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ActionContext } from '../../connector_spec';
+import { Whois } from './whois';
+import {
+  LookupAsnInputSchema,
+  LookupDomainInputSchema,
+  LookupEntityInputSchema,
+  LookupIpInputSchema,
+  LookupNameserverInputSchema,
+} from './types';
+
+const RDAP_HEADERS = { headers: { Accept: 'application/rdap+json' } };
+
+interface MockClient {
+  get: jest.Mock;
+  post: jest.Mock;
+  put: jest.Mock;
+  patch: jest.Mock;
+  delete: jest.Mock;
+}
+
+const createContext = (config: Record<string, unknown> = {}) => {
+  const client: MockClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  };
+  const ctx = {
+    client,
+    config,
+    secrets: { authType: 'none' },
+    log: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  } as unknown as ActionContext;
+  return { ctx, client };
+};
+
+const httpError = (status: number, data?: unknown) => ({ response: { status, data } });
+
+/**
+ * A realistic .com domain response, shaped from the live rdap.verisign.com reply for
+ * elastic.com: a registrar entity with a nested abuse child, registration/expiration events,
+ * a nameserver array, and the notices/links boilerplate the trim is meant to drop.
+ */
+const domainResponse = {
+  objectClassName: 'domain',
+  handle: '133013863_DOMAIN_COM-VRSN',
+  ldhName: 'ELASTIC.COM',
+  links: [{ rel: 'self', href: 'https://rdap.verisign.com/com/v1/domain/elastic.com' }],
+  status: ['client delete prohibited', 'client transfer prohibited'],
+  entities: [
+    {
+      objectClassName: 'entity',
+      handle: '146',
+      roles: ['registrar'],
+      publicIds: [{ type: 'IANA Registrar ID', identifier: '146' }],
+      vcardArray: [
+        'vcard',
+        [
+          ['version', {}, 'text', '4.0'],
+          ['fn', {}, 'text', 'GoDaddy.com, LLC'],
+        ],
+      ],
+      entities: [
+        {
+          objectClassName: 'entity',
+          roles: ['abuse'],
+          vcardArray: [
+            'vcard',
+            [
+              ['version', {}, 'text', '4.0'],
+              ['tel', { type: 'voice' }, 'uri', 'tel:480-624-2505'],
+              ['email', {}, 'text', 'abuse@godaddy.com'],
+            ],
+          ],
+        },
+      ],
+    },
+    {
+      objectClassName: 'entity',
+      handle: 'REG-123',
+      roles: ['registrant'],
+      vcardArray: [
+        'vcard',
+        [
+          ['version', {}, 'text', '4.0'],
+          ['fn', {}, 'text', 'REDACTED FOR PRIVACY'],
+          ['org', {}, 'text', 'Elasticsearch BV'],
+          ['adr', {}, 'text', ['', '', '', 'Amsterdam', '', '1011', 'NL']],
+        ],
+      ],
+    },
+  ],
+  events: [
+    { eventAction: 'registration', eventDate: '2004-10-16T18:08:31Z' },
+    { eventAction: 'expiration', eventDate: '2026-10-16T18:08:31Z' },
+    { eventAction: 'last changed', eventDate: '2024-10-26T03:31:33Z' },
+  ],
+  secureDNS: { delegationSigned: false },
+  nameservers: [
+    { objectClassName: 'nameserver', ldhName: 'NS1-34.AZURE-DNS.COM' },
+    {
+      objectClassName: 'nameserver',
+      ldhName: 'NS2-34.AZURE-DNS.NET',
+      ipAddresses: { v4: ['1.2.3.4'] },
+    },
+  ],
+  notices: [{ title: 'Terms of Service', description: ['Service subject to Terms of Use.'] }],
+  rdapConformance: ['rdap_level_0'],
+  port43: 'whois.verisign-grs.com',
+};
+
+/** Shaped from the live rdap.arin.net reply for 8.8.8.8. */
+const ipResponse = {
+  objectClassName: 'ip network',
+  handle: 'NET-8-8-8-0-2',
+  startAddress: '8.8.8.0',
+  endAddress: '8.8.8.255',
+  ipVersion: 'v4',
+  name: 'GOGL',
+  type: 'DIRECT ALLOCATION',
+  parentHandle: 'NET-8-0-0-0-0',
+  status: ['active'],
+  cidr0_cidrs: [{ v4prefix: '8.8.8.0', length: 24 }],
+  arin_originas0_originautnums: [15169],
+  events: [
+    { eventAction: 'registration', eventDate: '2023-12-28T17:24:33-05:00' },
+    { eventAction: 'last changed', eventDate: '2023-12-28T17:24:56-05:00' },
+  ],
+  entities: [
+    {
+      objectClassName: 'entity',
+      handle: 'GOGL',
+      roles: ['registrant'],
+      vcardArray: [
+        'vcard',
+        [
+          ['version', {}, 'text', '4.0'],
+          ['fn', {}, 'text', 'Google LLC'],
+          [
+            'adr',
+            { label: '1600 Amphitheatre Parkway\nMountain View\nCA\n94043\nUnited States' },
+            'text',
+            ['', '', '', '', '', '', ''],
+          ],
+        ],
+      ],
+      entities: [
+        {
+          objectClassName: 'entity',
+          handle: 'ABUSE5250-ARIN',
+          roles: ['abuse'],
+          vcardArray: [
+            'vcard',
+            [
+              ['version', {}, 'text', '4.0'],
+              ['fn', {}, 'text', 'Abuse'],
+              ['org', {}, 'text', 'Google Inc.'],
+              ['email', {}, 'text', 'network-abuse@google.com'],
+              ['tel', { type: ['work', 'voice'] }, 'text', '+1-650-253-0000'],
+            ],
+          ],
+        },
+      ],
+    },
+  ],
+  port43: 'whois.arin.net',
+};
+
+/** Shaped from the live rdap.arin.net reply for AS15169. */
+const autnumResponse = {
+  objectClassName: 'autnum',
+  handle: 'AS15169',
+  startAutnum: 15169,
+  endAutnum: 15169,
+  name: 'GOOGLE',
+  status: ['active'],
+  events: [
+    { eventAction: 'registration', eventDate: '2000-03-30T00:00:00-05:00' },
+    { eventAction: 'last changed', eventDate: '2012-02-24T09:44:34-05:00' },
+  ],
+  entities: [
+    {
+      handle: 'GOGL',
+      roles: ['registrant'],
+      vcardArray: [
+        'vcard',
+        [
+          ['version', {}, 'text', '4.0'],
+          ['fn', {}, 'text', 'Google LLC'],
+        ],
+      ],
+      entities: [
+        {
+          handle: 'ABUSE5250-ARIN',
+          roles: ['abuse'],
+          vcardArray: [
+            'vcard',
+            [
+              ['version', {}, 'text', '4.0'],
+              ['email', {}, 'text', 'network-abuse@google.com'],
+            ],
+          ],
+        },
+      ],
+    },
+  ],
+  port43: 'whois.arin.net',
+};
+
+describe('WHOIS connector', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('metadata', () => {
+    it('exposes the expected id, display name, and description', () => {
+      expect(Whois.metadata.id).toBe('.whois');
+      expect(Whois.metadata.displayName).toBe('WHOIS');
+      expect(Whois.metadata.description.length).toBeGreaterThan(0);
+    });
+
+    it('supports both workflows and agentBuilder', () => {
+      expect(Whois.metadata.supportedFeatureIds).toEqual(['workflows', 'agentBuilder']);
+    });
+
+    it('uses a built-in EUI icon instead of a custom brand mark', () => {
+      // WHOIS is a protocol with no vendor logo. Setting metadata.icon also means the spec
+      // must be absent from ConnectorIconsMap; connector_spec_contract.test.ts enforces that.
+      expect(Whois.metadata.icon).toBe('globe');
+    });
+
+    it('offers an unauthenticated path plus an optional gateway key', () => {
+      const authTypes = (Whois.auth?.types ?? []).map((type) =>
+        typeof type === 'string' ? type : type.type
+      );
+      expect(authTypes).toEqual(['none', 'api_key_header']);
+    });
+
+    it('marks the base URL for allowedHosts enforcement at save time', () => {
+      // The load-bearing assertion is the field-level `validate.allowedHosts` meta: that is
+      // what generate_config_schema reads to install the ensureUriAllowed check. Asserting
+      // only the spec-level validateUrls list would pass without any enforcement existing.
+      const baseUrl = Whois.schema?.shape.baseUrl;
+      const meta = baseUrl?.meta() as { validate?: { allowedHosts?: boolean } } | undefined;
+      expect(meta?.validate?.allowedHosts).toBe(true);
+      expect(Whois.validateUrls?.fields).toContain('baseUrl');
+    });
+
+    it('exposes every action as a tool, since all of them are reads', () => {
+      for (const [name, action] of Object.entries(Whois.actions)) {
+        expect({ name, isTool: action.isTool }).toEqual({ name, isTool: true });
+      }
+    });
+
+    it('gives every action a substantive description', () => {
+      for (const [name, action] of Object.entries(Whois.actions)) {
+        expect({ name, described: (action.description ?? '').length > 50 }).toEqual({
+          name,
+          described: true,
+        });
+      }
+    });
+
+    it('enables the connectivity test', () => {
+      expect(Whois.test.enabled).toBe(true);
+    });
+  });
+
+  describe('lookupDomain', () => {
+    it('GETs the bootstrap domain path with the RDAP media type', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      await Whois.actions.lookupDomain.handler(ctx, { domain: 'elastic.com' });
+
+      expect(client.get).toHaveBeenCalledTimes(1);
+      expect(client.get).toHaveBeenCalledWith('https://rdap.org/domain/elastic.com', RDAP_HEADERS);
+    });
+
+    it('honours a configured base URL', async () => {
+      const { ctx, client } = createContext({ baseUrl: 'https://rdap.verisign.com/com/v1' });
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      await Whois.actions.lookupDomain.handler(ctx, { domain: 'elastic.com' });
+
+      expect(client.get).toHaveBeenCalledWith(
+        'https://rdap.verisign.com/com/v1/domain/elastic.com',
+        RDAP_HEADERS
+      );
+    });
+
+    it('lets a per-call baseUrl override the configured one', async () => {
+      const { ctx, client } = createContext({ baseUrl: 'https://rdap.org' });
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      await Whois.actions.lookupDomain.handler(ctx, {
+        domain: 'elastic.com',
+        baseUrl: 'https://rdap.arin.net/registry',
+      });
+
+      expect(client.get).toHaveBeenCalledWith(
+        'https://rdap.arin.net/registry/domain/elastic.com',
+        RDAP_HEADERS
+      );
+    });
+
+    it('strips a trailing slash from the base URL so the path has no double slash', async () => {
+      const { ctx, client } = createContext({ baseUrl: 'https://rdap.org/' });
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      await Whois.actions.lookupDomain.handler(ctx, { domain: 'elastic.com' });
+
+      expect(client.get).toHaveBeenCalledWith('https://rdap.org/domain/elastic.com', RDAP_HEADERS);
+    });
+
+    it('sends a punycoded A-label through unchanged', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      await Whois.actions.lookupDomain.handler(ctx, { domain: 'xn--80ak6aa92e.com' });
+
+      expect(client.get).toHaveBeenCalledWith(
+        'https://rdap.org/domain/xn--80ak6aa92e.com',
+        RDAP_HEADERS
+      );
+    });
+
+    it('projects the registrar, dates, nameservers, and abuse contact', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      const result = (await Whois.actions.lookupDomain.handler(ctx, {
+        domain: 'elastic.com',
+      })) as Record<string, unknown>;
+
+      expect(result).toMatchObject({
+        found: true,
+        queryType: 'domain',
+        domain: 'ELASTIC.COM',
+        handle: '133013863_DOMAIN_COM-VRSN',
+        status: ['client delete prohibited', 'client transfer prohibited'],
+        registrationDate: '2004-10-16T18:08:31Z',
+        expirationDate: '2026-10-16T18:08:31Z',
+        lastChangedDate: '2024-10-26T03:31:33Z',
+        registrar: { name: 'GoDaddy.com, LLC', handle: '146', ianaId: '146' },
+        registrant: {
+          handle: 'REG-123',
+          name: 'REDACTED FOR PRIVACY',
+          organization: 'Elasticsearch BV',
+          country: 'NL',
+        },
+        // Published as a child of the registrar entity, not a sibling.
+        abuseContact: { email: 'abuse@godaddy.com', phone: '480-624-2505' },
+        nameservers: [
+          { ldhName: 'NS1-34.AZURE-DNS.COM' },
+          { ldhName: 'NS2-34.AZURE-DNS.NET', ipAddresses: { v4: ['1.2.3.4'] } },
+        ],
+        dnssec: false,
+        port43: 'whois.verisign-grs.com',
+      });
+    });
+
+    it('drops the notices, links, and rdapConformance boilerplate', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      const result = (await Whois.actions.lookupDomain.handler(ctx, {
+        domain: 'elastic.com',
+      })) as Record<string, unknown>;
+
+      expect(result.notices).toBeUndefined();
+      expect(result.links).toBeUndefined();
+      expect(result.rdapConformance).toBeUndefined();
+      expect(result.raw).toBeUndefined();
+    });
+
+    it('computes ageInDays and daysUntilExpiry from the event dates', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-08-06T00:00:00Z'));
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      const result = (await Whois.actions.lookupDomain.handler(ctx, {
+        domain: 'elastic.com',
+      })) as { ageInDays: number; daysUntilExpiry: number };
+
+      // 2004-10-16T18:08:31Z to 2026-08-06T00:00:00Z, floored to whole days.
+      expect(result.ageInDays).toBe(7963);
+      // 2026-08-06T00:00:00Z to 2026-10-16T18:08:31Z, floored the same way.
+      expect(result.daysUntilExpiry).toBe(71);
+    });
+
+    it('reports a negative daysUntilExpiry for an already-expired domain', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(Date.parse('2027-01-01T00:00:00Z'));
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      const result = (await Whois.actions.lookupDomain.handler(ctx, {
+        domain: 'elastic.com',
+      })) as { daysUntilExpiry: number };
+
+      expect(result.daysUntilExpiry).toBeLessThan(0);
+    });
+
+    it('omits the computed ages when the registry publishes no dates', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: { objectClassName: 'domain', ldhName: 'bare.com' } });
+
+      const result = (await Whois.actions.lookupDomain.handler(ctx, {
+        domain: 'bare.com',
+      })) as Record<string, unknown>;
+
+      expect(result).toMatchObject({
+        found: true,
+        domain: 'bare.com',
+        status: [],
+        nameservers: [],
+        dnssec: false,
+      });
+      expect(result.ageInDays).toBeUndefined();
+      expect(result.daysUntilExpiry).toBeUndefined();
+      expect(result.registrar).toBeUndefined();
+      expect(result.registrant).toBeUndefined();
+      expect(result.abuseContact).toBeUndefined();
+    });
+
+    it('reports dnssec true when the delegation is signed', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: { ...domainResponse, secureDNS: { delegationSigned: true, zoneSigned: true } },
+      });
+
+      const result = (await Whois.actions.lookupDomain.handler(ctx, {
+        domain: 'elastic.com',
+      })) as { dnssec: boolean };
+
+      expect(result.dnssec).toBe(true);
+    });
+
+    it('attaches the full record when includeRaw is set', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: domainResponse });
+
+      const result = (await Whois.actions.lookupDomain.handler(ctx, {
+        domain: 'elastic.com',
+        includeRaw: true,
+      })) as { raw: unknown; found: boolean };
+
+      expect(result.found).toBe(true);
+      expect(result.raw).toEqual(domainResponse);
+    });
+
+    it('returns found:false on a 404 rather than throwing', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(httpError(404));
+
+      const result = (await Whois.actions.lookupDomain.handler(ctx, {
+        domain: 'nonexistent99xyz.com',
+      })) as Record<string, unknown>;
+
+      expect(result).toEqual({
+        found: false,
+        queryType: 'domain',
+        query: 'nonexistent99xyz.com',
+        message: expect.stringContaining('HTTP 404'),
+      });
+    });
+
+    it('surfaces the registry error title and description on a 400', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(
+        httpError(400, {
+          errorCode: 400,
+          title: 'Bad Request',
+          description: ['Unsupported query type'],
+        })
+      );
+
+      await expect(
+        Whois.actions.lookupDomain.handler(ctx, { domain: 'elastic.com' })
+      ).rejects.toThrow('RDAP error (400): Bad Request: Unsupported query type');
+    });
+
+    it('falls back to the raw error body when the registry sends no RDAP error object', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(httpError(429, { retryAfter: 60 }));
+
+      await expect(
+        Whois.actions.lookupDomain.handler(ctx, { domain: 'elastic.com' })
+      ).rejects.toThrow('RDAP error (429): {"retryAfter":60}');
+    });
+
+    it('still reports the status when the error body is empty', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(httpError(503, ''));
+
+      await expect(
+        Whois.actions.lookupDomain.handler(ctx, { domain: 'elastic.com' })
+      ).rejects.toThrow('RDAP error (503): the registry returned no error detail');
+    });
+
+    it('rethrows a transport error that never reached the registry', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(
+        Whois.actions.lookupDomain.handler(ctx, { domain: 'elastic.com' })
+      ).rejects.toThrow('ECONNREFUSED');
+    });
+  });
+
+  describe('lookupIp', () => {
+    it('GETs the IP path with an unencoded IPv4 literal', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: ipResponse });
+
+      await Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.8' });
+
+      expect(client.get).toHaveBeenCalledWith('https://rdap.org/ip/8.8.8.8', RDAP_HEADERS);
+    });
+
+    it('leaves IPv6 colons unencoded, since encoding them makes registries 400', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: ipResponse });
+
+      await Whois.actions.lookupIp.handler(ctx, { ip: '2001:4860:4860::8888' });
+
+      const [url] = client.get.mock.calls[0];
+      expect(url).toBe('https://rdap.org/ip/2001:4860:4860::8888');
+      // The bug this guards against: encodeURIComponent would send %3A and get a 400 back.
+      expect(url).not.toContain('%3A');
+    });
+
+    it('leaves a CIDR slash unencoded, since encoding it makes registries 400', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: ipResponse });
+
+      await Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.0/24' });
+
+      const [url] = client.get.mock.calls[0];
+      expect(url).toBe('https://rdap.org/ip/8.8.8.0/24');
+      expect(url).not.toContain('%2F');
+    });
+
+    it('projects the netblock, holder, origin AS, and abuse contact', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: ipResponse });
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.8' })) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result).toMatchObject({
+        found: true,
+        queryType: 'ip',
+        handle: 'NET-8-8-8-0-2',
+        netName: 'GOGL',
+        startAddress: '8.8.8.0',
+        endAddress: '8.8.8.255',
+        // Flattened from the cidr0 extension's prefix/length pair.
+        cidr: ['8.8.8.0/24'],
+        ipVersion: 'v4',
+        allocationType: 'DIRECT ALLOCATION',
+        parentHandle: 'NET-8-0-0-0-0',
+        status: ['active'],
+        // From ARIN's originas0 extension: feeds straight into lookupAsn.
+        originAutnums: [15169],
+        organization: { handle: 'GOGL', name: 'Google LLC' },
+        abuseContact: { email: 'network-abuse@google.com', phone: '+1-650-253-0000' },
+        port43: 'whois.arin.net',
+      });
+    });
+
+    it('flattens an IPv6 cidr0 prefix', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: { ...ipResponse, cidr0_cidrs: [{ v6prefix: '2001:4860::', length: 32 }] },
+      });
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, {
+        ip: '2001:4860:4860::8888',
+      })) as { cidr: string[] };
+
+      expect(result.cidr).toEqual(['2001:4860::/32']);
+    });
+
+    it('carries the holder address ARIN publishes as a label, where country is unavailable', async () => {
+      // ARIN leaves the structured jCard address array empty and puts the whole location in the
+      // row's `label` param, so there is no ISO country code to read. Verified live against
+      // 8.8.8.8, whose real record this fixture mirrors: the analyst would otherwise get no
+      // location at all for any ARIN-registered address.
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: ipResponse });
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.8' })) as {
+        organization: { address?: string; country?: string };
+      };
+
+      expect(result.organization.country).toBeUndefined();
+      expect(result.organization.address).toBe(
+        '1600 Amphitheatre Parkway\nMountain View\nCA\n94043\nUnited States'
+      );
+    });
+
+    it('prefers the top-level country an RIR publishes', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: { ...ipResponse, country: 'NL' } });
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, { ip: '193.0.6.139' })) as {
+        country: string;
+      };
+
+      expect(result.country).toBe('NL');
+    });
+
+    it('falls back to the holder vCard country when the RIR omits the top-level one', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: {
+          ...ipResponse,
+          entities: [
+            {
+              handle: 'ORG-1',
+              roles: ['registrant'],
+              vcardArray: [
+                'vcard',
+                [
+                  ['fn', {}, 'text', 'Example Org'],
+                  ['adr', {}, 'text', ['', '', '', 'Berlin', '', '10115', 'DE']],
+                ],
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.8' })) as {
+        country: string;
+      };
+
+      expect(result.country).toBe('DE');
+    });
+
+    it('treats the first entity as the holder when no registrant role is published', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: {
+          ...ipResponse,
+          entities: [
+            {
+              handle: 'NO-ROLE',
+              vcardArray: ['vcard', [['fn', {}, 'text', 'Unlabelled Holder']]],
+            },
+          ],
+        },
+      });
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.8' })) as {
+        organization: { handle: string; name: string };
+      };
+
+      expect(result.organization).toMatchObject({ handle: 'NO-ROLE', name: 'Unlabelled Holder' });
+    });
+
+    it('finds a top-level abuse contact, not just a nested one', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: {
+          ...ipResponse,
+          entities: [
+            {
+              handle: 'ABUSE-TOP',
+              roles: ['abuse'],
+              vcardArray: ['vcard', [['email', {}, 'text', 'abuse@example.net']]],
+            },
+          ],
+        },
+      });
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.8' })) as {
+        abuseContact: { email: string };
+      };
+
+      expect(result.abuseContact.email).toBe('abuse@example.net');
+    });
+
+    it('omits abuseContact when the abuse entity publishes no reachable detail', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: { ...ipResponse, entities: [{ handle: 'ABUSE-EMPTY', roles: ['abuse'] }] },
+      });
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.8' })) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.abuseContact).toBeUndefined();
+    });
+
+    it('defaults originAutnums to an empty array outside ARIN', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: { ...ipResponse, arin_originas0_originautnums: undefined },
+      });
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.8' })) as {
+        originAutnums: number[];
+      };
+
+      expect(result.originAutnums).toEqual([]);
+    });
+
+    it('returns found:false on a 404', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(httpError(404));
+
+      const result = (await Whois.actions.lookupIp.handler(ctx, { ip: '203.0.113.1' })) as {
+        found: boolean;
+        queryType: string;
+        query: string;
+      };
+
+      expect(result).toMatchObject({ found: false, queryType: 'ip', query: '203.0.113.1' });
+    });
+
+    it('throws on a non-404 error', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(httpError(500, { title: 'Internal Server Error' }));
+
+      await expect(Whois.actions.lookupIp.handler(ctx, { ip: '8.8.8.8' })).rejects.toThrow(
+        'RDAP error (500): Internal Server Error'
+      );
+    });
+  });
+
+  describe('lookupAsn', () => {
+    it('GETs the autnum path with a bare number', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: autnumResponse });
+
+      await Whois.actions.lookupAsn.handler(ctx, { asn: '15169' });
+
+      expect(client.get).toHaveBeenCalledWith('https://rdap.org/autnum/15169', RDAP_HEADERS);
+    });
+
+    it('strips an uppercase AS prefix, which registries reject in the path', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: autnumResponse });
+
+      await Whois.actions.lookupAsn.handler(ctx, { asn: 'AS15169' });
+
+      expect(client.get).toHaveBeenCalledWith('https://rdap.org/autnum/15169', RDAP_HEADERS);
+    });
+
+    it('strips a lowercase as prefix too', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: autnumResponse });
+
+      await Whois.actions.lookupAsn.handler(ctx, { asn: 'as15169' });
+
+      expect(client.get).toHaveBeenCalledWith('https://rdap.org/autnum/15169', RDAP_HEADERS);
+    });
+
+    it('projects the AS name, range, holder, and abuse contact', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: autnumResponse });
+
+      const result = (await Whois.actions.lookupAsn.handler(ctx, { asn: 'AS15169' })) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result).toMatchObject({
+        found: true,
+        queryType: 'autnum',
+        handle: 'AS15169',
+        asName: 'GOOGLE',
+        startAutnum: 15169,
+        endAutnum: 15169,
+        status: ['active'],
+        registrationDate: '2000-03-30T00:00:00-05:00',
+        lastChangedDate: '2012-02-24T09:44:34-05:00',
+        organization: { handle: 'GOGL', name: 'Google LLC' },
+        abuseContact: { email: 'network-abuse@google.com' },
+        port43: 'whois.arin.net',
+      });
+    });
+
+    it('reports the stripped number in a found:false result', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(httpError(404));
+
+      const result = (await Whois.actions.lookupAsn.handler(ctx, { asn: 'AS4294967290' })) as {
+        found: boolean;
+        query: string;
+      };
+
+      expect(result).toMatchObject({ found: false, query: '4294967290' });
+    });
+  });
+
+  describe('lookupNameserver', () => {
+    it('GETs the nameserver path and projects the glue addresses', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: {
+          objectClassName: 'nameserver',
+          ldhName: 'NS1.GOOGLE.COM',
+          ipAddresses: { v4: ['216.239.32.10'], v6: ['2001:4860:4802:32::A'] },
+        },
+      });
+
+      const result = (await Whois.actions.lookupNameserver.handler(ctx, {
+        nameserver: 'ns1.google.com',
+      })) as Record<string, unknown>;
+
+      expect(client.get).toHaveBeenCalledWith(
+        'https://rdap.org/nameserver/ns1.google.com',
+        RDAP_HEADERS
+      );
+      expect(result).toMatchObject({
+        found: true,
+        queryType: 'nameserver',
+        ldhName: 'NS1.GOOGLE.COM',
+        ipAddresses: { v4: ['216.239.32.10'], v6: ['2001:4860:4802:32::A'] },
+        status: [],
+      });
+    });
+
+    it('defaults ipAddresses to an empty object when no glue is registered', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: { objectClassName: 'nameserver', ldhName: 'NS1.EXAMPLE.COM' },
+      });
+
+      const result = (await Whois.actions.lookupNameserver.handler(ctx, {
+        nameserver: 'ns1.example.com',
+      })) as { ipAddresses: Record<string, unknown> };
+
+      expect(result.ipAddresses).toEqual({});
+    });
+
+    it('returns found:false on a 404, which is common for nameservers', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(httpError(404));
+
+      const result = (await Whois.actions.lookupNameserver.handler(ctx, {
+        nameserver: 'ns1.example.com',
+      })) as { found: boolean; queryType: string };
+
+      expect(result).toMatchObject({ found: false, queryType: 'nameserver' });
+    });
+  });
+
+  describe('lookupEntity', () => {
+    it('GETs the entity path with the handle', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: ipResponse.entities[0] });
+
+      await Whois.actions.lookupEntity.handler(ctx, { handle: 'ABUSE5250-ARIN' });
+
+      expect(client.get).toHaveBeenCalledWith(
+        'https://rdap.org/entity/ABUSE5250-ARIN',
+        RDAP_HEADERS
+      );
+    });
+
+    it('flattens the jCard and one level of child contacts', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: {
+          ...ipResponse.entities[0],
+          events: [
+            { eventAction: 'registration', eventDate: '2000-03-30T00:00:00-05:00' },
+            { eventAction: 'last changed', eventDate: '2019-10-31T15:45:45-04:00' },
+          ],
+        },
+      });
+
+      const result = (await Whois.actions.lookupEntity.handler(ctx, {
+        handle: 'GOGL',
+        baseUrl: 'https://rdap.arin.net/registry',
+      })) as Record<string, unknown>;
+
+      expect(client.get).toHaveBeenCalledWith(
+        'https://rdap.arin.net/registry/entity/GOGL',
+        RDAP_HEADERS
+      );
+      expect(result).toMatchObject({
+        found: true,
+        queryType: 'entity',
+        handle: 'GOGL',
+        roles: ['registrant'],
+        name: 'Google LLC',
+        // ARIN puts the address in the adr row's `label` param, not the structured array.
+        address: '1600 Amphitheatre Parkway\nMountain View\nCA\n94043\nUnited States',
+        registrationDate: '2000-03-30T00:00:00-05:00',
+        lastChangedDate: '2019-10-31T15:45:45-04:00',
+        childEntities: [
+          {
+            handle: 'ABUSE5250-ARIN',
+            roles: ['abuse'],
+            name: 'Abuse',
+            organization: 'Google Inc.',
+            email: 'network-abuse@google.com',
+            phone: '+1-650-253-0000',
+          },
+        ],
+      });
+    });
+
+    it('strips the tel: URI scheme so phone numbers have one shape', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: {
+          handle: 'REG-1',
+          roles: ['registrar'],
+          vcardArray: ['vcard', [['tel', { type: 'voice' }, 'uri', 'tel:480-624-2505']]],
+        },
+      });
+
+      const result = (await Whois.actions.lookupEntity.handler(ctx, { handle: 'REG-1' })) as {
+        phone: string;
+      };
+
+      expect(result.phone).toBe('480-624-2505');
+    });
+
+    it('reads the structured adr array when there is no label param', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: {
+          handle: 'REG-2',
+          vcardArray: [
+            'vcard',
+            [['adr', {}, 'text', ['', '', 'Keizersgracht 1', 'Amsterdam', '', '1015', 'NL']]],
+          ],
+        },
+      });
+
+      const result = (await Whois.actions.lookupEntity.handler(ctx, { handle: 'REG-2' })) as {
+        address: string;
+        country: string;
+      };
+
+      expect(result.address).toBe('Keizersgracht 1, Amsterdam, 1015, NL');
+      expect(result.country).toBe('NL');
+    });
+
+    it('surfaces the IANA registrar id when the entity is a registrar', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({
+        data: {
+          handle: '146',
+          roles: ['registrar'],
+          publicIds: [{ type: 'IANA Registrar ID', identifier: '146' }],
+        },
+      });
+
+      const result = (await Whois.actions.lookupEntity.handler(ctx, { handle: '146' })) as {
+        ianaRegistrarId: string;
+      };
+
+      expect(result.ianaRegistrarId).toBe('146');
+    });
+
+    it('returns found:false on a 404', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(httpError(404));
+
+      const result = (await Whois.actions.lookupEntity.handler(ctx, { handle: 'NOPE-ARIN' })) as {
+        found: boolean;
+        queryType: string;
+      };
+
+      expect(result).toMatchObject({ found: false, queryType: 'entity' });
+    });
+  });
+
+  describe('test handler', () => {
+    it('calls the RDAP /help capability endpoint', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockResolvedValue({ data: { rdapConformance: ['rdap_level_0'] } });
+
+      const result = await Whois.test.handler(ctx);
+
+      expect(client.get).toHaveBeenCalledWith('https://rdap.org/help', RDAP_HEADERS);
+      // Resolving is the success signal. ConnectorTestHandlerResult forbids an `ok` key so the
+      // legacy `{ ok: false }` failure shape cannot be expressed.
+      expect(result).toMatchObject({ rdapServer: 'https://rdap.org' });
+      expect(result.ok).toBeUndefined();
+    });
+
+    it('probes the configured base URL rather than the default', async () => {
+      const { ctx, client } = createContext({ baseUrl: 'https://rdap.arin.net/registry' });
+      client.get.mockResolvedValue({ data: {} });
+
+      await Whois.test.handler(ctx);
+
+      expect(client.get).toHaveBeenCalledWith('https://rdap.arin.net/registry/help', RDAP_HEADERS);
+    });
+
+    it('throws when the server rejects the request, so the UI reports a failure', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(httpError(401, { title: 'Unauthorized' }));
+
+      await expect(Whois.test.handler(ctx)).rejects.toThrow('RDAP error (401): Unauthorized');
+    });
+
+    it('throws when the server is unreachable', async () => {
+      const { ctx, client } = createContext();
+      client.get.mockRejectedValue(new Error('ENOTFOUND'));
+
+      await expect(Whois.test.handler(ctx)).rejects.toThrow('ENOTFOUND');
+    });
+  });
+
+  describe('input schemas', () => {
+    it('accepts a normal domain and rejects a scheme, path, or space', () => {
+      expect(LookupDomainInputSchema.safeParse({ domain: 'example.com' }).success).toBe(true);
+      expect(LookupDomainInputSchema.safeParse({ domain: 'xn--80ak6aa92e.com' }).success).toBe(
+        true
+      );
+      expect(LookupDomainInputSchema.safeParse({ domain: 'https://example.com' }).success).toBe(
+        false
+      );
+      expect(LookupDomainInputSchema.safeParse({ domain: 'example.com/path' }).success).toBe(false);
+      expect(LookupDomainInputSchema.safeParse({ domain: 'exa mple.com' }).success).toBe(false);
+      // A bare label is not a registrable domain.
+      expect(LookupDomainInputSchema.safeParse({ domain: 'localhost' }).success).toBe(false);
+      // A leading hyphen in a label breaks the LDH rule.
+      expect(LookupDomainInputSchema.safeParse({ domain: '-bad.com' }).success).toBe(false);
+    });
+
+    it('bounds the domain at the 253-octet DNS limit', () => {
+      const tooLong = `${'a'.repeat(60)}.${'b'.repeat(60)}.${'c'.repeat(60)}.${'d'.repeat(
+        60
+      )}.${'e'.repeat(20)}.com`;
+      expect(tooLong.length).toBeGreaterThan(253);
+      expect(LookupDomainInputSchema.safeParse({ domain: tooLong }).success).toBe(false);
+    });
+
+    it('rejects a unicode domain rather than mangling it', () => {
+      // RDAP addresses an IDN by its A-label, so the caller must punycode first.
+      expect(LookupDomainInputSchema.safeParse({ domain: 'пример.com' }).success).toBe(false);
+    });
+
+    it('requires an https base URL override', () => {
+      expect(
+        LookupDomainInputSchema.safeParse({
+          domain: 'example.com',
+          baseUrl: 'https://rdap.example.com/v1',
+        }).success
+      ).toBe(true);
+      // Plain HTTP would leak the indicator under investigation.
+      expect(
+        LookupDomainInputSchema.safeParse({ domain: 'example.com', baseUrl: 'http://rdap.org' })
+          .success
+      ).toBe(false);
+      expect(
+        LookupDomainInputSchema.safeParse({
+          domain: 'example.com',
+          baseUrl: 'file:///etc/passwd',
+        }).success
+      ).toBe(false);
+    });
+
+    it('accepts IPv4, IPv6, and CIDR, and rejects a host name', () => {
+      expect(LookupIpInputSchema.safeParse({ ip: '8.8.8.8' }).success).toBe(true);
+      expect(LookupIpInputSchema.safeParse({ ip: '8.8.8.0/24' }).success).toBe(true);
+      expect(LookupIpInputSchema.safeParse({ ip: '2001:4860:4860::8888' }).success).toBe(true);
+      expect(LookupIpInputSchema.safeParse({ ip: '2001:db8::/32' }).success).toBe(true);
+      expect(LookupIpInputSchema.safeParse({ ip: 'example.com' }).success).toBe(false);
+      // A prefix length above 128 is meaningless.
+      expect(LookupIpInputSchema.safeParse({ ip: '8.8.8.0/999' }).success).toBe(false);
+      // Path-structural characters must not survive into the unencoded path segment.
+      expect(LookupIpInputSchema.safeParse({ ip: '8.8.8.8?x=1' }).success).toBe(false);
+      expect(LookupIpInputSchema.safeParse({ ip: '../../help' }).success).toBe(false);
+    });
+
+    it('accepts the compressed and v4-mapped IPv6 forms registries return', () => {
+      expect(LookupIpInputSchema.safeParse({ ip: '::1' }).success).toBe(true);
+      expect(LookupIpInputSchema.safeParse({ ip: '2001:db8::' }).success).toBe(true);
+      expect(LookupIpInputSchema.safeParse({ ip: '::ffff:8.8.8.8' }).success).toBe(true);
+      expect(
+        LookupIpInputSchema.safeParse({ ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334' }).success
+      ).toBe(true);
+      expect(LookupIpInputSchema.safeParse({ ip: '2001:4860:4860::8888/128' }).success).toBe(true);
+    });
+
+    it('rejects a dot-run that would traverse out of the /ip/ path prefix', () => {
+      // The IP is interpolated into the path WITHOUT percent-encoding, so a value made only of
+      // permitted characters can still retarget the request: `..` resolves to the server root
+      // and `../12` to /12, escaping /ip/ entirely. A charset-only bound let these through, so
+      // the pattern matches the address structurally and every case below must be rejected.
+      for (const ip of ['..', '../12', '.../24', '....', '...', '.:.', '.']) {
+        expect({ ip, accepted: LookupIpInputSchema.safeParse({ ip }).success }).toEqual({
+          ip,
+          accepted: false,
+        });
+      }
+    });
+
+    it('accepts an ASN with or without the AS prefix and rejects a non-numeric one', () => {
+      expect(LookupAsnInputSchema.safeParse({ asn: '15169' }).success).toBe(true);
+      expect(LookupAsnInputSchema.safeParse({ asn: 'AS15169' }).success).toBe(true);
+      expect(LookupAsnInputSchema.safeParse({ asn: 'as15169' }).success).toBe(true);
+      expect(LookupAsnInputSchema.safeParse({ asn: 'ASN15169' }).success).toBe(false);
+      expect(LookupAsnInputSchema.safeParse({ asn: '15169; DROP' }).success).toBe(false);
+    });
+
+    it('validates a nameserver host name like a domain', () => {
+      expect(LookupNameserverInputSchema.safeParse({ nameserver: 'ns1.example.com' }).success).toBe(
+        true
+      );
+      expect(LookupNameserverInputSchema.safeParse({ nameserver: 'ns1' }).success).toBe(false);
+    });
+
+    it('bounds and charset-constrains an entity handle', () => {
+      expect(LookupEntityInputSchema.safeParse({ handle: 'GOGL' }).success).toBe(true);
+      expect(LookupEntityInputSchema.safeParse({ handle: 'ABUSE5250-ARIN' }).success).toBe(true);
+      expect(
+        LookupEntityInputSchema.safeParse({ handle: '133013863_DOMAIN_COM-VRSN' }).success
+      ).toBe(true);
+      expect(LookupEntityInputSchema.safeParse({ handle: 'a/../help' }).success).toBe(false);
+      expect(LookupEntityInputSchema.safeParse({ handle: 'x'.repeat(129) }).success).toBe(false);
+    });
+
+    it('leaves includeRaw unset so responses stay trimmed by default', () => {
+      const parsed = LookupDomainInputSchema.safeParse({ domain: 'example.com' });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.includeRaw).toBeUndefined();
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/whois/whois.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/whois/whois.ts
@@ -1,0 +1,693 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import { z, lazySchema } from '@kbn/zod/v4';
+import type { ActionContext, ConnectorSpec } from '../../connector_spec';
+import type {
+  LookupAsnInput,
+  LookupDomainInput,
+  LookupEntityInput,
+  LookupIpInput,
+  LookupNameserverInput,
+  RdapAutnumResponse,
+  RdapDomainResponse,
+  RdapEntity,
+  RdapEvent,
+  RdapIpResponse,
+  RdapNameserver,
+  VcardEntry,
+} from './types';
+import {
+  LookupAsnInputSchema,
+  LookupDomainInputSchema,
+  LookupEntityInputSchema,
+  LookupIpInputSchema,
+  LookupNameserverInputSchema,
+  RdapBaseUrlSchema,
+} from './types';
+
+/**
+ * RDAP.org is an aggregating bootstrap server: it holds the registry of every known RDAP
+ * service and 302-redirects a query to the authoritative one. That keeps this connector out
+ * of the business of shipping and refreshing the IANA bootstrap files.
+ */
+const DEFAULT_RDAP_BASE_URL = 'https://rdap.org';
+
+/**
+ * Legacy WHOIS is a plain-text protocol on TCP port 43. Kibana connectors speak HTTP through
+ * axios only, and Kibana egress almost always blocks raw TCP, so port 43 is not reachable
+ * from here at all. RDAP over HTTPS is the only viable transport, which is why every action
+ * in this connector is an RDAP call rather than a WHOIS one. RDAP is the IETF's replacement
+ * for WHOIS (RFC 7480-7484, restated as RFC 9082/9083) and is mandatory for gTLD registries
+ * and all five RIRs, so the coverage loss is limited to ccTLDs that never adopted it.
+ */
+const getBaseUrl = (ctx: ActionContext, override?: string): string => {
+  const configured = (ctx.config?.baseUrl as string | undefined) ?? DEFAULT_RDAP_BASE_URL;
+  const chosen = override ?? configured;
+  // Trailing slashes would produce `//domain/x`, which some registry servers 404 on.
+  return chosen.replace(/\/+$/, '');
+};
+
+/** RDAP responses are JSON but served under their own media type (RFC 9083 section 1.2). */
+const RDAP_HEADERS = { Accept: 'application/rdap+json' } as const;
+
+/**
+ * Surface the registry's own error text. RDAP servers return an errorCode/title/description
+ * body (RFC 9083 section 6); an unwrapped axios message says only "Request failed with
+ * status code 400", which hides which part of the query the registry rejected.
+ */
+const throwWithApiError = (error: unknown): never => {
+  const axiosError = error as {
+    response?: { status?: number; data?: unknown };
+    message?: string;
+  };
+  const status = axiosError.response?.status;
+  const data = axiosError.response?.data as
+    | { errorCode?: number; title?: string; description?: string[] }
+    | undefined;
+  if (data?.title !== undefined || data?.description !== undefined) {
+    const detail = [data.title, ...(data.description ?? [])].filter(Boolean).join(': ');
+    throw new Error(`RDAP error (${status}): ${detail}`);
+  }
+  if (axiosError.response?.data !== undefined && axiosError.response.data !== '') {
+    throw new Error(`RDAP error (${status}): ${JSON.stringify(axiosError.response.data)}`);
+  }
+  if (status !== undefined) {
+    throw new Error(`RDAP error (${status}): the registry returned no error detail`);
+  }
+  throw error;
+};
+
+/**
+ * An RDAP 404 means one of three different things, and the connector cannot tell them apart
+ * because the bootstrap layer collapses them all into a bare 404 with an empty body
+ * (confirmed live against rdap.org for an unregistered .com, and for elastic.co whose TLD
+ * has no RDAP service at all):
+ *   1. the object is genuinely unregistered/unallocated,
+ *   2. the TLD or registry publishes no RDAP service,
+ *   3. the name was malformed in a way the server treats as not-found.
+ * Returning it as `{ found: false }` data rather than throwing is deliberate: a triage
+ * workflow branching on "no record" must not have its run failed by a legitimate answer.
+ * Every other status still throws.
+ */
+const isNotFound = (error: unknown): boolean =>
+  (error as { response?: { status?: number } }).response?.status === 404;
+
+const notFound = (queryType: string, query: string) => ({
+  found: false as const,
+  queryType,
+  query,
+  message:
+    'No RDAP record was returned (HTTP 404). The object may be unregistered or unallocated, or its registry may not operate an RDAP service. RDAP does not distinguish these cases.',
+});
+
+/**
+ * Read the rows of a jCard (RFC 7095): the array-of-arrays form RDAP uses for contact detail.
+ * Each row is [name, params, valueType, value], so a value lives at index 3.
+ */
+const vcardRows = (entity: RdapEntity | undefined): VcardEntry[] => entity?.vcardArray?.[1] ?? [];
+
+const vcardText = (entity: RdapEntity | undefined, name: string): string | undefined => {
+  const row = vcardRows(entity).find((entry) => entry[0] === name);
+  const value = row?.[3];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+};
+
+/**
+ * A `tel` value arrives either as bare text or as a `tel:` URI depending on the registry, so
+ * the scheme is stripped to give a workflow one consistent shape.
+ */
+const vcardPhone = (entity: RdapEntity | undefined): string | undefined => {
+  const value = vcardText(entity, 'tel');
+  return value?.replace(/^tel:/, '');
+};
+
+/**
+ * ADR is the messiest jCard property. Registries either fill the 7-element structured array
+ * (pobox, ext, street, locality, region, postcode, country) or leave it empty and put a
+ * newline-joined address in the row's `label` parameter. ARIN does the latter, SIDN the
+ * former, so both are read.
+ */
+const vcardAddress = (entity: RdapEntity | undefined): { address?: string; country?: string } => {
+  const row = vcardRows(entity).find((entry) => entry[0] === 'adr');
+  if (!row) {
+    return {};
+  }
+  const label = row[1]?.label;
+  const parts = Array.isArray(row[3])
+    ? (row[3] as unknown[]).map((part) => String(part ?? ''))
+    : [];
+  const country = parts[6] !== undefined && parts[6].length > 0 ? parts[6] : undefined;
+  const structured = parts.filter((part) => part.length > 0).join(', ');
+  return {
+    address: typeof label === 'string' && label.length > 0 ? label : structured || undefined,
+    country,
+  };
+};
+
+const ianaRegistrarId = (entity: RdapEntity | undefined): string | undefined =>
+  entity?.publicIds?.find((id) => id.type === 'IANA Registrar ID')?.identifier;
+
+/** The shared contact projection: who they are and how to reach them, without the jCard noise. */
+const trimContact = (entity: RdapEntity) => {
+  const { address, country } = vcardAddress(entity);
+  return {
+    handle: entity.handle,
+    roles: entity.roles ?? [],
+    name: vcardText(entity, 'fn'),
+    organization: vcardText(entity, 'org'),
+    email: vcardText(entity, 'email'),
+    phone: vcardPhone(entity),
+    address,
+    country,
+  };
+};
+
+/**
+ * Flatten one entity plus one level of its children. The nesting matters: a registrar's abuse
+ * contact is published as a child entity, not a sibling, so a flat projection would drop it.
+ */
+const trimEntity = (entity: RdapEntity) => ({
+  ...trimContact(entity),
+  ianaRegistrarId: ianaRegistrarId(entity),
+  childEntities: (entity.entities ?? []).map(trimContact),
+});
+
+const findEntityByRole = (entities: RdapEntity[] | undefined, role: string) =>
+  (entities ?? []).find((entity) => (entity.roles ?? []).includes(role));
+
+/**
+ * Find a contact by role anywhere in the first two entity levels. An abuse contact sits under
+ * the registrar for a domain but at the top level for an IP netblock, so a single-level
+ * search misses it half the time.
+ */
+const findNestedEntityByRole = (
+  entities: RdapEntity[] | undefined,
+  role: string
+): RdapEntity | undefined => {
+  const direct = findEntityByRole(entities, role);
+  if (direct) {
+    return direct;
+  }
+  for (const entity of entities ?? []) {
+    const nested = findEntityByRole(entity.entities, role);
+    if (nested) {
+      return nested;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Returns undefined rather than an empty object when the registry publishes an abuse entity
+ * with no reachable detail (verified live: example.com's registrar entity has an abuse role
+ * but no email or phone). `abuseContact: {}` would read to a workflow as "there is a contact"
+ * when there is nothing to send to.
+ */
+const abuseContactOf = (entities: RdapEntity[] | undefined) => {
+  const abuse = findNestedEntityByRole(entities, 'abuse');
+  if (!abuse) {
+    return undefined;
+  }
+  const email = vcardText(abuse, 'email');
+  const phone = vcardPhone(abuse);
+  return email === undefined && phone === undefined ? undefined : { email, phone };
+};
+
+/**
+ * The org that holds an allocation. RIRs disagree on how to mark it: RIPE and APNIC use the
+ * `registrant` role, ARIN sometimes publishes the holder without one, so the first entity is
+ * the fallback rather than returning nothing.
+ */
+const holderOf = (entities: RdapEntity[] | undefined): RdapEntity | undefined =>
+  findEntityByRole(entities, 'registrant') ?? (entities ?? [])[0];
+
+/**
+ * `address` is included, not just `country`, because the two RIR styles are not
+ * interchangeable. ARIN leaves the structured jCard address array empty and publishes the
+ * whole location as a newline-joined `label` param, so a country code cannot be read from it
+ * (verified live: 8.8.8.8's holder has `label` "1600 Amphitheatre Parkway\nMountain
+ * View\nCA\n94043\nUnited States" and a 7-element array of empty strings). RIPE and APNIC do
+ * publish a top-level ISO `country`. Rather than guess a code from the label's last line,
+ * which would yield "United States" where another registry yields "NL" and break any workflow
+ * comparing the field, `country` stays absent for ARIN space and `address` carries the
+ * location the registry actually published.
+ */
+const organizationOf = (entity: RdapEntity | undefined) => {
+  if (!entity) {
+    return undefined;
+  }
+  const { address, country } = vcardAddress(entity);
+  return {
+    handle: entity.handle,
+    name: vcardText(entity, 'fn'),
+    organization: vcardText(entity, 'org'),
+    address,
+    country,
+  };
+};
+
+/** Pull one dated event out of the RDAP events array by its eventAction name. */
+const eventDate = (events: RdapEvent[] | undefined, action: string): string | undefined =>
+  (events ?? []).find((event) => event.eventAction === action)?.eventDate;
+
+const MS_PER_DAY = 86_400_000;
+
+const parseIsoDate = (isoDate: string | undefined): number | undefined => {
+  if (isoDate === undefined) {
+    return undefined;
+  }
+  const parsed = Date.parse(isoDate);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+/**
+ * Age in whole elapsed days. Domain age is the most load-bearing signal in phishing triage
+ * ("registered 3 days ago"), and computing it here saves every workflow from doing its own
+ * date arithmetic on a string.
+ */
+const daysSince = (isoDate: string | undefined): number | undefined => {
+  const parsed = parseIsoDate(isoDate);
+  return parsed === undefined ? undefined : Math.floor((Date.now() - parsed) / MS_PER_DAY);
+};
+
+/**
+ * Whole days remaining, negative once the date has passed so an expired domain reads as a
+ * negative countdown. Floored in its own direction rather than by negating daysSince: negating
+ * a floored negative rounds away from zero and would report 72 days left when only 71 full days
+ * remain, which is the wrong way to be wrong for an expiry threshold.
+ */
+const daysUntil = (isoDate: string | undefined): number | undefined => {
+  const parsed = parseIsoDate(isoDate);
+  return parsed === undefined ? undefined : Math.floor((parsed - Date.now()) / MS_PER_DAY);
+};
+
+const trimNameserver = (nameserver: RdapNameserver) => ({
+  ldhName: nameserver.ldhName,
+  ipAddresses: nameserver.ipAddresses,
+});
+
+const withRaw = <T extends object>(trimmed: T, raw: unknown, includeRaw?: boolean) =>
+  includeRaw === true ? { ...trimmed, raw } : trimmed;
+
+/**
+ * RDAP domain responses run 2-8 KB and are mostly boilerplate: `notices` alone (terms of
+ * service, status-code glossary, ICANN complaint form) is often half the payload, and every
+ * object repeats a `links` array of self-referencing URLs. Passing that through would burn an
+ * agent's context for no analytical value, so only the triage-relevant members survive.
+ */
+const trimDomain = (data: RdapDomainResponse) => {
+  const registrar = findEntityByRole(data.entities, 'registrar');
+  const registrant = findEntityByRole(data.entities, 'registrant');
+  const registrationDate = eventDate(data.events, 'registration');
+  const expirationDate = eventDate(data.events, 'expiration');
+
+  return {
+    found: true as const,
+    queryType: 'domain',
+    domain: data.ldhName,
+    unicodeName: data.unicodeName,
+    handle: data.handle,
+    status: data.status ?? [],
+    registrationDate,
+    expirationDate,
+    lastChangedDate: eventDate(data.events, 'last changed'),
+    // Both signals a triage rule actually branches on: a very young domain is suspicious, and
+    // an already-expired one often means a dangling or hijacked delegation.
+    ageInDays: daysSince(registrationDate),
+    daysUntilExpiry: daysUntil(expirationDate),
+    registrar: registrar
+      ? {
+          name: vcardText(registrar, 'fn'),
+          handle: registrar.handle,
+          ianaId: ianaRegistrarId(registrar),
+        }
+      : undefined,
+    registrant: registrant
+      ? {
+          handle: registrant.handle,
+          name: vcardText(registrant, 'fn'),
+          organization: vcardText(registrant, 'org'),
+          email: vcardText(registrant, 'email'),
+          country: vcardAddress(registrant).country,
+        }
+      : undefined,
+    abuseContact: abuseContactOf(data.entities),
+    nameservers: (data.nameservers ?? []).map(trimNameserver),
+    dnssec: data.secureDNS?.delegationSigned === true,
+    port43: data.port43,
+  };
+};
+
+/**
+ * IP responses are the largest RDAP objects (the live 8.8.8.8 record is ~6.5 KB, mostly
+ * nested vCard arrays and remark prose), so the same aggressive trim applies.
+ */
+const trimIp = (data: RdapIpResponse) => {
+  const holder = holderOf(data.entities);
+  const cidr = (data.cidr0_cidrs ?? [])
+    .map((block) => {
+      const prefix = block.v4prefix ?? block.v6prefix;
+      return prefix !== undefined && block.length !== undefined
+        ? `${prefix}/${block.length}`
+        : undefined;
+    })
+    .filter((value): value is string => value !== undefined);
+
+  return {
+    found: true as const,
+    queryType: 'ip',
+    handle: data.handle,
+    netName: data.name,
+    startAddress: data.startAddress,
+    endAddress: data.endAddress,
+    cidr,
+    ipVersion: data.ipVersion,
+    allocationType: data.type,
+    // `country` is a top-level member at the RIRs that publish it (RIPE, APNIC); ARIN does
+    // not, so it falls back to the holder's vCard address.
+    country: data.country ?? vcardAddress(holder).country,
+    parentHandle: data.parentHandle,
+    status: data.status ?? [],
+    // ARIN's originas0 extension names the AS that announces the block. It is the handle to
+    // pass straight into lookupAsn.
+    originAutnums: data.arin_originas0_originautnums ?? [],
+    registrationDate: eventDate(data.events, 'registration'),
+    lastChangedDate: eventDate(data.events, 'last changed'),
+    organization: organizationOf(holder),
+    abuseContact: abuseContactOf(data.entities),
+    port43: data.port43,
+  };
+};
+
+const trimAutnum = (data: RdapAutnumResponse) => {
+  const holder = holderOf(data.entities);
+
+  return {
+    found: true as const,
+    queryType: 'autnum',
+    handle: data.handle,
+    asName: data.name,
+    startAutnum: data.startAutnum,
+    endAutnum: data.endAutnum,
+    allocationType: data.type,
+    country: data.country ?? vcardAddress(holder).country,
+    status: data.status ?? [],
+    registrationDate: eventDate(data.events, 'registration'),
+    lastChangedDate: eventDate(data.events, 'last changed'),
+    organization: organizationOf(holder),
+    abuseContact: abuseContactOf(data.entities),
+    port43: data.port43,
+  };
+};
+
+export const Whois: ConnectorSpec = {
+  metadata: {
+    id: '.whois',
+    displayName: 'WHOIS',
+    description: i18n.translate('core.kibanaConnectorSpecs.whois.metadata.description', {
+      defaultMessage:
+        'Look up domain, IP, ASN, nameserver, and contact registration records over RDAP',
+    }),
+    // WHOIS is a protocol, not a vendor, so there is no brand mark to ship. A built-in EUI
+    // glyph is used instead of a drawn logo, which also means this spec must NOT appear in
+    // connector_icons_map.ts: the contract test asserts the map's keys equal exactly the set
+    // of spec ids that have no metadata.icon.
+    icon: 'globe',
+    minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
+    supportedFeatureIds: ['workflows', 'agentBuilder'],
+  },
+
+  auth: {
+    types: [
+      {
+        // The default, and the reason this connector needs no setup: RDAP is an open,
+        // unauthenticated protocol, so every action works with no credential at all.
+        type: 'none',
+        isRecommended: true,
+        defaults: {},
+        overrides: {
+          label: i18n.translate('core.kibanaConnectorSpecs.whois.auth.none.label', {
+            defaultMessage: 'No authentication (public RDAP)',
+          }),
+        },
+      },
+      {
+        // For a commercial or private RDAP gateway that gates access behind a key. The key
+        // rides as a request header on every call to the configured base URL; it does not
+        // change the response shape, which stays RDAP.
+        type: 'api_key_header',
+        defaults: {},
+        overrides: {
+          label: i18n.translate('core.kibanaConnectorSpecs.whois.auth.apiKeyHeader.label', {
+            defaultMessage: 'API key header (commercial RDAP gateway)',
+          }),
+          meta: {
+            headerField: {
+              helpText: i18n.translate(
+                'core.kibanaConnectorSpecs.whois.auth.apiKeyHeader.headerField.helpText',
+                {
+                  defaultMessage:
+                    'The header name your RDAP gateway expects, for example Authorization or X-Api-Key. Only a gateway needs this; public RDAP requires no credential.',
+                }
+              ),
+            },
+          },
+        },
+      },
+    ],
+  },
+
+  schema: lazySchema(() =>
+    z.object({
+      baseUrl: RdapBaseUrlSchema.default(DEFAULT_RDAP_BASE_URL)
+        .describe('Base URL of the RDAP server or bootstrap service every lookup is sent to')
+        .meta({
+          widget: 'text',
+          label: i18n.translate('core.kibanaConnectorSpecs.whois.config.baseUrl.label', {
+            defaultMessage: 'RDAP server URL',
+          }),
+          placeholder: DEFAULT_RDAP_BASE_URL,
+          helpText: i18n.translate('core.kibanaConnectorSpecs.whois.config.baseUrl.helpText', {
+            defaultMessage:
+              'Defaults to https://rdap.org, a bootstrap service that redirects each query to the authoritative registry. Point it at one registry server, such as https://rdap.verisign.com/com/v1 or https://rdap.arin.net/registry, to skip the bootstrap hop, or at a commercial RDAP gateway. Must be https. Because the bootstrap service answers with a redirect to a registry host, a restrictive Kibana actions allowedHosts list must allow the registry hosts too.',
+          }),
+          // Enforces xpack.actions.allowedHosts when the connector is saved, so a disallowed
+          // host is rejected at configuration time rather than at first execution.
+          validate: { allowedHosts: true },
+        }),
+    })
+  ),
+
+  validateUrls: {
+    fields: ['baseUrl'],
+  },
+
+  skill: `WHOIS registration data, served over RDAP (the IETF replacement for the port-43 WHOIS protocol). Use this connector to enrich a domain or address indicator during phishing and IOC triage.
+
+Typical phishing triage flow:
+1. lookupDomain on the domain from the alert. Read ageInDays: a domain registered days ago is a strong phishing signal. Read daysUntilExpiry for a dangling delegation, and status for registry locks or a pendingDelete.
+2. lookupNameserver on an entry from the returned nameservers array if the delegation itself looks suspicious.
+3. lookupEntity on the registrar or registrant handle if you need the full contact record behind it.
+
+Typical IOC-address flow:
+1. lookupIp on the address. Read organization for who controls the space, cidr for the allocation size, and abuseContact for where to report.
+2. lookupAsn on an entry from originAutnums (or on an ASN from another tool) for the announcing network's own registration.
+3. lookupEntity on a handle from either result to pull a specific contact's full record.
+
+Gotchas that matter:
+- A 404 comes back as data, not an error: check the found field. found: false means "no record returned", which conflates three cases RDAP cannot tell apart: unregistered/unallocated, the registry runs no RDAP service, or a malformed query. Branch on found rather than expecting a thrown error.
+- RDAP coverage is not universal. Every gTLD (.com, .net, .org, .dev, .xyz) and all five RIRs serve RDAP, but many ccTLDs never adopted it: .co, .io, .de, .ru, .cn and roughly 235 others are absent from the IANA bootstrap registry and return found: false. That is a protocol gap, not a bug, and there is no fallback, because legacy WHOIS runs on TCP port 43 which Kibana cannot reach.
+- Query the registrable apex, not a subdomain: lookupDomain on "mail.example.com" returns found: false because only "example.com" is registered.
+- An internationalized domain must be punycoded to its xn-- form before you pass it.
+- Registrant identity is usually redacted. Post-GDPR most registries return "REDACTED FOR PRIVACY" for the registrant name and email while still publishing the registrar, dates, nameservers, and status. Do not read a missing registrant as suspicious.
+- country is not populated for every registry, so never treat its absence as a signal. RIPE and APNIC publish a top-level ISO country code; ARIN does not publish one at all, so for North American address space country is absent and the holder's location is in organization.address instead (a newline-joined postal address). Read organization.address as the fallback, and do not compare country across registries.
+- Responses are trimmed to the triage-relevant fields on purpose. Set includeRaw: true on any action to also get the full RDAP object, but only when a field you need is genuinely missing: raw records are large and will crowd out your context.
+- originAutnums is an ARIN-only extension and is often an empty array even at ARIN (verified for 8.8.8.8). When it is empty, get the announcing AS from another tool rather than assuming the address is unannounced.
+- Pass baseUrl on an individual call to query one registry directly. Handles from lookupIp are only resolvable at the registry that issued them, so an ARIN handle such as GOGL needs baseUrl https://rdap.arin.net/registry on lookupEntity.`,
+
+  actions: {
+    lookupDomain: {
+      isTool: true,
+      description:
+        'Look up the registration record for a domain name over RDAP. Returns the registrar, registration and expiry dates, a precomputed ageInDays and daysUntilExpiry, EPP status codes, nameservers, DNSSEC state, and whatever registrant and abuse contacts the registry publishes. ' +
+        'The primary enrichment step in phishing triage: a domain with a small ageInDays was registered for this campaign. ' +
+        'Query the registrable apex ("example.com"), not a subdomain. Returns found: false rather than failing when the registry has no record or serves no RDAP.',
+      input: LookupDomainInputSchema,
+      handler: async (ctx, input: LookupDomainInput) => {
+        const baseUrl = getBaseUrl(ctx, input.baseUrl);
+        try {
+          const response = await ctx.client.get(
+            `${baseUrl}/domain/${encodeURIComponent(input.domain)}`,
+            { headers: RDAP_HEADERS }
+          );
+          const data = response.data as RdapDomainResponse;
+          return withRaw(trimDomain(data), data, input.includeRaw);
+        } catch (error) {
+          if (isNotFound(error)) {
+            return notFound('domain', input.domain);
+          }
+          return throwWithApiError(error);
+        }
+      },
+    },
+
+    lookupIp: {
+      isTool: true,
+      description:
+        'Look up the registration record for an IPv4 or IPv6 address, or a CIDR block, over RDAP. Returns the owning organization, country, the netblock as CIDR plus its start and end addresses, the allocation type, the announcing AS numbers, and the abuse contact. ' +
+        'Use it to enrich an IOC address with who controls the space before deciding how to handle an alert, and to get an address to report abuse to. ' +
+        'Any address inside an allocation returns that whole allocation. Returns found: false rather than failing when the address is unallocated.',
+      input: LookupIpInputSchema,
+      handler: async (ctx, input: LookupIpInput) => {
+        const baseUrl = getBaseUrl(ctx, input.baseUrl);
+        try {
+          // NOT percent-encoded, deliberately. An IPv6 literal's colons and a CIDR's slash
+          // are structural in the RDAP path: encoding them makes registries reject the query
+          // with a 400 (verified live against rdap.org for both `2001:4860:4860::8888` and
+          // `8.8.8.0/24`). Safety comes from the input schema matching the address
+          // structurally (see IP_OR_CIDR_PATTERN): every accepted value is a real IPv4/IPv6
+          // literal with an optional `/NN`, so no dot-run such as `..` can traverse out of
+          // this path prefix.
+          const response = await ctx.client.get(`${baseUrl}/ip/${input.ip}`, {
+            headers: RDAP_HEADERS,
+          });
+          const data = response.data as RdapIpResponse;
+          return withRaw(trimIp(data), data, input.includeRaw);
+        } catch (error) {
+          if (isNotFound(error)) {
+            return notFound('ip', input.ip);
+          }
+          return throwWithApiError(error);
+        }
+      },
+    },
+
+    lookupAsn: {
+      isTool: true,
+      description:
+        'Look up the registration record for an autonomous system number over RDAP. Returns the AS name, the allocated range, the holding organization, country, and the abuse contact. ' +
+        'Use it after lookupIp to identify the network that announces a suspect address: a bulletproof or high-abuse hosting AS is a stronger signal than one netblock on its own. ' +
+        'Accepts "15169" or "AS15169". Returns found: false rather than failing when the number is unallocated.',
+      input: LookupAsnInputSchema,
+      handler: async (ctx, input: LookupAsnInput) => {
+        const baseUrl = getBaseUrl(ctx, input.baseUrl);
+        // RDAP addresses an autnum by its bare number: the `AS` prefix is a human convention
+        // and a registry 404s on `/autnum/AS15169`.
+        const asn = input.asn.replace(/^(AS|as)/, '');
+        try {
+          const response = await ctx.client.get(`${baseUrl}/autnum/${encodeURIComponent(asn)}`, {
+            headers: RDAP_HEADERS,
+          });
+          const data = response.data as RdapAutnumResponse;
+          return withRaw(trimAutnum(data), data, input.includeRaw);
+        } catch (error) {
+          if (isNotFound(error)) {
+            return notFound('autnum', asn);
+          }
+          return throwWithApiError(error);
+        }
+      },
+    },
+
+    lookupNameserver: {
+      isTool: true,
+      description:
+        'Look up a nameserver host object over RDAP. Returns its registered glue IP addresses (v4 and v6) and status. ' +
+        'Use it to pivot from a suspicious domain to the infrastructure behind its delegation: several phishing domains sharing one nameserver is a campaign signal. ' +
+        'Only nameservers registered as host objects resolve, and many registries publish none at all, so found: false is common here and is not an error.',
+      input: LookupNameserverInputSchema,
+      handler: async (ctx, input: LookupNameserverInput) => {
+        const baseUrl = getBaseUrl(ctx, input.baseUrl);
+        try {
+          const response = await ctx.client.get(
+            `${baseUrl}/nameserver/${encodeURIComponent(input.nameserver)}`,
+            { headers: RDAP_HEADERS }
+          );
+          const data = response.data as RdapNameserver;
+          const trimmed = {
+            found: true as const,
+            queryType: 'nameserver',
+            ldhName: data.ldhName,
+            unicodeName: data.unicodeName,
+            handle: data.handle,
+            ipAddresses: data.ipAddresses ?? {},
+            status: data.status ?? [],
+          };
+          return withRaw(trimmed, data, input.includeRaw);
+        } catch (error) {
+          if (isNotFound(error)) {
+            return notFound('nameserver', input.nameserver);
+          }
+          return throwWithApiError(error);
+        }
+      },
+    },
+
+    lookupEntity: {
+      isTool: true,
+      description:
+        'Look up a contact or organization by its registry-assigned RDAP handle. Returns the name, organization, email, phone, address, country, roles, and any child contacts. ' +
+        'Use it to expand a handle another lookup returned only as an identifier, for example to get a full abuse contact from an IP record. ' +
+        'A handle is only resolvable at the registry that issued it, so pass that registry as baseUrl when the handle came from elsewhere.',
+      input: LookupEntityInputSchema,
+      handler: async (ctx, input: LookupEntityInput) => {
+        const baseUrl = getBaseUrl(ctx, input.baseUrl);
+        try {
+          const response = await ctx.client.get(
+            `${baseUrl}/entity/${encodeURIComponent(input.handle)}`,
+            { headers: RDAP_HEADERS }
+          );
+          const data = response.data as RdapEntity;
+          const trimmed = {
+            found: true as const,
+            queryType: 'entity',
+            ...trimEntity(data),
+            status: data.status ?? [],
+            registrationDate: eventDate(data.events, 'registration'),
+            lastChangedDate: eventDate(data.events, 'last changed'),
+          };
+          return withRaw(trimmed, data, input.includeRaw);
+        } catch (error) {
+          if (isNotFound(error)) {
+            return notFound('entity', input.handle);
+          }
+          return throwWithApiError(error);
+        }
+      },
+    },
+  },
+
+  test: {
+    enabled: true,
+    description: i18n.translate('core.kibanaConnectorSpecs.whois.test.description', {
+      defaultMessage:
+        'Verifies the RDAP server is reachable, and any configured key accepted, by calling its /help endpoint',
+    }),
+    handler: async (ctx) => {
+      const baseUrl = getBaseUrl(ctx);
+      try {
+        // /help is the RFC 9083 server-capability endpoint: the cheapest RDAP call there is.
+        // It consumes no lookup quota and needs no valid indicator, so a failure here is
+        // unambiguously "server unreachable or key rejected" rather than "bad query".
+        await ctx.client.get(`${baseUrl}/help`, { headers: RDAP_HEADERS });
+        // A resolved value is success; `ok` is deliberately absent, since ConnectorTestHandlerResult
+        // forbids it to keep the legacy `{ ok: false }` failure shape unrepresentable.
+        return {
+          message: `Successfully reached the RDAP server at ${baseUrl}`,
+          rdapServer: baseUrl,
+        };
+      } catch (error) {
+        return throwWithApiError(error);
+      }
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Adds a **WHOIS** connector spec (`.whois`) with five lookup actions for enriching a domain or address
indicator during phishing and IOC triage: registration records for domains, IP addresses and CIDR
blocks, ASNs, nameservers, and registry contacts.

Transport is **RDAP over HTTPS, not classic WHOIS**. Legacy WHOIS is a plain-text protocol on TCP port
43, which a connector cannot reach because the framework speaks HTTP through axios only, so RDAP (the
IETF replacement, RFC 7483/9083) is the only viable transport. The docs page states this explicitly.
The connector needs **no credentials**: public RDAP is unauthenticated.

- `lookupDomain`, `lookupIp`, `lookupAsn`, `lookupNameserver`, `lookupEntity`

Closes elastic/security-team#18372

## Try it: a workflow that exercises the connector

This ran green in a local Kibana against live registries. To use it: create a WHOIS connector in
**Stack Management > Connectors** (no credential needed), replace every `REPLACE_WITH_CONNECTOR_ID`
with its id, then run it from the Workflows app.

<details>
<summary><b>Indicator enrichment</b>: all 5 actions plus the no-coverage path. Read-only, no credentials, safe to run anywhere. (7 steps, all green)</summary>

Looks up a domain, probes a TLD that operates no RDAP service to show the `found: false` path, pivots
to the delegation's nameserver, then enriches an address and the AS that holds it, and finally expands
a contact handle at the registry that issued it.

```yaml
version: '1'
name: WHOIS RDAP indicator enrichment
description: >-
  Enrich a domain and an address indicator with registration data over RDAP.
  Every step is a read: look up the domain, pivot to its delegation and its
  registrar contact, then look up the address and the AS that holds it.
enabled: false
tags: [connector-test, whois, rdap, threat-intel]

triggers:
  - type: manual
    inputs:
      properties:
        domain:
          type: string
          description: Domain to enrich, for example example.com
          default: example.com
        ip:
          type: string
          description: Address to enrich, for example 8.8.8.8
          default: 8.8.8.8
        asn:
          type: string
          description: AS number to enrich, with or without the AS prefix
          default: AS15169
        nameserver:
          type: string
          description: Nameserver host object to pivot on
          default: ns1.google.com
        arin_handle:
          type: string
          description: An ARIN-issued contact handle to expand
          default: ABUSE5250-ARIN

steps:
  - name: lookup_domain
    type: whois.lookupDomain
    connector-id: REPLACE_WITH_CONNECTOR_ID
    with:
      domain: '{{ inputs.domain }}'

  - name: lookup_uncovered_tld
    type: whois.lookupDomain
    connector-id: REPLACE_WITH_CONNECTOR_ID
    with:
      domain: elastic.co

  - name: lookup_nameserver
    type: whois.lookupNameserver
    connector-id: REPLACE_WITH_CONNECTOR_ID
    with:
      nameserver: '{{ inputs.nameserver }}'

  - name: lookup_ip
    type: whois.lookupIp
    connector-id: REPLACE_WITH_CONNECTOR_ID
    with:
      ip: '{{ inputs.ip }}'

  - name: lookup_asn
    type: whois.lookupAsn
    connector-id: REPLACE_WITH_CONNECTOR_ID
    with:
      asn: '{{ inputs.asn }}'

  - name: lookup_abuse_contact
    type: whois.lookupEntity
    connector-id: REPLACE_WITH_CONNECTOR_ID
    with:
      handle: '{{ inputs.arin_handle }}'
      baseUrl: https://rdap.arin.net/registry

  - name: report
    type: console
    with:
      message: |
        === WHOIS RDAP enrichment ===
        Domain: {{ steps.lookup_domain.output.domain }} found={{ steps.lookup_domain.output.found }}
        Registrar: {{ steps.lookup_domain.output.registrar.name }} (IANA {{ steps.lookup_domain.output.registrar.ianaId }})
        Age: {{ steps.lookup_domain.output.ageInDays }} days, expires in {{ steps.lookup_domain.output.daysUntilExpiry }} days
        DNSSEC: {{ steps.lookup_domain.output.dnssec }}
        Uncovered TLD probe: found={{ steps.lookup_uncovered_tld.output.found }} ({{ steps.lookup_uncovered_tld.output.message }})
        Nameserver: {{ steps.lookup_nameserver.output.ldhName }} found={{ steps.lookup_nameserver.output.found }}
        Netblock: {{ steps.lookup_ip.output.netName }} {{ steps.lookup_ip.output.cidr | join: ", " }} holder={{ steps.lookup_ip.output.organization.name }}
        Abuse (from IP record): {{ steps.lookup_ip.output.abuseContact.email }}
        AS: {{ steps.lookup_asn.output.asName }} ({{ steps.lookup_asn.output.startAutnum }}) holder={{ steps.lookup_asn.output.organization.name }}
        Expanded contact: {{ steps.lookup_abuse_contact.output.name }} / {{ steps.lookup_abuse_contact.output.email }}
```

</details>

### Design decisions worth reviewing

**A 404 comes back as data, not an error.** RDAP collapses three different situations into a bare 404:
the object is genuinely unregistered, the registry operates no RDAP service at all, or the query was
malformed. A triage workflow branching on "no record" must not have its run failed by a legitimate
answer, so every action returns `{ found: false }` with an explanatory message instead. This path is
common rather than exceptional: many ccTLDs never adopted RDAP, including `.co`, `.io` and `.de`.

**IP path segments are deliberately not percent-encoded, and the schema carries the safety instead.**
An IPv6 literal's colons and a CIDR's slash are structural in the RDAP path; encoding them makes real
registries answer 400 (verified live for both). Because the value therefore reaches the URL unencoded,
the input is matched **structurally** rather than by character set. A charset-only bound was the
original approach and it was not sufficient: `..` and `../12` consist entirely of permitted characters
yet resolve out of the `/ip/` prefix and would silently retarget the request. Every accepted value is
now a real IPv4/IPv6 literal with an optional prefix length. Every other path segment is encoded
normally.

**Responses are trimmed hard.** RDAP records are mostly boilerplate: terms-of-service notices, status
glossaries and self-referencing link arrays are often half the payload. A `.com` record trims from 2388
to 553 bytes. `includeRaw: true` is the escape hatch when a needed field is missing from the projection.

**`lookupDomain` precomputes the two signals a phishing rule branches on**, `ageInDays` and
`daysUntilExpiry`, so no workflow has to do date arithmetic on a string. `daysUntilExpiry` floors toward
the past rather than negating a floored elapsed count, which would over-report by a day.

**jCard (RFC 7095) parsing handles both address shapes registries use.** ARIN publishes the location as
a newline-joined `label` parameter and leaves the structured array empty; RIPE and APNIC fill the
structured 7-element array and a top-level ISO `country`. Because ARIN publishes no country code at all,
an IP result also carries the holder's postal address, so North American address space still yields a
location. The skill and docs warn against comparing `country` across registries or reading its absence
as a signal.

**Abuse contacts are searched two entity levels deep**, since a domain publishes one under the registrar
while an IP publishes it at the top level. A single-level search misses it half the time.

**`baseUrl` is enforced against `xpack.actions.allowedHosts` at save time** via
`.meta({ validate: { allowedHosts: true } })`, so a disallowed host is rejected when the connector is
created rather than at first execution. Note the spec-level `validateUrls` field has no read site
anywhere in the repo; the field-level meta is the mechanism that actually works.

**No brand icon.** WHOIS is a protocol, not a vendor, so there is no genuine mark to ship. The spec sets
`metadata.icon: 'globe'` (a built-in EUI glyph) and is deliberately **absent** from
`connector_icons_map.ts`: the icon-sync contract test asserts the map's keys equal exactly the set of
specs that lack `metadata.icon`, so doing both would fail. That test is green.

**On `supportedFeatureIds: ['workflows', 'agentBuilder']`.** This ships both feature ids in one PR,
which the `create-connector` skill's two-step guidance would split. Precedent:
elastic/kibana#283471 (Google Cloud IAM) merged to `main` with exactly this pair and no reviewer
pushback, per the reasoning in elastic/kibana#282364. Happy to split it if the platform position has
changed.

## Validated

**Every action was exercised end to end against live RDAP registries** (rdap.org's bootstrap service,
Verisign for `.com`, ARIN and RIPE NCC), driven through the connector inside a local Kibana build of
this branch. No credentials are involved and no resources are created, so there was nothing to clean up
beyond the disposable connector instance, which was deleted and its removal verified (404).

Coverage came from direct connector `_execute` calls for every action, an 18-case live handler probe,
and the workflow above, which ran **7 steps, all green**.

| Action | Verified how | Result |
| --- | --- | --- |
| test (connectivity) | `/help` against rdap.org, and again against `rdap.verisign.com/com/v1` | ✅ Pass |
| `lookupDomain` | `example.com` via bootstrap: registrar RESERVED-IANA (IANA id 376), age 11319 days, DNSSEC true; `elastic.com` via a per-call Verisign base URL; `elastic.co` (TLD has no RDAP) and an unregistered `.com` both returned `found: false` | ✅ Pass |
| `lookupIp` | `8.8.8.8` (ARIN: netblock 8.8.8.0/24, holder Google LLC, abuse network-abuse@google.com), `2001:4860:4860::8888` unencoded, CIDR `8.8.8.0/24`, and `193.0.6.139` (RIPE, top-level `country: NL`) | ✅ Pass (after tightening the IP pattern to reject `..` traversal) |
| `lookupAsn` | `15169` bare and `AS3333` prefixed, confirming the `AS` prefix is stripped: a registry 404s on `/autnum/AS15169` and answers `/autnum/15169` | ✅ Pass |
| `lookupNameserver` | `ns1.google.com` returned real glue (v4 216.239.32.10, v6 2001:4860:4802:32::A); `ns1.elastic.co` returned `found: false` | ✅ Pass |
| `lookupEntity` | `ABUSE5250-ARIN` at `rdap.arin.net/registry` returned the full contact; the same handle against the bootstrap correctly returned `found: false`, since a handle only resolves at the registry that issued it | ✅ Pass |

Also confirmed live: `includeRaw: true` attaches the untrimmed record (553 trimmed vs 2388 raw bytes for
`example.com`), and a malformed IP surfaces the registry's own error rather than a bare axios message.

## Test plan

- [x] 68 unit tests for this connector; **96 suites / 2628 tests green** across the whole
      `kbn-connector-specs` package
- [x] `node scripts/eslint` clean on every changed file including tests
- [x] `node scripts/type_check --project src/platform/packages/shared/kbn-connector-specs/tsconfig.json` clean
- [x] `connector_spec_contract.test.ts` green, including the icon-map sync assertion
- [x] Live-validated through a workflow: `valid: true` with 0 diagnostics, execution reached
      `status: completed`, 7/7 steps
- [x] Connector instance deleted and deletion verified
