### PR TITLE
[Entity Store][Scout] Fix failing 'remove_v1 SO cleanup'

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/infra/remove_v1.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/remove_v1.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { stopAndRemoveV1 } from './remove_v1';
+
+describe('stopAndRemoveV1', () => {
+  const namespace = 'default';
+  const type = 'user' as const;
+  const definitionId = `security_${type}_${namespace}`;
+
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+  let taskManager: jest.Mocked<Pick<TaskManagerStartContract, 'removeIfExists'>>;
+  let savedObjectsClient: ReturnType<typeof savedObjectsClientMock.create>;
+
+  beforeEach(() => {
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
+    taskManager = { removeIfExists: jest.fn().mockResolvedValue(undefined) };
+    savedObjectsClient = savedObjectsClientMock.create();
+    // savedObjectsClientMock.create() creates jest.fn() stubs that return undefined by default.
+    // The production code chains .catch() on the return value, so it must be a Promise.
+    savedObjectsClient.delete.mockResolvedValue({} as any);
+  });
+
+  const run = () =>
+    stopAndRemoveV1({
+      type,
+      namespace,
+      logger: loggerMock.create(),
+      esClient,
+      taskManager: taskManager as unknown as TaskManagerStartContract,
+      savedObjectsClient,
+    });
+
+  it('deletes the raw entity-definition SO document from .kibana with ignore: [404]', async () => {
+    await run();
+
+    // The entity-definition SO type is no longer registered, so stopAndRemoveV1 deletes
+    // the underlying Elasticsearch document directly. The exact raw _id is the contract:
+    // `entity-definition:<definitionId>` (namespaceType was 'multiple-isolated', so no
+    // namespace prefix). The call must tolerate 404 in case the doc was never written.
+    expect(esClient.delete).toHaveBeenCalledWith(
+      { index: '.kibana', id: `entity-definition:${definitionId}` },
+      { ignore: [404] }
+    );
+  });
+
+  it('deletes v1 transforms, pipelines, templates, enrich policy, indices, and data stream', async () => {
+    await run();
+
+    // Transforms
+    expect(esClient.transform.stopTransform).toHaveBeenCalledWith(
+      expect.objectContaining({ transform_id: `entities-v1-latest-${definitionId}` }),
+      { ignore: [404, 409] }
+    );
+    expect(esClient.transform.deleteTransform).toHaveBeenCalledWith(
+      expect.objectContaining({ transform_id: `entities-v1-history-${definitionId}` }),
+      { ignore: [404] }
+    );
+
+    // Ingest pipeline
+    expect(esClient.ingest.deletePipeline).toHaveBeenCalledWith(
+      { id: `entities-v1-latest-${definitionId}` },
+      { ignore: [404] }
+    );
+
+    // Index template
+    expect(esClient.indices.deleteIndexTemplate).toHaveBeenCalledWith(
+      { name: `entities_v1_reset_${definitionId}_index_template` },
+      { ignore: [404] }
+    );
+
+    // Component template
+    expect(esClient.cluster.deleteComponentTemplate).toHaveBeenCalledWith(
+      { name: `${definitionId}-updates@platform` },
+      { ignore: [404] }
+    );
+
+    // Enrich policy
+    expect(esClient.enrich.deletePolicy).toHaveBeenCalledWith(
+      { name: `entity_store_field_retention_${type}_${namespace}_v1.0.0` },
+      { ignore: [404] }
+    );
+
+    // Reset index
+    expect(esClient.indices.delete).toHaveBeenCalledWith(
+      { index: `.entities.v1.reset.${definitionId}` },
+      { ignore: [404] }
+    );
+
+    // Updates data stream
+    expect(esClient.indices.deleteDataStream).toHaveBeenCalledWith(
+      { name: `.entities.v1.updates.${definitionId}` },
+      { ignore: [404] }
+    );
+  });
+
+  it('removes v1 task manager tasks', async () => {
+    await run();
+
+    expect(taskManager.removeIfExists).toHaveBeenCalledWith(
+      `entity_store:snapshot:${type}:${namespace}:1.0.0`
+    );
+  });
+
+  it('deletes the legacy entity-engine-status SO descriptor', async () => {
+    await run();
+
+    expect(savedObjectsClient.delete).toHaveBeenCalledWith(
+      'entity-engine-status',
+      `entity-engine-descriptor-${type}-${namespace}`
+    );
+  });
+
+  it('tolerates a 404 on the entity-engine-status SO delete', async () => {
+    savedObjectsClient.delete.mockRejectedValue(
+      SavedObjectsErrorHelpers.createGenericNotFoundError('entity-engine-status', 'test-id')
+    );
+
+    // Must not throw — the 404 is expected when v1 was never enabled in this space.
+    await expect(run()).resolves.toBeUndefined();
+  });
+
+  it('tolerates a forbidden error on the entity-engine-status SO delete', async () => {
+    savedObjectsClient.delete.mockRejectedValue(
+      SavedObjectsErrorHelpers.decorateForbiddenError(new Error('forbidden'))
+    );
+
+    // isForbiddenError errors are swallowed so a missing privilege never blocks install.
+    await expect(run()).resolves.toBeUndefined();
+  });
+
+  it('surfaces other SO delete errors as a resource-removal failure (via tryAsBoolean → retry)', async () => {
+    // tryAsBoolean catches all rejections and returns false; the caller then
+    // throws "Failed to remove one or more entity store v1 resources" which
+    // triggers retries. After RETRY_ON_FAILURE_TIMES the last error propagates.
+    savedObjectsClient.delete.mockRejectedValue(new Error('unexpected database error'));
+
+    await expect(run()).rejects.toThrow(
+      'Failed to remove one or more entity store v1 resources for type: user'
+    );
+  });
+
+  it('retries on transient ES failure and succeeds on second attempt', async () => {
+    // stopTransform is the first ES call; fail it once to trigger a retry of the whole function.
+    esClient.transform.stopTransform
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue({} as any);
+
+    await expect(run()).resolves.toBeUndefined();
+    // 2 transforms × 2 attempts (1 fail → retry → 1 success each)
+    expect(esClient.transform.stopTransform).toHaveBeenCalledTimes(4);
+  });
+
+  it('throws after exhausting all retry attempts', async () => {
+    esClient.transform.stopTransform.mockRejectedValue(new Error('persistent'));
+
+    await expect(run()).rejects.toThrow();
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/lifecycle/api/fixtures/system_indices_es_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/lifecycle/api/fixtures/system_indices_es_client.ts
@@ -23,8 +23,14 @@ const systemIndicesSuperuser = {
  * system indices such as `.kibana` from tests.
  *
  * - On stateful: provisions the role and user idempotently.
- * - On serverless: the user is preconfigured by `@kbn/es` serverless
- *   resources, so no role/user mutations are performed.
+ * - On locally-managed serverless: the user is preconfigured by `@kbn/es`
+ *   serverless resources (bind-mounted file realm), so no role/user mutations
+ *   are performed.
+ * - On Cloud serverless (MKI): the file-realm user does not exist and cannot
+ *   be provisioned — do not call this on Cloud serverless targets. Tag suites
+ *   that use it with `@local-serverless-security_complete` (not the full
+ *   `tags.serverless.security.complete` which includes `@cloud-*`), or guard
+ *   tests with `apiTest.skip(config.isCloud && config.serverless, ...)`.
  *
  * Mirrors agent_builder's `createSystemIndicesEsClient`; candidate for lifting
  * into `@kbn/scout` as shared infrastructure.

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/lifecycle/api/tests/remove_v1.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/lifecycle/api/tests/remove_v1.spec.ts
@@ -25,29 +25,55 @@ const SYSTEM_INDEX_HEADERS = { 'x-elastic-product-origin': 'kibana' };
 const v1EntityDefinitionDocId = (entityType: string, namespace: string) =>
   `entity-definition:security_${entityType}_${namespace}`;
 
+// entity-engine-status is still a registered SO type (retained for v1 detection),
+// accessible through the public SO API on all targets including Cloud serverless.
+const V1_ENGINE_STATUS_TYPE = 'entity-engine-status';
+// Mirrors the id built in server/infra/remove_v1.ts:112.
+const v1EngineDescriptorId = (entityType: string, namespace: string) =>
+  `entity-engine-descriptor-${entityType}-${namespace}`;
+
 const ALL_ENTITY_TYPES = ['user', 'host', 'service', 'generic'] as const;
 
 apiTest.describe('Entity Store remove_v1 SO cleanup', { tag: ENTITY_STORE_TAGS }, () => {
   let defaultHeaders: Record<string, string>;
-  let systemIndicesEsClient: Client;
+  // system_indices_superuser is a file-realm account that @kbn/es bind-mounts
+  // into locally-managed clusters only (see kbn-es/src/serverless_resources/users).
+  // It does not exist on Cloud serverless (MKI), so this client is only created
+  // on non-MKI targets. Tests that need it guard themselves with
+  // config.isCloud && config.serverless.
+  let systemIndicesEsClient: Client | undefined;
 
   apiTest.beforeAll(async ({ samlAuth, kbnClient, esClient, config }) => {
     const credentials = await samlAuth.asInteractiveUser('admin');
     defaultHeaders = { ...credentials.cookieHeader, ...PUBLIC_HEADERS };
     await kbnClient.uiSettings.update({ [FF_ENABLE_ENTITY_STORE_V2]: true });
 
-    systemIndicesEsClient = await createSystemIndicesEsClient(esClient, config);
+    if (!(config.isCloud && config.serverless)) {
+      systemIndicesEsClient = await createSystemIndicesEsClient(esClient, config);
+    }
   });
 
   apiTest.afterEach(async ({ apiClient }) => {
-    // Remove any seeded docs first and unconditionally, so neither a failed
-    // install nor a failed uninstall can leak legacy documents into sibling
-    // suites sharing this cluster.
+    // Remove any seeded .kibana docs first and unconditionally so neither a failed
+    // install nor a failed uninstall can leak legacy documents into sibling suites
+    // sharing this cluster. Only attempted when the privileged client was created
+    // (i.e. not on Cloud serverless / MKI).
+    if (systemIndicesEsClient !== undefined) {
+      await Promise.all(
+        ALL_ENTITY_TYPES.map((type) =>
+          systemIndicesEsClient!.delete(
+            { index: KIBANA_INDEX, id: v1EntityDefinitionDocId(type, 'default'), refresh: true },
+            { headers: SYSTEM_INDEX_HEADERS, ignore: [404] }
+          )
+        )
+      );
+    }
+    // Remove any seeded entity-engine-status descriptors (accessible on all targets).
     await Promise.all(
       ALL_ENTITY_TYPES.map((type) =>
-        systemIndicesEsClient.delete(
-          { index: KIBANA_INDEX, id: v1EntityDefinitionDocId(type, 'default'), refresh: true },
-          { headers: SYSTEM_INDEX_HEADERS, ignore: [404] }
+        apiClient.delete(
+          `api/saved_objects/${V1_ENGINE_STATUS_TYPE}/${v1EngineDescriptorId(type, 'default')}`,
+          { headers: defaultHeaders }
         )
       )
     );
@@ -56,7 +82,14 @@ apiTest.describe('Entity Store remove_v1 SO cleanup', { tag: ENTITY_STORE_TAGS }
 
   apiTest(
     'install removes legacy entity-definition SO documents from .kibana',
-    async ({ apiClient }) => {
+    async ({ apiClient, config }) => {
+      // system_indices_superuser does not exist on Cloud serverless (MKI) — only
+      // @kbn/es-managed clusters have this file-realm account (see serverless_resources/users).
+      apiTest.skip(
+        config.isCloud && config.serverless,
+        'system_indices_superuser does not exist on Cloud serverless (MKI)'
+      );
+
       const soDocIds = ALL_ENTITY_TYPES.map((type) => v1EntityDefinitionDocId(type, 'default'));
 
       // Seed fake legacy entity-definition docs directly into .kibana. These
@@ -64,7 +97,7 @@ apiTest.describe('Entity Store remove_v1 SO cleanup', { tag: ENTITY_STORE_TAGS }
       // we simulate their presence to verify that stopAndRemoveV1 deletes them.
       await Promise.all(
         soDocIds.map((id) =>
-          systemIndicesEsClient.index(
+          systemIndicesEsClient!.index(
             {
               index: KIBANA_INDEX,
               id,
@@ -82,7 +115,7 @@ apiTest.describe('Entity Store remove_v1 SO cleanup', { tag: ENTITY_STORE_TAGS }
 
       const beforeExists = await Promise.all(
         soDocIds.map((id) =>
-          systemIndicesEsClient.exists(
+          systemIndicesEsClient!.exists(
             { index: KIBANA_INDEX, id },
             { headers: SYSTEM_INDEX_HEADERS }
           )
@@ -98,7 +131,7 @@ apiTest.describe('Entity Store remove_v1 SO cleanup', { tag: ENTITY_STORE_TAGS }
 
       const afterExists = await Promise.all(
         soDocIds.map((id) =>
-          systemIndicesEsClient.exists(
+          systemIndicesEsClient!.exists(
             { index: KIBANA_INDEX, id },
             { headers: SYSTEM_INDEX_HEADERS }
           )
@@ -110,14 +143,21 @@ apiTest.describe('Entity Store remove_v1 SO cleanup', { tag: ENTITY_STORE_TAGS }
 
   apiTest(
     'install succeeds with no legacy entity-definition SOs present',
-    async ({ apiClient }) => {
+    async ({ apiClient, config }) => {
+      // system_indices_superuser does not exist on Cloud serverless (MKI) — only
+      // @kbn/es-managed clusters have this file-realm account (see serverless_resources/users).
+      apiTest.skip(
+        config.isCloud && config.serverless,
+        'system_indices_superuser does not exist on Cloud serverless (MKI)'
+      );
+
       const soDocIds = ALL_ENTITY_TYPES.map((type) => v1EntityDefinitionDocId(type, 'default'));
 
       // Confirm nothing pre-exists — install must not fail when there is
       // nothing to clean up (the delete uses ignore: [404]).
       const beforeExists = await Promise.all(
         soDocIds.map((id) =>
-          systemIndicesEsClient.exists(
+          systemIndicesEsClient!.exists(
             { index: KIBANA_INDEX, id },
             { headers: SYSTEM_INDEX_HEADERS }
           )
@@ -129,4 +169,50 @@ apiTest.describe('Entity Store remove_v1 SO cleanup', { tag: ENTITY_STORE_TAGS }
       expect(install.statusCode).toBe(201);
     }
   );
+
+  apiTest('install removes legacy entity-engine-status SO descriptors', async ({ apiClient }) => {
+    // entity-engine-status is still a registered SO type (retained so the
+    // auto-install hook can detect whether a space previously had v1 enabled).
+    // Seeding and asserting via the public SO API works on all four targets
+    // including Cloud serverless (MKI) — no system-index access needed.
+
+    // Seed fake legacy v1 engine-status descriptors via the public SO API.
+    await Promise.all(
+      ALL_ENTITY_TYPES.map((type) =>
+        apiClient.post(
+          `api/saved_objects/${V1_ENGINE_STATUS_TYPE}/${v1EngineDescriptorId(type, 'default')}`,
+          {
+            headers: defaultHeaders,
+            responseType: 'json',
+            body: { attributes: { type, status: 'running' } },
+          }
+        )
+      )
+    );
+
+    const beforeStatus = await Promise.all(
+      ALL_ENTITY_TYPES.map((type) =>
+        apiClient.get(
+          `api/saved_objects/${V1_ENGINE_STATUS_TYPE}/${v1EngineDescriptorId(type, 'default')}`,
+          { headers: defaultHeaders, responseType: 'json' }
+        )
+      )
+    );
+    expect(beforeStatus.map((r) => r.statusCode)).toStrictEqual([200, 200, 200, 200]);
+
+    // install triggers AssetManagerClient.init → stopAndRemoveV1 for each entity type,
+    // which calls savedObjectsClient.delete('entity-engine-status', ...) (remove_v1.ts:164).
+    const install = await installAllEntityTypes(apiClient, defaultHeaders);
+    expect(install.statusCode).toBe(201);
+
+    const afterStatus = await Promise.all(
+      ALL_ENTITY_TYPES.map((type) =>
+        apiClient.get(
+          `api/saved_objects/${V1_ENGINE_STATUS_TYPE}/${v1EngineDescriptorId(type, 'default')}`,
+          { headers: defaultHeaders, responseType: 'json' }
+        )
+      )
+    );
+    expect(afterStatus.map((r) => r.statusCode)).toStrictEqual([404, 404, 404, 404]);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes failing Scout test resolving https://github.com/elastic/kibana/issues/280294




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->