### PR TITLE
[ML][Take Actions] Use unified case action

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/alerting/anomaly_detection_alerts_table/alert_actions.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/alerting/anomaly_detection_alerts_table/alert_actions.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiContextMenuItem, EuiPopover, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public';
@@ -15,6 +15,7 @@ import type { GetAlertsTableProp } from '@kbn/response-ops-alerts-table/types';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { DefaultAlertActions } from '@kbn/response-ops-alerts-table/components/default_alert_actions';
 import { ExpandableContextMenuPanel } from '@kbn/response-ops-alerts-table/components/expandable_context_menu_panel';
+import { AddToCaseContextMenuItem } from '@kbn/response-ops-alerts-table';
 import { STACK_MANAGEMENT_RULE_PAGE_URL_PREFIX } from '@kbn/response-ops-alerts-table/constants';
 import { PLUGIN_ID } from '../../../common/constants/app';
 import { useMlKibana } from '../../application/contexts/kibana';
@@ -96,24 +97,27 @@ export const AlertActions: GetAlertsTableProp<'renderActionsCell'> = (props) => 
   const actionsMenuItems = [
     ...(casesPrivileges && casesPrivileges?.create && casesPrivileges.read
       ? [
-          <EuiContextMenuItem
-            data-test-subj="add-to-existing-case-action"
-            key="addToExistingCase"
-            onClick={handleAddToExistingCaseClick}
-          >
-            {i18n.translate('xpack.ml.alerts.actions.addToCase', {
-              defaultMessage: 'Add to existing case',
-            })}
-          </EuiContextMenuItem>,
-          <EuiContextMenuItem
-            data-test-subj="add-to-new-case-action"
-            key="addToNewCase"
-            onClick={handleAddToNewCaseClick}
-          >
-            {i18n.translate('xpack.ml.alerts.actions.addToNewCase', {
-              defaultMessage: 'Add to new case',
-            })}
-          </EuiContextMenuItem>,
+          <AddToCaseContextMenuItem
+            key="addToCase"
+            actions={[
+              {
+                id: 'addToNewCase',
+                label: i18n.translate('xpack.ml.alerts.actions.addToNewCase', {
+                  defaultMessage: 'Add to new case',
+                }),
+                dataTestSubj: 'add-to-new-case-action',
+                onClick: handleAddToNewCaseClick,
+              },
+              {
+                id: 'addToExistingCase',
+                label: i18n.translate('xpack.ml.alerts.actions.addToCase', {
+                  defaultMessage: 'Add to existing case',
+                }),
+                dataTestSubj: 'add-to-existing-case-action',
+                onClick: handleAddToExistingCaseClick,
+              },
+            ]}
+          />,
         ]
       : []),
   ];

--- a/x-pack/platform/plugins/shared/ml/public/alerting/anomaly_detection_alerts_table/alert_actions.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/alerting/anomaly_detection_alerts_table/alert_actions.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenuItem, EuiPopover, EuiToolTip } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public';
@@ -15,7 +15,6 @@ import type { GetAlertsTableProp } from '@kbn/response-ops-alerts-table/types';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { DefaultAlertActions } from '@kbn/response-ops-alerts-table/components/default_alert_actions';
 import { ExpandableContextMenuPanel } from '@kbn/response-ops-alerts-table/components/expandable_context_menu_panel';
-import { AddToCaseContextMenuItem } from '@kbn/response-ops-alerts-table';
 import { STACK_MANAGEMENT_RULE_PAGE_URL_PREFIX } from '@kbn/response-ops-alerts-table/constants';
 import { PLUGIN_ID } from '../../../common/constants/app';
 import { useMlKibana } from '../../application/contexts/kibana';
@@ -59,7 +58,6 @@ export const AlertActions: GetAlertsTableProp<'renderActionsCell'> = (props) => 
     refresh();
   }, [refresh]);
 
-  const createCaseFlyout = cases?.hooks?.useCasesAddToNewCaseFlyout({ onSuccess });
   const selectCaseModal = cases?.hooks?.useCasesAddToExistingCaseModal({ onSuccess });
 
   const closeActionsPopover = () => {
@@ -70,12 +68,7 @@ export const AlertActions: GetAlertsTableProp<'renderActionsCell'> = (props) => 
     setIsPopoverOpen(!isPopoverOpen);
   };
 
-  const handleAddToNewCaseClick = () => {
-    createCaseFlyout?.open({ attachments: caseAttachments });
-    closeActionsPopover();
-  };
-
-  const handleAddToExistingCaseClick = () => {
+  const handleAddToCaseClick = () => {
     selectCaseModal?.open({ getAttachments: () => caseAttachments });
     closeActionsPopover();
   };
@@ -95,29 +88,21 @@ export const AlertActions: GetAlertsTableProp<'renderActionsCell'> = (props) => 
   );
 
   const actionsMenuItems = [
-    ...(casesPrivileges && casesPrivileges?.create && casesPrivileges.read
+    ...(casesPrivileges &&
+    casesPrivileges.read &&
+    casesPrivileges.createComment &&
+    (casesPrivileges.create || casesPrivileges.update)
       ? [
-          <AddToCaseContextMenuItem
+          <EuiContextMenuItem
             key="addToCase"
-            actions={[
-              {
-                id: 'addToNewCase',
-                label: i18n.translate('xpack.ml.alerts.actions.addToNewCase', {
-                  defaultMessage: 'Add to new case',
-                }),
-                dataTestSubj: 'add-to-new-case-action',
-                onClick: handleAddToNewCaseClick,
-              },
-              {
-                id: 'addToExistingCase',
-                label: i18n.translate('xpack.ml.alerts.actions.addToCase', {
-                  defaultMessage: 'Add to existing case',
-                }),
-                dataTestSubj: 'add-to-existing-case-action',
-                onClick: handleAddToExistingCaseClick,
-              },
-            ]}
-          />,
+            data-test-subj="add-to-case-action"
+            icon="briefcase"
+            onClick={handleAddToCaseClick}
+          >
+            {i18n.translate('xpack.ml.alerts.actions.addToCase', {
+              defaultMessage: 'Add to case',
+            })}
+          </EuiContextMenuItem>,
         ]
       : []),
   ];


### PR DESCRIPTION
## Summary

- replaces separate ML alert new/existing case choices with one **Add to case** action
- opens the unified case selector modal, which also provides the create-new-case path
- removes the obsolete nested case menu and new-case flyout callback
- supports users who can either create a case or update an existing case

Independent consumer of the shared action-menu foundation. Keep draft until #284116 merges.

Addresses #278607

### Checklist

- [x] Added text follows EUI writing and i18n guidelines
- [x] The ML project type check and lint pass
- [x] No plugin configuration or HTTP API changes were introduced

### Identify risks

Low risk. The existing alert attachment payload and refresh callback are reused.

## Release note

Simplifies case actions in the anomaly detection alerts table.

Made with [Cursor](https://cursor.com)

## Related PRs

- [#284116 — Shared action menu foundations](https://github.com/elastic/kibana/pull/284116)
- [#284127 — Alert action menus](https://github.com/elastic/kibana/pull/284127)
- [#284128 — Attack action menus](https://github.com/elastic/kibana/pull/284128)
- [#284129 — Document action menus](https://github.com/elastic/kibana/pull/284129)
- [#284130 — Events table bulk action menu](https://github.com/elastic/kibana/pull/284130)
- [#284131 — Entity analytics action menus](https://github.com/elastic/kibana/pull/284131)