### PR TITLE
chore(agent builder): add update agent API regression tests

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
@@ -1,0 +1,362 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * End-to-end API integration tests for the Agent Builder "update agent" endpoint
+ * (PUT /api/agent_builder/agents/:id).
+ *
+ * These tests exist to prevent the class of regression described in
+ * elastic/search-team#15698 where new properties added to Agent documents caused
+ * the update endpoint's strict schema to reject previously-valid UI payloads.
+ *
+ * Test coverage:
+ *   - Happy-path updates for every independently editable field.
+ *   - access_control schema contract: `access_mode` accepted, `entries` rejected.
+ *   - Unknown / extra top-level and nested properties rejected with 400.
+ *   - Partial updates do not clobber unrelated fields.
+ *   - GET-after-PUT round-trip parity.
+ */
+
+import { AgentAccessControlMode } from '@kbn/agent-builder-common';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+import type { AuthedApiClient } from '../../../scout_agent_builder_shared/lib/authed_api_client';
+import { apiTest } from '../fixtures';
+import { API_AGENT_BUILDER } from '../fixtures/constants';
+
+/** Minimal valid agent body used as the baseline for all update tests. */
+const BASE_AGENT = {
+  name: 'Update Test Agent',
+  description: 'Baseline agent for update endpoint tests',
+  configuration: {
+    instructions: 'You are a helpful baseline agent',
+    tools: [{ tool_ids: ['*'] }],
+  },
+};
+
+apiTest.describe(
+  'Agent Builder — update agent API (PUT /agents/:id)',
+  { tag: [...tags.stateful.classic, ...tags.serverless.search] },
+  () => {
+    /** IDs of agents created during this worker run; cleaned up in afterAll. */
+    const createdAgentIds: string[] = [];
+
+    /**
+     * Create a fresh agent and return its server-assigned ID.
+     * The ID is registered for cleanup automatically.
+     */
+    const createAgent = async (
+      asAdmin: AuthedApiClient,
+      overrides: Record<string, unknown> = {}
+    ): Promise<string> => {
+      const id = `update-test-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const response = await asAdmin.post(`${API_AGENT_BUILDER}/agents`, {
+        body: { ...BASE_AGENT, id, ...overrides },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      createdAgentIds.push(id);
+      return id;
+    };
+
+    apiTest.afterAll(async ({ asAdmin }) => {
+      await Promise.allSettled(
+        createdAgentIds.map((agentId) =>
+          asAdmin.delete(`${API_AGENT_BUILDER}/agents/${encodeURIComponent(agentId)}`)
+        )
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // Happy-path: individual field updates
+    // -------------------------------------------------------------------------
+
+    apiTest('updates name and description', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
+
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { name: 'Renamed Agent', description: 'Updated description' },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      expect(response.body).toMatchObject({
+        id,
+        name: 'Renamed Agent',
+        description: 'Updated description',
+      });
+    });
+
+    apiTest('updates labels', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
+
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { labels: ['alpha', 'beta', 'gamma'] },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      expect(response.body.labels).toStrictEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    apiTest('updates avatar_symbol and avatar_color', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
+
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { avatar_symbol: 'U', avatar_color: '#FF5733' },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      expect(response.body).toMatchObject({ avatar_symbol: 'U', avatar_color: '#FF5733' });
+    });
+
+    apiTest('updates configuration.instructions (the overview-page edit-details flow)', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
+
+      const newInstructions = 'Updated instructions for the agent prompt';
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { configuration: { instructions: newInstructions } },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      expect(response.body.configuration.instructions).toBe(newInstructions);
+    });
+
+    apiTest('updates configuration.enable_elastic_capabilities', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
+
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { configuration: { enable_elastic_capabilities: true } },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      expect(response.body.configuration.enable_elastic_capabilities).toBe(true);
+    });
+
+    apiTest('updates configuration.workflow_ids', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
+
+      const workflowIds = ['workflow-a', 'workflow-b'];
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { configuration: { workflow_ids: workflowIds } },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      expect(response.body.configuration.workflow_ids).toStrictEqual(workflowIds);
+    });
+
+    // -------------------------------------------------------------------------
+    // access_control schema contract
+    // -------------------------------------------------------------------------
+
+    apiTest(
+      'accepts access_control with only access_mode: public',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin);
+
+        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+          body: { access_control: { access_mode: AgentAccessControlMode.Public } },
+          responseType: 'json',
+        });
+        expect(response).toHaveStatusCode(200);
+        expect(response.body.access_control.access_mode).toBe(AgentAccessControlMode.Public);
+      }
+    );
+
+    apiTest(
+      'accepts access_control with only access_mode: private',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin);
+
+        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+          body: { access_control: { access_mode: AgentAccessControlMode.Private } },
+          responseType: 'json',
+        });
+        expect(response).toHaveStatusCode(200);
+        expect(response.body.access_control.access_mode).toBe(AgentAccessControlMode.Private);
+      }
+    );
+
+    apiTest(
+      'rejects access_control payload that includes entries (regression guard for elastic/search-team#15698)',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin);
+
+        // This is the exact payload shape that caused the regression on the
+        // overview-page "edit details" flyout — the UI was sending the full
+        // access_control object (including entries) instead of just access_mode.
+        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+          body: {
+            access_control: {
+              access_mode: AgentAccessControlMode.Public,
+              entries: [],
+            },
+          },
+          responseType: 'json',
+        });
+        expect(response).toHaveStatusCode(400);
+        // The error message must explicitly mention "entries" so callers understand
+        // which property was unexpected (matches @kbn/config-schema strict-mode output).
+        expect(String((response.body as { message?: string }).message ?? '')).toContain('entries');
+      }
+    );
+
+    // -------------------------------------------------------------------------
+    // Unknown / extra properties
+    // -------------------------------------------------------------------------
+
+    apiTest(
+      'rejects unknown top-level properties in the update body',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin);
+
+        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+          body: { unknown_field: 'some value' },
+          responseType: 'json',
+        });
+        expect(response).toHaveStatusCode(400);
+      }
+    );
+
+    apiTest(
+      'rejects unknown nested properties inside configuration',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin);
+
+        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+          body: {
+            configuration: {
+              instructions: 'Valid instruction',
+              unexpected_config_field: true,
+            },
+          },
+          responseType: 'json',
+        });
+        expect(response).toHaveStatusCode(400);
+      }
+    );
+
+    // -------------------------------------------------------------------------
+    // Partial updates — no clobbering
+    // -------------------------------------------------------------------------
+
+    apiTest(
+      'updating only instructions does not clobber other configuration fields',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin, {
+          labels: ['keep-me'],
+          avatar_symbol: 'K',
+          description: 'Original description',
+          configuration: {
+            instructions: 'Original instructions',
+            tools: [{ tool_ids: ['*'] }],
+            enable_elastic_capabilities: false,
+          },
+        });
+
+        // Simulate the exact UI flow that regressed: edit-details flyout sends
+        // only the updated instructions inside configuration.
+        const putResponse = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+          body: { configuration: { instructions: 'New instructions only' } },
+          responseType: 'json',
+        });
+        expect(putResponse).toHaveStatusCode(200);
+
+        // The instructions must be updated.
+        expect(putResponse.body.configuration.instructions).toBe('New instructions only');
+
+        // Top-level fields untouched by the partial update must still be present.
+        expect(putResponse.body.labels).toStrictEqual(['keep-me']);
+        expect(putResponse.body.avatar_symbol).toBe('K');
+        expect(putResponse.body.description).toBe('Original description');
+      }
+    );
+
+    apiTest(
+      'updating only access_mode does not affect configuration',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin, {
+          configuration: {
+            instructions: 'Stable instructions',
+            tools: [{ tool_ids: ['*'] }],
+          },
+        });
+
+        const putResponse = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+          body: { access_control: { access_mode: AgentAccessControlMode.Private } },
+          responseType: 'json',
+        });
+        expect(putResponse).toHaveStatusCode(200);
+        expect(putResponse.body.configuration.instructions).toBe('Stable instructions');
+        expect(putResponse.body.access_control.access_mode).toBe(AgentAccessControlMode.Private);
+      }
+    );
+
+    // -------------------------------------------------------------------------
+    // GET-after-PUT round-trip parity
+    // -------------------------------------------------------------------------
+
+    apiTest(
+      'GET after PUT returns the same document as the PUT response',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin);
+
+        const putResponse = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+          body: {
+            name: 'Round-trip Agent',
+            description: 'Round-trip description',
+            labels: ['round', 'trip'],
+            configuration: { instructions: 'Round-trip instructions' },
+          },
+          responseType: 'json',
+        });
+        expect(putResponse).toHaveStatusCode(200);
+
+        const getResponse = await asAdmin.get(`${API_AGENT_BUILDER}/agents/${id}`, {
+          responseType: 'json',
+        });
+        expect(getResponse).toHaveStatusCode(200);
+
+        // Core user-visible fields must match between PUT response and subsequent GET.
+        expect(getResponse.body).toMatchObject({
+          id,
+          name: 'Round-trip Agent',
+          description: 'Round-trip description',
+          labels: ['round', 'trip'],
+        });
+        expect(getResponse.body.configuration.instructions).toBe('Round-trip instructions');
+      }
+    );
+
+    apiTest(
+      'repeated GET-modify-PUT cycles keep the stored document stable',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin);
+
+        const createGet = await asAdmin.get(`${API_AGENT_BUILDER}/agents/${id}`, {
+          responseType: 'json',
+        });
+        expect(createGet).toHaveStatusCode(200);
+        const initialInstructions = createGet.body.configuration.instructions as string;
+
+        // Simulate the edit-details flyout doing a read-modify-write loop.
+        for (let i = 0; i < 2; i++) {
+          const getRes = await asAdmin.get(`${API_AGENT_BUILDER}/agents/${id}`, {
+            responseType: 'json',
+          });
+          expect(getRes).toHaveStatusCode(200);
+
+          const putRes = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+            body: { configuration: { instructions: getRes.body.configuration.instructions } },
+            responseType: 'json',
+          });
+          expect(putRes).toHaveStatusCode(200);
+          // Instructions must remain identical across cycles.
+          expect(putRes.body.configuration.instructions).toBe(initialInstructions);
+        }
+      }
+    );
+  }
+);

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
@@ -9,10 +9,6 @@
  * End-to-end API integration tests for the Agent Builder "update agent" endpoint
  * (PUT /api/agent_builder/agents/:id).
  *
- * These tests exist to prevent the class of regression described in
- * elastic/search-team#15698 where new properties added to Agent documents caused
- * the update endpoint's strict schema to reject previously-valid UI payloads.
- *
  * Test coverage:
  *   - Happy-path updates for every independently editable field.
  *   - access_control schema contract: `access_mode` accepted, `entries` rejected.

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
@@ -108,17 +108,20 @@ apiTest.describe(
       expect(response.body).toMatchObject({ avatar_symbol: 'U', avatar_color: '#FF5733' });
     });
 
-    apiTest('updates configuration.instructions (the overview-page edit-details flow)', async ({ asAdmin }) => {
-      const id = await createAgent(asAdmin);
+    apiTest(
+      'updates configuration.instructions (the overview-page edit-details flow)',
+      async ({ asAdmin }) => {
+        const id = await createAgent(asAdmin);
 
-      const newInstructions = 'Updated instructions for the agent prompt';
-      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
-        body: { configuration: { instructions: newInstructions } },
-        responseType: 'json',
-      });
-      expect(response).toHaveStatusCode(200);
-      expect(response.body.configuration.instructions).toBe(newInstructions);
-    });
+        const newInstructions = 'Updated instructions for the agent prompt';
+        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+          body: { configuration: { instructions: newInstructions } },
+          responseType: 'json',
+        });
+        expect(response).toHaveStatusCode(200);
+        expect(response.body.configuration.instructions).toBe(newInstructions);
+      }
+    );
 
     apiTest('updates configuration.enable_elastic_capabilities', async ({ asAdmin }) => {
       const id = await createAgent(asAdmin);
@@ -147,33 +150,27 @@ apiTest.describe(
     // access_control schema contract
     // -------------------------------------------------------------------------
 
-    apiTest(
-      'accepts access_control with only access_mode: public',
-      async ({ asAdmin }) => {
-        const id = await createAgent(asAdmin);
+    apiTest('accepts access_control with only access_mode: public', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
 
-        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
-          body: { access_control: { access_mode: AgentAccessControlMode.Public } },
-          responseType: 'json',
-        });
-        expect(response).toHaveStatusCode(200);
-        expect(response.body.access_control.access_mode).toBe(AgentAccessControlMode.Public);
-      }
-    );
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { access_control: { access_mode: AgentAccessControlMode.Public } },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      expect(response.body.access_control.access_mode).toBe(AgentAccessControlMode.Public);
+    });
 
-    apiTest(
-      'accepts access_control with only access_mode: private',
-      async ({ asAdmin }) => {
-        const id = await createAgent(asAdmin);
+    apiTest('accepts access_control with only access_mode: private', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
 
-        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
-          body: { access_control: { access_mode: AgentAccessControlMode.Private } },
-          responseType: 'json',
-        });
-        expect(response).toHaveStatusCode(200);
-        expect(response.body.access_control.access_mode).toBe(AgentAccessControlMode.Private);
-      }
-    );
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { access_control: { access_mode: AgentAccessControlMode.Private } },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(200);
+      expect(response.body.access_control.access_mode).toBe(AgentAccessControlMode.Private);
+    });
 
     apiTest(
       'rejects access_control payload that includes entries (regression guard for elastic/search-team#15698)',
@@ -203,36 +200,30 @@ apiTest.describe(
     // Unknown / extra properties
     // -------------------------------------------------------------------------
 
-    apiTest(
-      'rejects unknown top-level properties in the update body',
-      async ({ asAdmin }) => {
-        const id = await createAgent(asAdmin);
+    apiTest('rejects unknown top-level properties in the update body', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
 
-        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
-          body: { unknown_field: 'some value' },
-          responseType: 'json',
-        });
-        expect(response).toHaveStatusCode(400);
-      }
-    );
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { unknown_field: 'some value' },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(400);
+    });
 
-    apiTest(
-      'rejects unknown nested properties inside configuration',
-      async ({ asAdmin }) => {
-        const id = await createAgent(asAdmin);
+    apiTest('rejects unknown nested properties inside configuration', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
 
-        const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
-          body: {
-            configuration: {
-              instructions: 'Valid instruction',
-              unexpected_config_field: true,
-            },
+      const response = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: {
+          configuration: {
+            instructions: 'Valid instruction',
+            unexpected_config_field: true,
           },
-          responseType: 'json',
-        });
-        expect(response).toHaveStatusCode(400);
-      }
-    );
+        },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(400);
+    });
 
     // -------------------------------------------------------------------------
     // Partial updates — no clobbering
@@ -270,61 +261,55 @@ apiTest.describe(
       }
     );
 
-    apiTest(
-      'updating only access_mode does not affect configuration',
-      async ({ asAdmin }) => {
-        const id = await createAgent(asAdmin, {
-          configuration: {
-            instructions: 'Stable instructions',
-            tools: [{ tool_ids: ['*'] }],
-          },
-        });
+    apiTest('updating only access_mode does not affect configuration', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin, {
+        configuration: {
+          instructions: 'Stable instructions',
+          tools: [{ tool_ids: ['*'] }],
+        },
+      });
 
-        const putResponse = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
-          body: { access_control: { access_mode: AgentAccessControlMode.Private } },
-          responseType: 'json',
-        });
-        expect(putResponse).toHaveStatusCode(200);
-        expect(putResponse.body.configuration.instructions).toBe('Stable instructions');
-        expect(putResponse.body.access_control.access_mode).toBe(AgentAccessControlMode.Private);
-      }
-    );
+      const putResponse = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: { access_control: { access_mode: AgentAccessControlMode.Private } },
+        responseType: 'json',
+      });
+      expect(putResponse).toHaveStatusCode(200);
+      expect(putResponse.body.configuration.instructions).toBe('Stable instructions');
+      expect(putResponse.body.access_control.access_mode).toBe(AgentAccessControlMode.Private);
+    });
 
     // -------------------------------------------------------------------------
     // GET-after-PUT round-trip parity
     // -------------------------------------------------------------------------
 
-    apiTest(
-      'GET after PUT returns the same document as the PUT response',
-      async ({ asAdmin }) => {
-        const id = await createAgent(asAdmin);
+    apiTest('GET after PUT returns the same document as the PUT response', async ({ asAdmin }) => {
+      const id = await createAgent(asAdmin);
 
-        const putResponse = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
-          body: {
-            name: 'Round-trip Agent',
-            description: 'Round-trip description',
-            labels: ['round', 'trip'],
-            configuration: { instructions: 'Round-trip instructions' },
-          },
-          responseType: 'json',
-        });
-        expect(putResponse).toHaveStatusCode(200);
-
-        const getResponse = await asAdmin.get(`${API_AGENT_BUILDER}/agents/${id}`, {
-          responseType: 'json',
-        });
-        expect(getResponse).toHaveStatusCode(200);
-
-        // Core user-visible fields must match between PUT response and subsequent GET.
-        expect(getResponse.body).toMatchObject({
-          id,
+      const putResponse = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
+        body: {
           name: 'Round-trip Agent',
           description: 'Round-trip description',
           labels: ['round', 'trip'],
-        });
-        expect(getResponse.body.configuration.instructions).toBe('Round-trip instructions');
-      }
-    );
+          configuration: { instructions: 'Round-trip instructions' },
+        },
+        responseType: 'json',
+      });
+      expect(putResponse).toHaveStatusCode(200);
+
+      const getResponse = await asAdmin.get(`${API_AGENT_BUILDER}/agents/${id}`, {
+        responseType: 'json',
+      });
+      expect(getResponse).toHaveStatusCode(200);
+
+      // Core user-visible fields must match between PUT response and subsequent GET.
+      expect(getResponse.body).toMatchObject({
+        id,
+        name: 'Round-trip Agent',
+        description: 'Round-trip description',
+        labels: ['round', 'trip'],
+      });
+      expect(getResponse.body.configuration.instructions).toBe('Round-trip instructions');
+    });
 
     apiTest(
       'repeated GET-modify-PUT cycles keep the stored document stable',

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
@@ -258,13 +258,13 @@ apiTest.describe(
         expect(putResponse.body.labels).toStrictEqual(['keep-me']);
         expect(putResponse.body.avatar_symbol).toBe('K');
         expect(putResponse.body.description).toBe('Original description');
-      }
-        expect(putResponse.body.description).toBe('Original description');
 
         // Partial config updates must merge, not replace — the other
         // configuration fields must survive an instructions-only update.
         expect(putResponse.body.configuration.tools).toStrictEqual([{ tool_ids: ['*'] }]);
         expect(putResponse.body.configuration.enable_elastic_capabilities).toBe(false);
+      }
+    );
 
     apiTest('updating only access_mode does not affect configuration', async ({ asAdmin }) => {
       const id = await createAgent(asAdmin, {

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
@@ -259,7 +259,12 @@ apiTest.describe(
         expect(putResponse.body.avatar_symbol).toBe('K');
         expect(putResponse.body.description).toBe('Original description');
       }
-    );
+        expect(putResponse.body.description).toBe('Original description');
+
+        // Partial config updates must merge, not replace — the other
+        // configuration fields must survive an instructions-only update.
+        expect(putResponse.body.configuration.tools).toStrictEqual([{ tool_ids: ['*'] }]);
+        expect(putResponse.body.configuration.enable_elastic_capabilities).toBe(false);
 
     apiTest('updating only access_mode does not affect configuration', async ({ asAdmin }) => {
       const id = await createAgent(asAdmin, {

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/update_agent_api.spec.ts
@@ -315,34 +315,5 @@ apiTest.describe(
       });
       expect(getResponse.body.configuration.instructions).toBe('Round-trip instructions');
     });
-
-    apiTest(
-      'repeated GET-modify-PUT cycles keep the stored document stable',
-      async ({ asAdmin }) => {
-        const id = await createAgent(asAdmin);
-
-        const createGet = await asAdmin.get(`${API_AGENT_BUILDER}/agents/${id}`, {
-          responseType: 'json',
-        });
-        expect(createGet).toHaveStatusCode(200);
-        const initialInstructions = createGet.body.configuration.instructions as string;
-
-        // Simulate the edit-details flyout doing a read-modify-write loop.
-        for (let i = 0; i < 2; i++) {
-          const getRes = await asAdmin.get(`${API_AGENT_BUILDER}/agents/${id}`, {
-            responseType: 'json',
-          });
-          expect(getRes).toHaveStatusCode(200);
-
-          const putRes = await asAdmin.put(`${API_AGENT_BUILDER}/agents/${id}`, {
-            body: { configuration: { instructions: getRes.body.configuration.instructions } },
-            responseType: 'json',
-          });
-          expect(putRes).toHaveStatusCode(200);
-          // Instructions must remain identical across cycles.
-          expect(putRes.body.configuration.instructions).toBe(initialInstructions);
-        }
-      }
-    );
   }
 );

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/fixtures/page_objects/agent_builder_app.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/fixtures/page_objects/agent_builder_app.ts
@@ -557,6 +557,27 @@ export class AgentBuilderApp {
     return labelTexts;
   }
 
+  async navigateToAgentOverview(agentId: string) {
+    await this.page.gotoApp(`agent_builder/agents/${agentId}/overview`);
+    await this.page.testSubj.locator('agentOverviewPage').waitFor({
+      state: 'visible',
+      timeout: 60_000,
+    });
+  }
+
+  async openEditDetailsFlyout() {
+    await this.page.testSubj.click('agentOverviewEditDetailsButton');
+    await this.page.testSubj.locator('editDetailsFlyout').waitFor({ state: 'visible' });
+  }
+
+  async setEditDetailsInstructions(instructions: string) {
+    await this.page.testSubj.fill('editDetailsInstructionsInput', instructions);
+  }
+
+  async getEditDetailsInstructions() {
+    return this.page.testSubj.locator('editDetailsInstructionsInput').inputValue();
+  }
+
   async clickAgentChat(agentId: string) {
     await this.agentAction(agentId, `agentBuilderAgentsListChat-${agentId}`).click();
   }

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/edit_agent_overview.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/edit_agent_overview.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import {
+  createAgentViaKbn,
+  deleteAllAgentsFromEs,
+} from '../../../scout_agent_builder_shared/lib/agents_kbn';
+import { test, testData } from '../fixtures';
+
+const agent = { id: 'overview_edit_agent', name: 'Overview Edit Agent', labels: ['overview'] };
+
+// Regression coverage for the overview-page "edit details" flyout. That flyout used to send the
+// full access_control object (including `entries: []`) in the update body, which the update
+// endpoint's schema rejects with a 400 — breaking every prompt edit from the overview page.
+// This drives the real form -> http client -> PUT /agents/:id path so the regression can't
+// come back unnoticed. See elastic/search-team#15698.
+test.describe(
+  'Agent Builder — edit agent from overview page',
+  { tag: [...tags.stateful.classic, ...tags.serverless.search] },
+  () => {
+    test.beforeAll(async ({ kbnClient, esClient }) => {
+      await deleteAllAgentsFromEs(esClient, testData.CHAT_AGENTS_INDEX);
+      await createAgentViaKbn(kbnClient, {
+        id: agent.id,
+        name: agent.name,
+        labels: [...agent.labels],
+      });
+    });
+
+    test.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsAdmin();
+    });
+
+    test.afterAll(async ({ esClient }) => {
+      await deleteAllAgentsFromEs(esClient, testData.CHAT_AGENTS_INDEX);
+    });
+
+    test('edits the prompt from the overview flyout without a 400', async ({
+      page,
+      pageObjects,
+    }) => {
+      const newInstructions = 'Updated instructions from the overview flyout';
+
+      await test.step('opens the edit-details flyout', async () => {
+        await pageObjects.agentBuilder.navigateToAgentOverview(agent.id);
+        await pageObjects.agentBuilder.openEditDetailsFlyout();
+      });
+
+      await test.step('edits the prompt and saves', async () => {
+        // Editing the prompt is enough to dirty the form and enable Save. The buggy payload lived
+        // in the form's default access_control value, so any save reproduced the regression.
+        await pageObjects.agentBuilder.setEditDetailsInstructions(newInstructions);
+
+        const [response] = await Promise.all([
+          page.waitForResponse(
+            (res) =>
+              /\/api\/agent_builder\/agents\/[^/]+$/.test(res.url()) &&
+              res.request().method() === 'PUT'
+          ),
+          page.testSubj.click('editDetailsSaveButton'),
+        ]);
+
+        // Load-bearing assertion: this PUT returned 400 before the fix.
+        expect(response.status()).toBe(200);
+
+        // The update body must not carry access_control.entries — those go through the dedicated
+        // /access_control endpoint, and the update schema rejects them.
+        const requestBody = JSON.parse(response.request().postData() ?? '{}');
+        expect(requestBody.access_control ?? {}).not.toHaveProperty('entries');
+
+        // A successful save closes the flyout; an error keeps it open with an error toast.
+        await expect(page.testSubj.locator('editDetailsFlyout')).toBeHidden();
+      });
+
+      await test.step('persists the edited prompt after reload', async () => {
+        await pageObjects.agentBuilder.navigateToAgentOverview(agent.id);
+        await pageObjects.agentBuilder.openEditDetailsFlyout();
+        expect(await pageObjects.agentBuilder.getEditDetailsInstructions()).toBe(newInstructions);
+      });
+    });
+  }
+);


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/15698

The Agent Builder update agent endpoint (`PUT /api/agent_builder/agents/:id`) has regressed three times when new document properties caused the strict schema to reject previously-valid UI payloads (most recently: `access_control.entries` in the overview-page edit-details flyout → 400). This adds dedicated API integration tests to catch that class of regression automatically.

## New file: `update_agent_api.spec.ts`

- **Happy-path field updates** — `name`, `description`, `labels`, `avatar_symbol`/`avatar_color`, `configuration.instructions`, `enable_elastic_capabilities`, `workflow_ids` each return 200 with the updated value reflected in the response
- **`access_control` schema contract** — `{ access_mode }` alone is accepted; `{ access_mode, entries: [] }` must return 400 with `"entries"` in the error message
- **Extra property rejection** — unknown top-level or nested `configuration` properties return 400 (schema strictness regression guard)
- **Partial updates** — updating only `configuration.instructions` must not clobber `labels`, `description`, or `avatar_symbol`; updating only `access_mode` must not clobber `configuration` — mirrors the exact UI flow that has regressed
- **GET-after-PUT round-trip parity** — the document returned by GET after a PUT must reflect all changes; repeated read-modify-write cycles must be stable

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->