### PR TITLE
[ResponseOps][Alerting v2] Convert execution history response body to snake_case

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/constants.ts
@@ -90,7 +90,7 @@ export const VERSION_MAX_LENGTH = 256;
 /** Maximum number of execution-history events returned per page (rule + action policy streams). */
 export const EXECUTION_HISTORY_MAX_PER_PAGE = 100;
 
-/** Default number of execution-history events returned per page when `perPage` is omitted. */
+/** Default number of execution-history events returned per page when `per_page` is omitted. */
 export const EXECUTION_HISTORY_DEFAULT_PER_PAGE = 20;
 
 /**

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/policy_execution_history_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/policy_execution_history_schema.test.ts
@@ -30,7 +30,7 @@ const validItem = {
   episode_count: 2,
   action_group_count: 1,
   rules: [{ id: 'rule-1', name: 'Rule 1' }],
-  totalRuleCount: 1,
+  total_rule_count: 1,
   workflows: [{ id: 'workflow-1', name: 'Workflow 1' }],
 };
 
@@ -452,37 +452,37 @@ describe('policy_execution_history_schema', () => {
   });
 
   describe('listPolicyExecutionHistoryResponseSchema', () => {
-    it('accepts a valid empty page with searchMatches=null', () => {
+    it('accepts a valid empty page with search_matches=null', () => {
       const parsed = listPolicyExecutionHistoryResponseSchema.parse({
         items: [],
         page: 1,
-        perPage: EXECUTION_HISTORY_DEFAULT_PER_PAGE,
-        totalEvents: 0,
-        searchMatches: null,
+        per_page: EXECUTION_HISTORY_DEFAULT_PER_PAGE,
+        total_events: 0,
+        search_matches: null,
       });
       expect(parsed.items).toEqual([]);
-      expect(parsed.searchMatches).toBeNull();
+      expect(parsed.search_matches).toBeNull();
     });
 
-    it('accepts a page of items with populated searchMatches', () => {
+    it('accepts a page of items with populated search_matches', () => {
       const parsed = listPolicyExecutionHistoryResponseSchema.parse({
         items: [validItem],
         page: 1,
-        perPage: 20,
-        totalEvents: 1,
-        searchMatches: { policies: 1, rules: 1, cap: 100 },
+        per_page: 20,
+        total_events: 1,
+        search_matches: { policies: 1, rules: 1, cap: 100 },
       });
       expect(parsed.items).toHaveLength(1);
     });
 
-    it('accepts perPage=0 for a count-only read', () => {
+    it('accepts per_page=0 for a count-only read', () => {
       expect(
         listPolicyExecutionHistoryResponseSchema.safeParse({
           items: [],
           page: 1,
-          perPage: 0,
-          totalEvents: 42,
-          searchMatches: null,
+          per_page: 0,
+          total_events: 42,
+          search_matches: null,
         }).success
       ).toBe(true);
     });
@@ -492,33 +492,33 @@ describe('policy_execution_history_schema', () => {
         listPolicyExecutionHistoryResponseSchema.safeParse({
           items: [],
           page: 0,
-          perPage: 20,
-          totalEvents: 0,
-          searchMatches: null,
+          per_page: 20,
+          total_events: 0,
+          search_matches: null,
         }).success
       ).toBe(false);
     });
 
-    it('rejects a negative perPage', () => {
+    it('rejects a negative per_page', () => {
       expect(
         listPolicyExecutionHistoryResponseSchema.safeParse({
           items: [],
           page: 1,
-          perPage: -1,
-          totalEvents: 0,
-          searchMatches: null,
+          per_page: -1,
+          total_events: 0,
+          search_matches: null,
         }).success
       ).toBe(false);
     });
 
-    it('rejects a negative totalEvents', () => {
+    it('rejects a negative total_events', () => {
       expect(
         listPolicyExecutionHistoryResponseSchema.safeParse({
           items: [],
           page: 1,
-          perPage: 20,
-          totalEvents: -1,
-          searchMatches: null,
+          per_page: 20,
+          total_events: -1,
+          search_matches: null,
         }).success
       ).toBe(false);
     });
@@ -529,9 +529,9 @@ describe('policy_execution_history_schema', () => {
         listPolicyExecutionHistoryResponseSchema.safeParse({
           items: [badItem],
           page: 1,
-          perPage: 20,
-          totalEvents: 1,
-          searchMatches: null,
+          per_page: 20,
+          total_events: 1,
+          search_matches: null,
         }).success
       ).toBe(false);
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/policy_execution_history_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/policy_execution_history_schema.ts
@@ -113,7 +113,7 @@ export const namedRefSchema = z.object({
 const MAX_WORKFLOWS_PER_ITEM = 100;
 // Cap for the embedded `rules` array in each item. A broad Action Policy can
 // emit one event referencing thousands of rules; the response only carries a
-// bounded sample and clients rely on `totalRuleCount` for the true count.
+// bounded sample and clients rely on `total_rule_count` for the true count.
 export const MAX_EMBEDDED_RULES_PER_ITEM = 20;
 // Cap for the embedded `episodes` array in each item.
 export const MAX_EMBEDDED_EPISODES_PER_ITEM = 50;
@@ -137,9 +137,9 @@ export const policyExecutionHistoryItemSchema = z.object({
     .array(namedRefSchema)
     .max(MAX_EMBEDDED_RULES_PER_ITEM)
     .describe(
-      'Rules referenced by this event, bounded to MAX_EMBEDDED_RULES_PER_ITEM. When a search or rule filter narrows the match, this array is intersected with the matched subset server-side. Use `totalRuleCount` for the full count.'
+      'Rules referenced by this event, bounded to MAX_EMBEDDED_RULES_PER_ITEM. When a search or rule filter narrows the match, this array is intersected with the matched subset server-side. Use `total_rule_count` for the full count.'
     ),
-  totalRuleCount: z
+  total_rule_count: z
     .number()
     .describe(
       'Total number of rules referenced by this event after search / rule-filter narrowing. May exceed `rules.length` when the embedded array is truncated to the cap.'
@@ -160,10 +160,10 @@ export type SearchMatchCounts = z.infer<typeof searchMatchCountsSchema>;
 export const listPolicyExecutionHistoryResponseSchema = z.object({
   items: z.array(policyExecutionHistoryItemSchema),
   page: z.number().int().min(1),
-  // Allows 0 for count-only reads (perPage=0), unlike the rule executions response.
-  perPage: z.number().int().min(0),
-  totalEvents: z.number().int().nonnegative(),
-  searchMatches: searchMatchCountsSchema
+  // Allows 0 for count-only reads (per_page=0), unlike the rule executions response.
+  per_page: z.number().int().min(0),
+  total_events: z.number().int().nonnegative(),
+  search_matches: searchMatchCountsSchema
     .nullable()
     .describe(
       'Per-type match counts for the active search, plus the cap used as filter. Null when no search was provided. When policies > cap or rules > cap the result is truncated.'

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_execution_history_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_execution_history_schema.test.ts
@@ -22,10 +22,10 @@ import {
 const validView = {
   id: 'doc-1',
   rule: { id: 'rule-1', version: null },
-  spaceId: 'default',
-  startedAt: '2026-06-01T00:00:00.000Z',
-  endedAt: '2026-06-01T00:00:01.500Z',
-  timings: { duration: 1500, scheduledDelay: 250 },
+  space_id: 'default',
+  started_at: '2026-06-01T00:00:00.000Z',
+  ended_at: '2026-06-01T00:00:01.500Z',
+  timings: { duration: 1500, scheduled_delay: 250 },
   outcome: 'success' as const,
   reason: null,
   error: null,
@@ -212,7 +212,7 @@ describe('rule_execution_history_schema', () => {
       });
 
       it('rejects unknown sort fields', () => {
-        expect(listRuleExecutionsRequestSchema.safeParse({ sort: 'createdAt' }).success).toBe(
+        expect(listRuleExecutionsRequestSchema.safeParse({ sort: 'created_at' }).success).toBe(
           false
         );
       });
@@ -333,7 +333,7 @@ describe('rule_execution_history_schema', () => {
         ...validView,
         outcome: 'failure' as const,
         reason: 'rule executor threw',
-        error: { message: 'boom', stackTrace: null },
+        error: { message: 'boom', stack_trace: null },
       };
       expect(ruleExecutionViewSchema.parse(row)).toEqual(row);
     });
@@ -369,17 +369,17 @@ describe('rule_execution_history_schema', () => {
     });
 
     it('rejects negative duration', () => {
-      const row = { ...validView, timings: { duration: -1, scheduledDelay: 0 } };
+      const row = { ...validView, timings: { duration: -1, scheduled_delay: 0 } };
       expect(ruleExecutionViewSchema.safeParse(row).success).toBe(false);
     });
 
-    it('allows a negative scheduledDelay (run started ahead of scheduled time)', () => {
-      const row = { ...validView, timings: { duration: 100, scheduledDelay: -50 } };
-      expect(ruleExecutionViewSchema.parse(row).timings.scheduledDelay).toBe(-50);
+    it('allows a negative scheduled_delay (run started ahead of scheduled time)', () => {
+      const row = { ...validView, timings: { duration: 100, scheduled_delay: -50 } };
+      expect(ruleExecutionViewSchema.parse(row).timings.scheduled_delay).toBe(-50);
     });
 
     it('rejects non-integer timings', () => {
-      const row = { ...validView, timings: { duration: 1.5, scheduledDelay: 0 } };
+      const row = { ...validView, timings: { duration: 1.5, scheduled_delay: 0 } };
       expect(ruleExecutionViewSchema.safeParse(row).success).toBe(false);
     });
 
@@ -393,7 +393,7 @@ describe('rule_execution_history_schema', () => {
     });
 
     it('requires error.message when error is present', () => {
-      const row = { ...validView, error: { stackTrace: null } };
+      const row = { ...validView, error: { stack_trace: null } };
       expect(ruleExecutionViewSchema.safeParse(row).success).toBe(false);
     });
 
@@ -409,7 +409,7 @@ describe('rule_execution_history_schema', () => {
         items: [],
         total: 0,
         page: 1,
-        perPage: EXECUTION_HISTORY_DEFAULT_PER_PAGE,
+        per_page: EXECUTION_HISTORY_DEFAULT_PER_PAGE,
       });
       expect(parsed.items).toEqual([]);
     });
@@ -419,7 +419,7 @@ describe('rule_execution_history_schema', () => {
         items: [validView],
         total: 1,
         page: 1,
-        perPage: 20,
+        per_page: 20,
       });
       expect(parsed.items).toHaveLength(1);
     });
@@ -430,18 +430,18 @@ describe('rule_execution_history_schema', () => {
           items: [],
           total: -1,
           page: 1,
-          perPage: 20,
+          per_page: 20,
         }).success
       ).toBe(false);
     });
 
-    it('rejects page or perPage below 1', () => {
+    it('rejects page or per_page below 1', () => {
       expect(
         listRuleExecutionsResponseSchema.safeParse({
           items: [],
           total: 0,
           page: 0,
-          perPage: 20,
+          per_page: 20,
         }).success
       ).toBe(false);
 
@@ -450,7 +450,7 @@ describe('rule_execution_history_schema', () => {
           items: [],
           total: 0,
           page: 1,
-          perPage: 0,
+          per_page: 0,
         }).success
       ).toBe(false);
     });
@@ -462,7 +462,7 @@ describe('rule_execution_history_schema', () => {
           items: [badItem],
           total: 1,
           page: 1,
-          perPage: 20,
+          per_page: 20,
         }).success
       ).toBe(false);
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_execution_history_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_execution_history_schema.ts
@@ -82,19 +82,19 @@ export const ruleExecutionViewSchema = z.object({
     id: z.string(),
     version: z.number().int().nullable(),
   }),
-  spaceId: z.string(),
-  startedAt: z.string(),
-  endedAt: z.string(),
+  space_id: z.string(),
+  started_at: z.string(),
+  ended_at: z.string(),
   timings: z.object({
     duration: z.number().int().nonnegative(),
-    scheduledDelay: z.number().int(),
+    scheduled_delay: z.number().int(),
   }),
   outcome: ruleExecutionOutcomeSchema,
   reason: z.string().nullable(),
   error: z
     .object({
       message: z.string(),
-      stackTrace: z.string().nullable(),
+      stack_trace: z.string().nullable(),
     })
     .nullable(),
 });
@@ -105,7 +105,7 @@ export const listRuleExecutionsResponseSchema = z.object({
   items: z.array(ruleExecutionViewSchema),
   total: z.number().int().nonnegative(),
   page: z.number().int().min(1),
-  perPage: z.number().int().min(1),
+  per_page: z.number().int().min(1),
 });
 
 export type ListRuleExecutionsResponse = z.infer<typeof listRuleExecutionsResponseSchema>;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/components/episode_action_policy_history_tab.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/components/episode_action_policy_history_tab.test.tsx
@@ -66,7 +66,7 @@ const buildItem = (
   dispatched_at: '2026-05-05T10:00:00.000Z',
   policy: { id: 'policy-1', name: 'My Policy' },
   rules: [{ id: 'rule-1', name: 'My Rule' }],
-  totalRuleCount: 1,
+  total_rule_count: 1,
   outcome: 'dispatched',
   episode_count: 3,
   episodes: [],

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/components/episode_action_policy_history_tab.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/episode_details_page/components/episode_action_policy_history_tab.tsx
@@ -84,7 +84,7 @@ export const EpisodeActionPolicyHistoryTab = ({ episodeId, episodeStart }: Props
   );
 
   const items = data?.items ?? [];
-  const totalEvents = data?.totalEvents ?? 0;
+  const totalEvents = data?.total_events ?? 0;
   const isFiltered = searchParam !== undefined || outcome !== DEFAULT_OUTCOME;
 
   return (

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/policies_execution_history_table.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/policies_execution_history_table.test.tsx
@@ -43,7 +43,7 @@ const buildItem = (
   dispatched_at: '2026-05-05T10:00:00.000Z',
   policy: { id: 'policy-1', name: 'My Policy' },
   rules: [{ id: 'rule-1', name: 'My Rule' }],
-  totalRuleCount: 1,
+  total_rule_count: 1,
   outcome: 'dispatched',
   episode_count: 3,
   episodes: [],

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/policies_execution_history_table.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/policies_execution_history_table.tsx
@@ -121,7 +121,7 @@ const buildColumns = ({
             <RulesCell
               rules={item.rules}
               maxVisibleRules={MAX_VISIBLE_RULES}
-              totalRuleCount={item.totalRuleCount}
+              totalRuleCount={item.total_rule_count}
               activeRuleId={activeRuleId}
               onRuleClick={onRuleClick}
               canReadRules={canReadRules}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/policies_tab_content.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/policies_tab_content.tsx
@@ -64,7 +64,7 @@ export const PoliciesTabContent = ({ onPolicyClick, onRuleClick, activeRuleId }:
     outcome: outcomeParam,
     enabled: !isError,
   });
-  const newEventsCount = newCountData?.totalEvents ?? 0;
+  const newEventsCount = newCountData?.total_events ?? 0;
 
   // Once the list refetch settles, hide the banner by advancing the lastSeenAt anchor.
   useEffect(() => {
@@ -105,7 +105,7 @@ export const PoliciesTabContent = ({ onPolicyClick, onRuleClick, activeRuleId }:
   };
 
   const items = data?.items ?? [];
-  const totalEvents = data?.totalEvents ?? 0;
+  const totalEvents = data?.total_events ?? 0;
   const showBanner = newEventsCount > 0 && !isError;
   const isFiltered =
     searchParam !== undefined || ruleFilters.length > 0 || outcome !== DEFAULT_OUTCOME;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/rules_tab_content.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/rules_tab_content.test.tsx
@@ -49,10 +49,10 @@ jest.mock('@kbn/alerting-v2-episodes-ui/hooks/use_alerting_rules_cache', () => (
 const buildItem = (overrides: Partial<RuleExecutionView> = {}): RuleExecutionView => ({
   id: 'exec-1',
   rule: { id: 'rule-1', version: null },
-  spaceId: 'default',
-  startedAt: '2026-05-05T10:00:00.000Z',
-  endedAt: '2026-05-05T10:00:01.500Z',
-  timings: { duration: 1500, scheduledDelay: 0 },
+  space_id: 'default',
+  started_at: '2026-05-05T10:00:00.000Z',
+  ended_at: '2026-05-05T10:00:01.500Z',
+  timings: { duration: 1500, scheduled_delay: 0 },
   outcome: 'success',
   reason: 'Completed successfully',
   error: null,
@@ -61,13 +61,13 @@ const buildItem = (overrides: Partial<RuleExecutionView> = {}): RuleExecutionVie
 
 const mockResult = (
   overrides: Partial<{
-    data: { items: RuleExecutionView[]; total: number; page: number; perPage: number };
+    data: { items: RuleExecutionView[]; total: number; page: number; per_page: number };
     isFetching: boolean;
     isError: boolean;
   }> = {}
 ) => {
   mockUseFetchRuleExecutions.mockReturnValue({
-    data: { items: [], total: 0, page: 1, perPage: 10 },
+    data: { items: [], total: 0, page: 1, per_page: 10 },
     isFetching: false,
     isError: false,
     refetch: mockRefetch,
@@ -129,7 +129,7 @@ describe('RulesTabContent', () => {
         items: [buildItem()],
         total: 1,
         page: 1,
-        perPage: 10,
+        per_page: 10,
       },
     });
     renderComponent();
@@ -147,7 +147,7 @@ describe('RulesTabContent', () => {
         items: [buildItem()],
         total: 1,
         page: 1,
-        perPage: 10,
+        per_page: 10,
       },
     });
     renderComponent();
@@ -167,7 +167,7 @@ describe('RulesTabContent', () => {
         items: [buildItem({ rule: { id: 'rule-orphan', version: null } })],
         total: 1,
         page: 1,
-        perPage: 10,
+        per_page: 10,
       },
     });
     renderComponent();
@@ -183,12 +183,12 @@ describe('RulesTabContent', () => {
           buildItem({
             outcome: 'failure',
             reason: null,
-            error: { message: 'Index not found', stackTrace: null },
+            error: { message: 'Index not found', stack_trace: null },
           }),
         ],
         total: 1,
         page: 1,
-        perPage: 10,
+        per_page: 10,
       },
     });
     renderComponent();
@@ -203,7 +203,7 @@ describe('RulesTabContent', () => {
         items: [buildItem({ outcome: 'success', reason: null, error: null })],
         total: 1,
         page: 1,
-        perPage: 10,
+        per_page: 10,
       },
     });
     renderComponent();
@@ -217,7 +217,7 @@ describe('RulesTabContent', () => {
         items: [buildItem({ outcome: 'failure', reason: null, error: null })],
         total: 1,
         page: 1,
-        perPage: 10,
+        per_page: 10,
       },
     });
     renderComponent();
@@ -268,10 +268,10 @@ describe('RulesTabContent', () => {
   it('formats duration in ms for sub-second values', () => {
     mockResult({
       data: {
-        items: [buildItem({ timings: { duration: 250, scheduledDelay: 0 } })],
+        items: [buildItem({ timings: { duration: 250, scheduled_delay: 0 } })],
         total: 1,
         page: 1,
-        perPage: 10,
+        per_page: 10,
       },
     });
     renderComponent();
@@ -283,11 +283,11 @@ describe('RulesTabContent', () => {
     mockResult({
       data: {
         items: Array.from({ length: 10 }, (_, idx) =>
-          buildItem({ id: `exec-${idx}`, startedAt: `2026-05-05T10:0${idx}:00.000Z` })
+          buildItem({ id: `exec-${idx}`, started_at: `2026-05-05T10:0${idx}:00.000Z` })
         ),
         total: 150,
         page: 1,
-        perPage: 10,
+        per_page: 10,
       },
     });
     renderComponent();
@@ -298,7 +298,7 @@ describe('RulesTabContent', () => {
 
   it('caps totalItemCount at the API result window limit', () => {
     mockResult({
-      data: { items: [buildItem()], total: 1_200_000, page: 1, perPage: 100 },
+      data: { items: [buildItem()], total: 1_200_000, page: 1, per_page: 100 },
     });
     renderComponent();
 
@@ -322,7 +322,7 @@ describe('RulesTabContent', () => {
           items: [buildItem()],
           total: 1,
           page: 1,
-          perPage: 10,
+          per_page: 10,
         },
       });
       renderComponent();

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/rules_tab_content.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/rules_tab_content.tsx
@@ -70,7 +70,7 @@ const buildColumns = (
   rulesCache: Record<string, { metadata: { name: string } }>
 ): Array<EuiBasicTableColumn<RuleExecutionView>> => [
   {
-    field: 'startedAt',
+    field: 'started_at',
     name: i18n.translate('xpack.alertingV2.executionHistory.rulesTab.columns.timestamp', {
       defaultMessage: 'Timestamp',
     }),

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/truncated_callout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/components/truncated_callout.tsx
@@ -15,12 +15,12 @@ type TruncatedType = 'policies' | 'rules';
 interface Props {
   searchParam?: string;
   data?: {
-    searchMatches: SearchMatchCounts | null;
+    search_matches: SearchMatchCounts | null;
   };
 }
 
 export const TruncatedCallout = ({ data, searchParam }: Props) => {
-  const searchMatches = data?.searchMatches ?? null;
+  const searchMatches = data?.search_matches ?? null;
   const truncatedTypes: TruncatedType[] =
     searchMatches !== null
       ? (['policies', 'rules'] as const).filter((t) => searchMatches[t] > searchMatches.cap)

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/execution_history_page/execution_history_page.test.tsx
@@ -123,7 +123,7 @@ const buildItem = (
   dispatched_at: '2026-05-05T10:00:00.000Z',
   policy: { id: 'policy-1', name: 'My Policy' },
   rules: [{ id: 'rule-1', name: 'My Rule' }],
-  totalRuleCount: 1,
+  total_rule_count: 1,
   outcome: 'dispatched',
   episode_count: 3,
   episodes: [],
@@ -137,16 +137,16 @@ const mockFetchResult = (
     data: {
       items: PolicyExecutionHistoryItem[];
       page: number;
-      perPage: number;
-      totalEvents: number;
-      searchMatches: { policies: number; rules: number; cap: number } | null;
+      per_page: number;
+      total_events: number;
+      search_matches: { policies: number; rules: number; cap: number } | null;
     };
     isFetching: boolean;
     isError: boolean;
   }> = {}
 ) => {
   mockUseFetchExecutionHistory.mockReturnValue({
-    data: { items: [], page: 1, perPage: 50, totalEvents: 0, searchMatches: null },
+    data: { items: [], page: 1, per_page: 50, total_events: 0, search_matches: null },
     isFetching: false,
     isError: false,
     refetch: mockRefetch,
@@ -165,7 +165,7 @@ const mockRuleExecutionFetchResult = (
   overrides: Partial<ReturnType<typeof useFetchRuleExecutions>> = {}
 ) => {
   mockUseFetchRuleExecutions.mockReturnValue({
-    data: { items: [], total: 0, page: 1, perPage: 10 },
+    data: { items: [], total: 0, page: 1, per_page: 10 },
     isFetching: false,
     isError: false,
     refetch: mockRuleRefetch,
@@ -200,7 +200,7 @@ const switchToPoliciesTab = async () => {
 describe('ExecutionHistoryPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { totalEvents: 0 } });
+    mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { total_events: 0 } });
     mockRuleExecutionFetchResult();
   });
 
@@ -286,9 +286,9 @@ describe('ExecutionHistoryPage', () => {
         data: {
           items: [buildItem({ dispatched_at: '2026-05-05T10:00:00.000Z' })],
           page: 1,
-          perPage: 50,
-          totalEvents: 1,
-          searchMatches: null,
+          per_page: 50,
+          total_events: 1,
+          search_matches: null,
         },
       });
       renderPage();
@@ -303,9 +303,9 @@ describe('ExecutionHistoryPage', () => {
         data: {
           items: [buildItem()],
           page: 1,
-          perPage: 50,
-          totalEvents: 1,
-          searchMatches: null,
+          per_page: 50,
+          total_events: 1,
+          search_matches: null,
         },
       });
       renderPage();
@@ -328,9 +328,9 @@ describe('ExecutionHistoryPage', () => {
             }),
           ],
           page: 1,
-          perPage: 50,
-          totalEvents: 1,
-          searchMatches: null,
+          per_page: 50,
+          total_events: 1,
+          search_matches: null,
         },
       });
       renderPage();
@@ -365,9 +365,9 @@ describe('ExecutionHistoryPage', () => {
         data: {
           items: [buildItem()],
           page: 1,
-          perPage: 50,
-          totalEvents: 1,
-          searchMatches: null,
+          per_page: 50,
+          total_events: 1,
+          search_matches: null,
         },
       });
       renderPage();
@@ -387,9 +387,9 @@ describe('ExecutionHistoryPage', () => {
         data: {
           items: [buildItem()],
           page: 1,
-          perPage: 50,
-          totalEvents: 1,
-          searchMatches: null,
+          per_page: 50,
+          total_events: 1,
+          search_matches: null,
         },
       });
       renderPage();
@@ -409,9 +409,9 @@ describe('ExecutionHistoryPage', () => {
         data: {
           items: [buildItem()],
           page: 1,
-          perPage: 50,
-          totalEvents: 1,
-          searchMatches: null,
+          per_page: 50,
+          total_events: 1,
+          search_matches: null,
         },
       });
       renderPage();
@@ -505,7 +505,7 @@ describe('ExecutionHistoryPage', () => {
 
     it('shows the new-events banner when count > 0', async () => {
       mockFetchResult();
-      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { totalEvents: 3 } });
+      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { total_events: 3 } });
       renderPage();
       await switchToPoliciesTab();
 
@@ -515,7 +515,7 @@ describe('ExecutionHistoryPage', () => {
 
     it('hides the new-events banner when count is 0', async () => {
       mockFetchResult();
-      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { totalEvents: 0 } });
+      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { total_events: 0 } });
       renderPage();
       await switchToPoliciesTab();
 
@@ -524,7 +524,7 @@ describe('ExecutionHistoryPage', () => {
 
     it('hides the banner when in error state even if count > 0', async () => {
       mockFetchResult({ isError: true });
-      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { totalEvents: 5 } });
+      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { total_events: 5 } });
       renderPage();
       await switchToPoliciesTab();
 
@@ -533,7 +533,7 @@ describe('ExecutionHistoryPage', () => {
 
     it('clicking "Load new events" resets to page 1 and refetches', async () => {
       mockFetchResult();
-      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { totalEvents: 2 } });
+      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { total_events: 2 } });
       renderPage();
       await switchToPoliciesTab();
 
@@ -544,7 +544,7 @@ describe('ExecutionHistoryPage', () => {
 
     it('keeps the banner visible with a loading button while the fetch is in flight', async () => {
       mockFetchResult({ isFetching: true });
-      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { totalEvents: 2 } });
+      mockUseCountNewActionPolicyExecutions.mockReturnValue({ data: { total_events: 2 } });
       renderPage();
       await switchToPoliciesTab();
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/build_execution_history_item.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/build_execution_history_item.test.ts
@@ -198,7 +198,7 @@ describe('buildExecutionHistoryItem', () => {
     expect(buildExecutionHistoryItem(event, EMPTY_NAME_MAPS)).toMatchObject({
       policy: { id: 'policy-1' },
       rules: [],
-      totalRuleCount: 0,
+      total_rule_count: 0,
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/build_execution_history_item.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/build_execution_history_item.test.ts
@@ -420,7 +420,7 @@ describe('buildExecutionHistoryItem', () => {
     it('sets totalRuleCount = relevant rules and does not truncate below the cap', () => {
       const event = eventWithNRules(5);
       const historyItem = buildExecutionHistoryItem(event, EMPTY_NAME_MAPS);
-      expect(historyItem?.totalRuleCount).toBe(5);
+      expect(historyItem?.total_rule_count).toBe(5);
       expect(historyItem?.rules).toHaveLength(5);
     });
 
@@ -428,7 +428,7 @@ describe('buildExecutionHistoryItem', () => {
       const total = MAX_EMBEDDED_RULES_PER_ITEM + 15;
       const event = eventWithNRules(total);
       const historyItem = buildExecutionHistoryItem(event, EMPTY_NAME_MAPS);
-      expect(historyItem?.totalRuleCount).toBe(total);
+      expect(historyItem?.total_rule_count).toBe(total);
       expect(historyItem?.rules).toHaveLength(MAX_EMBEDDED_RULES_PER_ITEM);
       expect(historyItem?.rules[0]?.id).toBe('rule-0');
     });
@@ -451,7 +451,7 @@ describe('buildExecutionHistoryItem', () => {
         hasMatches: true,
         matches: null,
       });
-      expect(historyItem?.totalRuleCount).toBe(2);
+      expect(historyItem?.total_rule_count).toBe(2);
       expect(historyItem?.rules.map((r) => r.id)).toEqual(['rule-a', 'rule-c']);
     });
   });
@@ -476,7 +476,7 @@ describe('buildExecutionHistoryItem', () => {
         'rule-nonexistent',
       ]);
       expect(historyItem?.rules.map((r) => r.id)).toEqual(['rule-b', 'rule-d']);
-      expect(historyItem?.totalRuleCount).toBe(2);
+      expect(historyItem?.total_rule_count).toBe(2);
     });
 
     it('returns null when no event rule matches mandatoryRuleIds', () => {
@@ -515,7 +515,7 @@ describe('buildExecutionHistoryItem', () => {
       );
       // Union of search-scoped {a,b,c} with mandatory {b,d} = {a,b,c,d}
       expect(historyItem?.rules.map((r) => r.id)).toEqual(['rule-a', 'rule-b', 'rule-c', 'rule-d']);
-      expect(historyItem?.totalRuleCount).toBe(4);
+      expect(historyItem?.total_rule_count).toBe(4);
     });
   });
 
@@ -535,7 +535,7 @@ describe('buildExecutionHistoryItem', () => {
       const event = eventWithRules(['rule-a', 'rule-b', 'rule-c']);
       const historyItem = buildExecutionHistoryItem(event, EMPTY_NAME_MAPS, undefined, ['rule-b']);
       expect(historyItem?.rules.map((r) => r.id)).toEqual(['rule-b']);
-      expect(historyItem?.totalRuleCount).toBe(1);
+      expect(historyItem?.total_rule_count).toBe(1);
     });
 
     it('narrows to mandatoryRuleIds when search matches the policy but not any rules', () => {
@@ -547,7 +547,7 @@ describe('buildExecutionHistoryItem', () => {
         ['rule-b']
       );
       expect(historyItem?.rules.map((r) => r.id)).toEqual(['rule-b']);
-      expect(historyItem?.totalRuleCount).toBe(1);
+      expect(historyItem?.total_rule_count).toBe(1);
     });
 
     it('returns all rules when policy is search-matched and no mandatoryRuleIds is provided', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/build_execution_history_item.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/action_policy_execution_history_client/build_execution_history_item.ts
@@ -173,7 +173,7 @@ export function buildExecutionHistoryItem(
     episodes,
     action_group_count: Number(dispatcher.action_group_count ?? 0),
     rules,
-    totalRuleCount,
+    total_rule_count: totalRuleCount,
     workflows,
     failure_reason: failureReason as DispatchFailureReason | undefined,
     error: errorMessage !== undefined ? { message: errorMessage } : undefined,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/execution_history_client/execution_history_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/execution_history_client/execution_history_client.ts
@@ -6,11 +6,14 @@
  */
 
 import { inject, injectable } from 'inversify';
