### PR TITLE
[9.4] [Discover] Fix flaky search_source_alert confirm modal timeout when changing data view title (#265736)

### DIFF
--- a/x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/discover/search_source_alert.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/discover/search_source_alert.ts
@@ -546,9 +546,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       // change title
       await testSubjects.click('editIndexPatternButton');
-      await testSubjects.setValue('createIndexPatternTitleInput', 'search-s', {
-        clearWithKeyboard: true,
-        typeCharByChar: true,
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await retry.try(async () => {
+        await PageObjects.settings.setIndexPatternField('search-s*');
       });
       await testSubjects.click('saveIndexPatternButton');
       await testSubjects.click('confirmModalConfirmButton');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Discover] Fix flaky search_source_alert confirm modal timeout when changing data view title (#265736)](https://github.com/elastic/kibana/pull/265736)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-06T10:00:14Z","message":"[Discover] Fix flaky search_source_alert confirm modal timeout when changing data view title (#265736)\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexmarhaba <98395372+alexmarhaba@users.noreply.github.com>\nCo-authored-by: Matthias Polman <matthias.wilhelm@elastic.co>","sha":"95ff7ebc4b02f8c7a990aa71dafd7449cb0f1d79","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","💝community","Team:DataDiscovery","backport:version","v9.4.0","v9.5.0","v9.6.0"],"title":"Fix flaky test: search_source_alert confirm modal timeout when changing data view title","number":265736,"url":"https://github.com/elastic/kibana/pull/265736","mergeCommit":{"message":"[Discover] Fix flaky search_source_alert confirm modal timeout when changing data view title (#265736)\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexmarhaba <98395372+alexmarhaba@users.noreply.github.com>\nCo-authored-by: Matthias Polman <matthias.wilhelm@elastic.co>","sha":"95ff7ebc4b02f8c7a990aa71dafd7449cb0f1d79"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265736","number":265736,"mergeCommit":{"message":"[Discover] Fix flaky search_source_alert confirm modal timeout when changing data view title (#265736)\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexmarhaba <98395372+alexmarhaba@users.noreply.github.com>\nCo-authored-by: Matthias Polman <matthias.wilhelm@elastic.co>","sha":"95ff7ebc4b02f8c7a990aa71dafd7449cb0f1d79"}}]}] BACKPORT-->