### PR TITLE
[APM] Remove "health" mentions from ML callout in APM

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/ml_callout/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/ml_callout/index.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
+import { KbnInfoCallout, KbnSuccessCallout } from '@kbn/ui-callout';
 import { AnomalyDetectionSetupState } from '../../../../common/anomaly_detection/get_anomaly_detection_setup_state';
 import { useMlManageJobsHref } from '../../../hooks/use_ml_manage_jobs_href';
 import { useAPMHref } from '../links/apm/apm_link_hooks';
@@ -41,10 +42,9 @@ export function MLCallout({
   let properties:
     | {
         primaryAction: React.ReactNode | undefined;
-        color: 'primary' | 'success' | 'danger' | 'warning';
         title: string;
-        icon: string;
         text: string;
+        Component: typeof KbnInfoCallout | typeof KbnSuccessCallout;
       }
     | undefined;
 
@@ -66,14 +66,11 @@ export function MLCallout({
     case AnomalyDetectionSetupState.NoJobs:
       properties = {
         title: i18n.translate('xpack.apm.mlCallout.noJobsCalloutTitle', {
-          defaultMessage:
-            'Enable anomaly detection to add health status indicators to your services',
+          defaultMessage: 'Enable anomaly detection to surface anomaly scores across your services',
         }),
         text: i18n.translate('xpack.apm.mlCallout.noJobsCalloutText', {
-          defaultMessage: `Pinpoint anomalous transactions and see the health of upstream and downstream services with APM's anomaly detection integration. Get started in just a few minutes.`,
+          defaultMessage: `Pinpoint anomalous transactions and monitor anomaly scores for upstream and downstream services with APM's anomaly detection integration. Get started in just a few minutes.`,
         }),
-        icon: 'info',
-        color: 'primary',
         primaryAction: isOnSettingsPage ? (
           <EuiButton
             data-test-subj="apmMLCalloutCreateMlJobButton"
@@ -89,6 +86,7 @@ export function MLCallout({
         ) : (
           getLearnMoreLink('primary')
         ),
+        Component: KbnInfoCallout,
       };
       break;
 
@@ -101,8 +99,6 @@ export function MLCallout({
           defaultMessage:
             'We have updated the anomaly detection jobs that provide insights into degraded performance and added detectors for throughput and failed transaction rate. If you choose to upgrade, we will create the new jobs and close the existing legacy jobs. The data shown in the APM app will automatically switch to the new. Please note that the option to migrate all existing jobs will not be available if you choose to create a new job.',
         }),
-        color: 'success',
-        icon: 'wrench',
         primaryAction: isOnSettingsPage ? (
           <EuiButton
             data-test-subj="apmMLCalloutUpdateJobsButton"
@@ -122,6 +118,7 @@ export function MLCallout({
         ) : (
           getLearnMoreLink('success')
         ),
+        Component: KbnSuccessCallout,
       };
       break;
 
@@ -134,8 +131,6 @@ export function MLCallout({
           defaultMessage:
             'We have discovered legacy Machine Learning jobs from our previous integration which are no longer being used in the APM app',
         }),
-        icon: 'info',
-        color: 'primary',
         primaryAction: (
           <EuiButton data-test-subj="apmMLCalloutReviewJobsButton" href={mlManageJobsHref}>
             {i18n.translate('xpack.apm.settings.anomaly_detection.legacy_jobs.button', {
@@ -143,6 +138,7 @@ export function MLCallout({
             })}
           </EuiButton>
         ),
+        Component: KbnInfoCallout,
       };
       break;
   }
@@ -164,14 +160,12 @@ export function MLCallout({
   ) : null;
 
   return (
-    <EuiCallOut
+    <properties.Component
       title={properties.title}
-      iconType={properties.icon}
-      color={properties.color}
+      text={properties.text}
       onDismiss={dismissable ? onDismiss : undefined}
     >
-      <p>{properties.text}</p>
       {actions}
-    </EuiCallOut>
+    </properties.Component>
   );
 }


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/issues/266192, we replaced the concept of "health" in APM in favour of "Anomaly Score" During that migration, we overlooked the `MLCallout` component involved in this PR. The copy on one of the states of this callout still mentioned "health status" in relation to APM services. 

This PR introduces a quick update to rephrase the wording on the component. Instead of "health", the component will now reference "anomaly scores" to align with the direction we're taking with AD throughout APM

Since I was working around this component, I've also taken the liberty to apply the migration from plain `EuiCallout` components to `KbnXyzCallout` as introduced in https://github.com/elastic/kibana/pull/277978


## UI Changes

This is how the `NoJobs` callout looks like now, with the reworked copy

<img width="2277" height="145" alt="Screenshot 2026-08-11 at 11 19 10" src="https://github.com/user-attachments/assets/8abaeec2-599c-4e84-965c-aa457e23d8d8" />

The other 2 states remain identical. `KbnXyzCallout` components are simple wrappers over `EuiCallout` and will not cause any differences on how the component is visually rendered.

## Notes on backporting

https://github.com/elastic/kibana/pull/266194 was first introduced in 9.5 So, I'm backporting this update back to that version so we can correct it there as well. The change is very low risk as it's a simple copy change but it will improve the UX for users on that version. 

The migration in https://github.com/elastic/kibana/pull/277978 will not be present so the backport will have conflicts that, when resolved, will result in a 2 lane change updating the strings in use

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->