### PR TITLE
[8.19] Fix flaky ES client tests when they run in parallel (#284008)

### DIFF
--- a/src/core/server/integration_tests/elasticsearch/client.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/client.test.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { esTestConfig } from '@kbn/test';
 import * as http from 'http';
+import type { AddressInfo } from 'net';
 import { firstValueFrom, ReplaySubject } from 'rxjs';
 
 import { Root } from '@kbn/core-root-server-internal';
@@ -60,15 +60,16 @@ describe('elasticsearch clients', () => {
   });
 });
 
-function createFakeElasticsearchServer() {
-  const server = http.createServer((req, res) => {
-    // Reply with a 200 and empty response by default (intentionally malformed response)
-    res.writeHead(200);
-    res.end();
+function createFakeElasticsearchServer(): Promise<http.Server> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      // Reply with a 200 and empty response by default (intentionally malformed response)
+      res.writeHead(200);
+      res.end();
+    });
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve(server));
   });
-  server.listen(esTestConfig.getPort());
-
-  return server;
 }
 
 describe('fake elasticsearch', () => {
@@ -77,8 +78,13 @@ describe('fake elasticsearch', () => {
   let esStatus$: ReplaySubject<ServiceStatus<ElasticsearchStatusMeta>>;
 
   beforeAll(async () => {
-    kibanaServer = createRootWithCorePlugins({ status: { allowAnonymous: true } });
-    esServer = createFakeElasticsearchServer();
+    esServer = await createFakeElasticsearchServer();
+    kibanaServer = createRootWithCorePlugins({
+      elasticsearch: {
+        hosts: [`http://127.0.0.1:${(esServer.address() as AddressInfo).port}`],
+      },
+      status: { allowAnonymous: true },
+    });
 
     await kibanaServer.preboot();
     const { elasticsearch } = await kibanaServer.setup();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix flaky ES client tests when they run in parallel (#284008)](https://github.com/elastic/kibana/pull/284008)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michael Dokolin","email":"mikhail.dokolin@elastic.co"},"sourceCommit":{"committedDate":"2026-08-11T08:07:54Z","message":"Fix flaky ES client tests when they run in parallel (#284008)\n\nFixes #171294.\nFixes #171295.","sha":"8b24f06fd7acf08be5897c9832bb770e0965cf22","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:all-open","v9.6.0","v9.5.1"],"title":"Fix flaky ES client tests when they run in parallel","number":284008,"url":"https://github.com/elastic/kibana/pull/284008","mergeCommit":{"message":"Fix flaky ES client tests when they run in parallel (#284008)\n\nFixes #171294.\nFixes #171295.","sha":"8b24f06fd7acf08be5897c9832bb770e0965cf22"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284008","number":284008,"mergeCommit":{"message":"Fix flaky ES client tests when they run in parallel (#284008)\n\nFixes #171294.\nFixes #171295.","sha":"8b24f06fd7acf08be5897c9832bb770e0965cf22"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/284297","number":284297,"state":"MERGED","mergeCommit":{"sha":"f27693a20b9ba7015eb7414e8f26dee2f4ebb056","message":"[9.5] Fix flaky ES client tests when they run in parallel (#284008) (#284297)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [Fix flaky ES client tests when they run in parallel\n(#284008)](https://github.com/elastic/kibana/pull/284008)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Michael Dokolin <mikhail.dokolin@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/284296","number":284296,"branch":"9.4","state":"OPEN"}]}] BACKPORT-->