### PR TITLE
[Discover][Metrics] Add ACTION_FILTERS_NOTIFICATION to DEFAULT_DISABLED_ACTIONS

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.test.tsx
@@ -194,7 +194,7 @@ describe('LensWrapper', () => {
           disabledActions: expect.arrayContaining([
             'ACTION_CUSTOMIZE_PANEL',
             'ACTION_EXPORT_CSV',
-
+            'ACTION_FILTERS_NOTIFICATION',
             'alertRule',
           ]),
         }),

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.test.tsx
@@ -194,6 +194,7 @@ describe('LensWrapper', () => {
           disabledActions: expect.arrayContaining([
             'ACTION_CUSTOMIZE_PANEL',
             'ACTION_EXPORT_CSV',
+
             'alertRule',
           ]),
         }),

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.tsx
@@ -36,7 +36,12 @@ export type LensWrapperProps = {
   quickActionIds?: QuickActionIds;
 } & Pick<UnifiedMetricsGridProps, 'services' | 'onBrushEnd' | 'onFilter'>;
 
-const DEFAULT_DISABLED_ACTIONS = ['ACTION_CUSTOMIZE_PANEL', 'ACTION_EXPORT_CSV', 'alertRule'];
+const DEFAULT_DISABLED_ACTIONS = [
+  'ACTION_CUSTOMIZE_PANEL',
+  'ACTION_EXPORT_CSV',
+  'ACTION_FILTERS_NOTIFICATION',
+  'alertRule',
+];
 export function LensWrapper({
   lensProps,
   services,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/284282


`ACTION_FILTERS_NOTIFICATION` was not present in the metrics grid Lens panel menus before https://github.com/elastic/kibana/pull/282386. 

That PR moved the action from `PANEL_NOTIFICATION_TRIGGER` to `ON_OPEN_PANEL_MENU`, a global registration. Since `isCompatible` returns `true` for any ES|QL embeddable, it now appears in every Lens panel context menu, including the metrics grid.

Adds `ACTION_FILTERS_NOTIFICATION` to `DEFAULT_DISABLED_ACTIONS` in `lens_wrapper.tsx`, following the same pattern already used for `ACTION_CUSTOMIZE_PANEL` and `ACTION_EXPORT_CSV`.

|Before|After|
|-|-|
|<img width="1347" height="966" alt="Screenshot 2026-08-11 at 07 55 54" src="https://github.com/user-attachments/assets/2946658a-10e6-457f-9451-5b52d5c213fb" />|<img width="1920" height="966" alt="Screenshot 2026-08-11 at 08 46 00" src="https://github.com/user-attachments/assets/d4ba444b-460c-4abc-ba91-c09f4d332b09" />|



### How to test
1. Navigate to the metrics grid (`TS metrics*` in Discover).
2. Hover over any Lens panel , verify the filters notification icon is no longer shown in the quick actions row.
3. Open the "Panel menu" context menu on any Lens panel,verify the filters notification action is no longer listed.
4. Verify the other quick actions (Explore in Discover, Inspect) still appear as expected.

