### PR TITLE
[Security Solution][Entity Analytics] Raise base-scoring ES request timeout to 5m

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/steps/score_base_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/steps/score_base_entities.ts
@@ -24,6 +24,19 @@ import { fetchEntitiesByIds } from '../utils/fetch_entities_by_ids';
 import type { ScopedLogger } from '../utils/with_log_context';
 import { persistScoresToEntityStore, persistScoresToRiskIndex } from './persist_scores';
 
+/**
+ * Per-request ES timeout for base-scoring queries.
+ *
+ * Kibana's ES client defaults to a 30s `requestTimeout`. The composite EUID
+ * pagination and per-page ES|QL scoring queries against large alert indices
+ * routinely exceed that (observed on serverless `user` base scoring), throwing
+ * "Request timed out" and failing the entire base-scoring pass. Raise it to 5m
+ * — matching `risk_score_data_client` — while staying under the ~5m cloud proxy
+ * ceiling. This does not speed the queries up; it stops the client from
+ * aborting otherwise-healthy long-running requests.
+ */
+const BASE_SCORING_REQUEST_TIMEOUT = '5m';
+
 interface ScoreBaseEntitiesParams {
   esClient: ElasticsearchClient;
   crudClient: EntityUpdateClient;
@@ -234,7 +247,8 @@ const fetchNextEuidPage = async ({
       index: alertsIndex,
       pageSize,
       afterKey,
-    })
+    }),
+    { requestTimeout: BASE_SCORING_REQUEST_TIMEOUT }
   );
 
   const compositeAgg = (
@@ -269,10 +283,13 @@ const scorePageFromAlerts = async ({
   alertFilters: QueryDslQueryContainer[];
 }): Promise<ParsedRiskScore[]> => {
   const query = getBaseScoreESQL(entityType, bounds, sampleSize, pageSize, alertsIndex);
-  const esqlResponse = await esClient.esql.query({
-    query,
-    filter: { bool: { filter: alertFilters } },
-  });
+  const esqlResponse = await esClient.esql.query(
+    {
+      query,
+      filter: { bool: { filter: alertFilters } },
+    },
+    { requestTimeout: BASE_SCORING_REQUEST_TIMEOUT }
+  );
 
   return (esqlResponse.values ?? []).map(parseEsqlBaseScoreRow(alertsIndex));
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/steps/score_base_entities.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/steps/score_base_entities.ts
@@ -24,17 +24,6 @@ import { fetchEntitiesByIds } from '../utils/fetch_entities_by_ids';
 import type { ScopedLogger } from '../utils/with_log_context';
 import { persistScoresToEntityStore, persistScoresToRiskIndex } from './persist_scores';
 
-/**
- * Per-request ES timeout for base-scoring queries.
- *
- * Kibana's ES client defaults to a 30s `requestTimeout`. The composite EUID
- * pagination and per-page ES|QL scoring queries against large alert indices
- * routinely exceed that (observed on serverless `user` base scoring), throwing
- * "Request timed out" and failing the entire base-scoring pass. Raise it to 5m
- * — matching `risk_score_data_client` — while staying under the ~5m cloud proxy
- * ceiling. This does not speed the queries up; it stops the client from
- * aborting otherwise-healthy long-running requests.
- */
 const BASE_SCORING_REQUEST_TIMEOUT = '5m';
 
 interface ScoreBaseEntitiesParams {


### PR DESCRIPTION
## Summary

Risk-score base-scoring queries were failing on large envs because Kibana's ES client uses a default `requestTimeout` of **30s**, while the base-scoring pass issues long-running queries against large alert indices:

- **Composite EUID pagination** (`esClient.search`) — walks unique entity IDs page by page.
- **Per-page base-scoring ES|QL** (`esClient.esql.query`) — scores each page with `MV_PSERIES_WEIGHTED_SUM`.

On a serverless project we observed **`user` base scoring timing out every hour** with `Request timed out`, failing the entire base-scoring pass, while `host` and `service` (cheaper EUID evaluation) completed fine.

This PR sets an explicit **5m** `requestTimeout` on both calls via a shared `BASE_SCORING_REQUEST_TIMEOUT` constant. `5m` matches the timeout already used in `risk_score_data_client` and stays under the ~5m cloud proxy ceiling.

Related: https://github.com/elastic/security-team/issues/18624

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->