### PR TITLE
[9.5] [scout] improve datePicker setTextRange (#283919)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/date_picker.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/date_picker.ts
@@ -330,10 +330,11 @@ export class DatePicker {
     // `onInputKeyDown` calls `applyRange`, which the query bar's `onChange`
     // forwards to `onSubmit`. No separate querySubmitButton click is needed.
     await input.press('Enter');
-    // `applyRange` sets `isEditing=false`, which unmounts the input and closes
-    // the popover. Wait for edit mode to end so a following open/read isn't
-    // racing that close.
+    // The input unmounts immediately, but the popover panel closes with an
+    // animation and stays visible a bit longer — wait for it too, so a
+    // following `openDateRangePickerPresetsPanel()` doesn't skip re-opening it.
     await input.waitFor({ state: 'hidden' });
+    await this.page.testSubj.locator('dateRangePickerPopoverPanel').waitFor({ state: 'hidden' });
   }
 
   async saveCurrentRangeAsPreset() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[scout] improve datePicker setTextRange (#283919)](https://github.com/elastic/kibana/pull/283919)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-08-10T14:00:15Z","message":"[scout] improve datePicker setTextRange (#283919)\n\n## Summary\n\nFixes flaky test\n`src/platform/plugins/shared/unified_search/test/scout/ui/tests/date_range_picker_presets_persistence.spec.ts`\n\nCopying FTR implementation\n(`src/platform/test/functional/page_objects/time_picker.ts`), which\nexplicitly does\n`testSubjects.missingOrFail('dateRangePickerPopoverPanel', ...)` after\napplying a typed range.\n\nBased on comment it was a missing step in Scout: \"Ensure the popover is\nfully closed before returning, so it doesn't overlay other elements and\nintercept clicks.\"","sha":"2b32ed290aa80cd1a77bc895aa13f82a1d957604","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","reviewer:scout","v9.6.0"],"title":"[scout] improve datePicker setTextRange","number":283919,"url":"https://github.com/elastic/kibana/pull/283919","mergeCommit":{"message":"[scout] improve datePicker setTextRange (#283919)\n\n## Summary\n\nFixes flaky test\n`src/platform/plugins/shared/unified_search/test/scout/ui/tests/date_range_picker_presets_persistence.spec.ts`\n\nCopying FTR implementation\n(`src/platform/test/functional/page_objects/time_picker.ts`), which\nexplicitly does\n`testSubjects.missingOrFail('dateRangePickerPopoverPanel', ...)` after\napplying a typed range.\n\nBased on comment it was a missing step in Scout: \"Ensure the popover is\nfully closed before returning, so it doesn't overlay other elements and\nintercept clicks.\"","sha":"2b32ed290aa80cd1a77bc895aa13f82a1d957604"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283919","number":283919,"mergeCommit":{"message":"[scout] improve datePicker setTextRange (#283919)\n\n## Summary\n\nFixes flaky test\n`src/platform/plugins/shared/unified_search/test/scout/ui/tests/date_range_picker_presets_persistence.spec.ts`\n\nCopying FTR implementation\n(`src/platform/test/functional/page_objects/time_picker.ts`), which\nexplicitly does\n`testSubjects.missingOrFail('dateRangePickerPopoverPanel', ...)` after\napplying a typed range.\n\nBased on comment it was a missing step in Scout: \"Ensure the popover is\nfully closed before returning, so it doesn't overlay other elements and\nintercept clicks.\"","sha":"2b32ed290aa80cd1a77bc895aa13f82a1d957604"}}]}] BACKPORT-->