### PR TITLE
[OAS Docs] Pin Dashboards & Visualizations operationIds in the API overlays

### DIFF
--- a/oas_docs/overlays/dashboards.overlays.yaml
+++ b/oas_docs/overlays/dashboards.overlays.yaml
@@ -15,7 +15,7 @@ actions:
         ## When to use this API
 
         - Use this API to define a complete, self-contained dashboard in a single payload, including inline visualizations (both data view and ES|QL based), controls, and filters.
-        - Use the [Visualizations API](visualizations#tag/Visualizations/operation/post-visualizations) to create reusable charts saved to your [visualization library](https://www.elastic.co/docs/explore-analyze/visualize/visualize-library). You can then embed them in dashboards as linked panels using their ID.
+        - Use the [Visualizations API](visualizations#tag/Visualizations/operation/create-visualization) to create reusable charts saved to your [visualization library](https://www.elastic.co/docs/explore-analyze/visualize/visualize-library). You can then embed them in dashboards as linked panels using their ID.
 
         ## Get started
 
@@ -140,7 +140,7 @@ actions:
 
         `vis`, `discover_session`, `markdown`, and `links` panels can be embedded **inline** (full config stored in the dashboard) or **linked from library** (references a library item by ID).
 
-        For the full `config` schema for visualization panels, including chart types, metric operations, and breakdowns, refer to the [Visualizations API](visualizations#tag/Visualizations/operation/post-visualizations).
+        For the full `config` schema for visualization panels, including chart types, metric operations, and breakdowns, refer to the [Visualizations API](visualizations#tag/Visualizations/operation/create-visualization).
 
         - **Inline**: use when the panel is specific to this dashboard or must work across Kibana spaces. The panel configuration goes directly inside `config`:
 
@@ -172,7 +172,7 @@ actions:
           }
           ```
 
-        - **Linked from library**: references an item in your library by its ID. Use `ref_id` with any supported panel type (`vis`, `discover_session`, `markdown`, `links`). Use the [Visualizations API](visualizations#tag/Visualizations/operation/post-visualizations) to create and retrieve IDs for visualization items.
+        - **Linked from library**: references an item in your library by its ID. Use `ref_id` with any supported panel type (`vis`, `discover_session`, `markdown`, `links`). Use the [Visualizations API](visualizations#tag/Visualizations/operation/create-visualization) to create and retrieve IDs for visualization items.
 
           ```json
           {
@@ -221,9 +221,42 @@ actions:
           }
           ```
 
-        - **`xy` charts**: `data_source` goes inside each layer. Use `BUCKET(@timestamp, 75, ?_tstart, ?_tend)` to align time-series buckets with the dashboard's selected time range. For a complete xy chart example, see the [Create a dashboard](#operation/post-dashboards) endpoint.
+        - **`xy` charts**: `data_source` goes inside each layer. Use `BUCKET(@timestamp, 75, ?_tstart, ?_tend)` to align time-series buckets with the dashboard's selected time range. For a complete xy chart example, see the [Create a dashboard](#operation/create-dashboard) endpoint.
 
       externalDocs:
         description: Dashboards documentation
         url: https://www.elastic.co/docs/explore-analyze/dashboards
       x-displayName: Dashboards
+
+  # ──────────────────────────────────────────────
+  # Operation IDs
+  # ──────────────────────────────────────────────
+  # Pin every operationId to a stable, human-readable name.
+  #
+  # Without these actions the router generates the ID from the method and the
+  # path, which produces names like `put-dashboards-id`. Those names ship to
+  # SDK and CLI code generators, where they become command and method names.
+  #
+  # These pins must survive the retirement of the bump-slim overlay. See
+  # https://github.com/elastic/kibana/issues/266195. The bump-slim overlay sets
+  # the same IDs today. Keep the two files in agreement until it is retired.
+  - target: "$.paths['/api/dashboards'].get"
+    description: "Pin operationId for GET /api/dashboards"
+    update:
+      operationId: search-dashboards
+  - target: "$.paths['/api/dashboards'].post"
+    description: "Pin operationId for POST /api/dashboards"
+    update:
+      operationId: create-dashboard
+  - target: "$.paths['/api/dashboards/{id}'].get"
+    description: "Pin operationId for GET /api/dashboards/{id}"
+    update:
+      operationId: get-dashboard
+  - target: "$.paths['/api/dashboards/{id}'].put"
+    description: "Pin operationId for PUT /api/dashboards/{id}"
+    update:
+      operationId: upsert-dashboard
+  - target: "$.paths['/api/dashboards/{id}'].delete"
+    description: "Pin operationId for DELETE /api/dashboards/{id}"
+    update:
+      operationId: delete-dashboard

--- a/oas_docs/overlays/visualizations.overlays.yaml
+++ b/oas_docs/overlays/visualizations.overlays.yaml
@@ -14,8 +14,8 @@ actions:
 
         ## When to use this API
 
-        - Use this API to create reusable charts saved to the visualization library. You can then embed them in dashboards by referencing their ID from the [Dashboards API](dashboards#tag/Dashboards/operation/post-dashboards).
-        - Use the [Dashboards API](dashboards#tag/Dashboards/operation/post-dashboards) when you want to define a complete dashboard in one request, or when you need ES|QL-based visualizations.
+        - Use this API to create reusable charts saved to the visualization library. You can then embed them in dashboards by referencing their ID from the [Dashboards API](dashboards#tag/Dashboards/operation/create-dashboard).
+        - Use the [Dashboards API](dashboards#tag/Dashboards/operation/create-dashboard) when you want to define a complete dashboard in one request, or when you need ES|QL-based visualizations.
 
         ## Get started
 
@@ -66,11 +66,11 @@ actions:
         Every visualization requires at minimum:
 
         - **`type`**: the chart to render. Each chart type has its own required fields, so the full structure of the request body depends on which `type` you specify.
-        - **`data_source`**: how data is fetched. You can reference an existing Kibana data view by ID (`"type": "data_view_reference"`), define a data view inline using an index pattern (`"type": "data_view_spec"`), or use an ES|QL query (`"type": "esql"`). Note that ES|QL is only supported via the [Dashboards API](dashboards#tag/Dashboards/operation/post-dashboards). For most chart types, `data_source` is a top-level field. For XY charts, it belongs inside each layer in `layers[]`.
+        - **`data_source`**: how data is fetched. You can reference an existing Kibana data view by ID (`"type": "data_view_reference"`), define a data view inline using an index pattern (`"type": "data_view_spec"`), or use an ES|QL query (`"type": "esql"`). Note that ES|QL is only supported via the [Dashboards API](dashboards#tag/Dashboards/operation/create-dashboard). For most chart types, `data_source` is a top-level field. For XY charts, it belongs inside each layer in `layers[]`.
 
         You can also include `query` and `filters` to apply KQL or Lucene filters to all chart data. Both are optional and can be omitted.
 
-        Everything else is chart-specific: `layers` for XY charts, `metrics` for metric charts, and so on. Refer to the request schema on the [Create a visualization](#operation/post-visualizations) endpoint for the full shape of each type.
+        Everything else is chart-specific: `layers` for XY charts, `metrics` for metric charts, and so on. Refer to the request schema on the [Create a visualization](#operation/create-visualization) endpoint for the full shape of each type.
 
         ### Chart types
 
@@ -93,3 +93,36 @@ actions:
         description: Visualizations documentation
         url: https://www.elastic.co/docs/explore-analyze/visualize/lens
       x-displayName: Visualizations
+
+  # ──────────────────────────────────────────────
+  # Operation IDs
+  # ──────────────────────────────────────────────
+  # Pin every operationId to a stable, human-readable name.
+  #
+  # Without these actions the router generates the ID from the method and the
+  # path, which produces names like `put-visualizations-id`. Those names ship to
+  # SDK and CLI code generators, where they become command and method names.
+  #
+  # These pins must survive the retirement of the bump-slim overlay. See
+  # https://github.com/elastic/kibana/issues/266195. The bump-slim overlay sets
+  # the same IDs today. Keep the two files in agreement until it is retired.
+  - target: "$.paths['/api/visualizations'].get"
+    description: "Pin operationId for GET /api/visualizations"
+    update:
+      operationId: search-visualizations
+  - target: "$.paths['/api/visualizations'].post"
+    description: "Pin operationId for POST /api/visualizations"
+    update:
+      operationId: create-visualization
+  - target: "$.paths['/api/visualizations/{id}'].get"
+    description: "Pin operationId for GET /api/visualizations/{id}"
+    update:
+      operationId: get-visualization
+  - target: "$.paths['/api/visualizations/{id}'].put"
+    description: "Pin operationId for PUT /api/visualizations/{id}"
+    update:
+      operationId: upsert-visualization
+  - target: "$.paths['/api/visualizations/{id}'].delete"
+    description: "Pin operationId for DELETE /api/visualizations/{id}"
+    update:
+      operationId: delete-visualization


### PR DESCRIPTION
## Summary

Pins the 10 Dashboards and Visualizations operation IDs in the per-API overlays. `oas_docs` only, no code change.

## Why

`operationId` is not just a documentation anchor. Elastic CLI derives its command names from it, and SDK generators derive method names the same way. These are the same operation:

```
kb dashboards upsert-dashboard
kb dashboards put-dashboards-id
```

Only one of them is usable. The second is what the OAS generator produces, because it derives every ID mechanically from method and path.

The readable names that ship today come from the bump-slim overlay. That overlay will eventually retire under #266195. Without a replacement the IDs revert to the generated form and every generated command is renamed a second time.

The per-API overlays are applied in both pipelines, before bump-slim in one and without it in the other. Pins placed there outlive the retirement.

Explicit IDs are already established practice in Kibana. 817 of them are hand-authored across 299 spec files (`CreateRuleMigration`, `AttackDiscoveryFind`), and the generator's own docstring calls itself "best effort".

## What changed

Five `update` actions per overlay file, pinning `search-dashboards`, `create-dashboard`, `get-dashboard`, `upsert-dashboard`, `delete-dashboard`, and the visualizations equivalents. Tag description cross-links updated to match.

## longer-term fix: #284350

That one adds an `operationId` route option, so the name comes from the route instead of the docs pipeline. More correct: the ID sits with the API definition.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->