### PR TITLE
[Security Solution] Adjust Attack Discovery "has moved" empty-state copy and layout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/attack_discovery_moved/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/attack_discovery_moved/index.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { EuiEmptyPrompt, EuiImage, EuiLink, EuiText } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiImage, EuiLink, EuiSpacer, EuiTextColor } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -86,6 +87,13 @@ const AttackDiscoveryMovedPageComponent: React.FC = () => {
     <>
       <EuiEmptyPrompt
         data-test-subj="attackDiscoveryMovedPage"
+        css={css`
+          // Let each body line sit on a single line on wide screens, while the built-in
+          // 'max-width: max-content' still lets the prompt shrink and wrap on smaller ones.
+          .euiEmptyPrompt__content {
+            max-inline-size: none;
+          }
+        `}
         icon={
           <EuiImage
             url={isDarkMode ? simplifyDarkSvg : simplifyLightSvg}
@@ -96,17 +104,34 @@ const AttackDiscoveryMovedPageComponent: React.FC = () => {
         title={<h2 data-test-subj="attackDiscoveryMovedTitle">{TITLE}</h2>}
         titleSize="m"
         body={
-          <p data-test-subj="attackDiscoveryMovedBody">
-            <FormattedMessage
-              id="xpack.securitySolution.attackDiscovery.moved.description"
-              defaultMessage="{attackDiscovery} now exists as {attacks} and is located under {detections} in the side navigation"
-              values={{
-                attackDiscovery: <em>{ATTACK_DISCOVERY_LABEL}</em>,
-                attacks: <em>{ATTACKS_LABEL}</em>,
-                detections: <strong>{DETECTIONS_LABEL}</strong>,
-              }}
-            />
-          </p>
+          <>
+            <EuiSpacer size="s" />
+            <p data-test-subj="attackDiscoveryMovedBody">
+              <EuiTextColor color="default">
+                <FormattedMessage
+                  id="xpack.securitySolution.attackDiscovery.moved.description"
+                  defaultMessage="{attackDiscovery} now exists as {attacks} and is located under {detections} in the side navigation."
+                  values={{
+                    attackDiscovery: <em>{ATTACK_DISCOVERY_LABEL}</em>,
+                    attacks: <em>{ATTACKS_LABEL}</em>,
+                    detections: <strong>{DETECTIONS_LABEL}</strong>,
+                  }}
+                />
+              </EuiTextColor>
+              <br />
+              <EuiTextColor color="subdued" data-test-subj="attackDiscoveryMovedOptOut">
+                <FormattedMessage
+                  id="xpack.securitySolution.attackDiscovery.moved.optOut"
+                  defaultMessage="Prefer the previous experience? Disable alerts and attacks alignment in {advancedSettingsLink}."
+                  values={{
+                    advancedSettingsLink: (
+                      <EuiLink href={advancedSettingsUrl}>{ADVANCED_SETTINGS_LABEL}</EuiLink>
+                    ),
+                  }}
+                />
+              </EuiTextColor>
+            </p>
+          </>
         }
         actions={
           <SecuritySolutionLinkButton
@@ -117,19 +142,6 @@ const AttackDiscoveryMovedPageComponent: React.FC = () => {
           >
             {GO_TO_ATTACKS_BUTTON}
           </SecuritySolutionLinkButton>
-        }
-        footer={
-          <EuiText size="s" color="subdued" data-test-subj="attackDiscoveryMovedOptOut">
-            <FormattedMessage
-              id="xpack.securitySolution.attackDiscovery.moved.optOut"
-              defaultMessage="Prefer the previous experience? Disable alerts and attacks alignment in {advancedSettingsLink}."
-              values={{
-                advancedSettingsLink: (
-                  <EuiLink href={advancedSettingsUrl}>{ADVANCED_SETTINGS_LABEL}</EuiLink>
-                ),
-              }}
-            />
-          </EuiText>
         }
       />
 


### PR DESCRIPTION
## Summary

Follow-up copy and layout adjustments to the Attack Discovery "has moved" empty state introduced in #281173 (shown when the _alerts and attacks alignment_ advanced setting is enabled).

Changes:

- **Copy** — the opt-out note now lives in the description instead of a separate footer:
  - **Title:** `Attack Discovery has moved`
  - **Description (line 1):** _Attack Discovery_ now exists as _Attacks_ and is located under **Detections** in the side navigation.
  - **Description (line 2, subdued):** Prefer the previous experience? Disable alerts and attacks alignment in [Advanced Settings](http://localhost:5601/app/management/kibana/settings?query=alerts%20and%20attacks%20alignment).
- **Layout**
  - Both lines are now part of the same paragraph; the second line is rendered as subdued text.
  - Added extra spacing between the title and the description.
  - Widened the prompt content so each line fits on a single line on wide screens, while still wrapping/shrinking on smaller screens.
- Removed the footer entirely.

## Screenshots

<!-- Attach before/after screenshots of the Attack Discovery "has moved" empty state here. -->

| Before | After |
| --- | --- |
| <img width="1840" height="1196" alt="Screenshot 2026-08-11 at 12 45 13" src="https://github.com/user-attachments/assets/26b84007-d707-4852-ac2d-c688291598df" /> | <img width="1840" height="1196" alt="Screenshot 2026-08-11 at 12 38 19" src="https://github.com/user-attachments/assets/7b30a437-2ecc-4188-92cc-375fbe512d24" /> |

## Release notes

Skipped — internal copy/layout tweak with no functional change.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- Presentational-only change to an existing empty state; no functional or API impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->