### PR TITLE
[One Workflow] Polish global Executions view UX

### DIFF
--- a/src/platform/packages/shared/deeplinks/workflows/get_workflows_nav_panel.test.ts
+++ b/src/platform/packages/shared/deeplinks/workflows/get_workflows_nav_panel.test.ts
@@ -66,7 +66,7 @@ describe('getWorkflowsNavPanel', () => {
     ]);
   });
 
-  it('returns a panel opener with list, library, and executions children when both are enabled', () => {
+  it('returns a panel opener with list, executions, and library children when both are enabled', () => {
     expect(
       getWorkflowsNavPanel(createCore({ libraryEnabled: true, executionsViewEnabled: true }))
     ).toEqual([
@@ -76,11 +76,11 @@ describe('getWorkflowsNavPanel', () => {
         renderAs: 'panelOpener',
         children: [
           { link: `${WORKFLOWS_APP_ID}:${WorkflowsPageName.list}`, breadcrumbStatus: 'hidden' },
-          { link: `${WORKFLOWS_APP_ID}:${WorkflowsPageName.library}`, breadcrumbStatus: 'hidden' },
           {
             link: `${WORKFLOWS_APP_ID}:${WorkflowsPageName.executions}`,
             breadcrumbStatus: 'hidden',
           },
+          { link: `${WORKFLOWS_APP_ID}:${WorkflowsPageName.library}`, breadcrumbStatus: 'hidden' },
         ],
       },
     ]);

--- a/src/platform/packages/shared/deeplinks/workflows/get_workflows_nav_panel.ts
+++ b/src/platform/packages/shared/deeplinks/workflows/get_workflows_nav_panel.ts
@@ -62,15 +62,15 @@ export const getWorkflowsNavPanel = (core: WorkflowsNavPanelCore): WorkflowsNavN
 
   const links: NonNullable<WorkflowsNavNode['children']> = [];
 
-  if (libraryEnabled) {
-    links.push({ link: workflowsDeepLink(WorkflowsPageName.library), breadcrumbStatus: 'hidden' });
-  }
-
   if (executionsViewEnabled) {
     links.push({
       link: workflowsDeepLink(WorkflowsPageName.executions),
       breadcrumbStatus: 'hidden',
     });
+  }
+
+  if (libraryEnabled) {
+    links.push({ link: workflowsDeepLink(WorkflowsPageName.library), breadcrumbStatus: 'hidden' });
   }
 
   if (!links.length) {

--- a/src/platform/plugins/shared/workflows_management/public/deep_links.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/deep_links.test.ts
@@ -27,6 +27,20 @@ describe('getDeepLinks', () => {
     );
   });
 
+  it('includes projectSideNav on the executions deep link so solution nav does not strip it', () => {
+    const deepLinks = getDeepLinks({ executionsViewEnabled: true });
+
+    expect(deepLinks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'executions',
+          path: '/executions',
+          visibleIn: ['globalSearch', 'projectSideNav'],
+        }),
+      ])
+    );
+  });
+
   it('does not set visibleIn on the workflows deep link when the library is disabled', () => {
     const [workflowsDeepLink] = getDeepLinks({ libraryEnabled: false });
 

--- a/src/platform/plugins/shared/workflows_management/public/deep_links.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/deep_links.test.ts
@@ -41,6 +41,12 @@ describe('getDeepLinks', () => {
     );
   });
 
+  it('orders Executions before Template Library when both are enabled', () => {
+    const deepLinks = getDeepLinks({ executionsViewEnabled: true, libraryEnabled: true });
+
+    expect(deepLinks.map((link) => link.id)).toEqual(['list', 'executions', 'library']);
+  });
+
   it('does not set visibleIn on the workflows deep link when the library is disabled', () => {
     const [workflowsDeepLink] = getDeepLinks({ libraryEnabled: false });
 

--- a/src/platform/plugins/shared/workflows_management/public/deep_links.ts
+++ b/src/platform/plugins/shared/workflows_management/public/deep_links.ts
@@ -39,17 +39,6 @@ export function getDeepLinks({
     },
   ];
 
-  if (libraryEnabled) {
-    links.push({
-      id: WorkflowsPageName.library,
-      title: i18n.translate('workflowsManagement.nav.libraryDeepLinkTitle', {
-        defaultMessage: 'Template Library',
-      }),
-      path: '/library',
-      visibleIn: sideNavVisibleIn,
-    });
-  }
-
   if (executionsViewEnabled) {
     links.push({
       id: WorkflowsPageName.executions,
@@ -58,6 +47,17 @@ export function getDeepLinks({
       }),
       path: '/executions',
       // Without projectSideNav, solution nav strips this node (DEFAULT_LINK_VISIBILITY is globalSearch-only).
+      visibleIn: sideNavVisibleIn,
+    });
+  }
+
+  if (libraryEnabled) {
+    links.push({
+      id: WorkflowsPageName.library,
+      title: i18n.translate('workflowsManagement.nav.libraryDeepLinkTitle', {
+        defaultMessage: 'Template Library',
+      }),
+      path: '/library',
       visibleIn: sideNavVisibleIn,
     });
   }

--- a/src/platform/plugins/shared/workflows_management/public/deep_links.ts
+++ b/src/platform/plugins/shared/workflows_management/public/deep_links.ts
@@ -57,6 +57,8 @@ export function getDeepLinks({
         defaultMessage: 'Executions',
       }),
       path: '/executions',
+      // Without projectSideNav, solution nav strips this node (DEFAULT_LINK_VISIBILITY is globalSearch-only).
+      visibleIn: sideNavVisibleIn,
     });
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/executions_page.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/executions_page.test.tsx
@@ -66,8 +66,11 @@ describe('WorkflowExecutionsPage', () => {
     renderPage();
 
     expect(screen.getByTestId('workflowExecutionsPage')).toBeInTheDocument();
-    expect(screen.getByText('Experimental')).toBeInTheDocument();
+    expect(screen.getByTestId('workflowExecutionsExperimentalBadge')).toBeInTheDocument();
     expect(screen.getByTestId('workflowExecutionsPageContent')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Browse and filter workflow executions across your space.')
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId('searchBarStub')).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByTestId('workflowExecutionsFilters')).toBeInTheDocument();

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/executions_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/executions_page.tsx
@@ -7,14 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import {
-  EuiBetaBadge,
-  EuiPageTemplate,
-  EuiScreenReaderOnly,
-  EuiText,
-  useEuiTheme,
-} from '@elastic/eui';
-import React from 'react';
+import { EuiPageTemplate, EuiScreenReaderOnly, useEuiTheme } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { AppHeader } from '@kbn/app-header';
+import type { AppHeaderBadge } from '@kbn/app-header';
 import { i18n } from '@kbn/i18n';
 import { WorkflowExecutionsPageContent } from './workflow_executions_page_content';
 import { useWorkflowsBreadcrumbs } from '../../hooks/use_workflow_breadcrumbs/use_workflow_breadcrumbs';
@@ -23,17 +19,10 @@ const executionsPageTitle = i18n.translate('workflowsManagement.executionsPage.p
   defaultMessage: 'Executions',
 });
 
-const executionsPageDescription = i18n.translate(
-  'workflowsManagement.executionsPage.pageDescription',
-  {
-    defaultMessage: 'Browse and filter workflow executions across your space.',
-  }
-);
-
 const executionsPageExperimentalBadgeLabel = i18n.translate(
   'workflowsManagement.executionsPage.experimentalBadge',
   {
-    defaultMessage: 'Experimental',
+    defaultMessage: 'EXPERIMENTAL',
   }
 );
 
@@ -42,31 +31,27 @@ export function WorkflowExecutionsPage() {
 
   useWorkflowsBreadcrumbs(executionsPageTitle);
 
+  const headerBadges = useMemo<AppHeaderBadge[]>(
+    () => [
+      {
+        label: executionsPageExperimentalBadgeLabel,
+        color: 'hollow',
+        'data-test-subj': 'workflowExecutionsExperimentalBadge',
+      },
+    ],
+    []
+  );
+
   return (
     <EuiPageTemplate
       offset={0}
       css={{ backgroundColor: euiTheme.colors.backgroundBasePlain }}
       data-test-subj="workflowExecutionsPage"
     >
-      <EuiPageTemplate.Header
-        bottomBorder
-        pageTitle={executionsPageTitle}
-        restrictWidth={false}
-        rightSideItems={[
-          <EuiBetaBadge
-            key="experimental"
-            label={executionsPageExperimentalBadgeLabel}
-            color="hollow"
-          />,
-        ]}
-      >
-        <EuiScreenReaderOnly>
-          <h2 id="workflowExecutionsTableLabel">{executionsPageTitle}</h2>
-        </EuiScreenReaderOnly>
-        <EuiText size="s" color="subdued">
-          <p>{executionsPageDescription}</p>
-        </EuiText>
-      </EuiPageTemplate.Header>
+      <AppHeader title={executionsPageTitle} badges={headerBadges} />
+      <EuiScreenReaderOnly>
+        <h2 id="workflowExecutionsTableLabel">{executionsPageTitle}</h2>
+      </EuiScreenReaderOnly>
       <EuiPageTemplate.Section paddingSize="m" grow restrictWidth={false}>
         <WorkflowExecutionsPageContent />
       </EuiPageTemplate.Section>

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/use_workflow_executions_grid_selection.ts
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/use_workflow_executions_grid_selection.ts
@@ -107,14 +107,25 @@ export const useWorkflowExecutionsGridSelection = (
     };
   }, [selectedExecutionIdSet, visibleExecutionIds]);
 
-  return {
-    selectedExecutionIds,
-    selectedExecutionsCount: selectedExecutionIds.length,
-    isExecutionSelected,
-    toggleExecutionSelection,
-    selectAllVisibleExecutions,
-    deselectVisibleExecutions,
-    clearAllSelectedExecutions,
-    getVisibleSelectionState,
-  };
+  return useMemo(
+    () => ({
+      selectedExecutionIds,
+      selectedExecutionsCount: selectedExecutionIds.length,
+      isExecutionSelected,
+      toggleExecutionSelection,
+      selectAllVisibleExecutions,
+      deselectVisibleExecutions,
+      clearAllSelectedExecutions,
+      getVisibleSelectionState,
+    }),
+    [
+      clearAllSelectedExecutions,
+      deselectVisibleExecutions,
+      getVisibleSelectionState,
+      isExecutionSelected,
+      selectAllVisibleExecutions,
+      selectedExecutionIds,
+      toggleExecutionSelection,
+    ]
+  );
 };

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_data_grid.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_data_grid.tsx
@@ -14,16 +14,26 @@ import type {
   EuiDataGridSorting,
   EuiDataGridToolBarVisibilityOptions,
 } from '@elastic/eui';
-import { EuiCheckbox, EuiDataGrid, EuiScreenReaderOnly } from '@elastic/eui';
+import {
+  EuiCheckbox,
+  EuiDataGrid,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiScreenReaderOnly,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
 import React, { useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { WorkflowExecutionListItemDto } from '@kbn/workflows';
 import type { RerunWorkflowExecutionParams } from './build_replay_inputs_from_execution_context';
 import type { UseWorkflowExecutionsGridSelectionResult } from './use_workflow_executions_grid_selection';
+import { WorkflowExecutionsFullscreenButton } from './workflow_executions_fullscreen_button';
 import {
   useWorkflowExecutionsGridContext,
   WorkflowExecutionsGridProvider,
 } from './workflow_executions_grid_context';
+import type { ExecutionsGroupBy } from './workflow_executions_group_by';
+import { WorkflowExecutionsGroupByControl } from './workflow_executions_group_by_control';
 import type { ExecutionTableSortOrder } from './workflow_executions_page_constants';
 import { WorkflowExecutionsSelectionBar } from './workflow_executions_selection_bar';
 import { useWorkflowExecutionsTrailingControlColumns } from './workflow_executions_table_actions';
@@ -38,6 +48,7 @@ import {
   buildWorkflowExecutionsGridColumns,
   type WorkflowExecutionsGridCellContext,
 } from './workflow_executions_table_config';
+import { WorkflowExecutionsTableResultCount } from './workflow_executions_table_result_count';
 
 const SELECTION_COLUMN_ID = 'selection';
 const SELECTION_COLUMN_WIDTH = 36;
@@ -49,6 +60,18 @@ const gridStyle = {
   fontSize: 'm' as const,
   cellPadding: 'm' as const,
 };
+
+const hideGridBodyCss = css`
+  .euiDataGrid__content,
+  .euiDataGrid__pagination,
+  .euiDataGridHeader {
+    display: none !important;
+  }
+
+  .euiDataGrid {
+    border: none;
+  }
+`;
 
 const SelectionHeaderCell = () => {
   const { getVisibleSelectionState, selectAllVisibleExecutions, deselectVisibleExecutions } =
@@ -169,6 +192,17 @@ export interface WorkflowExecutionsDataGridProps {
   sort: ExecutionTableSortOrder;
   selectedExecutionId?: string;
   selectionState: UseWorkflowExecutionsGridSelectionResult;
+  pageIndex: number;
+  pageSize: number;
+  totalHits: number;
+  showToolbar?: boolean;
+  /** When true, hide the grid body so only the toolbar remains (used with grouped view). */
+  toolbarOnly?: boolean;
+  groupBy?: ExecutionsGroupBy;
+  onGroupByChange?: (value: ExecutionsGroupBy) => void;
+  isFullscreen?: boolean;
+  onToggleFullscreen?: () => void;
+  fullscreenButtonRef?: React.Ref<HTMLButtonElement>;
   onOpenExecution: (execution: WorkflowExecutionListItemDto) => void;
   onRefresh: () => void;
   onSetColumns: (columns: string[]) => void;
@@ -186,6 +220,16 @@ export const WorkflowExecutionsDataGrid = ({
   sort,
   selectedExecutionId,
   selectionState,
+  pageIndex,
+  pageSize,
+  totalHits,
+  showToolbar = true,
+  toolbarOnly = false,
+  groupBy = 'none',
+  onGroupByChange,
+  isFullscreen = false,
+  onToggleFullscreen,
+  fullscreenButtonRef,
   onOpenExecution,
   onRefresh,
   onSetColumns,
@@ -228,21 +272,66 @@ export const WorkflowExecutionsDataGrid = ({
     [cellContext]
   );
 
-  const toolbarVisibility = useMemo<EuiDataGridToolBarVisibilityOptions>(
-    () => ({
+  const rightControls = useMemo(() => {
+    if (!showToolbar || (!onGroupByChange && !onToggleFullscreen)) {
+      return undefined;
+    }
+
+    return (
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        {onGroupByChange ? (
+          <EuiFlexItem grow={false}>
+            <WorkflowExecutionsGroupByControl value={groupBy} onChange={onGroupByChange} />
+          </EuiFlexItem>
+        ) : null}
+        {onToggleFullscreen ? (
+          <EuiFlexItem grow={false}>
+            <WorkflowExecutionsFullscreenButton
+              isFullscreen={isFullscreen}
+              onToggle={onToggleFullscreen}
+              buttonRef={fullscreenButtonRef}
+            />
+          </EuiFlexItem>
+        ) : null}
+      </EuiFlexGroup>
+    );
+  }, [
+    fullscreenButtonRef,
+    groupBy,
+    isFullscreen,
+    onGroupByChange,
+    onToggleFullscreen,
+    showToolbar,
+  ]);
+
+  const toolbarVisibility = useMemo<EuiDataGridToolBarVisibilityOptions | boolean>(() => {
+    if (!showToolbar) {
+      return false;
+    }
+
+    return {
       showColumnSelector: { allowHide: false },
       showSortSelector: true,
-      showDisplaySelector: false,
+      showDisplaySelector: true,
+      // Shell-level fullscreen wraps pagination + end-of-results; keep grid built-in off.
       showFullScreenSelector: false,
-      showKeyboardShortcuts: false,
+      showKeyboardShortcuts: true,
       additionalControls: {
         left: {
+          prepend: (
+            <WorkflowExecutionsTableResultCount
+              pageIndex={pageIndex}
+              pageSize={pageSize}
+              pageItemCount={executions.length}
+              totalHits={totalHits}
+            />
+          ),
           append: <WorkflowExecutionsSelectionBar onRefresh={onRefresh} executions={executions} />,
         },
+        right: rightControls,
       },
-    }),
-    [executions, onRefresh]
-  );
+    };
+  }, [executions, onRefresh, pageIndex, pageSize, rightControls, showToolbar, totalHits]);
 
   const leadingControlColumns = useMemo<EuiDataGridControlColumn[]>(
     () => [
@@ -278,26 +367,30 @@ export const WorkflowExecutionsDataGrid = ({
     };
   }, [executions, selectedExecutionId]);
 
+  const rowCount = toolbarOnly ? 0 : executions.length;
+
   return (
     <WorkflowExecutionsGridProvider value={selectionState}>
-      <EuiDataGrid
-        aria-labelledby={ariaLabelledBy}
-        columns={gridColumns}
-        rowCount={executions.length}
-        renderCellValue={renderCellValue}
-        leadingControlColumns={leadingControlColumns}
-        trailingControlColumns={trailingControlColumns}
-        columnVisibility={{
-          visibleColumns,
-          setVisibleColumns: onSetColumns,
-          canDragAndDropColumns: true,
-        }}
-        sorting={sorting}
-        onColumnResize={({ columnId, width }) => onColumnResize(columnId, width)}
-        gridStyle={gridStyleWithSelection}
-        rowHeightsOptions={{ defaultHeight: { lineCount: 1 } }}
-        toolbarVisibility={toolbarVisibility}
-      />
+      <div css={toolbarOnly ? hideGridBodyCss : undefined}>
+        <EuiDataGrid
+          aria-labelledby={ariaLabelledBy}
+          columns={gridColumns}
+          rowCount={rowCount}
+          renderCellValue={renderCellValue}
+          leadingControlColumns={leadingControlColumns}
+          trailingControlColumns={trailingControlColumns}
+          columnVisibility={{
+            visibleColumns,
+            setVisibleColumns: onSetColumns,
+            canDragAndDropColumns: true,
+          }}
+          sorting={sorting}
+          onColumnResize={({ columnId, width }) => onColumnResize(columnId, width)}
+          gridStyle={gridStyleWithSelection}
+          rowHeightsOptions={{ defaultHeight: { lineCount: 1 } }}
+          toolbarVisibility={toolbarVisibility}
+        />
+      </div>
     </WorkflowExecutionsGridProvider>
   );
 };

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_fullscreen_button.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_fullscreen_button.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+
+export interface WorkflowExecutionsFullscreenButtonProps {
+  isFullscreen: boolean;
+  onToggle: () => void;
+  buttonRef?: React.Ref<HTMLButtonElement>;
+}
+
+export const WorkflowExecutionsFullscreenButton =
+  React.memo<WorkflowExecutionsFullscreenButtonProps>(({ isFullscreen, onToggle, buttonRef }) => {
+    const label = isFullscreen
+      ? i18n.translate('workflowsManagement.executionsPage.table.exitFullscreen', {
+          defaultMessage: 'Exit fullscreen',
+        })
+      : i18n.translate('workflowsManagement.executionsPage.table.enterFullscreen', {
+          defaultMessage: 'Enter fullscreen',
+        });
+
+    return (
+      <EuiToolTip content={label} disableScreenReaderOutput>
+        <EuiButtonIcon
+          buttonRef={buttonRef}
+          size="xs"
+          color="text"
+          iconType={isFullscreen ? 'fullScreenExit' : 'fullScreen'}
+          aria-label={label}
+          onClick={onToggle}
+          data-test-subj="executionsTableFullscreen"
+        />
+      </EuiToolTip>
+    );
+  });
+
+WorkflowExecutionsFullscreenButton.displayName = 'WorkflowExecutionsFullscreenButton';

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_group_by.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_group_by.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { WorkflowExecutionListItemDto } from '@kbn/workflows';
+import { ExecutionStatus } from '@kbn/workflows';
+import { groupExecutions } from './workflow_executions_group_by';
+
+const createExecution = (
+  overrides: Partial<WorkflowExecutionListItemDto> = {}
+): WorkflowExecutionListItemDto => ({
+  spaceId: 'default',
+  id: 'exec-1',
+  status: ExecutionStatus.COMPLETED,
+  isTestRun: false,
+  startedAt: '2026-01-01T00:00:00Z',
+  finishedAt: '2026-01-01T00:00:03Z',
+  duration: 3000,
+  error: null,
+  ...overrides,
+});
+
+describe('groupExecutions', () => {
+  it('returns an empty list for none', () => {
+    expect(groupExecutions([createExecution()], 'none')).toEqual([]);
+  });
+
+  it('groups by workflow and sorts by count descending', () => {
+    const groups = groupExecutions(
+      [
+        createExecution({ id: '1', workflowId: 'a', workflowName: 'Alpha' }),
+        createExecution({ id: '2', workflowId: 'b', workflowName: 'Beta' }),
+        createExecution({ id: '3', workflowId: 'a', workflowName: 'Alpha' }),
+      ],
+      'workflow'
+    );
+
+    expect(groups.map((group) => ({ key: group.key, count: group.executions.length }))).toEqual([
+      { key: 'a', count: 2 },
+      { key: 'b', count: 1 },
+    ]);
+  });
+
+  it('groups by status', () => {
+    const groups = groupExecutions(
+      [
+        createExecution({ id: '1', status: ExecutionStatus.COMPLETED }),
+        createExecution({ id: '2', status: ExecutionStatus.FAILED }),
+        createExecution({ id: '3', status: ExecutionStatus.COMPLETED }),
+      ],
+      'status'
+    );
+
+    expect(groups[0].key).toBe(ExecutionStatus.COMPLETED);
+    expect(groups[0].executions).toHaveLength(2);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_group_by.ts
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_group_by.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { WorkflowExecutionListItemDto } from '@kbn/workflows';
+import { formatExecutionTriggerLabel } from './format_execution_table_values';
+
+export const EXECUTIONS_GROUP_BY_VALUES = ['none', 'workflow', 'status', 'trigger'] as const;
+
+export type ExecutionsGroupBy = (typeof EXECUTIONS_GROUP_BY_VALUES)[number];
+
+export interface ExecutionsGroupBucket {
+  key: string;
+  label: string;
+  executions: WorkflowExecutionListItemDto[];
+}
+
+export const getExecutionsGroupByLabel = (value: ExecutionsGroupBy): string => {
+  switch (value) {
+    case 'workflow':
+      return i18n.translate('workflowsManagement.executionsPage.table.groupBy.workflow', {
+        defaultMessage: 'Workflow',
+      });
+    case 'status':
+      return i18n.translate('workflowsManagement.executionsPage.table.groupBy.status', {
+        defaultMessage: 'Status',
+      });
+    case 'trigger':
+      return i18n.translate('workflowsManagement.executionsPage.table.groupBy.trigger', {
+        defaultMessage: 'Trigger',
+      });
+    case 'none':
+    default:
+      return i18n.translate('workflowsManagement.executionsPage.table.groupBy.none', {
+        defaultMessage: 'None',
+      });
+  }
+};
+
+const getGroupKey = (
+  execution: WorkflowExecutionListItemDto,
+  groupBy: Exclude<ExecutionsGroupBy, 'none'>
+): { key: string; label: string } => {
+  switch (groupBy) {
+    case 'workflow': {
+      const label = execution.workflowName ?? execution.workflowId ?? '—';
+      return { key: execution.workflowId ?? label, label };
+    }
+    case 'status': {
+      const label = execution.status ?? '—';
+      return { key: label, label };
+    }
+    case 'trigger': {
+      const label = formatExecutionTriggerLabel(execution.triggeredBy) ?? '—';
+      return { key: execution.triggeredBy ?? label, label };
+    }
+    default:
+      return { key: '—', label: '—' };
+  }
+};
+
+/**
+ * Client-side grouping over the currently loaded page of executions.
+ * TODO: server-side aggregation for correct counts across the full result set.
+ */
+export const groupExecutions = (
+  executions: WorkflowExecutionListItemDto[],
+  groupBy: ExecutionsGroupBy
+): ExecutionsGroupBucket[] => {
+  if (groupBy === 'none') {
+    return [];
+  }
+
+  const buckets = new Map<string, ExecutionsGroupBucket>();
+
+  for (const execution of executions) {
+    const { key, label } = getGroupKey(execution, groupBy);
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.executions.push(execution);
+    } else {
+      buckets.set(key, { key, label, executions: [execution] });
+    }
+  }
+
+  return [...buckets.values()].sort((a, b) => b.executions.length - a.executions.length);
+};

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_group_by_control.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_group_by_control.tsx
@@ -65,7 +65,7 @@ export const WorkflowExecutionsGroupByControl = React.memo<WorkflowExecutionsGro
         button={
           <EuiButtonEmpty
             size="xs"
-            iconType="arrowDown"
+            iconType="chevronSingleDown"
             iconSide="right"
             color="text"
             onClick={toggle}

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_group_by_control.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_group_by_control.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EuiSelectableOption } from '@elastic/eui';
+import { EuiButtonEmpty, EuiPopover, EuiSelectable, useGeneratedHtmlId } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import {
+  EXECUTIONS_GROUP_BY_VALUES,
+  type ExecutionsGroupBy,
+  getExecutionsGroupByLabel,
+} from './workflow_executions_group_by';
+
+const optionsPanelCss = css`
+  width: 220px;
+`;
+
+export interface WorkflowExecutionsGroupByControlProps {
+  value: ExecutionsGroupBy;
+  onChange: (value: ExecutionsGroupBy) => void;
+}
+
+export const WorkflowExecutionsGroupByControl = React.memo<WorkflowExecutionsGroupByControlProps>(
+  ({ value, onChange }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const popoverId = useGeneratedHtmlId({ prefix: 'executionsTableGroupBy' });
+
+    const close = useCallback(() => setIsOpen(false), []);
+    const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+
+    const options = useMemo<Array<EuiSelectableOption & { key: ExecutionsGroupBy }>>(
+      () =>
+        EXECUTIONS_GROUP_BY_VALUES.map((optionValue) => ({
+          key: optionValue,
+          label: getExecutionsGroupByLabel(optionValue),
+          checked: optionValue === value ? ('on' as const) : undefined,
+          'data-test-subj': `executionsTableGroupBy-${optionValue}`,
+        })),
+      [value]
+    );
+
+    const buttonLabel = i18n.translate(
+      'workflowsManagement.executionsPage.table.groupBy.buttonLabel',
+      {
+        defaultMessage: 'Group executions by: {selection}',
+        values: { selection: getExecutionsGroupByLabel(value) },
+      }
+    );
+
+    return (
+      <EuiPopover
+        id={popoverId}
+        isOpen={isOpen}
+        closePopover={close}
+        anchorPosition="downLeft"
+        panelPaddingSize="none"
+        aria-label={buttonLabel}
+        button={
+          <EuiButtonEmpty
+            size="xs"
+            iconType="arrowDown"
+            iconSide="right"
+            color="text"
+            onClick={toggle}
+            data-test-subj="executionsTableGroupBySelector"
+          >
+            {buttonLabel}
+          </EuiButtonEmpty>
+        }
+      >
+        <EuiSelectable
+          singleSelection
+          options={options}
+          onChange={(nextOptions) => {
+            const selected = nextOptions.find((option) => option.checked === 'on');
+            if (selected?.key) {
+              onChange(selected.key as ExecutionsGroupBy);
+            }
+            close();
+          }}
+          listProps={{ rowHeight: 40, isVirtualized: false }}
+        >
+          {(list) => (
+            <div css={optionsPanelCss} data-test-subj="executionsTableGroupByOptions">
+              {list}
+            </div>
+          )}
+        </EuiSelectable>
+      </EuiPopover>
+    );
+  }
+);
+
+WorkflowExecutionsGroupByControl.displayName = 'WorkflowExecutionsGroupByControl';

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_grouped_view.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_grouped_view.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { ExecutionStatus, type WorkflowExecutionListItemDto } from '@kbn/workflows';
+import { WorkflowExecutionsGroupedView } from './workflow_executions_grouped_view';
+import { getTestProvider } from '../../shared/mocks/test_providers';
+
+jest.mock('../../shared/ui/formatted_relative_enhanced/formatted_relative_enhanced', () => ({
+  FormattedRelativeEnhanced: ({ value }: { value: Date }) => <span>{value.toISOString()}</span>,
+}));
+
+jest.mock('../../shared/ui/use_formatted_date', () => ({
+  useGetFormattedDateTime: () => (date: Date) => date.toISOString(),
+}));
+
+const createExecution = (
+  overrides: Partial<WorkflowExecutionListItemDto> = {}
+): WorkflowExecutionListItemDto => ({
+  spaceId: 'default',
+  id: 'exec-1',
+  status: ExecutionStatus.COMPLETED,
+  isTestRun: false,
+  startedAt: '2026-01-01T00:00:00Z',
+  finishedAt: '2026-01-01T00:00:03Z',
+  duration: 3000,
+  error: null,
+  ...overrides,
+});
+
+const renderGroupedView = (executions: WorkflowExecutionListItemDto[]) =>
+  render(
+    <WorkflowExecutionsGroupedView
+      executions={executions}
+      groupBy="workflow"
+      onOpenExecution={jest.fn()}
+    />,
+    { wrapper: getTestProvider({}) }
+  );
+
+describe('WorkflowExecutionsGroupedView', () => {
+  it('renders Alerts-style group headers collapsed by default with stats on the right', () => {
+    const executions = [
+      createExecution({ id: '1', workflowId: 'wf-a', workflowName: 'Alpha' }),
+      createExecution({ id: '2', workflowId: 'wf-a', workflowName: 'Alpha' }),
+      createExecution({ id: '3', workflowId: 'wf-b', workflowName: 'Beta' }),
+    ];
+
+    renderGroupedView(executions);
+
+    expect(screen.getByTestId('executionsTableGroupSummary')).toHaveTextContent(
+      '3 executions | 2 groups'
+    );
+
+    const alphaGroup = screen.getByTestId('executionsTableGroup-wf-a');
+    expect(within(alphaGroup).getByTestId('executionsTableGroupHeader')).toHaveTextContent('Alpha');
+    expect(within(alphaGroup).getByTestId('executionsTableGroupStats')).toHaveTextContent(
+      'Executions'
+    );
+    expect(within(alphaGroup).getByTestId('executionsTableGroupCount')).toHaveTextContent('2');
+    expect(screen.queryByText('Alpha', { selector: 'td' })).not.toBeInTheDocument();
+  });
+
+  it('expands one group at a time and mounts the nested table only when open', () => {
+    const executions = [
+      createExecution({ id: '1', workflowId: 'wf-a', workflowName: 'Alpha' }),
+      createExecution({ id: '2', workflowId: 'wf-b', workflowName: 'Beta' }),
+    ];
+
+    renderGroupedView(executions);
+
+    fireEvent.click(within(screen.getByTestId('executionsTableGroup-wf-a')).getByRole('button'));
+    expect(screen.getAllByRole('table')).toHaveLength(1);
+    expect(
+      within(screen.getByTestId('executionsTableGroup-wf-a')).getByRole('table')
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(screen.getByTestId('executionsTableGroup-wf-b')).getByRole('button'));
+    expect(screen.getAllByRole('table')).toHaveLength(1);
+    expect(
+      within(screen.getByTestId('executionsTableGroup-wf-b')).getByRole('table')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_grouped_view.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_grouped_view.tsx
@@ -167,7 +167,7 @@ const GroupTable = React.memo<{
         name: i18n.translate('workflowsManagement.executionsPage.column.tags', {
           defaultMessage: 'Tags',
         }),
-        width: '240px',
+        width: '250px',
         render: (_value, execution) => <WorkflowExecutionTagsCell execution={execution} />,
       },
       {
@@ -175,7 +175,7 @@ const GroupTable = React.memo<{
         name: i18n.translate('workflowsManagement.executionsPage.column.trigger', {
           defaultMessage: 'Trigger',
         }),
-        width: '120px',
+        width: '250px',
         render: (_value, execution) => <WorkflowExecutionTriggersCell execution={execution} />,
       },
       {
@@ -183,7 +183,7 @@ const GroupTable = React.memo<{
         name: i18n.translate('workflowsManagement.executionsPage.column.started', {
           defaultMessage: 'Started',
         }),
-        width: '160px',
+        width: '250px',
         render: (_value, execution) => <WorkflowExecutionStartedAtCell execution={execution} />,
       },
       {
@@ -191,7 +191,7 @@ const GroupTable = React.memo<{
         name: i18n.translate('workflowsManagement.executionsPage.column.duration', {
           defaultMessage: 'Duration',
         }),
-        width: '100px',
+        width: '250px',
         align: 'right',
         render: (_value, execution) => <WorkflowExecutionDurationCell execution={execution} />,
       },

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_grouped_view.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_grouped_view.tsx
@@ -175,7 +175,7 @@ const GroupTable = React.memo<{
         name: i18n.translate('workflowsManagement.executionsPage.column.trigger', {
           defaultMessage: 'Trigger',
         }),
-        width: '110px',
+        width: '120px',
         render: (_value, execution) => <WorkflowExecutionTriggersCell execution={execution} />,
       },
       {
@@ -183,7 +183,7 @@ const GroupTable = React.memo<{
         name: i18n.translate('workflowsManagement.executionsPage.column.started', {
           defaultMessage: 'Started',
         }),
-        width: '140px',
+        width: '160px',
         render: (_value, execution) => <WorkflowExecutionStartedAtCell execution={execution} />,
       },
       {
@@ -191,7 +191,7 @@ const GroupTable = React.memo<{
         name: i18n.translate('workflowsManagement.executionsPage.column.duration', {
           defaultMessage: 'Duration',
         }),
-        width: '88px',
+        width: '100px',
         align: 'right',
         render: (_value, execution) => <WorkflowExecutionDurationCell execution={execution} />,
       },

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_grouped_view.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_grouped_view.tsx
@@ -1,0 +1,328 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EuiBasicTableColumn, EuiThemeComputed } from '@elastic/eui';
+import {
+  EuiAccordion,
+  EuiBadge,
+  EuiBasicTable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  EuiToolTip,
+  useEuiFontSize,
+  useEuiTheme,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import type { WorkflowExecutionListItemDto } from '@kbn/workflows';
+import type { RerunWorkflowExecutionParams } from './build_replay_inputs_from_execution_context';
+import { type ExecutionsGroupBy, groupExecutions } from './workflow_executions_group_by';
+import {
+  getWorkflowExecutionActionContext,
+  WorkflowExecutionActionsMenu,
+} from './workflow_executions_table_actions';
+import {
+  WorkflowExecutionDurationCell,
+  WorkflowExecutionStartedAtCell,
+  WorkflowExecutionTagsCell,
+  WorkflowExecutionTriggersCell,
+  WorkflowExecutionWorkflowCell,
+} from './workflow_executions_table_cells';
+
+export interface WorkflowExecutionsGroupedViewProps {
+  executions: WorkflowExecutionListItemDto[];
+  groupBy: Exclude<ExecutionsGroupBy, 'none'>;
+  onOpenExecution: (execution: WorkflowExecutionListItemDto) => void;
+  onReRunExecution?: (params: RerunWorkflowExecutionParams) => Promise<void>;
+  onViewAllExecutionsForWorkflow?: (workflowId: string) => void;
+}
+
+const groupingContainerCss = (euiTheme: EuiThemeComputed) => css`
+  .executionsGroupingAccordion .euiAccordion__childWrapper .euiAccordion__children {
+    margin-left: ${euiTheme.size.s};
+    margin-right: ${euiTheme.size.s};
+    border-left: ${euiTheme.border.thin};
+    border-right: ${euiTheme.border.thin};
+    border-bottom: ${euiTheme.border.thin};
+    border-radius: 0 0 6px 6px;
+  }
+
+  .executionsGroupingAccordion .euiAccordion__triggerWrapper {
+    border-bottom: ${euiTheme.border.thin};
+    border-left: ${euiTheme.border.thin};
+    border-right: ${euiTheme.border.thin};
+    border-radius: 6px;
+    min-height: 78px;
+    padding-left: ${euiTheme.size.base};
+    padding-right: ${euiTheme.size.base};
+  }
+
+  .executionsGroupingAccordion {
+    border-top: ${euiTheme.border.thin};
+    border-bottom: none;
+    border-radius: 6px;
+  }
+
+  .executionsGroupingPanelRenderer {
+    display: table;
+    table-layout: fixed;
+    width: 100%;
+    padding-right: ${euiTheme.size.xl};
+  }
+`;
+
+const GroupPanelTitle = ({ title }: { title: string }) => (
+  <div className="executionsGroupingPanelRenderer" data-test-subj="executionsTableGroupHeader">
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false} className="eui-textTruncate">
+        <EuiTitle size="xs">
+          <h4 className="eui-textTruncate" title={title}>
+            {title}
+          </h4>
+        </EuiTitle>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+);
+
+const GroupStats = ({ count }: { count: number }) => {
+  const { euiTheme } = useEuiTheme();
+  const xsFontSize = useEuiFontSize('xs').fontSize;
+  const badgeValue = count > 99 ? '99+' : count.toString();
+  const executionsLabel = i18n.translate(
+    'workflowsManagement.executionsPage.table.groupBy.stat.executions',
+    { defaultMessage: 'Executions' }
+  );
+
+  return (
+    <EuiFlexGroup
+      data-test-subj="executionsTableGroupStats"
+      gutterSize="m"
+      alignItems="center"
+      responsive={false}
+    >
+      <EuiFlexItem grow={false}>
+        <span
+          css={css`
+            font-size: ${xsFontSize};
+            font-weight: ${euiTheme.font.weight.semiBold};
+          `}
+        >
+          {executionsLabel}
+          <EuiToolTip position="top" content={count}>
+            <EuiBadge
+              tabIndex={0}
+              color="hollow"
+              css={css`
+                margin-left: ${euiTheme.size.s};
+                width: 35px;
+                .euiBadge__text {
+                  text-align: center;
+                  width: 100%;
+                }
+              `}
+              data-test-subj="executionsTableGroupCount"
+            >
+              {badgeValue}
+            </EuiBadge>
+          </EuiToolTip>
+        </span>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+const GroupTable = React.memo<{
+  executions: WorkflowExecutionListItemDto[];
+  onOpenExecution: (execution: WorkflowExecutionListItemDto) => void;
+  onReRunExecution?: (params: RerunWorkflowExecutionParams) => Promise<void>;
+  onViewAllExecutionsForWorkflow?: (workflowId: string) => void;
+}>(({ executions, onOpenExecution, onReRunExecution, onViewAllExecutionsForWorkflow }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const columns = useMemo<Array<EuiBasicTableColumn<WorkflowExecutionListItemDto>>>(
+    () => [
+      {
+        field: 'workflow',
+        name: i18n.translate('workflowsManagement.executionsPage.column.workflow', {
+          defaultMessage: 'Workflow',
+        }),
+        render: (_value, execution) => (
+          <WorkflowExecutionWorkflowCell execution={execution} onOpen={onOpenExecution} />
+        ),
+      },
+      {
+        field: 'tags',
+        name: i18n.translate('workflowsManagement.executionsPage.column.tags', {
+          defaultMessage: 'Tags',
+        }),
+        width: '240px',
+        render: (_value, execution) => <WorkflowExecutionTagsCell execution={execution} />,
+      },
+      {
+        field: 'triggers',
+        name: i18n.translate('workflowsManagement.executionsPage.column.trigger', {
+          defaultMessage: 'Trigger',
+        }),
+        width: '110px',
+        render: (_value, execution) => <WorkflowExecutionTriggersCell execution={execution} />,
+      },
+      {
+        field: 'startedAt',
+        name: i18n.translate('workflowsManagement.executionsPage.column.started', {
+          defaultMessage: 'Started',
+        }),
+        width: '140px',
+        render: (_value, execution) => <WorkflowExecutionStartedAtCell execution={execution} />,
+      },
+      {
+        field: 'duration',
+        name: i18n.translate('workflowsManagement.executionsPage.column.duration', {
+          defaultMessage: 'Duration',
+        }),
+        width: '88px',
+        align: 'right',
+        render: (_value, execution) => <WorkflowExecutionDurationCell execution={execution} />,
+      },
+      {
+        name: i18n.translate('workflowsManagement.executionsPage.column.actions', {
+          defaultMessage: 'Actions',
+        }),
+        width: '56px',
+        align: 'right',
+        render: (execution: WorkflowExecutionListItemDto) => (
+          <WorkflowExecutionActionsMenu
+            actionContext={getWorkflowExecutionActionContext(execution)}
+            onReRunExecution={onReRunExecution}
+            onViewAllExecutionsForWorkflow={onViewAllExecutionsForWorkflow}
+            variant="icon"
+          />
+        ),
+      },
+    ],
+    [onOpenExecution, onReRunExecution, onViewAllExecutionsForWorkflow]
+  );
+
+  return (
+    <EuiBasicTable
+      tableCaption={i18n.translate(
+        'workflowsManagement.executionsPage.table.groupBy.tableCaption',
+        {
+          defaultMessage: 'Executions in this group',
+        }
+      )}
+      items={executions}
+      columns={columns}
+      tableLayout="auto"
+      css={css`
+        .euiTableRowCell {
+          vertical-align: middle;
+        }
+        .euiTableHeaderCell {
+          background-color: ${euiTheme.components.dataGridRowBackground};
+        }
+      `}
+    />
+  );
+});
+
+GroupTable.displayName = 'GroupTable';
+
+export const WorkflowExecutionsGroupedView = React.memo<WorkflowExecutionsGroupedViewProps>(
+  ({ executions, groupBy, onOpenExecution, onReRunExecution, onViewAllExecutionsForWorkflow }) => {
+    const { euiTheme } = useEuiTheme();
+    const xsFontSize = useEuiFontSize('xs').fontSize;
+    const accordionId = useGeneratedHtmlId({ prefix: 'executionsTableGroups' });
+    // TODO: server-side aggregation for correct counts across the full result set.
+    const groups = useMemo(() => groupExecutions(executions, groupBy), [executions, groupBy]);
+    const [openGroupKey, setOpenGroupKey] = useState<string | null>(null);
+
+    useEffect(() => {
+      setOpenGroupKey(null);
+    }, [groupBy]);
+
+    const handleToggle = useCallback((groupKey: string, isOpen: boolean) => {
+      setOpenGroupKey(isOpen ? groupKey : null);
+    }, []);
+
+    const summaryCss = css`
+      font-size: ${xsFontSize};
+      font-weight: ${euiTheme.font.weight.semiBold};
+    `;
+
+    if (groups.length === 0) {
+      return (
+        <div data-test-subj="executionsTableGroupedView">
+          <EuiText size="s" color="subdued">
+            {i18n.translate('workflowsManagement.executionsPage.table.groupBy.empty', {
+              defaultMessage: 'No executions to group.',
+            })}
+          </EuiText>
+        </div>
+      );
+    }
+
+    return (
+      <div css={groupingContainerCss(euiTheme)} data-test-subj="executionsTableGroupedView">
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiText css={summaryCss} data-test-subj="executionsTableGroupSummary">
+              {i18n.translate('workflowsManagement.executionsPage.table.groupBy.summary', {
+                defaultMessage:
+                  '{executionCount} {executionCount, plural, one {execution} other {executions}} | {groupCount} {groupCount, plural, one {group} other {groups}}',
+                values: {
+                  executionCount: executions.length,
+                  groupCount: groups.length,
+                },
+              })}
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size="s" />
+        {groups.map((group, index) => {
+          const isOpen = openGroupKey === group.key;
+          return (
+            <React.Fragment key={group.key}>
+              {index > 0 ? <EuiSpacer size="s" /> : null}
+              <EuiAccordion
+                id={`${accordionId}-${group.key}`}
+                className="executionsGroupingAccordion"
+                buttonElement="div"
+                buttonContent={<GroupPanelTitle title={group.label} />}
+                extraAction={<GroupStats count={group.executions.length} />}
+                forceState={isOpen ? 'open' : 'closed'}
+                onToggle={(nextIsOpen) => handleToggle(group.key, nextIsOpen)}
+                paddingSize="m"
+                data-test-subj={`executionsTableGroup-${group.key}`}
+              >
+                {isOpen ? (
+                  <GroupTable
+                    executions={group.executions}
+                    onOpenExecution={onOpenExecution}
+                    onReRunExecution={onReRunExecution}
+                    onViewAllExecutionsForWorkflow={onViewAllExecutionsForWorkflow}
+                  />
+                ) : (
+                  <span />
+                )}
+              </EuiAccordion>
+            </React.Fragment>
+          );
+        })}
+      </div>
+    );
+  }
+);
+
+WorkflowExecutionsGroupedView.displayName = 'WorkflowExecutionsGroupedView';

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_page_constants.ts
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_page_constants.ts
@@ -14,7 +14,7 @@ export type ExecutionTableSortOrder = ReadonlyArray<readonly [string, 'asc' | 'd
 
 export const EXECUTION_FILTERS_URL_PARAM_KEY = 'workflowsExecutionsPageFilters' as const;
 export const EXECUTION_FILTERS_STORAGE_KEY = 'workflows.executions.pageFilters' as const;
-export const EXECUTION_TABLE_DEFAULT_PAGE_SIZE = 25;
+export const EXECUTION_TABLE_DEFAULT_PAGE_SIZE = 50;
 export const EXECUTION_TABLE_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
 export const EXECUTION_TABLE_DEFAULT_SORT: ExecutionTableSortOrder = [['startedAt', 'desc']];
 

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_page_content.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_page_content.tsx
@@ -137,6 +137,28 @@ export const WorkflowExecutionsPageContent = React.memo(() => {
     [applyWorkflowIdFilter, setSelectedExecution]
   );
 
+  const handleTimeRangeLinkClick = useCallback(() => {
+    // Prefer focusing the date-range toggle so the user can narrow the window.
+    // Fallbacks cover unified-search markup differences across versions.
+    const datePickerTrigger =
+      document.querySelector<HTMLElement>(
+        '[data-test-subj="workflowExecutionsSearchBar"] [data-test-subj="superDatePickerToggleQuickMenuButton"]'
+      ) ??
+      document.querySelector<HTMLElement>(
+        '[data-test-subj="workflowExecutionsSearchBar"] [data-test-subj="superDatePickerShowDatesButton"]'
+      ) ??
+      document.querySelector<HTMLElement>(
+        '[data-test-subj="workflowExecutionsSearchBar"] [data-test-subj="superDatePickerstartDatePopoverButton"]'
+      );
+
+    if (datePickerTrigger) {
+      datePickerTrigger.focus();
+      datePickerTrigger.click();
+    }
+
+    // TODO: Wire a SearchBar/date-picker ref API when available instead of DOM query.
+  }, []);
+
   return (
     <div data-test-subj="workflowExecutionsPageContent">
       <WorkflowExecutionsSearchBar
@@ -170,6 +192,7 @@ export const WorkflowExecutionsPageContent = React.memo(() => {
           }
           onReRunExecution={rerunExecution}
           onViewAllExecutionsForWorkflow={handleViewAllExecutionsForWorkflow}
+          onTimeRangeLinkClick={handleTimeRangeLinkClick}
           query={submittedQuery}
           spaceId={spaceId}
           timeRange={timeRange}

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table.test.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { WorkflowExecutionsTable } from './workflow_executions_table';
 import { WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW } from '../../../common';
@@ -102,7 +102,7 @@ describe('WorkflowExecutionsTable', () => {
     expect(screen.queryByTestId('workflowExecutionsTableError')).not.toBeInTheDocument();
   });
 
-  it('shows a pagination limit callout when total exceeds the result window', async () => {
+  it('does not show a persistent pagination-limit callout when total exceeds the result window', async () => {
     const services = createStartServicesMock();
 
     jest.mocked(services.http.get).mockResolvedValue({
@@ -135,17 +135,55 @@ describe('WorkflowExecutionsTable', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('workflowExecutionsTablePaginationLimit')).toBeInTheDocument();
+      expect(screen.getByTestId('workflowExecutionsTable')).toBeInTheDocument();
     });
 
-    expect(jest.mocked(services.http.get).mock.calls[0][1]).toEqual(
-      expect.objectContaining({
-        query: expect.objectContaining({
-          page: 1,
-          size: 25,
-        }),
-      })
+    expect(screen.queryByTestId('workflowExecutionsTablePaginationLimit')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('executionsTableEndOfResults')).not.toBeInTheDocument();
+  });
+
+  it('shows the end-of-results strip on the last reachable page when total exceeds the window', async () => {
+    const services = createStartServicesMock();
+
+    jest.mocked(services.http.get).mockResolvedValue({
+      results: [
+        {
+          id: 'exec-1',
+          spaceId: 'default',
+          workflowId: 'wf-1',
+          status: 'completed',
+          isTestRun: false,
+          startedAt: '2024-01-01T10:00:00Z',
+          finishedAt: '2024-01-01T10:00:03Z',
+          duration: 3000,
+          error: null,
+        },
+      ],
+      page: 1,
+      size: 25,
+      total: WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW + 500,
+    });
+
+    render(
+      <WorkflowExecutionsTable
+        filters={[]}
+        query={defaultQuery}
+        spaceId="default"
+        timeRange={defaultTimeRange}
+      />,
+      { wrapper: getTestProvider({ services }) }
     );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflowExecutionsTable')).toBeInTheDocument();
+    });
+
+    // Jump to the last reachable page (page 400 → index 399 at 25 rows/page).
+    fireEvent.click(screen.getByTestId('pagination-button-399'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('executionsTableEndOfResults')).toBeInTheDocument();
+    });
   });
 
   it('shows a generic error prompt for non-index errors', async () => {

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table.tsx
@@ -11,12 +11,14 @@ import {
   EuiButtonEmpty,
   EuiCallOut,
   EuiEmptyPrompt,
+  EuiFocusTrap,
   EuiPanel,
   EuiSkeletonText,
   EuiTablePagination,
+  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Filter, Query, TimeRange } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -24,6 +26,8 @@ import type { RerunWorkflowExecutionParams } from './build_replay_inputs_from_ex
 import { useWorkflowExecutionsGridSelection } from './use_workflow_executions_grid_selection';
 import { useWorkflowExecutionsSearch } from './use_workflow_executions_search';
 import { WorkflowExecutionsDataGrid } from './workflow_executions_data_grid';
+import type { ExecutionsGroupBy } from './workflow_executions_group_by';
+import { WorkflowExecutionsGroupedView } from './workflow_executions_grouped_view';
 import {
   EXECUTION_TABLE_DEFAULT_PAGE_SIZE,
   EXECUTION_TABLE_DEFAULT_SORT,
@@ -35,6 +39,7 @@ import {
   DEFAULT_WORKFLOW_EXECUTIONS_TABLE_COLUMNS,
   WORKFLOW_EXECUTIONS_TABLE_GRID_SETTINGS,
 } from './workflow_executions_table_config';
+import { WorkflowExecutionsTableEndOfResults } from './workflow_executions_table_end_of_results';
 import { getWorkflowExecutionsTableGridWrapperCss } from './workflow_executions_table_styles';
 import { WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW } from '../../../common';
 import { useSerialPolling } from '../../hooks/use_serial_polling';
@@ -60,6 +65,7 @@ export interface WorkflowExecutionsTableProps {
   liveUpdateIntervalMs?: number;
   onReRunExecution?: (params: RerunWorkflowExecutionParams) => Promise<void>;
   onViewAllExecutionsForWorkflow?: (workflowId: string) => void;
+  onTimeRangeLinkClick?: () => void;
   timeRange: TimeRange;
   spaceId: string;
 }
@@ -70,6 +76,7 @@ export const WorkflowExecutionsTable = React.memo<WorkflowExecutionsTableProps>(
     liveUpdateIntervalMs,
     onReRunExecution,
     onViewAllExecutionsForWorkflow,
+    onTimeRangeLinkClick,
     query,
     spaceId,
     timeRange,
@@ -87,6 +94,10 @@ export const WorkflowExecutionsTable = React.memo<WorkflowExecutionsTableProps>(
     const [sort, setSort] = useState<ExecutionTableSortOrder>(EXECUTION_TABLE_DEFAULT_SORT);
     const [pageSize, setPageSize] = useState(EXECUTION_TABLE_DEFAULT_PAGE_SIZE);
     const [pageIndex, setPageIndex] = useState(0);
+    const [groupBy, setGroupBy] = useState<ExecutionsGroupBy>('none');
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const fullscreenButtonRef = useRef<HTMLButtonElement>(null);
+    const { euiTheme } = useEuiTheme();
     const { selectedExecutionId, setSelectedExecution } = useWorkflowUrlState();
 
     const handleOpenExecution = useCallback(
@@ -140,9 +151,42 @@ export const WorkflowExecutionsTable = React.memo<WorkflowExecutionsTableProps>(
       setPageIndex(0);
     }, [searchCriteriaKey]);
 
+    useEffect(() => {
+      if (!isFullscreen) {
+        return undefined;
+      }
+
+      const previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          setIsFullscreen(false);
+        }
+      };
+
+      window.addEventListener('keydown', onKeyDown);
+      return () => {
+        document.body.style.overflow = previousOverflow;
+        window.removeEventListener('keydown', onKeyDown);
+      };
+    }, [isFullscreen]);
+
+    const wasFullscreenRef = useRef(false);
+    useEffect(() => {
+      if (wasFullscreenRef.current && !isFullscreen) {
+        fullscreenButtonRef.current?.focus();
+      }
+      wasFullscreenRef.current = isFullscreen;
+    }, [isFullscreen]);
+
     const handleRetry = useCallback(() => {
       void refetch();
     }, [refetch]);
+
+    const handleToggleFullscreen = useCallback(() => {
+      setIsFullscreen((prev) => !prev);
+    }, []);
 
     const handleSetColumns = useCallback((nextColumns: string[]) => {
       setVisibleColumns(nextColumns);
@@ -181,6 +225,25 @@ export const WorkflowExecutionsTable = React.memo<WorkflowExecutionsTableProps>(
       [pageSize, total]
     );
     const isPaginationLimited = total > WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW;
+    const showEndOfResults = isPaginationLimited && pageIndex === maxPageIndex;
+    const isGrouped = groupBy !== 'none';
+
+    const fullscreenCss = useMemo(
+      () =>
+        isFullscreen
+          ? css`
+              position: fixed;
+              inset: 0;
+              z-index: ${euiTheme.levels.mask};
+              background: ${euiTheme.colors.emptyShade};
+              padding: ${euiTheme.size.l};
+              display: flex;
+              flex-direction: column;
+              min-height: 0;
+            `
+          : undefined,
+      [euiTheme.colors.emptyShade, euiTheme.levels.mask, euiTheme.size.l, isFullscreen]
+    );
 
     if (errorMessage) {
       return (
@@ -232,55 +295,62 @@ export const WorkflowExecutionsTable = React.memo<WorkflowExecutionsTableProps>(
     }
 
     return (
-      <div css={tableContainerCss} data-test-subj="workflowExecutionsTable">
-        <div css={gridWrapperCss}>
-          <WorkflowExecutionsDataGrid
-            ariaLabelledBy="workflowExecutionsTableLabel"
-            executions={executions}
-            visibleColumns={visibleColumns}
-            columnWidths={columnWidths}
-            sort={sort}
-            selectedExecutionId={selectedExecutionId}
-            selectionState={selectionState}
-            onOpenExecution={handleOpenExecution}
-            onRefresh={handleRetry}
-            onSetColumns={handleSetColumns}
-            onSort={handleSortWithPageReset}
-            onColumnResize={handleColumnResize}
-            onReRunExecution={onReRunExecution}
-            onViewAllExecutionsForWorkflow={onViewAllExecutionsForWorkflow}
+      <EuiFocusTrap disabled={!isFullscreen} returnFocus={false}>
+        <div
+          css={[tableContainerCss, fullscreenCss]}
+          data-test-subj="workflowExecutionsTable"
+          data-fullscreen={isFullscreen ? 'true' : undefined}
+        >
+          <div css={gridWrapperCss}>
+            <WorkflowExecutionsDataGrid
+              ariaLabelledBy="workflowExecutionsTableLabel"
+              executions={executions}
+              visibleColumns={visibleColumns}
+              columnWidths={columnWidths}
+              sort={sort}
+              selectedExecutionId={selectedExecutionId}
+              selectionState={selectionState}
+              pageIndex={pageIndex}
+              pageSize={pageSize}
+              totalHits={total}
+              toolbarOnly={isGrouped}
+              groupBy={groupBy}
+              onGroupByChange={setGroupBy}
+              isFullscreen={isFullscreen}
+              onToggleFullscreen={handleToggleFullscreen}
+              fullscreenButtonRef={fullscreenButtonRef}
+              onOpenExecution={handleOpenExecution}
+              onRefresh={handleRetry}
+              onSetColumns={handleSetColumns}
+              onSort={handleSortWithPageReset}
+              onColumnResize={handleColumnResize}
+              onReRunExecution={onReRunExecution}
+              onViewAllExecutionsForWorkflow={onViewAllExecutionsForWorkflow}
+            />
+            {isGrouped ? (
+              <WorkflowExecutionsGroupedView
+                executions={executions}
+                groupBy={groupBy}
+                onOpenExecution={handleOpenExecution}
+                onReRunExecution={onReRunExecution}
+                onViewAllExecutionsForWorkflow={onViewAllExecutionsForWorkflow}
+              />
+            ) : null}
+          </div>
+          {showEndOfResults ? (
+            <WorkflowExecutionsTableEndOfResults onTimeRangeLinkClick={onTimeRangeLinkClick} />
+          ) : null}
+          <EuiTablePagination
+            activePage={pageIndex}
+            itemsPerPage={pageSize}
+            itemsPerPageOptions={PAGE_SIZE_OPTIONS}
+            onChangeItemsPerPage={handlePageSizeChange}
+            onChangePage={handlePageChange}
+            pageCount={totalPages}
+            showPerPageOptions
           />
         </div>
-        {isPaginationLimited && (
-          <EuiCallOut
-            announceOnMount
-            color="warning"
-            data-test-subj="workflowExecutionsTablePaginationLimit"
-            size="s"
-            title={i18n.translate('workflowsManagement.executionsPage.paginationLimitTitle', {
-              defaultMessage: 'Showing the first {maxRows} executions only',
-              values: { maxRows: WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW.toLocaleString() },
-            })}
-          >
-            <p>
-              {i18n.translate('workflowsManagement.executionsPage.paginationLimitBody', {
-                defaultMessage:
-                  'Refine your search or time range to find older executions. Deep pagination beyond {maxRows} results is not supported.',
-                values: { maxRows: WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW.toLocaleString() },
-              })}
-            </p>
-          </EuiCallOut>
-        )}
-        <EuiTablePagination
-          activePage={pageIndex}
-          itemsPerPage={pageSize}
-          itemsPerPageOptions={PAGE_SIZE_OPTIONS}
-          onChangeItemsPerPage={handlePageSizeChange}
-          onChangePage={handlePageChange}
-          pageCount={totalPages}
-          showPerPageOptions
-        />
-      </div>
+      </EuiFocusTrap>
     );
   }
 );

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_actions.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_actions.test.tsx
@@ -207,6 +207,29 @@ describe('workflow executions actions column', () => {
     expect(screen.getByTestId('workflowExecutionActionViewAllExecutions')).toBeInTheDocument();
   });
 
+  it('opens the row actions menu with a downLeft anchor position', () => {
+    const services = createStartServicesMock();
+    services.application.navigateToApp = mockNavigateToApp;
+
+    render(
+      <ActionsCellHarness
+        onViewAllExecutionsForWorkflow={jest.fn()}
+        execution={createExecution({
+          id: 'exec-1',
+          workflowId: 'wf-1',
+          status: ExecutionStatus.COMPLETED,
+        })}
+      />,
+      { wrapper: getTestProvider({ services }) }
+    );
+
+    fireEvent.click(screen.getByTestId('workflowExecutionActionsButton'));
+
+    // EUI applies the anchor class on the popover panel; downLeft keeps the menu below the row.
+    expect(document.querySelector('.euiPopover')).toBeInTheDocument();
+    expect(screen.getByTestId('workflowExecutionActionReRun')).toBeInTheDocument();
+  });
+
   it('hides actions when user lacks all relevant privileges', () => {
     mockUseWorkflowsCapabilities.mockReturnValue({
       canExecuteWorkflow: false,

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_actions.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_actions.tsx
@@ -213,7 +213,7 @@ export const WorkflowExecutionActionsMenu = ({
           aria-label={showActionsLabel}
           color="text"
           data-test-subj="workflowExecutionActionsButton"
-          iconType="boxesVertical"
+          iconType="ellipsis"
           onClick={() => setIsOpen((prev) => !prev)}
         />
       </EuiToolTip>

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_actions.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_actions.tsx
@@ -26,7 +26,7 @@ import { getWorkflowExecutionActionContextFromDto } from './workflow_executions_
 import { useKibana } from '../../hooks/use_kibana';
 
 export const WORKFLOW_EXECUTIONS_ACTIONS_COLUMN_ID = 'actions';
-const WORKFLOW_EXECUTIONS_ACTIONS_COLUMN_WIDTH = 64;
+const WORKFLOW_EXECUTIONS_ACTIONS_COLUMN_WIDTH = 56;
 
 export interface WorkflowExecutionActionContext {
   executionId?: string;
@@ -181,7 +181,7 @@ export const WorkflowExecutionActionsMenu = ({
   });
 
   const anchorPosition: EuiPopoverProps['anchorPosition'] =
-    variant === 'takeAction' ? 'upRight' : 'upCenter';
+    variant === 'takeAction' ? 'upRight' : 'downLeft';
 
   if (!listItems?.length) {
     return null;

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_cells.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_cells.test.tsx
@@ -13,6 +13,7 @@ import { ExecutionStatus, type WorkflowExecutionListItemDto } from '@kbn/workflo
 import {
   WorkflowExecutionDurationCell,
   WorkflowExecutionStartedAtCell,
+  WorkflowExecutionTagsCell,
   WorkflowExecutionWorkflowCell,
 } from './workflow_executions_table_cells';
 import { getTestProvider } from '../../shared/mocks/test_providers';
@@ -61,6 +62,7 @@ describe('WorkflowExecutionWorkflowCell', () => {
     expect(screen.getByTestId('workflowExecutionWorkflowLink')).toHaveTextContent(
       'OpenAI entity extraction'
     );
+    expect(screen.getByTestId('executionsTableWorkflowName')).toBeInTheDocument();
   });
 
   it('opens execution details when workflow link is clicked', () => {
@@ -173,5 +175,43 @@ describe('WorkflowExecutionDurationCell', () => {
     );
 
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('WorkflowExecutionTagsCell', () => {
+  it('shows two badges and an overflow control for five tags', () => {
+    render(
+      <WorkflowExecutionTagsCell
+        execution={createExecution({
+          tags: ['alpha', 'bravo', 'charlie', 'delta', 'echo'],
+        })}
+      />,
+      { wrapper: getTestProvider({}) }
+    );
+
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('bravo')).toBeInTheDocument();
+    expect(screen.queryByText('charlie')).not.toBeInTheDocument();
+    expect(screen.getByTestId('executionsTableTagsOverflow')).toHaveTextContent('+3');
+  });
+
+  it('opens a popover with all tags when overflow is clicked', () => {
+    render(
+      <WorkflowExecutionTagsCell
+        execution={createExecution({
+          tags: ['alpha', 'bravo', 'charlie', 'delta', 'echo'],
+        })}
+      />,
+      { wrapper: getTestProvider({}) }
+    );
+
+    fireEvent.click(screen.getByTestId('executionsTableTagsOverflow'));
+
+    expect(screen.getByText('charlie')).toBeInTheDocument();
+    expect(screen.getByText('delta')).toBeInTheDocument();
+    expect(screen.getByText('echo')).toBeInTheDocument();
+    // Visible + popover copies: all five names appear at least once.
+    expect(screen.getAllByText('alpha').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('bravo').length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_cells.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_cells.tsx
@@ -16,6 +16,7 @@ import {
   EuiLoadingSpinner,
   EuiPopover,
   EuiPopoverTitle,
+  EuiTextTruncate,
   EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
@@ -53,6 +54,23 @@ const overflowPopoverStyle = css`
   overflow: auto;
 `;
 
+const workflowNameFlexItemCss = css`
+  min-width: 0;
+  overflow: hidden;
+`;
+
+const workflowLinkCss = css`
+  display: block;
+  width: 100%;
+  min-width: 0;
+`;
+
+const durationCellCss = css`
+  font-variant-numeric: tabular-nums;
+  width: 100%;
+  text-align: right;
+`;
+
 export const getWorkflowExecutionActionContextFromDto = (
   execution: WorkflowExecutionListItemDto
 ) => ({
@@ -60,14 +78,6 @@ export const getWorkflowExecutionActionContextFromDto = (
   workflowId: execution.workflowId,
   context: execution.context,
 });
-
-const workflowLinkCss = css`
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: block;
-  max-width: 100%;
-`;
 
 export const WorkflowExecutionWorkflowCell = ({
   execution,
@@ -102,22 +112,30 @@ export const WorkflowExecutionWorkflowCell = ({
       {execution.status ? (
         <EuiFlexItem grow={false}>{getExecutionStatusIcon(euiTheme, execution.status)}</EuiFlexItem>
       ) : null}
-      <EuiFlexItem
-        grow={false}
-        css={css`
-          min-width: 0;
-          overflow: hidden;
-        `}
-      >
+      <EuiFlexItem grow css={workflowNameFlexItemCss}>
         <EuiLink
           onClick={handleClick}
           data-test-subj="workflowExecutionWorkflowLink"
           css={workflowLinkCss}
-          title={name}
           aria-label={name}
           href="#"
         >
-          {name}
+          <EuiTextTruncate
+            text={name}
+            truncation="middle"
+            data-test-subj="executionsTableWorkflowName"
+          >
+            {(truncatedText) => {
+              const content = <span>{truncatedText}</span>;
+              return truncatedText !== name ? (
+                <EuiToolTip content={name} anchorProps={{ style: { width: '100%' } }}>
+                  {content}
+                </EuiToolTip>
+              ) : (
+                content
+              );
+            }}
+          </EuiTextTruncate>
         </EuiLink>
       </EuiFlexItem>
       {execution.status === ExecutionStatus.WAITING_FOR_INPUT ? (
@@ -143,6 +161,14 @@ export const WorkflowExecutionTagsCell = ({
   );
 };
 
+const TruncatedTagBadge = ({ tag }: { tag: string }) => (
+  <EuiToolTip content={tag}>
+    <EuiBadge color="hollow" css={visibleTagStyle} title={tag} tabIndex={0}>
+      {tag}
+    </EuiBadge>
+  </EuiToolTip>
+);
+
 const WorkflowExecutionTagsContent = ({
   tags,
   isManaged,
@@ -163,7 +189,7 @@ const WorkflowExecutionTagsContent = ({
     0,
     isManaged ? MAX_VISIBLE_TAGS - 1 : MAX_VISIBLE_TAGS
   );
-  const hidden = workflowTags.slice(visibleWorkflowTags.length);
+  const hiddenCount = workflowTags.length - visibleWorkflowTags.length;
 
   return (
     <EuiFlexGroup
@@ -179,44 +205,48 @@ const WorkflowExecutionTagsContent = ({
         </EuiFlexItem>
       ) : null}
       {visibleWorkflowTags.map((tag) => (
-        <EuiFlexItem key={tag} grow={false} css={visibleTagStyle}>
-          <EuiBadge color="hollow" title={tag}>
-            {tag}
-          </EuiBadge>
+        <EuiFlexItem key={tag} grow={false}>
+          <TruncatedTagBadge tag={tag} />
         </EuiFlexItem>
       ))}
-      {hidden.length > 0 && (
+      {hiddenCount > 0 && (
         <EuiFlexItem grow={false}>
           <EuiPopover
             ownFocus
             isOpen={isOpen}
             closePopover={close}
-            aria-label={i18n.translate('workflowsManagement.executionsPage.tags.popoverTitle', {
-              defaultMessage: 'Tags',
-            })}
+            anchorPosition="downLeft"
+            panelPaddingSize="s"
+            aria-label={i18n.translate(
+              'workflowsManagement.executionsPage.table.tagsPopoverTitle',
+              {
+                defaultMessage: 'All tags',
+              }
+            )}
             button={
               <EuiBadge
                 color="hollow"
                 onClick={toggle}
                 onClickAriaLabel={i18n.translate(
-                  'workflowsManagement.executionsPage.tags.moreAriaLabel',
+                  'workflowsManagement.executionsPage.table.showAllTagsAriaLabel',
                   {
-                    defaultMessage: 'View more tags',
+                    defaultMessage: 'Show all {count} tags',
+                    values: { count: workflowTags.length },
                   }
                 )}
-                data-test-subj="workflowExecutionTagsOverflowBadge"
+                data-test-subj="executionsTableTagsOverflow"
               >
-                {`+${hidden.length}`}
+                {`+${hiddenCount}`}
               </EuiBadge>
             }
           >
             <EuiPopoverTitle>
-              {i18n.translate('workflowsManagement.executionsPage.tags.popoverTitle', {
-                defaultMessage: 'Tags',
+              {i18n.translate('workflowsManagement.executionsPage.table.tagsPopoverTitle', {
+                defaultMessage: 'All tags',
               })}
             </EuiPopoverTitle>
             <EuiBadgeGroup gutterSize="xs" css={overflowPopoverStyle}>
-              {hidden.map((tag) => (
+              {workflowTags.map((tag) => (
                 <EuiBadge key={tag} color="hollow">
                   {tag}
                 </EuiBadge>
@@ -279,7 +309,11 @@ export const WorkflowExecutionDurationCell = ({
   const duration = execution.duration;
 
   if (duration != null) {
-    return <span data-test-subj="workflowExecutionDurationCell">{formatDuration(duration)}</span>;
+    return (
+      <span data-test-subj="workflowExecutionDurationCell" css={durationCellCss}>
+        {formatDuration(duration)}
+      </span>
+    );
   }
 
   if (execution.status && !isTerminalStatus(execution.status)) {

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_config.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_config.tsx
@@ -28,12 +28,12 @@ export type WorkflowExecutionsTableColumnId =
  * Values sized for typical content (e.g. "13 minutes ago", "Schedule", duration).
  */
 export const EXECUTIONS_TABLE_COLUMN_WIDTH_TAGS = 240;
-export const EXECUTIONS_TABLE_COLUMN_WIDTH_TRIGGER = 110;
-export const EXECUTIONS_TABLE_COLUMN_WIDTH_STARTED = 140;
-export const EXECUTIONS_TABLE_COLUMN_WIDTH_DURATION = 88;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_TRIGGER = 120;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_STARTED = 160;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_DURATION = 100;
 
 /** Floor width so fixed columns + Actions + a usable Workflow column (~200px) still fit; below this we scroll. */
-export const EXECUTIONS_TABLE_MIN_WIDTH_PX = 880;
+export const EXECUTIONS_TABLE_MIN_WIDTH_PX = 920;
 
 export interface WorkflowExecutionsGridColumnSettings {
   display: string;

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_config.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_config.tsx
@@ -24,16 +24,15 @@ export type WorkflowExecutionsTableColumnId =
 
 /**
  * Fixed widths for predictable columns so Workflow can absorb leftover space.
- * Sized tightly so trailing Actions (control column) still fits without horizontal scroll.
- * Values sized for typical content (e.g. "13 minutes ago", "Schedule", duration).
+ * Restored to the pre-tightening 250px spacing for a roomier table layout.
  */
-export const EXECUTIONS_TABLE_COLUMN_WIDTH_TAGS = 240;
-export const EXECUTIONS_TABLE_COLUMN_WIDTH_TRIGGER = 120;
-export const EXECUTIONS_TABLE_COLUMN_WIDTH_STARTED = 160;
-export const EXECUTIONS_TABLE_COLUMN_WIDTH_DURATION = 100;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_TAGS = 250;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_TRIGGER = 250;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_STARTED = 250;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_DURATION = 250;
 
 /** Floor width so fixed columns + Actions + a usable Workflow column (~200px) still fit; below this we scroll. */
-export const EXECUTIONS_TABLE_MIN_WIDTH_PX = 920;
+export const EXECUTIONS_TABLE_MIN_WIDTH_PX = 1300;
 
 export interface WorkflowExecutionsGridColumnSettings {
   display: string;

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_config.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_config.tsx
@@ -22,10 +22,24 @@ export const DEFAULT_WORKFLOW_EXECUTIONS_TABLE_COLUMNS = [
 export type WorkflowExecutionsTableColumnId =
   (typeof DEFAULT_WORKFLOW_EXECUTIONS_TABLE_COLUMNS)[number];
 
+/**
+ * Fixed widths for predictable columns so Workflow can absorb leftover space.
+ * Sized tightly so trailing Actions (control column) still fits without horizontal scroll.
+ * Values sized for typical content (e.g. "13 minutes ago", "Schedule", duration).
+ */
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_TAGS = 240;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_TRIGGER = 110;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_STARTED = 140;
+export const EXECUTIONS_TABLE_COLUMN_WIDTH_DURATION = 88;
+
+/** Floor width so fixed columns + Actions + a usable Workflow column (~200px) still fit; below this we scroll. */
+export const EXECUTIONS_TABLE_MIN_WIDTH_PX = 880;
+
 export interface WorkflowExecutionsGridColumnSettings {
   display: string;
   isResizable?: boolean;
   initialWidth?: number;
+  schema?: EuiDataGridColumn['schema'];
 }
 
 export const WORKFLOW_EXECUTIONS_TABLE_COLUMN_SETTINGS: Record<
@@ -42,25 +56,26 @@ export const WORKFLOW_EXECUTIONS_TABLE_COLUMN_SETTINGS: Record<
     display: i18n.translate('workflowsManagement.executionsPage.column.tags', {
       defaultMessage: 'Tags',
     }),
-    initialWidth: 250,
+    initialWidth: EXECUTIONS_TABLE_COLUMN_WIDTH_TAGS,
   },
   triggers: {
     display: i18n.translate('workflowsManagement.executionsPage.column.trigger', {
       defaultMessage: 'Trigger',
     }),
-    initialWidth: 250,
+    initialWidth: EXECUTIONS_TABLE_COLUMN_WIDTH_TRIGGER,
   },
   startedAt: {
     display: i18n.translate('workflowsManagement.executionsPage.column.started', {
       defaultMessage: 'Started',
     }),
-    initialWidth: 250,
+    initialWidth: EXECUTIONS_TABLE_COLUMN_WIDTH_STARTED,
   },
   duration: {
     display: i18n.translate('workflowsManagement.executionsPage.column.duration', {
       defaultMessage: 'Duration',
     }),
-    initialWidth: 250,
+    initialWidth: EXECUTIONS_TABLE_COLUMN_WIDTH_DURATION,
+    schema: 'numeric',
   },
 };
 
@@ -86,6 +101,7 @@ export const buildWorkflowExecutionsGridColumns = (
       isSortable: SORTABLE_COLUMNS.has(columnId),
       initialWidth: columnWidths[columnId] ?? settings.initialWidth,
       isResizable: settings.isResizable,
+      schema: settings.schema,
     };
 
     return column;

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_end_of_results.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_end_of_results.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLink, EuiPanel, EuiText } from '@elastic/eui';
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW } from '../../../common';
+
+export interface WorkflowExecutionsTableEndOfResultsProps {
+  onTimeRangeLinkClick?: () => void;
+}
+
+export const WorkflowExecutionsTableEndOfResults =
+  React.memo<WorkflowExecutionsTableEndOfResultsProps>(({ onTimeRangeLinkClick }) => {
+    return (
+      <EuiPanel
+        color="subdued"
+        hasBorder={false}
+        hasShadow={false}
+        paddingSize="s"
+        data-test-subj="executionsTableEndOfResults"
+      >
+        <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="info" size="s" aria-hidden={true} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs">
+              <FormattedMessage
+                id="workflowsManagement.executionsPage.table.endOfResults"
+                defaultMessage="You've reached the first {maxResults} executions. {timeRangeLink} to see older executions."
+                values={{
+                  maxResults: WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW.toLocaleString(),
+                  timeRangeLink: (
+                    <EuiLink
+                      onClick={onTimeRangeLinkClick}
+                      data-test-subj="executionsTableNarrowTimeRange"
+                    >
+                      <FormattedMessage
+                        id="workflowsManagement.executionsPage.table.narrowTimeRange"
+                        defaultMessage="Narrow the time range"
+                      />
+                    </EuiLink>
+                  ),
+                }}
+              />
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    );
+  });
+
+WorkflowExecutionsTableEndOfResults.displayName = 'WorkflowExecutionsTableEndOfResults';

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_result_count.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_result_count.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { WorkflowExecutionsTableResultCount } from './workflow_executions_table_result_count';
+import { WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW } from '../../../common';
+
+describe('WorkflowExecutionsTableResultCount', () => {
+  it('shows an exact count when totalHits is within the result window', () => {
+    render(
+      <WorkflowExecutionsTableResultCount
+        pageIndex={0}
+        pageSize={25}
+        pageItemCount={25}
+        totalHits={8432}
+      />
+    );
+
+    expect(screen.getByTestId('executionsTableResultCount')).toHaveTextContent(
+      'Showing 1–25 of 8,432 executions'
+    );
+    expect(screen.queryByTestId('executionsTableLimitTip')).not.toBeInTheDocument();
+  });
+
+  it('shows a capped count and tip when totalHits exceeds the result window', () => {
+    render(
+      <WorkflowExecutionsTableResultCount
+        pageIndex={0}
+        pageSize={25}
+        pageItemCount={25}
+        totalHits={WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW + 500}
+      />
+    );
+
+    expect(screen.getByTestId('executionsTableResultCount')).toHaveTextContent(
+      'Showing 1–25 of 10,000+ executions'
+    );
+    expect(screen.getByTestId('executionsTableLimitTip')).toBeInTheDocument();
+  });
+
+  it('updates the visible range for later pages', () => {
+    render(
+      <WorkflowExecutionsTableResultCount
+        pageIndex={1}
+        pageSize={50}
+        pageItemCount={50}
+        totalHits={8432}
+      />
+    );
+
+    expect(screen.getByTestId('executionsTableResultCount')).toHaveTextContent(
+      'Showing 51–100 of 8,432 executions'
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_result_count.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_result_count.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiIconTip, EuiText } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import { WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW } from '../../../common';
+
+export interface WorkflowExecutionsTableResultCountProps {
+  pageIndex: number;
+  pageSize: number;
+  pageItemCount: number;
+  totalHits: number;
+}
+
+const formatCount = (value: number): string => value.toLocaleString();
+
+export const WorkflowExecutionsTableResultCount =
+  React.memo<WorkflowExecutionsTableResultCountProps>(
+    ({ pageIndex, pageSize, pageItemCount, totalHits }) => {
+      const isCapped = totalHits > WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW;
+      const rangeStart = pageIndex * pageSize + 1;
+      const rangeEnd = pageIndex * pageSize + pageItemCount;
+
+      const countLabel = useMemo(() => {
+        if (isCapped) {
+          return i18n.translate('workflowsManagement.executionsPage.table.resultCountCapped', {
+            defaultMessage: 'Showing {rangeStart}–{rangeEnd} of {maxResults}+ executions',
+            values: {
+              rangeStart: formatCount(rangeStart),
+              rangeEnd: formatCount(rangeEnd),
+              maxResults: formatCount(WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW),
+            },
+          });
+        }
+
+        return i18n.translate('workflowsManagement.executionsPage.table.resultCountExact', {
+          defaultMessage: 'Showing {rangeStart}–{rangeEnd} of {totalHits} executions',
+          values: {
+            rangeStart: formatCount(rangeStart),
+            rangeEnd: formatCount(rangeEnd),
+            totalHits: formatCount(totalHits),
+          },
+        });
+      }, [isCapped, rangeEnd, rangeStart, totalHits]);
+
+      const limitTip = i18n.translate(
+        'workflowsManagement.executionsPage.table.resultCountLimitTip',
+        {
+          defaultMessage:
+            'Results are limited to the first {maxResults} executions. Refine your search or narrow the time range to see more.',
+          values: { maxResults: formatCount(WORKFLOWS_EXECUTIONS_MAX_RESULT_WINDOW) },
+        }
+      );
+
+      return (
+        <EuiFlexGroup
+          alignItems="center"
+          gutterSize="s"
+          responsive={false}
+          data-test-subj="executionsTableResultCountGroup"
+        >
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color="subdued" data-test-subj="executionsTableResultCount">
+              {countLabel}
+            </EuiText>
+          </EuiFlexItem>
+          {isCapped ? (
+            <EuiFlexItem grow={false} data-test-subj="executionsTableLimitTip">
+              <EuiIconTip type="info" size="s" color="subdued" content={limitTip} />
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+      );
+    }
+  );
+
+WorkflowExecutionsTableResultCount.displayName = 'WorkflowExecutionsTableResultCount';

--- a/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_styles.ts
+++ b/src/platform/plugins/shared/workflows_management/public/pages/executions/workflow_executions_table_styles.ts
@@ -9,6 +9,7 @@
 
 import type { UseEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { EXECUTIONS_TABLE_MIN_WIDTH_PX } from './workflow_executions_table_config';
 
 export const getWorkflowExecutionsTableGridWrapperCss = (themeContext: UseEuiTheme) => {
   const { euiTheme } = themeContext;
@@ -17,9 +18,11 @@ export const getWorkflowExecutionsTableGridWrapperCss = (themeContext: UseEuiThe
     flex: 1 1 auto;
     width: 100%;
     min-width: 0;
+    overflow-x: auto;
 
     .euiDataGrid {
       width: 100%;
+      min-width: ${EXECUTIONS_TABLE_MIN_WIDTH_PX}px;
     }
 
     .euiDataGrid__leftControls {
@@ -52,6 +55,11 @@ export const getWorkflowExecutionsTableGridWrapperCss = (themeContext: UseEuiThe
       .euiDataGridRowCell__content--defaultHeight {
       display: flex;
       align-items: center;
+    }
+
+    .euiDataGridRowCell[data-gridcell-column-id='duration']
+      .euiDataGridRowCell__content--defaultHeight {
+      justify-content: flex-end;
     }
 
     .workflowExecutionsTableRow--selected .euiDataGridRowCell {

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_actions_menu.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_actions_menu.tsx
@@ -51,7 +51,7 @@ const WorkflowDetailActionsMenuContent = (): JSX.Element => {
         <EuiToolTip content={actionsMenuAriaLabel} disableScreenReaderOutput>
           <EuiButtonIcon
             display="base"
-            iconType="boxesVertical"
+            iconType="ellipsis"
             size="s"
             aria-label={actionsMenuAriaLabel}
             data-test-subj="workflowDetailActionsMenuButton"

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_data_table.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_data_table.tsx
@@ -28,8 +28,8 @@ import { TableFieldValue } from './table_field_value';
 import { appendKeyPath, flattenKeyPaths } from '../../lib/flatten_key_paths';
 import { useGetFormattedDateTime } from '../use_formatted_date';
 
-const MIN_NAME_COLUMN_WIDTH = 120;
-const MAX_NAME_COLUMN_WIDTH = 300;
+const MIN_NAME_COLUMN_WIDTH = 220;
+const MAX_NAME_COLUMN_WIDTH = 360;
 
 interface JSONDataTableRecord {
   field: string;

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_editor_common.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_editor_common.test.tsx
@@ -34,10 +34,11 @@ jest.mock('@kbn/css-utils/public/use_memo_css', () => ({
   }),
 }));
 
-// Mock theme constant
+// Mock theme constant + registration hook
 jest.mock('@kbn/workflows-ui', () => ({
   ...jest.requireActual('@kbn/workflows-ui'),
   WORKFLOWS_MONACO_EDITOR_THEME: 'workflows-theme',
+  useWorkflowsMonacoTheme: jest.fn(),
 }));
 
 describe('JsonCodeEditorCommon', () => {

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_editor_common.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/execution_data_viewer/json_editor_common.tsx
@@ -14,7 +14,7 @@ import { CodeEditor } from '@kbn/code-editor';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { i18n } from '@kbn/i18n';
 import type { monaco } from '@kbn/monaco';
-import { WORKFLOWS_MONACO_EDITOR_THEME } from '@kbn/workflows-ui';
+import { useWorkflowsMonacoTheme, WORKFLOWS_MONACO_EDITOR_THEME } from '@kbn/workflows-ui';
 
 const codeEditorAriaLabel = i18n.translate('workflows.jsonDataView.codeEditorAriaLabel', {
   defaultMessage: 'Read only JSON view',
@@ -45,6 +45,9 @@ export const JsonCodeEditorCommon = ({
   'data-test-subj': dataTestSubj,
 }: JsonCodeEditorCommonProps) => {
   const styles = useMemoCss(componentStyles);
+  // Keep Monaco token colors in sync with EUI color mode (transparent editor bg uses the container).
+  useWorkflowsMonacoTheme();
+
   if (jsonValue === '') {
     return null;
   }
@@ -58,7 +61,6 @@ export const JsonCodeEditorCommon = ({
       editorDidMount={onEditorDidMount}
       aria-label={codeEditorAriaLabel}
       options={{
-        // Limitation: it's not possible to use different themes for different code editors in the same page, so the same theme as the workflow yaml editor is used.
         theme: WORKFLOWS_MONACO_EDITOR_THEME,
         automaticLayout: true,
         fontSize: 12,

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/filter_controls/context_menu.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/filter_controls/context_menu.tsx
@@ -144,7 +144,7 @@ export const FilterGroupContextMenu = () => {
             aria-label={FILTER_GROUP_MENU}
             display="empty"
             size="s"
-            iconType="boxesVertical"
+            iconType="ellipsis"
             onClick={toggleContextMenu}
             data-test-subj={TEST_IDS.CONTEXT_MENU.BTN}
           />

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/filter_controls/translations.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/filter_controls/translations.ts
@@ -19,7 +19,7 @@ export const PENDING_CHANGES_REMINDER = i18n.translate(
 export const EDIT_CONTROLS = i18n.translate(
   'workflowsManagement.filterControls.contextMenu.editControls',
   {
-    defaultMessage: 'Edit Controls',
+    defaultMessage: 'Edit controls',
   }
 );
 
@@ -66,14 +66,14 @@ export const FILTER_GROUP_BANNER_MESSAGE = i18n.translate(
 export const CONTEXT_MENU_RESET_TOOLTIP = i18n.translate(
   'workflowsManagement.filterControls.contextMenu.resetTooltip',
   {
-    defaultMessage: 'Reset Controls to factory settings',
+    defaultMessage: 'Reset controls to factory settings',
   }
 );
 
 export const CONTEXT_MENU_RESET = i18n.translate(
   'workflowsManagement.filterControls.contextMenu.reset',
   {
-    defaultMessage: 'Reset Controls',
+    defaultMessage: 'Reset controls',
   }
 );
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/step_actions.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/step_actions.tsx
@@ -62,7 +62,7 @@ export const StepActions = React.memo<StepActionsProps>(({ onStepRun }) => {
           aria-label={i18n.translate('console.requestOptionsButtonAriaLabel', {
             defaultMessage: 'Request options',
           })}
-          iconType="boxesVertical"
+          iconType="ellipsis"
           iconSize="s"
         />
       </EuiToolTip>


### PR DESCRIPTION
## Summary
- Design QA / polish for the global Workflow Executions page (table layout, grouping, 10k-limit messaging, page header, detail JSON viewer theming, and nav order).
- Addresses elastic/security-team#15770

## Test plan
- [ ] Open Workflows → Executions with `workflowsManagement:globalExecutionsView:enabled` and library enabled
- [ ] Confirm side nav order: Workflows → Executions → Template library
- [ ] Verify table column widths, truncation, tags overflow, and Actions column fit without unnecessary horizontal scroll
- [ ] Switch group-by (None / Workflow / Status / Trigger) without UI freeze; expand one group at a time
- [ ] Confirm 10k result-count toolbar messaging and end-of-results strip on last reachable page
- [ ] Open execution detail; Field column readable; JSON code view follows dark/light theme
- [ ] Confirm Experimental badge beside title (no page description) and filter menu sentence case


Made with [Cursor](https://cursor.com)