### PR TITLE
[kbn-evals] Bound request string lengths in evals API schemas

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/add_examples_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/add_examples_route.gen.ts
@@ -27,7 +27,7 @@ export type AddExamplesPayload = z.infer<typeof AddExamplesPayload>;
 
 export const AddEvaluationDatasetExamplesRequestParams = lazySchema(() =>
   z.object({
-    datasetId: z.string(),
+    datasetId: z.string().max(1024),
   })
 );
 export type AddEvaluationDatasetExamplesRequestParams = z.infer<

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/add_examples_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/add_examples_route.gen.ts
@@ -39,7 +39,7 @@ export type AddEvaluationDatasetExamplesRequestParamsInput = z.input<
 
 export const AddEvaluationDatasetExamplesRequestBody = lazySchema(() =>
   z.object({
-    examples: z.array(AddExamplesPayload),
+    examples: z.array(AddExamplesPayload).max(10000),
   })
 );
 export type AddEvaluationDatasetExamplesRequestBody = z.infer<

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/add_examples_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/add_examples_route.schema.yaml
@@ -28,6 +28,8 @@ paths:
               properties:
                 examples:
                   type: array
+                  # Keep in sync with MAX_EXAMPLES_PER_DATASET in constants.ts
+                  maxItems: 10000
                   items:
                     $ref: '#/components/schemas/AddExamplesPayload'
               required:

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/add_examples_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/add_examples_route.schema.yaml
@@ -18,6 +18,7 @@ paths:
           required: true
           schema:
             type: string
+            maxLength: 1024
       requestBody:
         required: true
         content:

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/delete_dataset_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/delete_dataset_route.gen.ts
@@ -18,7 +18,7 @@ import { z, lazySchema } from '@kbn/zod/v4';
 
 export const DeleteEvaluationDatasetRequestParams = lazySchema(() =>
   z.object({
-    datasetId: z.string(),
+    datasetId: z.string().max(1024),
   })
 );
 export type DeleteEvaluationDatasetRequestParams = z.infer<

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/delete_dataset_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/delete_dataset_route.schema.yaml
@@ -18,6 +18,7 @@ paths:
           required: true
           schema:
             type: string
+            maxLength: 1024
       responses:
         "200":
           description: Successful response

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/delete_example_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/delete_example_route.gen.ts
@@ -18,8 +18,8 @@ import { z, lazySchema } from '@kbn/zod/v4';
 
 export const DeleteEvaluationDatasetExampleRequestParams = lazySchema(() =>
   z.object({
-    datasetId: z.string(),
-    exampleId: z.string(),
+    datasetId: z.string().max(1024),
+    exampleId: z.string().max(1024),
   })
 );
 export type DeleteEvaluationDatasetExampleRequestParams = z.infer<

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/delete_example_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/delete_example_route.schema.yaml
@@ -18,11 +18,13 @@ paths:
           required: true
           schema:
             type: string
+            maxLength: 1024
         - name: exampleId
           in: path
           required: true
           schema:
             type: string
+            maxLength: 1024
       responses:
         "200":
           description: Successful response

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/get_dataset_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/get_dataset_route.gen.ts
@@ -32,7 +32,7 @@ export type DatasetExample = z.infer<typeof DatasetExample>;
 
 export const GetEvaluationDatasetRequestParams = lazySchema(() =>
   z.object({
-    datasetId: z.string(),
+    datasetId: z.string().max(1024),
   })
 );
 export type GetEvaluationDatasetRequestParams = z.infer<typeof GetEvaluationDatasetRequestParams>;

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/get_dataset_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/get_dataset_route.schema.yaml
@@ -18,6 +18,7 @@ paths:
           required: true
           schema:
             type: string
+            maxLength: 1024
       responses:
         '200':
           description: Successful response

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/update_dataset_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/update_dataset_route.gen.ts
@@ -20,7 +20,7 @@ import { DatasetTags, DatasetMaturity } from '../common_attributes.gen';
 
 export const UpdateEvaluationDatasetRequestParams = lazySchema(() =>
   z.object({
-    datasetId: z.string(),
+    datasetId: z.string().max(1024),
   })
 );
 export type UpdateEvaluationDatasetRequestParams = z.infer<

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/update_dataset_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/update_dataset_route.schema.yaml
@@ -18,6 +18,7 @@ paths:
           required: true
           schema:
             type: string
+            maxLength: 1024
       requestBody:
         required: true
         content:

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/update_example_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/update_example_route.gen.ts
@@ -27,8 +27,8 @@ export type UpdateExamplePayload = z.infer<typeof UpdateExamplePayload>;
 
 export const UpdateEvaluationDatasetExampleRequestParams = lazySchema(() =>
   z.object({
-    datasetId: z.string(),
-    exampleId: z.string(),
+    datasetId: z.string().max(1024),
+    exampleId: z.string().max(1024),
   })
 );
 export type UpdateEvaluationDatasetExampleRequestParams = z.infer<

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/update_example_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/datasets/update_example_route.schema.yaml
@@ -18,11 +18,13 @@ paths:
           required: true
           schema:
             type: string
