### PR TITLE
[Fleet] Fix newline normalization in YAML in agent policy compilation

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
@@ -672,6 +672,16 @@ type: {{_meta.stream.data_stream.type}}
       type: 'logs',
     });
   });
+
+  it('should fold single newlines to a space in double-quoted YAML scalars', () => {
+    // Regression: https://github.com/elastic/sdh-beats/issues/7456
+    // Multi-line double-quoted SQL in stream templates (e.g. Oracle tablespace) had
+    // tokens concatenated because a single \n was deleted instead of folded to a space.
+    const template = `sql: "SUM(bytes) AS TOTAL_BYTES\nFROM details"\n`;
+
+    const output = compileTemplate({}, getMockedMetaVariable(), template);
+    expect(output).toEqual({ sql: 'SUM(bytes) AS TOTAL_BYTES FROM details' });
+  });
 });
 
 describe('encode', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
@@ -121,7 +121,10 @@ export function compileTemplate(
   compiledTemplate = compiledTemplate.replace(/'(?:[^']|'')*'|"(?:[^"\\]|\\.)*"/gs, (match) => {
     if (match[0] === "'") return match; // single-quoted scalar — no escaping needed
     return match.includes('\n')
-      ? match.replace(/\n+/g, (newlines) => '\\n'.repeat(newlines.length - 1))
+      ? match.replace(/\n+/g, (newlines) =>
+          // YAML 1.1 folds a single newline to a space; N≥2 consecutive → N-1 \n escapes.
+          newlines.length === 1 ? ' ' : '\\n'.repeat(newlines.length - 1)
+        )
       : match;
   });
 


### PR DESCRIPTION
## Summary

A regression introduced in https://github.com/elastic/kibana/pull/252345 causes the Fleet plugin to silently delete every single newline character inside double-quoted YAML scalars during agent policy compilation. For integrations whose stream templates use multi-line double-quoted SQL queries, this causes adjacent SQL tokens to be concatenated (e.g. `TOTAL_BYTES FROM` → `TOTAL_BYTESFROM`), producing errors at collection time.

The bug is an off-by-one in a newline-normalization regex added to bridge a behavioral difference between `js-yaml` (YAML 1.1) and the yaml package (YAML 1.2).

An integrations-side workaround for Oracle 1.31.4 https://github.com/elastic/integrations/pull/20654 is open but not yet merged.

This PR implements the required Kibana-side fix by correcting the newline normalization so a single `\n` is not deleted.

Note: a previous follow-up fix https://github.com/elastic/kibana/pull/279391 addressed a related but distinct YAML corruption issue.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low: narrow fix of an existing bug: the change only affects double-quoted YAML scalars that contain literal single newline characters.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->