### PR TITLE
[Security Solution][Attacks][Bug] Restore access to anonymization settings on the Attacks page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_view_options_popover.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_view_options_popover.test.tsx
@@ -14,6 +14,19 @@ import { AttacksEventTypes } from '../../../../common/lib/telemetry';
 
 jest.mock('../../../../common/lib/kibana');
 
+jest.mock(
+  '@kbn/elastic-assistant/impl/data_anonymization/settings/anonymization_settings_management',
+  () => ({
+    AnonymizationSettingsManagement: ({ onClose }: { onClose: () => void }) => (
+      <div data-test-subj="anonymizationSettingsModal">
+        <button type="button" data-test-subj="closeAnonymizationSettingsModal" onClick={onClose}>
+          {'Close'}
+        </button>
+      </div>
+    ),
+  })
+);
+
 describe('AttacksViewOptionsPopover', () => {
   const defaultProps = {
     showAnonymized: false,
@@ -101,6 +114,60 @@ describe('AttacksViewOptionsPopover', () => {
 
       expect(anonymizedSwitch).toHaveAttribute('aria-checked', 'true');
       expect(attacksOnlySwitch).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  it('renders the anonymization settings button inside the popover', async () => {
+    const { getByTestId } = render(<AttacksViewOptionsPopover {...defaultProps} />);
+
+    fireEvent.click(getByTestId(`${TABLE_SECTION_TEST_ID}-view-options-button`));
+
+    await waitFor(() => {
+      expect(
+        getByTestId(`${TABLE_SECTION_TEST_ID}-anonymization-settings-button`)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('opens the anonymization settings modal when the settings button is clicked', async () => {
+    const { getByTestId } = render(<AttacksViewOptionsPopover {...defaultProps} />);
+
+    fireEvent.click(getByTestId(`${TABLE_SECTION_TEST_ID}-view-options-button`));
+
+    await waitFor(() => {
+      expect(
+        getByTestId(`${TABLE_SECTION_TEST_ID}-anonymization-settings-button`)
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByTestId(`${TABLE_SECTION_TEST_ID}-anonymization-settings-button`));
+
+    await waitFor(() => {
+      expect(getByTestId('anonymizationSettingsModal')).toBeInTheDocument();
+    });
+  });
+
+  it('closes the anonymization settings modal when onClose is triggered', async () => {
+    const { getByTestId, queryByTestId } = render(<AttacksViewOptionsPopover {...defaultProps} />);
+
+    fireEvent.click(getByTestId(`${TABLE_SECTION_TEST_ID}-view-options-button`));
+
+    await waitFor(() => {
+      expect(
+        getByTestId(`${TABLE_SECTION_TEST_ID}-anonymization-settings-button`)
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByTestId(`${TABLE_SECTION_TEST_ID}-anonymization-settings-button`));
+
+    await waitFor(() => {
+      expect(getByTestId('anonymizationSettingsModal')).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByTestId('closeAnonymizationSettingsModal'));
+
+    await waitFor(() => {
+      expect(queryByTestId('anonymizationSettingsModal')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_view_options_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_view_options_popover.tsx
@@ -8,14 +8,17 @@
 import React, { useCallback, useState } from 'react';
 import type { EuiSwitchEvent } from '@elastic/eui';
 import {
+  EuiButtonEmpty,
   EuiButtonIcon,
   EuiFormRow,
+  EuiHorizontalRule,
   EuiPopover,
   EuiSpacer,
   EuiSwitch,
   EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
+import { AnonymizationSettingsManagement } from '@kbn/elastic-assistant/impl/data_anonymization/settings/anonymization_settings_management';
 
 import { useKibana } from '../../../../common/lib/kibana';
 import { AttacksEventTypes } from '../../../../common/lib/telemetry';
@@ -37,6 +40,7 @@ export const AttacksViewOptionsPopover: React.FC<AttacksViewOptionsPopoverProps>
 }) => {
   const { euiTheme } = useEuiTheme();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isAnonymizationModalVisible, setIsAnonymizationModalVisible] = useState(false);
   const {
     services: { telemetry },
   } = useKibana();
@@ -48,6 +52,13 @@ export const AttacksViewOptionsPopover: React.FC<AttacksViewOptionsPopoverProps>
   const closePopover = useCallback(() => {
     setIsPopoverOpen(false);
   }, []);
+
+  const showAnonymizationModal = useCallback(() => {
+    setIsPopoverOpen(false);
+    setIsAnonymizationModalVisible(true);
+  }, []);
+
+  const closeAnonymizationModal = useCallback(() => setIsAnonymizationModalVisible(false), []);
 
   const handleToggleShowAnonymized = useCallback(
     (e: EuiSwitchEvent) => {
@@ -83,35 +94,52 @@ export const AttacksViewOptionsPopover: React.FC<AttacksViewOptionsPopoverProps>
   );
 
   return (
-    <EuiPopover
-      id="attacksViewOptionsPopover"
-      aria-label={i18n.VIEW_OPTIONS_ARIA_LABEL}
-      button={button}
-      isOpen={isPopoverOpen}
-      closePopover={closePopover}
-      panelPaddingSize="m"
-      anchorPosition="downRight"
-      panelStyle={{ minWidth: euiTheme.base * 18 }}
-    >
-      <EuiFormRow display="rowCompressed">
-        <EuiSwitch
-          label={i18n.SHOW_ANONYMIZED_LABEL}
-          checked={showAnonymized}
-          onChange={handleToggleShowAnonymized}
-          data-test-subj={`${TABLE_SECTION_TEST_ID}-show-anonymized-switch`}
-          compressed
-        />
-      </EuiFormRow>
-      <EuiSpacer size="m" />
-      <EuiFormRow display="rowCompressed">
-        <EuiSwitch
-          label={i18n.SHOW_ATTACKS_ONLY_LABEL}
-          checked={showAttacksOnly}
-          onChange={handleToggleShowAttacksOnly}
-          data-test-subj={`${TABLE_SECTION_TEST_ID}-show-attacks-only-switch`}
-          compressed
-        />
-      </EuiFormRow>
-    </EuiPopover>
+    <>
+      <EuiPopover
+        id="attacksViewOptionsPopover"
+        aria-label={i18n.VIEW_OPTIONS_ARIA_LABEL}
+        button={button}
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}
+        panelPaddingSize="m"
+        anchorPosition="downRight"
+        panelStyle={{ minWidth: euiTheme.base * 18 }}
+      >
+        <EuiFormRow display="rowCompressed">
+          <EuiSwitch
+            label={i18n.SHOW_ANONYMIZED_LABEL}
+            checked={showAnonymized}
+            onChange={handleToggleShowAnonymized}
+            data-test-subj={`${TABLE_SECTION_TEST_ID}-show-anonymized-switch`}
+            compressed
+          />
+        </EuiFormRow>
+        <EuiSpacer size="m" />
+        <EuiFormRow display="rowCompressed">
+          <EuiSwitch
+            label={i18n.SHOW_ATTACKS_ONLY_LABEL}
+            checked={showAttacksOnly}
+            onChange={handleToggleShowAttacksOnly}
+            data-test-subj={`${TABLE_SECTION_TEST_ID}-show-attacks-only-switch`}
+            compressed
+          />
+        </EuiFormRow>
+        <EuiHorizontalRule margin="s" />
+        <EuiButtonEmpty
+          iconType="gear"
+          size="s"
+          flush="left"
+          color="text"
+          onClick={showAnonymizationModal}
+          data-test-subj={`${TABLE_SECTION_TEST_ID}-anonymization-settings-button`}
+        >
+          {i18n.ANONYMIZATION_SETTINGS_LABEL}
+        </EuiButtonEmpty>
+      </EuiPopover>
+
+      {isAnonymizationModalVisible && (
+        <AnonymizationSettingsManagement modalMode onClose={closeAnonymizationModal} />
+      )}
+    </>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/translations.ts
@@ -97,3 +97,10 @@ export const SHOW_ATTACKS_ONLY_LABEL = i18n.translate(
     defaultMessage: 'Show attacks only',
   }
 );
+
+export const ANONYMIZATION_SETTINGS_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.attacks.tableSection.anonymizationSettingsLabel',
+  {
+    defaultMessage: 'Anonymization settings',
+  }
+);


### PR DESCRIPTION
## Summary

InfoSec reported that Attack discovery schedules were failing with:

> Your Security AI Anonymization settings are configured to not allow any fields. Fields must be allowed to generate Attack discoveries.

**Root cause:** the new Attacks page replaced the Attack Discovery page (#281173). The old Attack Discovery page exposed a settings button that opened the anonymization settings modal, but that access was lost in the move. Users had no UI to review or change their anonymization settings, so there was no way to allow fields again once none were allowed.

This restores that access on the new Attacks page by adding an **"Anonymization settings"** entry to the table's **"View options"** popover (alongside the existing "Show anonymized values" / "Show attacks only" toggles). It opens the same `AnonymizationSettingsManagement` modal, mirroring the earlier Attack Discovery fix (#247297).

### Changes
- Add an **"Anonymization settings"** button to `AttacksViewOptionsPopover` that opens the `AnonymizationSettingsManagement` modal.
- Add the `ANONYMIZATION_SETTINGS_LABEL` i18n string.
- Add unit tests covering the button render and modal open/close.

### Testing
1. Enable the alerts-and-attacks alignment (the new Attacks page).
2. Open the **Attacks** page → table toolbar → **View options** (controls icon).
3. Click **Anonymization settings** → the anonymization settings modal opens and fields can be allowed again.

## References
- Related: #281173 (moved the Attack Discovery page → new Attacks page)
- Related: #247297 (equivalent fix on the Attack Discovery page)

## Recordings

https://github.com/user-attachments/assets/5803bc38-dab6-4d9e-b2e7-65f84e007468


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->