### PR TITLE
[Synthetics] Update Scout policy fixtures for certificate_error_spki_allowlist

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/project_monitors/api/fixtures/data/test_policy.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/project_monitors/api/fixtures/data/test_policy.ts
@@ -431,6 +431,7 @@ export const getBrowserInput = ({ id, params, isBrowser }: PolicyProps) => {
         screenshots: { value: 'on', type: 'text' },
         synthetics_args: { value: null, type: 'text' },
         ignore_https_errors: { value: false, type: 'bool' },
+        certificate_error_spki_allowlist: { type: 'yaml' },
         'throttling.config': {
           value: JSON.stringify({ download: 5, upload: 3, latency: 20 }),
           type: 'text',
@@ -472,6 +473,7 @@ export const getBrowserInput = ({ id, params, isBrowser }: PolicyProps) => {
         screenshots: { type: 'text' },
         synthetics_args: { type: 'text' },
         ignore_https_errors: { type: 'bool' },
+        certificate_error_spki_allowlist: { type: 'yaml' },
         'throttling.config': { type: 'text' },
         'filter_journeys.tags': { type: 'yaml' },
         'filter_journeys.match': { type: 'text' },

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/project_monitors/api/fixtures/data/test_project_monitor_policy.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/project_monitors/api/fixtures/data/test_project_monitor_policy.ts
@@ -432,6 +432,7 @@ export const getTestProjectSyntheticsPolicyLightweight = (
             screenshots: { type: 'text' },
             synthetics_args: { type: 'text' },
             ignore_https_errors: { type: 'bool' },
+            certificate_error_spki_allowlist: { type: 'yaml' },
             'throttling.config': {
               type: 'text',
             },
@@ -757,6 +758,7 @@ export const getTestProjectSyntheticsPolicy = (
             screenshots: { value: 'on', type: 'text' },
             synthetics_args: { value: null, type: 'text' },
             ignore_https_errors: { value: false, type: 'bool' },
+            certificate_error_spki_allowlist: { type: 'yaml' },
             'throttling.config': {
               value: JSON.stringify({ download: 5, upload: 3, latency: 20 }),
               type: 'text',

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/project_monitors/api/tests/create_monitor_project_private_location.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/project_monitors/api/tests/create_monitor_project_private_location.spec.ts
@@ -50,8 +50,7 @@ type ProjectMonitor = Record<string, any>;
 
 const MONITOR_SO_TYPES = [syntheticsMonitorSavedObjectType, 'synthetics-monitor'];
 
-// Failing: See https://github.com/elastic/kibana/issues/284369
-apiTest.describe.skip(
+apiTest.describe(
   'AddProjectMonitorsPrivateLocations',
   { tag: ['@local-stateful-classic', '@local-serverless-observability_complete'] },
   () => {


### PR DESCRIPTION
## Summary
- Fleet's `synthetics` package now includes `certificate_error_spki_allowlist` (`{ type: 'yaml' }`) on the browser data stream, so Scout `comparePolicies` `toStrictEqual` asserts failed against stale expected fixtures.
- Add the var to browser stream `vars` in `getTestProjectSyntheticsPolicy`, the lightweight variant, and `getBrowserInput` — matching the package type (`yaml`, no value when unset), not `text`.

Closes #284369
Closes #284370
Closes #284371

> Note: open feature PR #284094 also touches these fixtures but currently expects `{ value: null, type: 'text' }`, which would still fail against the package. This PR unblocks `main` with the package-accurate shape; #284094 should rebase onto this (or align its fixture type to `yaml`).

## Test plan
- [ ] Confirm CI Scout `project_monitors` API suite is green (`create_monitor_project_private_location` policy create/update/delete cases)
- [ ] Spot-check fixture shape matches compiled policy `vars.certificate_error_spki_allowlist: { type: 'yaml' }`