### PR TITLE
docs: add csp.media_src setting (#7696)

### DIFF
--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -149,7 +149,7 @@ groups:
       - setting: csp.script_src
         description: |
           Add sources for the [Content Security Policy `script-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -171,7 +171,7 @@ groups:
       - setting: csp.worker_src
         description: |
           Add sources for the [Content Security Policy `worker-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -180,7 +180,7 @@ groups:
       - setting: csp.style_src
         description: |
           Add sources for the [Content Security Policy `style-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -189,7 +189,7 @@ groups:
       - setting: csp.connect_src
         description: |
           Add sources for the [Content Security Policy `connect-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -198,7 +198,7 @@ groups:
       - setting: csp.default_src
         description: |
           Add sources for the [Content Security Policy `default-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -207,7 +207,7 @@ groups:
       - setting: csp.font_src
         description: |
           Add sources for the [Content Security Policy `font-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -216,7 +216,7 @@ groups:
       - setting: csp.frame_src
         description: |
           Add sources for the [Content Security Policy `frame-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -225,7 +225,7 @@ groups:
       - setting: csp.img_src
         description: |
           Add sources for the [Content Security Policy `img-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -234,16 +234,25 @@ groups:
       - setting: csp.object_src
         description: |
           Add sources for the [Content Security Policy `object-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src).
-        datatype: string
+        datatype: array of strings
         applies_to:
           - "stack: ga 9.3"
+          - "ech: unavailable"
+          - "self: ga"
+
+      - setting: csp.media_src
+        description: |
+          Add sources for the [Content Security Policy `media-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/media-src).
+        datatype: array of strings
+        applies_to:
+          - "stack: ga 9.6"
           - "ech: unavailable"
           - "self: ga"
 
       - setting: csp.frame_ancestors
         description: |
           Add sources for the [Content Security Policy `frame-ancestors` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -253,7 +262,7 @@ groups:
       - setting: csp.form_action
         description: |
           Add sources for the [Content Security Policy `form-action` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action).
-        datatype: string
+        datatype: array of strings
         default: "'self'"
         applies_to:
           - "stack: ga 9.5"
@@ -263,7 +272,7 @@ groups:
       - setting: csp.report_only.form_action
         description: |
           Add sources for the [Content Security Policy `form-action` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action) in reporting mode.
-        datatype: string
+        datatype: array of strings
         applies_to:
           - "stack: deprecated 9.5"
           - "ech: ga"
@@ -273,7 +282,7 @@ groups:
       - setting: csp.report_only.object_src
         description: |
           Add sources for the [Content Security Policy `object-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/object-src) in reporting mode.
-        datatype: string
+        datatype: array of strings
         applies_to:
           - "stack: deprecated 9.3"
           - "ech: unavailable"
@@ -283,7 +292,7 @@ groups:
       - setting: csp.report_only.connect_src
         description: |
           Add sources for the [Content Security Policy `connect-src` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src) in reporting mode.
-        datatype: string
+        datatype: array of strings
         applies_to:
           - "stack: ga 9.5"
           - "ech: ga"
@@ -292,7 +301,7 @@ groups:
       - setting: csp.report_uri
         description: |
           Add sources for the [Content Security Policy `report-uri` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable
@@ -301,7 +310,7 @@ groups:
       - setting: csp.report_to
         description: |
           Add sources for the [Content Security Policy `report-to` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to).
-        datatype: string
+        datatype: array of strings
         applies_to:
           stack: ga
           ech: unavailable


### PR DESCRIPTION
## Summary

This PR addresses [elastic/docs-content#7696](https://github.com/elastic/docs-content/issues/7696) with the following changes:

- **`docs/reference/configuration-reference/general-settings.yml`**: adds a `csp.media_src` reference entry for the new optional CSP directive introduced in [elastic/kibana#281412](https://github.com/elastic/kibana/pull/281412), which wires `media_src` to the `media-src` Content Security Policy directive. Available from Stack 9.6 and later, not available on Elastic Cloud Hosted, GA on self-managed — matching the sibling `csp.*_src` entries.
- **`docs/reference/configuration-reference/general-settings.yml`**: corrects the `datatype` label on all 17 `csp.*` settings that take a list of sources (`script_src`, `worker_src`, `style_src`, `connect_src`, `default_src`, `font_src`, `frame_src`, `img_src`, `object_src`, `media_src`, `frame_ancestors`, `form_action`, `report_only.form_action`, `report_only.object_src`, `report_only.connect_src`, `report_uri`, `report_to`) from `string` to `array of strings`. These are all `schema.arrayOf(schema.string())` in `src/core/packages/http/server-internal/src/csp/config.ts`, and the `string` label doesn't reflect that a reader must supply a YAML list. This surfaced during a reader-comprehension pass on the new `media_src` entry — leaving it as `string` (to match the pre-existing siblings) would have carried the same ambiguity forward, and fixing only the new entry would have made it inconsistent with the rest of the group. Confirmed with the issue author to fix the whole CSP group in this PR rather than opening a separate follow-up.

Since this page is generated from this YAML file via the `{settings}` directive, the change automatically propagates to the [Elastic Cloud Kibana settings](https://www.elastic.co/docs/reference/kibana/cloud/elastic-cloud-kibana-settings) page too (which reuses the same file filtered to `ech`-available entries — `csp.media_src` is correctly excluded there since it's `ech: unavailable`).

## Resolves

Closes elastic/docs-content#7696

---

> **AI-generated draft** — created with Claude Sonnet 4.6.
> Review all generated content for factual accuracy before merging.