### PR TITLE
[Security Solution][Take Actions] Add events table bulk action menu

### DIFF
--- a/x-pack/solutions/security/packages/data-table/components/toolbar/bulk_actions/types.ts
+++ b/x-pack/solutions/security/packages/data-table/components/toolbar/bulk_actions/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { IconType } from '@elastic/eui';
 import type { TimelineItem } from '@kbn/timelines-plugin/common';
 
 export type AlertWorkflowStatus = 'open' | 'closed' | 'acknowledged';
@@ -12,6 +13,7 @@ export type AlertWorkflowStatus = 'open' | 'closed' | 'acknowledged';
 export interface CustomBulkAction {
   key: string;
   label: string;
+  icon?: IconType;
   disableOnQuery?: boolean;
   disabledLabel?: string;
   onClick: (items?: TimelineItem[]) => void;

--- a/x-pack/solutions/security/plugins/security_solution/common/types/bulk_actions/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/types/bulk_actions/index.ts
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
+import type { IconType } from '@elastic/eui';
 import type { TimelineItem } from '../../search_strategy';
+
 export interface CustomBulkAction {
   key: string;
   label: string;
+  icon?: IconType;
   disableOnQuery?: boolean;
   disabledLabel?: string;
   onClick: (items?: TimelineItem[]) => void;

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/hooks/use_bulk_event_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/hooks/use_bulk_event_actions.test.tsx
@@ -11,13 +11,14 @@ import { TestProviders } from '../../../../common/mock';
 import type { TimelineItem } from '@kbn/timelines-plugin/common';
 import { SECURITY_EVENT_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common';
 
-const mockOpenNewCase = jest.fn();
 const mockOpenExistingCase = jest.fn();
-const mockCanUseCases = jest.fn(() => ({ create: true, read: true }));
-const mockGetCasesContext = jest.fn(() => ({}));
-const mockUseCasesAddToNewCaseFlyout = jest.fn(() => ({
-  open: mockOpenNewCase,
+const mockCanUseCases = jest.fn(() => ({
+  create: true,
+  createComment: true,
+  read: true,
+  update: false,
 }));
+const mockGetCasesContext = jest.fn(() => ({}));
 const mockUseCasesAddToExistingCaseModal = jest.fn(() => ({
   open: mockOpenExistingCase,
 }));
@@ -33,7 +34,6 @@ jest.mock('../../../../common/lib/kibana', () => ({
           getCasesContext: mockGetCasesContext,
         },
         hooks: {
-          useCasesAddToNewCaseFlyout: mockUseCasesAddToNewCaseFlyout,
           useCasesAddToExistingCaseModal: mockUseCasesAddToExistingCaseModal,
         },
       },
@@ -48,35 +48,26 @@ describe('useBulkAddEventsToCaseActions', () => {
     jest.clearAllMocks();
   });
 
-  it('returns two actions when permissions and services are available', () => {
+  it('returns one action when permissions and services are available', () => {
     const { result } = renderHook(() => useBulkAddEventsToCaseActions({ clearSelection }), {
       wrapper: TestProviders,
     });
-    expect(result.current).toHaveLength(2);
+    expect(result.current).toHaveLength(1);
     expect(result.current[0].label).toBeDefined();
-    expect(result.current[1].label).toBeDefined();
   });
 
-  it('calls createCaseFlyout.open with correct attachments', () => {
+  it('returns one action when the user can only update existing cases', () => {
+    mockCanUseCases.mockReturnValueOnce({
+      create: false,
+      createComment: true,
+      read: true,
+      update: true,
+    });
     const { result } = renderHook(() => useBulkAddEventsToCaseActions({ clearSelection }), {
       wrapper: TestProviders,
     });
-    const events = [
-      { _id: '1', _index: 'foo' },
-      { _id: '2', _index: 'bar' },
-    ] as unknown as TimelineItem[];
-    act(() => {
-      result.current[0].onClick(events);
-    });
-    expect(mockOpenNewCase).toHaveBeenCalledWith({
-      attachments: [
-        {
-          type: SECURITY_EVENT_ATTACHMENT_TYPE,
-          attachmentId: ['1', '2'],
-          metadata: { index: ['foo', 'bar'] },
-        },
-      ],
-    });
+
+    expect(result.current).toHaveLength(1);
   });
 
   it('calls selectCaseModal.open with correct getAttachments', () => {
@@ -88,7 +79,7 @@ describe('useBulkAddEventsToCaseActions', () => {
       { _id: '2', _index: 'bar' },
     ] as unknown as TimelineItem[];
     act(() => {
-      result.current[1].onClick(events);
+      result.current[0].onClick(events);
     });
     expect(mockOpenExistingCase).toHaveBeenCalled();
     const mappedEvents = mockOpenExistingCase.mock.lastCall[0].getAttachments();
@@ -111,19 +102,23 @@ describe('useBulkAddEventsToCaseActions', () => {
       result.current[0].onClick(events);
     });
 
-    expect(mockOpenNewCase).toHaveBeenCalledWith({
-      attachments: [
-        {
-          type: SECURITY_EVENT_ATTACHMENT_TYPE,
-          attachmentId: '1',
-          metadata: { index: 'foo' },
-        },
-      ],
-    });
+    const mappedEvents = mockOpenExistingCase.mock.lastCall[0].getAttachments();
+    expect(mappedEvents).toEqual([
+      {
+        type: SECURITY_EVENT_ATTACHMENT_TYPE,
+        attachmentId: '1',
+        metadata: { index: 'foo' },
+      },
+    ]);
   });
 
   it('returns empty array if permissions are missing', () => {
-    mockCanUseCases.mockReturnValueOnce({ create: false, read: false });
+    mockCanUseCases.mockReturnValueOnce({
+      create: false,
+      createComment: false,
+      read: false,
+      update: false,
+    });
     const { result } = renderHook(() => useBulkAddEventsToCaseActions({ clearSelection }), {
       wrapper: TestProviders,
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/hooks/use_bulk_event_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/hooks/use_bulk_event_actions.ts
@@ -11,7 +11,7 @@ import type { CaseAttachmentWithoutOwner } from '@kbn/cases-plugin/public/types'
 import { APP_ID } from '../../../../../common';
 import { useKibana } from '../../../../common/lib/kibana';
 import type { CustomBulkAction } from '../../../../../common/types';
-import { ADD_TO_EXISTING_CASE, ADD_TO_NEW_CASE } from '../translations';
+import { ADD_TO_CASE } from '../translations';
 import { generateEventAttachmentWithoutOwner } from '../utils';
 
 /**
@@ -49,35 +49,23 @@ export const useBulkAddEventsToCaseActions = ({
     clearSelection();
   }, [clearSelection]);
 
-  const createCaseFlyout = casesService?.hooks.useCasesAddToNewCaseFlyout({ onSuccess });
   const selectCaseModal = casesService?.hooks.useCasesAddToExistingCaseModal({
     onSuccess,
   });
 
   return useMemo(() => {
     return isCasesContextAvailable &&
-      createCaseFlyout &&
       selectCaseModal &&
-      userCasesPermissions?.create &&
+      userCasesPermissions?.createComment &&
+      (userCasesPermissions.create || userCasesPermissions.update) &&
       userCasesPermissions?.read
       ? [
           {
-            label: ADD_TO_NEW_CASE,
-            key: 'attach-new-case',
-            'data-test-subj': 'attach-new-case',
+            label: ADD_TO_CASE,
+            key: 'attach-case',
+            'data-test-subj': 'attach-case',
             disableOnQuery: true,
-            disabledLabel: ADD_TO_NEW_CASE,
-            onClick: (events: TimelineItem[] = []) =>
-              createCaseFlyout.open({
-                attachments: timelineItemsToCaseEventAttachment(events),
-              }),
-          },
-          {
-            label: ADD_TO_EXISTING_CASE,
-            key: 'attach-existing-case',
-            disableOnQuery: true,
-            disabledLabel: ADD_TO_EXISTING_CASE,
-            'data-test-subj': 'attach-existing-case',
+            disabledLabel: ADD_TO_CASE,
             onClick: (events: TimelineItem[] = []) =>
               selectCaseModal.open({
                 getAttachments: (): CaseAttachmentWithoutOwner[] =>
@@ -87,10 +75,11 @@ export const useBulkAddEventsToCaseActions = ({
         ]
       : [];
   }, [
-    createCaseFlyout,
     isCasesContextAvailable,
     selectCaseModal,
     userCasesPermissions?.create,
+    userCasesPermissions?.createComment,
     userCasesPermissions?.read,
+    userCasesPermissions?.update,
   ]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/translations.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/event/translations.tsx
@@ -29,16 +29,9 @@ export const NO_EVENTS_TITLE = i18n.translate('xpack.securitySolution.caseEvents
   defaultMessage: 'No Events Found',
 });
 
-export const ADD_TO_NEW_CASE = i18n.translate('xpack.securitySolution.caseEvents.addToNewCase', {
-  defaultMessage: 'Add to new case',
+export const ADD_TO_CASE = i18n.translate('xpack.securitySolution.caseEvents.addToCase', {
+  defaultMessage: 'Add to case',
 });
-
-export const ADD_TO_EXISTING_CASE = i18n.translate(
-  'xpack.securitySolution.caseEvents.addToExistingCase',
-  {
-    defaultMessage: 'Add to existing case',
-  }
-);
 export const EVENT_COMMENT_LABEL_TITLE = i18n.translate(
   'xpack.securitySolution.cases.eventAttachment.eventCommentLabelTitle',
   {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.test.tsx
@@ -6,14 +6,13 @@
  */
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { EventsTableBulkActionMenu } from './events_table_bulk_action_menu';
 
 describe('EventsTableBulkActionMenu', () => {
-  it('groups new and existing case actions in a case type panel', async () => {
-    const onAddToNewCase = jest.fn();
-    const onAddToExistingCase = jest.fn();
+  it('renders the singular case action with the other bulk actions', async () => {
+    const onAddToCase = jest.fn();
 
     render(
       <EventsTableBulkActionMenu
@@ -31,16 +30,11 @@ describe('EventsTableBulkActionMenu', () => {
             icon: 'workflow',
           },
           {
-            key: 'attach-new-case',
-            name: 'Add to new case',
-            'data-test-subj': 'attach-new-case',
-            onActionClick: onAddToNewCase,
-          },
-          {
-            key: 'attach-existing-case',
-            name: 'Add to existing case',
-            'data-test-subj': 'attach-existing-case',
-            onActionClick: onAddToExistingCase,
+            key: 'attach-case',
+            name: 'Add to case',
+            'data-test-subj': 'attach-case',
+            icon: 'briefcase',
+            onClick: onAddToCase,
           },
         ]}
         panels={[]}
@@ -55,19 +49,13 @@ describe('EventsTableBulkActionMenu', () => {
         .getByTestId('run-document-workflow-action')
         .querySelector('[data-euiicon-type="workflow"]')
     ).toBeInTheDocument();
-    expect(screen.getByTestId('add-to-case')).toBeInTheDocument();
-    expect(screen.queryByTestId('attach-new-case')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('attach-existing-case')).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('attach-case').querySelector('[data-euiicon-type="briefcase"]')
+    ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTestId('add-to-case'));
+    await userEvent.click(screen.getByTestId('attach-case'));
 
-    expect(await screen.findByText('Case type')).toBeInTheDocument();
-    expect(screen.queryByTestId('add-to-case-submit')).not.toBeInTheDocument();
-
-    fireEvent.click(await screen.findByTestId('attach-existing-case'));
-
-    expect(onAddToExistingCase).toHaveBeenCalledTimes(1);
-    expect(onAddToNewCase).not.toHaveBeenCalled();
+    expect(onAddToCase).toHaveBeenCalledTimes(1);
   });
 
   it('leaves an individual case action in the initial panel', () => {
@@ -75,16 +63,15 @@ describe('EventsTableBulkActionMenu', () => {
       <EventsTableBulkActionMenu
         items={[
           {
-            key: 'attach-new-case',
-            name: 'Add to new case',
-            'data-test-subj': 'attach-new-case',
+            key: 'attach-case',
+            name: 'Add to case',
+            'data-test-subj': 'attach-case',
           },
         ]}
         panels={[]}
       />
     );
 
-    expect(screen.getByTestId('attach-new-case')).toBeInTheDocument();
-    expect(screen.queryByTestId('add-to-case')).not.toBeInTheDocument();
+    expect(screen.getByTestId('attach-case')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.test.tsx
@@ -62,12 +62,9 @@ describe('EventsTableBulkActionMenu', () => {
     await userEvent.click(screen.getByTestId('add-to-case'));
 
     expect(await screen.findByText('Case type')).toBeInTheDocument();
-    const submitButton = await screen.findByTestId('add-to-case-submit');
-    expect(submitButton).toBeDisabled();
+    expect(screen.queryByTestId('add-to-case-submit')).not.toBeInTheDocument();
 
     fireEvent.click(await screen.findByTestId('attach-existing-case'));
-    expect(submitButton).toBeEnabled();
-    fireEvent.click(submitButton);
 
     expect(onAddToExistingCase).toHaveBeenCalledTimes(1);
     expect(onAddToNewCase).not.toHaveBeenCalled();

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EventsTableBulkActionMenu } from './events_table_bulk_action_menu';
+
+describe('EventsTableBulkActionMenu', () => {
+  it('groups new and existing case actions in a case type panel', async () => {
+    const onAddToNewCase = jest.fn();
+    const onAddToExistingCase = jest.fn();
+
+    render(
+      <EventsTableBulkActionMenu
+        items={[
+          {
+            key: 'add-to-timeline',
+            name: 'Add to timeline',
+            'data-test-subj': 'add-to-timeline',
+            icon: 'timeline',
+          },
+          {
+            key: 'run-document-workflow-action',
+            name: 'Run workflow',
+            'data-test-subj': 'run-document-workflow-action',
+            icon: 'workflow',
+          },
+          {
+            key: 'attach-new-case',
+            name: 'Add to new case',
+            'data-test-subj': 'attach-new-case',
+            onActionClick: onAddToNewCase,
+          },
+          {
+            key: 'attach-existing-case',
+            name: 'Add to existing case',
+            'data-test-subj': 'attach-existing-case',
+            onActionClick: onAddToExistingCase,
+          },
+        ]}
+        panels={[]}
+      />
+    );
+
+    expect(
+      screen.getByTestId('add-to-timeline').querySelector('[data-euiicon-type="timeline"]')
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId('run-document-workflow-action')
+        .querySelector('[data-euiicon-type="workflow"]')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('add-to-case')).toBeInTheDocument();
+    expect(screen.queryByTestId('attach-new-case')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('attach-existing-case')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('add-to-case'));
+
+    expect(await screen.findByText('Case type')).toBeInTheDocument();
+    const submitButton = await screen.findByTestId('add-to-case-submit');
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.click(await screen.findByTestId('attach-existing-case'));
+    expect(submitButton).toBeEnabled();
+    fireEvent.click(submitButton);
+
+    expect(onAddToExistingCase).toHaveBeenCalledTimes(1);
+    expect(onAddToNewCase).not.toHaveBeenCalled();
+  });
+
+  it('leaves an individual case action in the initial panel', () => {
+    render(
+      <EventsTableBulkActionMenu
+        items={[
+          {
+            key: 'attach-new-case',
+            name: 'Add to new case',
+            'data-test-subj': 'attach-new-case',
+          },
+        ]}
+        panels={[]}
+      />
+    );
+
+    expect(screen.getByTestId('attach-new-case')).toBeInTheDocument();
+    expect(screen.queryByTestId('add-to-case')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.tsx
@@ -7,18 +7,8 @@
 
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiContextMenu } from '@elastic/eui';
-import { AddToCaseActionPanel, ADD_TO_CASE, CASE_TYPE } from '@kbn/response-ops-alerts-table';
 import React, { useMemo } from 'react';
-import {
-  ADD_TO_EXISTING_CASE,
-  ADD_TO_NEW_CASE,
-} from '../../../../cases/attachments/event/translations';
 import type { BulkActionMenuItem } from './use_bulk_action_items';
-
-const ADD_TO_NEW_CASE_ACTION_ID = 'attach-new-case';
-const ADD_TO_EXISTING_CASE_ACTION_ID = 'attach-existing-case';
-const ADD_TO_CASE_ACTION_ID = 'add-to-case';
-const ADD_TO_CASE_PANEL_ID = 'events-table-add-to-case-panel';
 
 interface EventsTableBulkActionMenuProps {
   items: BulkActionMenuItem[];
@@ -26,58 +16,10 @@ interface EventsTableBulkActionMenuProps {
 }
 
 export const EventsTableBulkActionMenu = ({ items, panels }: EventsTableBulkActionMenuProps) => {
-  const menuPanels = useMemo<EuiContextMenuPanelDescriptor[]>(() => {
-    const addToNewCase = items.find(({ key }) => key === ADD_TO_NEW_CASE_ACTION_ID);
-    const addToExistingCase = items.find(({ key }) => key === ADD_TO_EXISTING_CASE_ACTION_ID);
-
-    if (!addToNewCase?.onActionClick || !addToExistingCase?.onActionClick) {
-      return [{ id: 0, items }, ...panels];
-    }
-
-    const firstCaseActionIndex = items.findIndex(
-      ({ key }) => key === ADD_TO_NEW_CASE_ACTION_ID || key === ADD_TO_EXISTING_CASE_ACTION_ID
-    );
-    const initialItems = items.filter(
-      ({ key }) => key !== ADD_TO_NEW_CASE_ACTION_ID && key !== ADD_TO_EXISTING_CASE_ACTION_ID
-    );
-    initialItems.splice(firstCaseActionIndex, 0, {
-      key: ADD_TO_CASE_ACTION_ID,
-      'data-test-subj': ADD_TO_CASE_ACTION_ID,
-      disabled: Boolean(addToNewCase.disabled && addToExistingCase.disabled),
-      icon: 'briefcase',
-      name: ADD_TO_CASE,
-      panel: ADD_TO_CASE_PANEL_ID,
-    });
-
-    return [
-      { id: 0, items: initialItems },
-      {
-        id: ADD_TO_CASE_PANEL_ID,
-        title: CASE_TYPE,
-        content: (
-          <AddToCaseActionPanel
-            actions={[
-              {
-                id: ADD_TO_NEW_CASE_ACTION_ID,
-                label: ADD_TO_NEW_CASE,
-                dataTestSubj: addToNewCase['data-test-subj'],
-                disabled: addToNewCase.disabled,
-                onClick: addToNewCase.onActionClick,
-              },
-              {
-                id: ADD_TO_EXISTING_CASE_ACTION_ID,
-                label: ADD_TO_EXISTING_CASE,
-                dataTestSubj: addToExistingCase['data-test-subj'],
-                disabled: addToExistingCase.disabled,
-                onClick: addToExistingCase.onActionClick,
-              },
-            ]}
-          />
-        ),
-      },
-      ...panels,
-    ];
-  }, [items, panels]);
+  const menuPanels = useMemo<EuiContextMenuPanelDescriptor[]>(
+    () => [{ id: 0, items }, ...panels],
+    [items, panels]
+  );
 
   return <EuiContextMenu panels={menuPanels} initialPanelId={0} />;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/events_table_bulk_action_menu.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import { EuiContextMenu } from '@elastic/eui';
+import { AddToCaseActionPanel, ADD_TO_CASE, CASE_TYPE } from '@kbn/response-ops-alerts-table';
+import React, { useMemo } from 'react';
+import {
+  ADD_TO_EXISTING_CASE,
+  ADD_TO_NEW_CASE,
+} from '../../../../cases/attachments/event/translations';
+import type { BulkActionMenuItem } from './use_bulk_action_items';
+
+const ADD_TO_NEW_CASE_ACTION_ID = 'attach-new-case';
+const ADD_TO_EXISTING_CASE_ACTION_ID = 'attach-existing-case';
+const ADD_TO_CASE_ACTION_ID = 'add-to-case';
+const ADD_TO_CASE_PANEL_ID = 'events-table-add-to-case-panel';
+
+interface EventsTableBulkActionMenuProps {
+  items: BulkActionMenuItem[];
+  panels: EuiContextMenuPanelDescriptor[];
+}
+
+export const EventsTableBulkActionMenu = ({ items, panels }: EventsTableBulkActionMenuProps) => {
+  const menuPanels = useMemo<EuiContextMenuPanelDescriptor[]>(() => {
+    const addToNewCase = items.find(({ key }) => key === ADD_TO_NEW_CASE_ACTION_ID);
+    const addToExistingCase = items.find(({ key }) => key === ADD_TO_EXISTING_CASE_ACTION_ID);
+
+    if (!addToNewCase?.onActionClick || !addToExistingCase?.onActionClick) {
+      return [{ id: 0, items }, ...panels];
+    }
+
+    const firstCaseActionIndex = items.findIndex(
+      ({ key }) => key === ADD_TO_NEW_CASE_ACTION_ID || key === ADD_TO_EXISTING_CASE_ACTION_ID
+    );
+    const initialItems = items.filter(
+      ({ key }) => key !== ADD_TO_NEW_CASE_ACTION_ID && key !== ADD_TO_EXISTING_CASE_ACTION_ID
+    );
+    initialItems.splice(firstCaseActionIndex, 0, {
+      key: ADD_TO_CASE_ACTION_ID,
+      'data-test-subj': ADD_TO_CASE_ACTION_ID,
+      disabled: Boolean(addToNewCase.disabled && addToExistingCase.disabled),
+      icon: 'briefcase',
+      name: ADD_TO_CASE,
+      panel: ADD_TO_CASE_PANEL_ID,
+    });
+
+    return [
+      { id: 0, items: initialItems },
+      {
+        id: ADD_TO_CASE_PANEL_ID,
+        title: CASE_TYPE,
+        content: (
+          <AddToCaseActionPanel
+            actions={[
+              {
+                id: ADD_TO_NEW_CASE_ACTION_ID,
+                label: ADD_TO_NEW_CASE,
+                dataTestSubj: addToNewCase['data-test-subj'],
+                disabled: addToNewCase.disabled,
+                onClick: addToNewCase.onActionClick,
+              },
+              {
+                id: ADD_TO_EXISTING_CASE_ACTION_ID,
+                label: ADD_TO_EXISTING_CASE,
+                dataTestSubj: addToExistingCase['data-test-subj'],
+                disabled: addToExistingCase.disabled,
+                onClick: addToExistingCase.onActionClick,
+              },
+            ]}
+          />
+        ),
+      },
+      ...panels,
+    ];
+  }, [items, panels]);
+
+  return <EuiContextMenu panels={menuPanels} initialPanelId={0} />;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/index.tsx
@@ -6,10 +6,11 @@
  */
 
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
-import { EuiPopover, EuiButtonEmpty, EuiContextMenu } from '@elastic/eui';
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import { EuiPopover, EuiButtonEmpty } from '@elastic/eui';
+import React, { useState, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
-import type { AlertTableContextMenuItem } from '../../../../detections/components/alerts_table/types';
+import { EventsTableBulkActionMenu } from './events_table_bulk_action_menu';
+import type { BulkActionMenuItem } from './use_bulk_action_items';
 
 interface OwnProps {
   selectText: string;
@@ -17,7 +18,7 @@ interface OwnProps {
   showClearSelection: boolean;
   onSelectAll: () => void;
   onClearSelection: () => void;
-  bulkActionItems: AlertTableContextMenuItem[];
+  bulkActionItems: BulkActionMenuItem[];
   bulkActionPanels: EuiContextMenuPanelDescriptor[];
   closePopoverRef?: React.MutableRefObject<() => void>;
 }
@@ -66,17 +67,6 @@ const BulkActionsComponent: React.FC<OwnProps> = ({
     }
   }, [onClearSelection, onSelectAll, showClearSelection]);
 
-  const panels = useMemo(
-    () => [
-      {
-        id: 0,
-        items: bulkActionItems,
-      },
-      ...bulkActionPanels,
-    ],
-    [bulkActionItems, bulkActionPanels]
-  );
-
   return (
     <BulkActionsContainer data-test-subj="bulk-actions-button-container">
       <EuiPopover
@@ -99,7 +89,7 @@ const BulkActionsComponent: React.FC<OwnProps> = ({
         }
         closePopover={closeActionPopover}
       >
-        <EuiContextMenu panels={panels} initialPanelId={0} />
+        <EventsTableBulkActionMenu items={bulkActionItems} panels={bulkActionPanels} />
       </EuiPopover>
 
       <EuiButtonEmpty

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
+import type { MouseEvent } from 'react';
 import type { BulkActionsProps } from './use_bulk_action_items';
 import { useBulkActionItems } from './use_bulk_action_items';
 import { useAppToasts } from '../../../hooks/use_app_toasts';
@@ -99,16 +100,16 @@ describe('useBulkActionItems', () => {
     const { result } = renderUseBulkActionItems({
       customBulkActions: [
         {
-          key: 'attach-new-case',
-          label: 'Add to new case',
+          key: 'attach-case',
+          label: 'Add to case',
           icon: 'briefcase',
           onClick,
         },
       ],
     });
 
-    const customAction = result.current.items.find(({ key }) => key === 'attach-new-case');
-    customAction?.onActionClick?.();
+    const customAction = result.current.items.find(({ key }) => key === 'attach-case');
+    customAction?.onClick?.({} as MouseEvent<HTMLHRElement>);
 
     expect(onClick).toHaveBeenCalledWith(['mockEventId']);
     expect(customAction?.icon).toBe('briefcase');

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.test.tsx
@@ -94,6 +94,26 @@ describe('useBulkActionItems', () => {
     ).toBeUndefined();
   });
 
+  it('exposes custom actions for composed bulk action menus', () => {
+    const onClick = jest.fn();
+    const { result } = renderUseBulkActionItems({
+      customBulkActions: [
+        {
+          key: 'attach-new-case',
+          label: 'Add to new case',
+          icon: 'briefcase',
+          onClick,
+        },
+      ],
+    });
+
+    const customAction = result.current.items.find(({ key }) => key === 'attach-new-case');
+    customAction?.onActionClick?.();
+
+    expect(onClick).toHaveBeenCalledWith(['mockEventId']);
+    expect(customAction?.icon).toBe('briefcase');
+  });
+
   describe('workflow actions', () => {
     it('should include workflow menu items when useRunDocumentWorkflowPanel returns items', () => {
       const mockMenuItem = {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.tsx
@@ -29,6 +29,15 @@ import { useAlertCloseInfoModal } from '../../../../detections/hooks/use_alert_c
 import { useAlertsPrivileges } from '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { useRunDocumentWorkflowPanel } from '../../../../detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel';
 
+export type BulkActionMenuItem = AlertTableContextMenuItem & {
+  onActionClick?: () => void;
+};
+
+export const ALERT_STATUS_ACTION_IDS = {
+  markAsAcknowledged: 'acknowledge',
+  markAsOpen: 'open',
+} as const;
+
 export interface BulkActionsProps {
   eventIds: string[];
   currentStatus?: AlertWorkflowStatus;
@@ -194,12 +203,12 @@ export const useBulkActionItems = ({
     closePopover: closePopover ?? noop,
   });
 
-  const items = useMemo(() => {
-    const actionItems: AlertTableContextMenuItem[] = [];
+  const items = useMemo<BulkActionMenuItem[]>(() => {
+    const actionItems: BulkActionMenuItem[] = [];
     if (showAlertStatusActions && hasAlertsUpdate) {
       if (currentStatus !== FILTER_OPEN) {
         actionItems.push({
-          key: 'open',
+          key: ALERT_STATUS_ACTION_IDS.markAsOpen,
           'data-test-subj': 'open-alert-status',
           onClick: () => {
             closePopover?.();
@@ -210,7 +219,7 @@ export const useBulkActionItems = ({
       }
       if (currentStatus !== FILTER_ACKNOWLEDGED) {
         actionItems.push({
-          key: 'acknowledge',
+          key: ALERT_STATUS_ACTION_IDS.markAsAcknowledged,
           'data-test-subj': 'acknowledged-alert-status',
           onClick: () => {
             closePopover?.();
@@ -230,17 +239,20 @@ export const useBulkActionItems = ({
     }
 
     const additionalItems = customBulkActions
-      ? customBulkActions.reduce<AlertTableContextMenuItem[]>((acc, action) => {
+      ? customBulkActions.reduce<BulkActionMenuItem[]>((acc, action) => {
           const isDisabled = !!(query && action.disableOnQuery);
+          const onActionClick = () => {
+            closePopover?.();
+            action.onClick(eventIds);
+          };
           acc.push({
             key: action.key,
             disabled: isDisabled,
             'data-test-subj': action['data-test-subj'],
+            icon: action.icon,
             toolTipContent: isDisabled ? action.disabledLabel : null,
-            onClick: () => {
-              closePopover?.();
-              action.onClick(eventIds);
-            },
+            onClick: onActionClick,
+            onActionClick,
             name: action.label,
           });
           return acc;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_action_items.tsx
@@ -29,9 +29,7 @@ import { useAlertCloseInfoModal } from '../../../../detections/hooks/use_alert_c
 import { useAlertsPrivileges } from '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { useRunDocumentWorkflowPanel } from '../../../../detections/components/alerts_table/timeline_actions/use_run_document_workflow_panel';
 
-export type BulkActionMenuItem = AlertTableContextMenuItem & {
-  onActionClick?: () => void;
-};
+export type BulkActionMenuItem = AlertTableContextMenuItem;
 
 export const ALERT_STATUS_ACTION_IDS = {
   markAsAcknowledged: 'acknowledge',
@@ -241,7 +239,7 @@ export const useBulkActionItems = ({
     const additionalItems = customBulkActions
       ? customBulkActions.reduce<BulkActionMenuItem[]>((acc, action) => {
           const isDisabled = !!(query && action.disableOnQuery);
-          const onActionClick = () => {
+          const onClick = () => {
             closePopover?.();
             action.onClick(eventIds);
           };
@@ -251,8 +249,7 @@ export const useBulkActionItems = ({
             'data-test-subj': action['data-test-subj'],
             icon: action.icon,
             toolTipContent: isDisabled ? action.disabledLabel : null,
-            onClick: onActionClick,
-            onActionClick,
+            onClick,
             name: action.label,
           });
           return acc;


### PR DESCRIPTION
## Summary

- adds a dedicated bulk action menu for event selections
- exposes one **Add to case** action that opens the unified case selector modal
- removes the event-specific nested case panel and its extra callback contract
- supports users who can either create a case or update an existing case
- preserves investigate and workflow icons

Independent consumer of the shared action-menu foundation. Keep draft until #284116 merges.

Addresses #278607

### Checklist

- [x] Added text follows EUI writing and i18n guidelines
- [x] Unit tests cover the direct event case action and permissions
- [x] No plugin configuration or HTTP API changes were introduced

### Identify risks

Low risk. The existing event attachment generator is reused by the selector modal.

## Release note

Improves case and workflow actions in event table bulk menus.

Made with [Cursor](https://cursor.com)

## Related PRs

- [#284116 — Shared action menu foundations](https://github.com/elastic/kibana/pull/284116)
- [#284127 — Alert action menus](https://github.com/elastic/kibana/pull/284127)
- [#284128 — Attack action menus](https://github.com/elastic/kibana/pull/284128)
- [#284129 — Document action menus](https://github.com/elastic/kibana/pull/284129)
- [#284131 — Entity analytics action menus](https://github.com/elastic/kibana/pull/284131)
- [#284132 — ML case action menu](https://github.com/elastic/kibana/pull/284132)