-import type { ListRuleExecutionsResponse } from '@kbn/alerting-v2-schemas';
 import { EventLogServiceToken } from '../services/event_log_service/tokens';
 import type { EventLogServiceContract } from '../services/event_log_service/event_log_service';
 import { RequestSpaceIdToken } from '../services/spaces_service/tokens';
-import type { ExecutionHistoryClientContract, ListRuleExecutionsArgs } from './types';
+import type {
+  ExecutionHistoryClientContract,
+  ListRuleExecutionsArgs,
+  ListRuleExecutionsResult,
+} from './types';
 
 @injectable()
 export class ExecutionHistoryClient implements ExecutionHistoryClientContract {
@@ -19,9 +22,7 @@ export class ExecutionHistoryClient implements ExecutionHistoryClientContract {
     @inject(RequestSpaceIdToken) private readonly spaceId: string
   ) {}
 
-  public async listRuleExecutions(
-    args: ListRuleExecutionsArgs
-  ): Promise<ListRuleExecutionsResponse> {
+  public async listRuleExecutions(args: ListRuleExecutionsArgs): Promise<ListRuleExecutionsResult> {
     return this.eventLog.findRuleExecutions({ spaceId: this.spaceId, ...args });
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/execution_history_client/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/execution_history_client/index.ts
@@ -7,4 +7,8 @@
 
 export { ExecutionHistoryClient } from './execution_history_client';
 export { ExecutionHistoryClientToken } from './tokens';
-export type { ExecutionHistoryClientContract, ListRuleExecutionsArgs } from './types';
+export type {
+  ExecutionHistoryClientContract,
+  ListRuleExecutionsArgs,
+  ListRuleExecutionsResult,
+} from './types';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/execution_history_client/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/execution_history_client/types.ts
@@ -5,14 +5,23 @@
  * 2.0.
  */
 
-import type { ListRuleExecutionsResponse } from '@kbn/alerting-v2-schemas';
-import type { FindRuleExecutionsQuery } from '../services/event_log_service/types';
+import type {
+  FindRuleExecutionsQuery,
+  PaginatedResult,
+  RuleExecution,
+} from '../services/event_log_service/types';
 
 /**
  * Client-side arguments for {@link ExecutionHistoryClientContract.getRuleExecutions}.
  */
 export type ListRuleExecutionsArgs = Omit<FindRuleExecutionsQuery, 'spaceId'>;
 
+/**
+ * Internal (camelCase) result of a rule-execution read. The route maps it to
+ * the snake_case API contract via `toListRuleExecutionsResponse`.
+ */
+export type ListRuleExecutionsResult = PaginatedResult<RuleExecution>;
+
 export interface ExecutionHistoryClientContract {
-  listRuleExecutions(args: ListRuleExecutionsArgs): Promise<ListRuleExecutionsResponse>;
+  listRuleExecutions(args: ListRuleExecutionsArgs): Promise<ListRuleExecutionsResult>;
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_action_policy_executions_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_action_policy_executions_oas_example.ts
@@ -19,14 +19,14 @@ export const LIST_ACTION_POLICY_EXECUTIONS_RESPONSE: ListPolicyExecutionHistoryR
       episodes: [{ id: 'episode-1' }],
       action_group_count: 1,
       rules: [{ id: 'rule-1', name: 'Host CPU high' }],
-      totalRuleCount: 1,
+      total_rule_count: 1,
       workflows: [{ id: 'workflow-1', name: 'Notify oncall' }],
     },
   ],
   page: 1,
-  perPage: 20,
-  totalEvents: 1,
-  searchMatches: null,
+  per_page: 20,
+  total_events: 1,
+  search_matches: null,
 };
 
 // Mirrors the page * per_page refinement message in listPolicyExecutionHistoryRequestSchema.

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_action_policy_executions_route.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_action_policy_executions_route.test.ts
@@ -106,9 +106,15 @@ describe('ListActionPolicyExecutionsRoute', () => {
     });
   });
 
