### PR TITLE
[Lens][FTR] Skip serverless smokescreen suite on MKI

### DIFF
--- a/x-pack/platform/test/serverless/functional/test_suites/visualizations/group1/smokescreen.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/visualizations/group1/smokescreen.ts
@@ -19,7 +19,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const filterBar = getService('filterBar');
   const config = getService('config');
 
-  describe('lens smokescreen tests', () => {
+  // Flaky on MKI (#kibana-serverless-test-alerts); keep local serverless coverage.
+  // Tracking: https://github.com/elastic/kibana/issues/282284
+  describe('lens smokescreen tests', function () {
+    this.tags(['skipMKI']);
+
     before(async () => {
       await PageObjects.svlCommonPage.loginWithPrivilegedRole();
     });


### PR DESCRIPTION
## Summary
Temporarily skips the Lens serverless **smokescreen** suite on MKI only (`skipMKI`), so local serverless / PR CI keeps running it. We are planning to migrate these Serverless tests in this ticket: https://github.com/elastic/kibana/issues/282284

### Failure overview (last ~5 days)
Recurring flakes in `lens serverless - group 1 - subgroup 1 lens smokescreen tests`:

|Test|Failure|
|---|---|
|`should transition from unique count to last value` (most frequent) | #283191, #283188 |
|`should allow creation of a multi-axis chart and switching multiple times` | #283902, #284031 |
|`should override axis title` | #284101|
|`should transition from a multi-layer stacked bar to treemap chart using suggestions` | #274962|
| `should create a heatmap chart and transition to barchart` | #283949|
|`should allow creation of lens xy chart` / save timeouts||
|`should create a valid XY chart with references`||
|`should allow filtering by legend on an xy/pie chart` | #283766, #284036|
|`should be able to add very long labels…` | #283894, #284334, #284338|
|`should keep the field selection while transitioning to every reference-based operation` | #283943|
| Suite `"before all"` hook failures (also co-failed with vega on some runs)||



Made with [Cursor](https://cursor.com)