### PR TITLE
[Chrome Next] Fix global search modal blocking confirmation modals

### DIFF
--- a/x-pack/platform/plugins/private/global_search_bar/public/components/types.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/types.ts
@@ -33,5 +33,5 @@ export interface SearchBarProps extends SearchProps {
 
 /* @internal */
 export interface SearchModalProps extends SearchProps {
-  onClose: () => void;
+  onClose: () => void | Promise<void>;
 }

--- a/x-pack/platform/plugins/private/global_search_bar/public/plugin.test.ts
+++ b/x-pack/platform/plugins/private/global_search_bar/public/plugin.test.ts
@@ -8,8 +8,24 @@
 import { coreMock } from '@kbn/core/public/mocks';
 import { globalSearchPluginMock } from '@kbn/global-search-plugin/public/mocks';
 import { GlobalSearchBarPlugin } from './plugin';
+import type { SearchModalProps } from './components/types';
+
+let lastSearchModalProps: SearchModalProps | undefined;
+
+jest.mock('@kbn/react-kibana-mount', () => ({
+  toMountPoint: (node: React.ReactElement) => {
+    if (node?.props) {
+      lastSearchModalProps = node.props as SearchModalProps;
+    }
+    return () => () => undefined;
+  },
+}));
 
 describe('GlobalSearchBarPlugin', () => {
+  beforeEach(() => {
+    lastSearchModalProps = undefined;
+  });
+
   describe('start', () => {
     const createPlugin = () => {
       return new GlobalSearchBarPlugin(
@@ -56,6 +72,51 @@ describe('GlobalSearchBarPlugin', () => {
       });
 
       expect(setSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('awaits search overlay close before navigateToUrl from the search modal', async () => {
+      const coreSetup = coreMock.createSetup();
+      const service = createPlugin();
+      service.setup(coreSetup);
+
+      const coreStart = coreMock.createStart();
+      jest.spyOn(coreStart.chrome.next, 'isEnabled', 'get').mockReturnValue(true);
+
+      let resolveClose: () => void = () => {};
+      const onClosePromise = new Promise<void>((resolve) => {
+        resolveClose = resolve;
+      });
+      const overlayRef = {
+        close: jest.fn().mockReturnValue(onClosePromise),
+        onClose: onClosePromise,
+      };
+      coreStart.overlays.openModal = jest.fn().mockReturnValue(overlayRef);
+
+      const order: string[] = [];
+      jest.spyOn(coreStart.application, 'navigateToUrl').mockImplementation(async () => {
+        order.push('navigate');
+      });
+
+      service.start(coreStart, {
+        globalSearch: globalSearchPluginMock.createStartContract(),
+      });
+
+      const onClick = (coreStart.chrome.next.globalSearch.set as jest.Mock).mock.calls[0][0]
+        .onClick as () => void;
+      onClick();
+
+      expect(coreStart.overlays.openModal).toHaveBeenCalledTimes(1);
+      expect(lastSearchModalProps).toBeDefined();
+
+      const navigatePromise = lastSearchModalProps!.navigateToUrl('/app/discover');
+      expect(overlayRef.close).toHaveBeenCalledTimes(1);
+      expect(coreStart.application.navigateToUrl).not.toHaveBeenCalled();
+
+      resolveClose();
+      await navigatePromise;
+
+      expect(coreStart.application.navigateToUrl).toHaveBeenCalledWith('/app/discover', undefined);
+      expect(order).toEqual(['navigate']);
     });
   });
 });

--- a/x-pack/platform/plugins/private/global_search_bar/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/plugin.tsx
@@ -6,6 +6,7 @@
  */
 
 import type {
+  ApplicationStart,
   CoreSetup,
   CoreStart,
   OverlayRef,
@@ -59,15 +60,38 @@ export class GlobalSearchBarPlugin implements Plugin<{}, {}, {}, GlobalSearchBar
     };
 
     let activeModalRef: OverlayRef | null = null;
+    let closingPromise: Promise<void> | null = null;
 
-    const closeModal = () => {
-      activeModalRef?.close();
+    const closeModal = (): Promise<void> => {
+      if (closingPromise) {
+        return closingPromise;
+      }
+
+      const ref = activeModalRef;
       activeModalRef = null;
+      if (!ref) {
+        return Promise.resolve();
+      }
+
+      // Share the in-flight close so navigate-from-search can await the same unmount
+      // even if onResultSelect already started closing the overlay.
+      closingPromise = ref.close().finally(() => {
+        closingPromise = null;
+      });
+      return closingPromise;
+    };
+
+    // Close the search overlay and wait for ModalService cleanup before navigating.
+    // Otherwise leave-confirm (openConfirm) replaces the search modal mid-click and
+    // the confirm buttons become inert (single-slot overlays modal host).
+    const navigateFromSearchModal: ApplicationStart['navigateToUrl'] = async (url, options) => {
+      await closeModal();
+      return application.navigateToUrl(url, options);
     };
 
     const toggleSearchModal = () => {
-      if (activeModalRef) {
-        closeModal();
+      if (activeModalRef || closingPromise) {
+        void closeModal();
         return;
       }
 
@@ -75,9 +99,8 @@ export class GlobalSearchBarPlugin implements Plugin<{}, {}, {}, GlobalSearchBar
         toMountPoint(
           <SearchModal
             {...searchProps}
-            onClose={() => {
-              closeModal();
-            }}
+            navigateToUrl={navigateFromSearchModal}
+            onClose={closeModal}
           />,
           core
         ),


### PR DESCRIPTION
## Summary

This PR fixes a bug where in Chrome Next, opening global search modal and trying to navigate away while having unsaved changes in Lens, would make the unsaved changes confirmation modal unusable. The bug was not specific to Lens, it was a gap in the new global search modal. 

Closes: https://github.com/elastic/kibana/issues/284352