+            maxLength: 1024
         - name: exampleId
           in: path
           required: true
           schema:
             type: string
+            maxLength: 1024
       requestBody:
         required: true
         content:

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/examples/get_example_scores_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/examples/get_example_scores_route.gen.ts
@@ -20,7 +20,7 @@ import { EvaluationScoreDocument } from '../common_attributes.gen';
 
 export const GetExampleScoresRequestParams = lazySchema(() =>
   z.object({
-    exampleId: z.string(),
+    exampleId: z.string().max(1024),
   })
 );
 export type GetExampleScoresRequestParams = z.infer<typeof GetExampleScoresRequestParams>;

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/examples/get_example_scores_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/examples/get_example_scores_route.schema.yaml
@@ -18,6 +18,7 @@ paths:
           required: true
           schema:
             type: string
+            maxLength: 1024
       responses:
         "200":
           description: Successful response

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/traces/get_trace_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/traces/get_trace_route.gen.ts
@@ -20,7 +20,7 @@ import { TraceSpan } from '../common_attributes.gen';
 
 export const GetTraceRequestParams = lazySchema(() =>
   z.object({
-    traceId: z.string(),
+    traceId: z.string().max(256),
   })
 );
 export type GetTraceRequestParams = z.infer<typeof GetTraceRequestParams>;

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/traces/get_trace_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/traces/get_trace_route.schema.yaml
@@ -18,6 +18,7 @@ paths:
           required: true
           schema:
             type: string
+            maxLength: 256
       responses:
         "200":
           description: Successful response

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/tracing/get_project_traces_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/tracing/get_project_traces_route.gen.ts
@@ -45,15 +45,15 @@ export const GetProjectTracesRequestQuery = lazySchema(() =>
     /**
      * Start of time range (ISO 8601)
      */
-    from: z.string().optional(),
+    from: z.string().max(64).optional(),
     /**
      * End of time range (ISO 8601)
      */
-    to: z.string().optional(),
+    to: z.string().max(64).optional(),
     /**
      * Filter traces by input, output, or prompt ID content
      */
-    name: z.string().optional(),
+    name: z.string().max(256).optional(),
     sort_field: z.enum(['start_time', 'duration', 'name']).optional().default('start_time'),
     sort_order: z.enum(['asc', 'desc']).optional().default('desc'),
     page: z.coerce.number().int().min(1).optional().default(1),
@@ -65,7 +65,7 @@ export type GetProjectTracesRequestQueryInput = z.input<typeof GetProjectTracesR
 
 export const GetProjectTracesRequestParams = lazySchema(() =>
   z.object({
-    projectName: z.string(),
+    projectName: z.string().max(256),
   })
 );
 export type GetProjectTracesRequestParams = z.infer<typeof GetProjectTracesRequestParams>;

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/tracing/get_project_traces_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/tracing/get_project_traces_route.schema.yaml
@@ -18,23 +18,27 @@ paths:
           required: true
           schema:
             type: string
+            maxLength: 256
         - name: from
           in: query
           required: false
           schema:
             type: string
+            maxLength: 64
           description: Start of time range (ISO 8601)
         - name: to
           in: query
           required: false
           schema:
             type: string
+            maxLength: 64
           description: End of time range (ISO 8601)
         - name: name
           in: query
           required: false
           schema:
             type: string
+            maxLength: 256
           description: Filter traces by input, output, or prompt ID content
         - name: sort_field
           in: query

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/tracing/get_tracing_projects_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/tracing/get_tracing_projects_route.gen.ts
@@ -37,15 +37,15 @@ export const GetTracingProjectsRequestQuery = lazySchema(() =>
     /**
      * Start of time range (ISO 8601)
      */
-    from: z.string().optional(),
+    from: z.string().max(64).optional(),
     /**
      * End of time range (ISO 8601)
      */
-    to: z.string().optional(),
+    to: z.string().max(64).optional(),
     /**
      * Filter projects by name (case-insensitive substring match)
      */
-    name: z.string().optional(),
+    name: z.string().max(256).optional(),
     page: z.coerce.number().int().min(1).optional().default(1),
     per_page: z.coerce.number().int().min(1).max(100).optional().default(25),
   })

--- a/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/tracing/get_tracing_projects_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/impl/schemas/tracing/get_tracing_projects_route.schema.yaml
@@ -18,18 +18,21 @@ paths:
           required: false
           schema:
             type: string
+            maxLength: 64
           description: Start of time range (ISO 8601)
         - name: to
           in: query
           required: false
           schema:
             type: string
+            maxLength: 64
           description: End of time range (ISO 8601)
         - name: name
           in: query
           required: false
           schema:
             type: string
+            maxLength: 256
           description: Filter projects by name (case-insensitive substring match)
         - name: page
           in: query


### PR DESCRIPTION
## Summary

Adds bounds to several string properties in kbn-evals APIs

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low: kbn-evals is behind a feature flag


