### PR TITLE
[Docs][Scout] Document how to verify a flaky fix against Cloud

### DIFF
--- a/docs/extend/testing/scout-best-practices.md
+++ b/docs/extend/testing/scout-best-practices.md
@@ -116,7 +116,30 @@ Scout is deployment-agnostic: write once, run locally and on Elastic Cloud.
 
 - Every suite must have [deployment tags](../testing/deployment-tags.md). Use tags to target the environments where your tests apply (for example, a feature that only exists in stateful deployments).
 - Within a test, avoid relying on configuration, data, or behavior specific to a single deployment. Test logic should produce the same result locally and on Cloud.
-- Run your tests against a real Elastic Cloud project before merging to catch environment-specific surprises early.
+- Run your tests against a real Cloud target before merging, especially when fixing a flake that CI reported on a `@cloud-*` target. Pass `--location cloud`; the default is `local`:
+
+  ```bash
+  # Elastic Cloud Hosted deployment (ECH)
+  node scripts/scout run-tests --location cloud --arch stateful --domain classic \
+    --config <module-root>/test/scout/ui/playwright.config.ts
+
+  # Elastic Cloud project (MKI)
+  node scripts/scout run-tests --location cloud --arch serverless --domain search \
+    --config <module-root>/test/scout/ui/playwright.config.ts
+  ```
+
+A Cloud target differs from your local stack in ways that break otherwise-correct tests:
+
+| On Cloud                                                        | What tends to break                                                                        |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| the deployment already holds data your suite didn't create      | assertions over collections: exact counts, result caps, pagination, whichever row is first |
+| requests cross a real network to a shared deployment            | timeouts and polling budgets calibrated against a local stack                              |
+| serverless project types render different navigation and chrome | direct clicks on controls that collapse into an overflow menu                              |
+
+::::::{warning}
+**The Flaky Test Runner only covers local targets.** It fans out over `--arch` and `--domain` only, so `@local-stateful-classic` and `@cloud-stateful-classic` collapse into the same locally provisioned run. A green 50-iteration flaky run says nothing about whether the test passes on a `@cloud-*` target. When the failure you're fixing was reported on a cloud target, reproduce it with `--location cloud` before trusting the fix.
+::::::
+
 ## Keep tests close to the code they test [keep-tests-close-to-source-code]
 
 A test should live in the plugin or package that owns the code it exercises. When writing or reviewing a test, confirm that the scenarios logically belong to the plugin they were added to:
@@ -136,7 +159,14 @@ For the full guide (including when a custom server config is unavoidable), see [
 
 When you add new tests, fix flakes, or make significant changes, run the same tests multiple times to catch flakiness early. A good starting point is **20–50 runs**.
 
-Prefer doing this locally first (faster feedback), and use the Flaky Test Runner in CI when needed. See [Debug flaky tests](../testing/debugging.md#scout-debugging-flaky-tests) for guidance.
+Prefer doing this locally first (faster feedback) with `--repeatEach`, and use the Flaky Test Runner in CI when needed. See [Debug flaky tests](../testing/debugging.md#scout-debugging-flaky-tests) for guidance.
+
+```bash
+node scripts/scout run-tests --arch stateful --domain classic \
+  --config <module-root>/test/scout/ui/playwright.config.ts --repeatEach 25
+```
+
+Repetition only tells you about the target you repeated on. Neither `--repeatEach` nor the Flaky Test Runner exercises Cloud, so see [the Cloud warning](#design-tests-with-a-cloud-first-mindset) when the flake was reported on a `@cloud-*` target.
 
 ## Keep test suites independent [keep-test-suites-independent]
 


### PR DESCRIPTION
## Summary

The "Design tests with a cloud-first mindset" section told readers to run their tests against a real Cloud deployment before merging, but never said how — and `--location cloud` appeared in **no** page under `docs/extend/testing/`, even though `scout run-tests` supports it. This adds the missing command and, more importantly, documents that repeated local runs cannot substitute for it.

Three changes to `scout-best-practices.md`:

- **The actual command**, taken from the `run-tests` CLI help so it stays in step with the tool: the ECH (`--arch stateful --domain classic`) and MKI (`--arch serverless --domain search`) invocations.
- **A short table of what differs on Cloud**, each row tied to the class of assertion it tends to break: preexisting data versus collection assertions, real network latency versus locally calibrated timeouts, and serverless chrome versus direct clicks.
- **A warning that the Flaky Test Runner only covers local targets.** `getServerRunFlagsFromTags` maps tags to `--arch`/`--domain` and drops the `location` dimension — its own comment notes that `@local-stateful-classic` and `@cloud-stateful-classic` "resolve to the same target" — and the flaky-runner pipeline consumes those flags via `SCOUT_SERVER_RUN_FLAGS`. Since `--location` defaults to `local`, every iteration runs against a locally provisioned stack. The "Run tests multiple times" section now names `--repeatEach` and points here.

## Why

From an outcome audit of merged `flaky-test-fixer` PRs: of the Scout fixes that did not hold, **5 of 7 recurred on a `cloud-*` target, and all 7 had a green flaky-test-runner run of 10–50 iterations before merge**. One was broken across three serverless project types while passing 30 times locally. That is a documentation and tooling gap rather than author error — nothing told these authors that a green flaky run says nothing about Cloud, and no doc showed them how to reproduce a cloud failure.

## Test plan

- [ ] Docs preview renders the two code blocks, the table, and the warning admonition.
- [ ] The `#design-tests-with-a-cloud-first-mindset` anchor link from the flaky-runner section resolves.

Made with [Cursor](https://cursor.com)