### PR TITLE
[Security Solution][Take Actions] Add shared action menu utilities

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/action_menu_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/action_menu_items.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiIcon } from '@elastic/eui';
+import type { EuiContextMenuPanelItemDescriptor, EuiIconProps, IconType } from '@elastic/eui';
+import type { ReactNode } from 'react';
+import React from 'react';
+
+export const ACTION_MENU_GROUP_SEPARATOR_TEST_ID = 'securityActionMenuGroupSeparator';
+
+interface ActionMenuGroupSeparator {
+  key: string;
+  isSeparator: true;
+  'data-test-subj': typeof ACTION_MENU_GROUP_SEPARATOR_TEST_ID;
+}
+
+export const isActionMenuItem = (
+  item: EuiContextMenuPanelItemDescriptor
+): item is Extract<EuiContextMenuPanelItemDescriptor, { name: ReactNode }> => 'name' in item;
+
+export const withActionIcon = (
+  items: readonly EuiContextMenuPanelItemDescriptor[],
+  icon: IconType
+): EuiContextMenuPanelItemDescriptor[] =>
+  items.map((item) => (isActionMenuItem(item) ? { ...item, icon } : item));
+
+export const withActionIcons = (
+  items: readonly EuiContextMenuPanelItemDescriptor[],
+  iconsByActionId: Readonly<Record<string, IconType>>
+): EuiContextMenuPanelItemDescriptor[] =>
+  items.map((item) => {
+    if (!isActionMenuItem(item) || typeof item.key !== 'string') {
+      return item;
+    }
+
+    const icon = iconsByActionId[item.key];
+
+    return icon ? { ...item, icon } : item;
+  });
+
+export const withStatusDotIcons = (
+  items: readonly EuiContextMenuPanelItemDescriptor[],
+  colorsByTestSubject: Readonly<Record<string, EuiIconProps['color']>>,
+  defaultColor?: EuiIconProps['color']
+): EuiContextMenuPanelItemDescriptor[] =>
+  items.map((item) => {
+    if (!isActionMenuItem(item)) {
+      return item;
+    }
+
+    const testSubject = item['data-test-subj'];
+    const color =
+      (typeof testSubject === 'string' ? colorsByTestSubject[testSubject] : undefined) ??
+      defaultColor;
+
+    if (!color) {
+      return item;
+    }
+
+    return {
+      ...item,
+      icon: <EuiIcon type="dot" color={color} aria-hidden />,
+    };
+  });
+
+export const getActionMenuGroupSeparator = (key: string): ActionMenuGroupSeparator => ({
+  key,
+  isSeparator: true,
+  'data-test-subj': ACTION_MENU_GROUP_SEPARATOR_TEST_ID,
+});


### PR DESCRIPTION
## Summary

- adds reusable helpers for action icons and separators
- provides the common composition foundation used by the named action menus

Foundation 2 of 2. Depends on #284116. Consumer PRs remain draft until both foundations merge.

Addresses #278607

### Checklist

- [x] No user-facing text, plugin configuration, or HTTP API changes were introduced
- [x] Documentation is not required for this internal composition utility
- [x] Validation from PR #284050 is preserved

### Identify risks

Low risk. This PR only introduces shared presentation helpers.

## Release note

Improves the internal consistency of Security Solution action menus.

Made with [Cursor](https://cursor.com)

## Related PRs

### Foundations

1. [#284116 — Two-layer case action menu](https://github.com/elastic/kibana/pull/284116)
2. [#284126 — Shared action menu utilities](https://github.com/elastic/kibana/pull/284126)

### Independent consumers

- [#284127 — Alert action menus](https://github.com/elastic/kibana/pull/284127)
- [#284128 — Attack action menus](https://github.com/elastic/kibana/pull/284128)
- [#284129 — Document action menus](https://github.com/elastic/kibana/pull/284129)
- [#284130 — Events table bulk action menu](https://github.com/elastic/kibana/pull/284130)
- [#284131 — Entity analytics action menus](https://github.com/elastic/kibana/pull/284131)
- [#284132 — ML case action menu](https://github.com/elastic/kibana/pull/284132)