### PR TITLE
[9.4] [Field formats] Fix Base64 Decode transform on server and for UTF-8 (#281366)

### DIFF
--- a/src/platform/plugins/shared/field_formats/common/converters/string.test.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/string.test.ts
@@ -53,6 +53,39 @@ describe('String Format', () => {
     expect(stripSpan(string.convert('Zm9vYmFy', 'html'))).toBe('foobar');
   });
 
+  test('decode a base64 string with multi-byte UTF-8 characters', () => {
+    const string = new StringFormat(
+      {
+        transform: 'base64',
+      },
+      jest.fn()
+    );
+    const base64 = Buffer.from('été', 'utf8').toString('base64');
+    expect(string.convert(base64)).toBe('été');
+    expect(stripSpan(string.convert(base64, 'html'))).toBe('été');
+  });
+
+  test('decode a base64 string when window.atob is unavailable', () => {
+    const string = new StringFormat(
+      {
+        transform: 'base64',
+      },
+      jest.fn()
+    );
+    const originalAtob = window.atob;
+    Object.defineProperty(window, 'atob', { value: undefined, configurable: true, writable: true });
+    try {
+      expect(string.convert('Zm9vYmFy')).toBe('foobar');
+      expect(string.convert(Buffer.from('été', 'utf8').toString('base64'))).toBe('été');
+    } finally {
+      Object.defineProperty(window, 'atob', {
+        value: originalAtob,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
   test('convert a string to title case', () => {
     const string = new StringFormat(
       {

--- a/src/platform/plugins/shared/field_formats/common/converters/string.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/string.ts
@@ -93,7 +93,12 @@ export class StringFormat extends FieldFormat {
 
   private base64Decode(val: string) {
     try {
-      if (window && window.atob) return window.atob(val);
+      if (typeof window !== 'undefined' && window.atob) {
+        // atob produces a binary (latin1) string; decode its bytes as UTF-8 to handle multi-byte characters
+        return new TextDecoder().decode(
+          Uint8Array.from(window.atob(val), (char) => char.charCodeAt(0))
+        );
+      }
       // referencing from `global` tricks webpack to not include `Buffer` polyfill into this bundle
       return global.Buffer.from(val, 'base64').toString('utf8');
     } catch (e) {

--- a/src/platform/plugins/shared/vis_types/timeseries/public/application/components/lib/create_field_formatter.test.ts
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/application/components/lib/create_field_formatter.test.ts
@@ -27,6 +27,7 @@ describe('createFieldFormatter(fieldName, fieldFormatMap?, contextType?, hasColo
   );
   const value = 1234567890;
   const stringValue = 'some string';
+  const base64Value = 'w6l0w6k=';
   const fieldFormatMap = {
     bytesField: {
       id: 'bytes',
@@ -69,7 +70,7 @@ describe('createFieldFormatter(fieldName, fieldFormatMap?, contextType?, hasColo
   it('should return base64 formatted value for stringField', () => {
     const formatter = createFieldFormatter('stringField', fieldFormatMap);
 
-    expect(formatter(value)).toBe('×møç®ü÷');
+    expect(formatter(base64Value)).toBe('été');
   });
 
   it('should return color formatted value for colorField', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Field formats] Fix Base64 Decode transform on server and for UTF-8 (#281366)](https://github.com/elastic/kibana/pull/281366)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"bassem chagra","email":"chagra.bassem@yahoo.fr"},"sourceCommit":{"committedDate":"2026-08-06T16:29:43Z","message":"[Field formats] Fix Base64 Decode transform on server and for UTF-8 (#281366)\n\nCloses #281364\n\nFix two regressions in the String field format's Base64 Decode\ntransform:\n\n- Guard browser-only code with `typeof window !== 'undefined'` so the\n  Buffer fallback works correctly on the server.\n- Decode `atob` output as UTF-8 to correctly handle multi-byte\n  characters in the browser.\n\nAdd regression tests for UTF-8 decoding and the Buffer fallback.\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"2fd1c1395128716601964b40503c40c4ff663f12","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","💝community","Team:DataDiscovery","backport:version","reviewer:claude","v9.6.0","v9.4.5","v9.5.1"],"title":"[Field formats] Fix Base64 Decode transform on server and for UTF-8","number":281366,"url":"https://github.com/elastic/kibana/pull/281366","mergeCommit":{"message":"[Field formats] Fix Base64 Decode transform on server and for UTF-8 (#281366)\n\nCloses #281364\n\nFix two regressions in the String field format's Base64 Decode\ntransform:\n\n- Guard browser-only code with `typeof window !== 'undefined'` so the\n  Buffer fallback works correctly on the server.\n- Decode `atob` output as UTF-8 to correctly handle multi-byte\n  characters in the browser.\n\nAdd regression tests for UTF-8 decoding and the Buffer fallback.\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"2fd1c1395128716601964b40503c40c4ff663f12"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281366","number":281366,"mergeCommit":{"message":"[Field formats] Fix Base64 Decode transform on server and for UTF-8 (#281366)\n\nCloses #281364\n\nFix two regressions in the String field format's Base64 Decode\ntransform:\n\n- Guard browser-only code with `typeof window !== 'undefined'` so the\n  Buffer fallback works correctly on the server.\n- Decode `atob` output as UTF-8 to correctly handle multi-byte\n  characters in the browser.\n\nAdd regression tests for UTF-8 decoding and the Buffer fallback.\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"2fd1c1395128716601964b40503c40c4ff663f12"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/283530","number":283530,"state":"OPEN"}]}] BACKPORT-->