-  it('returns the client result verbatim in the response body', async () => {
+  it('maps the client result onto the snake_case response body', async () => {
     const mocks = createMocks();
-    const clientResult = { items: [{ id: 'x' }], page: 4, perPage: 25, totalEvents: 137 };
+    const clientResult = {
+      items: [{ id: 'x' }],
+      page: 4,
+      perPage: 25,
+      totalEvents: 137,
+      searchMatches: null,
+    };
     mocks.executionHistoryClient.listExecutionHistory.mockResolvedValue(clientResult as any);
 
     const request = httpServerMock.createKibanaRequest();
@@ -117,7 +123,13 @@ describe('ListActionPolicyExecutionsRoute', () => {
     await route.handle();
 
     const okCall = (mocks.deps.response.ok as jest.Mock).mock.calls[0][0];
-    expect(okCall.body).toEqual(clientResult);
+    expect(okCall.body).toEqual({
+      items: [{ id: 'x' }],
+      page: 4,
+      per_page: 25,
+      total_events: 137,
+      search_matches: null,
+    });
   });
 
   it('lets errors propagate so BaseAlertingRoute.onError handles the response', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_action_policy_executions_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_action_policy_executions_route.ts
@@ -14,9 +14,13 @@ import {
   listPolicyExecutionHistoryRequestSchema,
   listPolicyExecutionHistoryResponseSchema,
   type ListPolicyExecutionHistoryRequest,
+  type ListPolicyExecutionHistoryResponse,
 } from '@kbn/alerting-v2-schemas';
 import { ActionPolicyExecutionHistoryClient } from '../../lib/action_policy_execution_history_client';
-import type { ListExecutionHistoryArgs } from '../../lib/action_policy_execution_history_client';
+import type {
+  ListExecutionHistoryArgs,
+  ListExecutionHistoryResult,
+} from '../../lib/action_policy_execution_history_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
 import { BaseAlertingRoute } from '../base_alerting_route';
 import { listActionPolicyExecutionsOasExamples } from './list_action_policy_executions_oas_example';
@@ -44,6 +48,24 @@ export const toListExecutionHistoryArgs = ({
     outcome,
     episodeIds,
     startDate,
+  };
+};
+
+export const toListExecutionHistoryResponse = ({
+  items,
+  page,
+  perPage,
+  totalEvents,
+  searchMatches,
+  ...rest
+}: ListExecutionHistoryResult): Complete<ListPolicyExecutionHistoryResponse> => {
+  assertAllFieldsMapped(rest);
+  return {
+    items,
+    page,
+    per_page: perPage,
+    total_events: totalEvents,
+    search_matches: searchMatches,
   };
 };
 
@@ -100,6 +122,6 @@ export class ListActionPolicyExecutionsRoute extends BaseAlertingRoute {
       ...toListExecutionHistoryArgs(this.request.query ?? {}),
     });
 
-    return this.ctx.response.ok({ body: result });
+    return this.ctx.response.ok({ body: toListExecutionHistoryResponse(result) });
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_rule_executions_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_rule_executions_oas_example.ts
@@ -14,10 +14,10 @@ export const LIST_RULE_EXECUTIONS_RESPONSE: ListRuleExecutionsResponse = {
     {
       id: 'execution-1',
       rule: { id: 'rule-1', version: 3 },
-      spaceId: 'default',
-      startedAt: '2026-01-15T12:00:00.000Z',
-      endedAt: '2026-01-15T12:00:01.250Z',
-      timings: { duration: 1250, scheduledDelay: 40 },
+      space_id: 'default',
+      started_at: '2026-01-15T12:00:00.000Z',
+      ended_at: '2026-01-15T12:00:01.250Z',
+      timings: { duration: 1250, scheduled_delay: 40 },
       outcome: 'success',
       reason: null,
       error: null,
@@ -25,14 +25,14 @@ export const LIST_RULE_EXECUTIONS_RESPONSE: ListRuleExecutionsResponse = {
   ],
   total: 1,
   page: 1,
-  perPage: 20,
+  per_page: 20,
 };
 
-// Mirrors the page * perPage refinement message in listRuleExecutionsQuerySchema.
+// Mirrors the page * per_page refinement message in listRuleExecutionsQuerySchema.
 const INVALID_RULE_EXECUTIONS_QUERY_RESPONSE = invalidResponseExample({
   summary: 'Exceeds the max result window',
-  message: 'page * perPage cannot exceed 10000.',
-  details: { errors: { page: ['page * perPage cannot exceed 10000.'] } },
+  message: 'page * per_page cannot exceed 10000.',
+  details: { errors: { page: ['page * per_page cannot exceed 10000.'] } },
 });
 
 export const listRuleExecutionsOasExamples = (): AlertingOasOperationObject =>

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_rule_executions_route.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_rule_executions_route.test.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { toListRuleExecutionsArgs } from './list_rule_executions_route';
+import type { ListRuleExecutionsResult } from '../../lib/execution_history_client';
+import {
+  toListRuleExecutionsArgs,
+  toListRuleExecutionsResponse,
+} from './list_rule_executions_route';
 
 describe('toListRuleExecutionsArgs', () => {
   it('maps the snake_case request to camelCase client args and translates the sort value', () => {
@@ -29,6 +33,63 @@ describe('toListRuleExecutionsArgs', () => {
       sortOrder: 'asc',
       page: 2,
       perPage: 25,
+    });
+  });
+});
+
+describe('toListRuleExecutionsResponse', () => {
+  const item: ListRuleExecutionsResult['items'][number] = {
+    id: 'exec-1',
+    rule: { id: 'rule-1', version: 3 },
+    spaceId: 'default',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    endedAt: '2026-01-01T00:00:01.500Z',
+    timings: { duration: 1500, scheduledDelay: 250 },
+    outcome: 'success',
+    reason: null,
+    error: null,
+  };
+
+  it('maps the camelCase client result onto the snake_case response body', () => {
+    expect(toListRuleExecutionsResponse({ items: [item], total: 1, page: 2, perPage: 25 })).toEqual(
+      {
+        items: [
+          {
+            id: 'exec-1',
+            rule: { id: 'rule-1', version: 3 },
+            space_id: 'default',
+            started_at: '2026-01-01T00:00:00.000Z',
+            ended_at: '2026-01-01T00:00:01.500Z',
+            timings: { duration: 1500, scheduled_delay: 250 },
+            outcome: 'success',
+            reason: null,
+            error: null,
+          },
+        ],
+        total: 1,
+        page: 2,
+        per_page: 25,
+      }
+    );
+  });
+
+  it('maps the nested error stack trace and keeps a null error null', () => {
+    const [mapped] = toListRuleExecutionsResponse({
+      items: [{ ...item, outcome: 'failure', error: { message: 'boom', stackTrace: 'at x' } }],
+      total: 1,
+      page: 1,
+      perPage: 10,
+    }).items;
+
+    expect(mapped.error).toEqual({ message: 'boom', stack_trace: 'at x' });
+  });
+
+  it('returns an empty items array untouched', () => {
+    expect(toListRuleExecutionsResponse({ items: [], total: 0, page: 1, perPage: 10 })).toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      per_page: 10,
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_rule_executions_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/execution_history/list_rule_executions_route.ts
@@ -12,12 +12,15 @@ import {
   listRuleExecutionsRequestSchema,
   listRuleExecutionsResponseSchema,
   type ListRuleExecutionsRequest,
+  type ListRuleExecutionsResponse,
+  type RuleExecutionView,
 } from '@kbn/alerting-v2-schemas';
 import { inject, injectable } from 'inversify';
 import { ExecutionHistoryClientToken } from '../../lib/execution_history_client';
 import type {
   ExecutionHistoryClientContract,
   ListRuleExecutionsArgs,
+  ListRuleExecutionsResult,
 } from '../../lib/execution_history_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
 import { BaseAlertingRoute } from '../base_alerting_route';
@@ -48,6 +51,49 @@ export const toListRuleExecutionsArgs = ({
     sortOrder,
     page,
     perPage,
+  };
+};
+
+const toRuleExecutionView = ({
+  id,
+  rule,
+  spaceId,
+  startedAt,
+  endedAt,
+  timings: { duration, scheduledDelay, ...restTimings },
+  outcome,
+  reason,
+  error,
+  ...rest
+}: ListRuleExecutionsResult['items'][number]): Complete<RuleExecutionView> => {
+  assertAllFieldsMapped(rest);
+  assertAllFieldsMapped(restTimings);
+  return {
+    id,
+    rule,
+    space_id: spaceId,
+    started_at: startedAt,
+    ended_at: endedAt,
+    timings: { duration, scheduled_delay: scheduledDelay },
+    outcome,
+    reason,
+    error: error && { message: error.message, stack_trace: error.stackTrace },
+  };
+};
+
+export const toListRuleExecutionsResponse = ({
+  items,
+  total,
+  page,
+  perPage,
+  ...rest
+}: ListRuleExecutionsResult): Complete<ListRuleExecutionsResponse> => {
+  assertAllFieldsMapped(rest);
+  return {
+    items: items.map(toRuleExecutionView),
+    total,
+    page,
+    per_page: perPage,
   };
 };
 
@@ -97,6 +143,6 @@ export class ListRuleExecutionsRoute extends BaseAlertingRoute {
     const result = await this.executionHistoryClient.listRuleExecutions(
       toListRuleExecutionsArgs(this.request.query)
     );
-    return this.ctx.response.ok({ body: result });
+    return this.ctx.response.ok({ body: toListRuleExecutionsResponse(result) });
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/execution_history/list_execution_history.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/execution_history/list_execution_history.spec.ts
@@ -48,7 +48,7 @@ apiTest.describe(
         headers: readerHeaders,
       });
       expect(response).toHaveStatusCode(200);
-      expect(response.body.perPage).toBe(0);
+      expect(response.body.per_page).toBe(0);
       expect(response.body.items).toStrictEqual([]);
     });
 
@@ -58,7 +58,7 @@ apiTest.describe(
         { headers: readerHeaders }
       );
       expect(response).toHaveStatusCode(200);
-      expect(response.body.perPage).toBe(EXECUTION_HISTORY_MAX_PER_PAGE);
+      expect(response.body.per_page).toBe(EXECUTION_HISTORY_MAX_PER_PAGE);
     });
 
     apiTest('validation: rejects perPage above the maximum', async ({ apiClient }) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/execution_history/list_rule_executions.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/execution_history/list_rule_executions.spec.ts
@@ -61,11 +61,11 @@ apiTest.describe('List rule executions API', { tag: '@local-stateful-classic' },
       for (const item of response.body.items) {
         expect(item.rule.id).toBe(rule.id);
         expect(item.spaceId).toBe('default');
-        expect(Date.parse(item.startedAt)).toBeGreaterThan(0);
-        expect(Date.parse(item.endedAt)).toBeGreaterThan(0);
+        expect(Date.parse(item.started_at)).toBeGreaterThan(0);
+        expect(Date.parse(item.ended_at)).toBeGreaterThan(0);
         expect(['success', 'failure']).toContain(item.outcome);
         expect(Number.isInteger(item.timings.duration)).toBe(true);
-        expect(Number.isInteger(item.timings.scheduledDelay)).toBe(true);
+        expect(Number.isInteger(item.timings.scheduled_delay)).toBe(true);
       }
 
       const successful = response.body.items.find(

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/execution_history/list_rule_executions.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/execution_history/list_rule_executions.spec.ts
@@ -60,7 +60,7 @@ apiTest.describe('List rule executions API', { tag: '@local-stateful-classic' },
 
       for (const item of response.body.items) {
         expect(item.rule.id).toBe(rule.id);
-        expect(item.spaceId).toBe('default');
+        expect(item.space_id).toBe('default');
         expect(Date.parse(item.started_at)).toBeGreaterThan(0);
         expect(Date.parse(item.ended_at)).toBeGreaterThan(0);
         expect(['success', 'failure']).toContain(item.outcome);
@@ -107,18 +107,18 @@ apiTest.describe('List rule executions API', { tag: '@local-stateful-classic' },
 
       const items = response.body.items as Array<{
         rule: { id: string };
-        spaceId: string;
+        space_id: string;
       }>;
 
       const sawDefaultSpaceRule = items.some(
-        (item) => item.rule.id === ruleInDefaultSpace.id && item.spaceId === 'default'
+        (item) => item.rule.id === ruleInDefaultSpace.id && item.space_id === 'default'
       );
 
       expect(sawDefaultSpaceRule).toBe(true);
 
       const leaked = items
-        .filter((item) => item.spaceId === OTHER_SPACE_ID || item.rule.id === ruleInOtherSpace.id)
-        .map((item) => `${item.spaceId}/${item.rule.id}`);
+        .filter((item) => item.space_id === OTHER_SPACE_ID || item.rule.id === ruleInOtherSpace.id)
+        .map((item) => `${item.space_id}/${item.rule.id}`);
 
       expect(leaked).toHaveLength(0);
     }


### PR DESCRIPTION
## 📄 Summary

> [!important]
> Alerting v2 work under feature flag disabled by default. See **🧪 Verification steps** > **⚙️ Environment Setup** for more information.

> [!warning]
> Fixing the casing of all the alerting v2 API response bodies cited in https://github.com/elastic/rna-program/issues/348 results in almost 200 changed files. ~~I'm using GH stacked PRs~~ I split the work in different levels for ease of review. More PRs fill follow, stacked on this one.
> **EDIT** I found out that stacked PRs were recently disabled. Using switching base instead.

The two execution history endpoints returned camelCase keys in their response bodies — `startedAt`, `perPage`, `totalRuleCount` — where the [Kibana API guidelines](https://github.com/elastic/kibana/blob/main/dev_docs/contributing/kibana_http_api_design_guidelines.mdx) require snake_case. This renames them and updates the UI, OAS examples and API tests that read them.

Internally the server types stay camelCase: the conversion now happens in a small mapper at each route, the same way the request side already converts incoming params.

<details>
<summary>

## 🧪 Verification steps

</summary>

### ⚙️ Environment Setup

Add the following flag to your `kibana.dev.yml`:

```yaml
xpack.alerting_v2.enabled: true
```

Then navigate to Stack Management > Advanced settings > Global, and enable Alerting v2.

1. Create a rule and let it execute at least twice so the event log has `task-run` documents.
2. Create an action policy matching that rule and let the dispatcher run so action policy execution events exist.

### ✅ Happy Path

1. `GET /api/alerting/v2/execution_history/rules?per_page=5` — response envelope has `per_page` (not `perPage`), and every item uses `space_id`, `started_at`, `ended_at`, `timings.scheduled_delay`. No camelCase keys anywhere in the body.
2. `GET /api/alerting/v2/execution_history/action_policies?per_page=5` — envelope has `per_page`, `total_events`, `search_matches`; each item has `total_rule_count` alongside the already-snake_case `episode_count` / `action_group_count` / `dispatched_at`.
3. Open **Stack Management → Alerts → Execution history**. Both the **Rules** and **Policies** tabs render rows with timestamps, durations, outcomes and messages, and pagination works (change the page size and page through results).
4. Sort the Rules tab by timestamp — the column is backed by `started_at` now, so confirm sorting still applies.
5. Open an episode's detail page → **Action policy history** tab. The event count and rows render correctly (this reads `total_events`).

### ⚡️ Edge Cases

1. Rule executions with a failure: `error.stack_trace` is present and `null` when Task Manager recorded no stack. The Rules tab shows the error message.
2. `per_page=0` on the action policy endpoint (count-only read) — returns `items: []` with a correct `total_events`.
3. Search on the Policies tab wide enough to exceed the server's id cap — the truncated-search callout still appears (it reads `search_matches`, whose shape is unchanged apart from the key name).
4. An action policy event referencing more rules than the embedded cap — `total_rule_count` exceeds `rules.length` and the rules cell reflects the true total.

### ❌ Failure Cases

1. `GET /api/alerting/v2/execution_history/rules?per_page=0` → `400` (this endpoint requires `per_page >= 1`, unlike the action policy one).
2. `per_page` above the maximum, or `page * per_page` beyond the result window → `400` with the `page * per_page cannot exceed …` message.
3. Passing the old camelCase query param (`?perPage=5`) is silently ignored and the server default applies — unchanged behaviour, tracked separately (see Known issues).

</details>

<details>
<summary>

## 🧰 Implementation details

</summary>

**Why mappers instead of renaming the internal types.** The saved object attributes and the event log projections are deliberately camelCase — the SO attributes cannot be renamed without a model version migration, and the event log types are internal projections of ES documents rather than API shapes. The codebase already resolves this asymmetry on the request side with compile-time-checked mappers (`toListRuleExecutionsArgs` etc.). This PR completes the pattern in the response direction.

`Complete<T>` plus `assertAllFieldsMapped(rest)` make the mappers fail to compile if a field is added to either side and not explicitly handled, so the contract cannot silently drift. `toRuleExecutionView` also asserts on the nested `timings` rest object for the same reason.

**Untyped surfaces.** Renaming response keys is not fully covered by the compiler: object literals passed to `toEqual`, `JSON.stringify` request bodies, `http.get` query objects, and string-literal table column `field:` references are all invisible to `tsc`. Those were audited by hand for this layer — the notable one is `rules_tab_content.tsx`, whose EUI column was `field: 'startedAt'` and is now `field: 'started_at'`; a pure type-driven rename would have left the timestamp column silently blank.

</details>

<details>
<summary>

## 📚 Docs suggestions

</summary>

If we're mentioning any API response keys in the non-automatically-generated docs, then they should be updated according to these changes

</details>

## ⏪ Backport rationale

Pre-GA work, not backporting

## 🔗 References

Refs elastic/rna-program#348

> 🤖 PR Co-authored by Claude Code

## ☑️ Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
    > We're fixing the touched APIs while they are still experimental
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.