### PR TITLE
[Connectors] Elastic Slack (Relay) connector v2 for alerts and workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2649,6 +2649,7 @@ src/platform/packages/shared/kbn-connector-specs/src/specs/brave_search/** @elas
 src/platform/packages/shared/kbn-connector-specs/src/specs/buildkite/** @elastic/nightshift-context-and-research-team
 src/platform/packages/shared/kbn-connector-specs/src/specs/databricks/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/dropbox/** @elastic/workchat-eng
+src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_apps_slack/** @elastic/response-ops
 src/platform/packages/shared/kbn-connector-specs/src/specs/figma/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/firecrawl/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/gcp_cloud_functions/** @elastic/workflows-eng

--- a/docs/reference/connectors-kibana/_snippets/alerting-cases-connectors-list.md
+++ b/docs/reference/connectors-kibana/_snippets/alerting-cases-connectors-list.md
@@ -14,6 +14,7 @@
 * [{{sn-itom}}](/reference/connectors-kibana/servicenow-itom-action-type.md): Create an event in {{sn}}.
 * [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md): Create a security incident in {{sn}}.
 * [Slack](/reference/connectors-kibana/slack-action-type.md): Send a message to a Slack channel or user.
+* [Slack (Elastic app)](/reference/connectors-kibana/elastic-slack-action-type.md): Send a message to a Slack channel connected through the Elastic Slack app.
 * [{{swimlane}}](/reference/connectors-kibana/swimlane-action-type.md): Create an incident in {{swimlane}}.
 * [{{hive}}](/reference/connectors-kibana/thehive-action-type.md): Create cases and alerts in {{hive}}.
 * [Tines](/reference/connectors-kibana/tines-action-type.md): Send events to a Tines Story.

--- a/docs/reference/connectors-kibana/_snippets/alerting-cases-connectors-list.md
+++ b/docs/reference/connectors-kibana/_snippets/alerting-cases-connectors-list.md
@@ -14,7 +14,7 @@
 * [{{sn-itom}}](/reference/connectors-kibana/servicenow-itom-action-type.md): Create an event in {{sn}}.
 * [{{sn-sir}}](/reference/connectors-kibana/servicenow-sir-action-type.md): Create a security incident in {{sn}}.
 * [Slack](/reference/connectors-kibana/slack-action-type.md): Send a message to a Slack channel or user.
-* [Slack (Elastic app)](/reference/connectors-kibana/elastic-slack-action-type.md): Send a message to a Slack channel connected through the Elastic Slack app.
+* [Slack (Elastic app)](/reference/connectors-kibana/elastic-apps-slack-action-type.md): Send a message to a Slack channel connected through the Elastic Slack app.
 * [{{swimlane}}](/reference/connectors-kibana/swimlane-action-type.md): Create an incident in {{swimlane}}.
 * [{{hive}}](/reference/connectors-kibana/thehive-action-type.md): Create cases and alerts in {{hive}}.
 * [Tines](/reference/connectors-kibana/tines-action-type.md): Send events to a Tines Story.

--- a/docs/reference/connectors-kibana/elastic-apps-slack-action-type.md
+++ b/docs/reference/connectors-kibana/elastic-apps-slack-action-type.md
@@ -7,7 +7,7 @@ applies_to:
   serverless: preview
 ---
 
-# Slack (Elastic app) connector [elastic-slack-action-type]
+# Slack (Elastic app) connector [elastic-apps-slack-action-type]
 
 The Slack (Elastic app) connector posts messages to Slack channels through the Elastic Slack app that your deployment has installed. Unlike the [Slack](/reference/connectors-kibana/slack-action-type.md) connector, it holds no Slack credentials of its own: the Slack token is held by Elastic's Relay service, which only lets a deployment post to the channels that deployment has connected.
 
@@ -21,7 +21,7 @@ The connector can only reach **connected channels** — channels that a user has
 The connector exists only while the Elastic Slack app is connected. Disconnecting the app removes it, and any rule or workflow referencing it stops sending until the app is reconnected.
 ::::
 
-## Connect the Elastic Slack app [elastic-slack-connect-app]
+## Connect the Elastic Slack app [elastic-apps-slack-connect-app]
 
 1. In {{kib}}, go to **Streams > Significant events > Settings**, and connect the Slack app. This starts a Slack OAuth flow and installs the Elastic app into your workspace.
 2. In Slack, invite `@Elastic` to each channel you want to post to.
@@ -29,7 +29,7 @@ The connector exists only while the Elastic Slack app is connected. Disconnectin
 
 Each connected channel becomes selectable in the rule form and in the workflow YAML editor.
 
-## Available actions [elastic-slack-available-actions]
+## Available actions [elastic-apps-slack-available-actions]
 
 | Action | Description |
 |--------|-------------|
@@ -40,17 +40,17 @@ Each connected channel becomes selectable in the rule form and in the workflow Y
 
 `sendMessage` returns a `ref` for the posted message; pass it back as `threadTs` to reply in the same thread.
 
-## Use in workflows [elastic-slack-workflows]
+## Use in workflows [elastic-apps-slack-workflows]
 
 ```yaml
 - name: notify_slack
-  type: elastic_slack.sendMessage
-  connector-id: elastic-slack
+  type: elastic_apps_slack.sendMessage
+  connector-id: elastic-apps-slack
   with:
     channel: "C0123456789"
     text: "Alert fired: {{ event.alerts[0].kibana.alert.reason }}"
 ```
 
-## Connector networking configuration [elastic-slack-connector-networking-configuration]
+## Connector networking configuration [elastic-apps-slack-connector-networking-configuration]
 
 Calls go to the Relay service configured by `xpack.actions.relay`, not directly to Slack. The Relay host must be reachable from {{kib}} and permitted by [`xpack.actions.allowedHosts`](/reference/configuration-reference/alerting-settings.md#action-settings).

--- a/docs/reference/connectors-kibana/elastic-slack-action-type.md
+++ b/docs/reference/connectors-kibana/elastic-slack-action-type.md
@@ -1,0 +1,56 @@
+---
+navigation_title: "Slack (Elastic app)"
+type: reference
+description: "Use the Slack (Elastic app) connector to post messages to Slack channels connected to your deployment, without managing a Slack token or webhook."
+applies_to:
+  stack: preview 9.4
+  serverless: preview
+---
+
+# Slack (Elastic app) connector [elastic-slack-action-type]
+
+The Slack (Elastic app) connector posts messages to Slack channels through the Elastic Slack app that your deployment has installed. Unlike the [Slack](/reference/connectors-kibana/slack-action-type.md) connector, it holds no Slack credentials of its own: the Slack token is held by Elastic's Relay service, which only lets a deployment post to the channels that deployment has connected.
+
+## Overview
+
+This connector is created for you. Once you install the Elastic Slack app and connect at least one channel, a single connector instance named **Slack (Elastic app)** becomes available to rules and workflows. There is no connector creation form, no token to rotate, and no webhook URL to store.
+
+The connector can only reach **connected channels** — channels that a user has invited `@Elastic` to and connected from the Slack app settings. A message to any other channel is rejected, even if the workspace's Slack app can technically see that channel.
+
+::::{note}
+The connector exists only while the Elastic Slack app is connected. Disconnecting the app removes it, and any rule or workflow referencing it stops sending until the app is reconnected.
+::::
+
+## Connect the Elastic Slack app [elastic-slack-connect-app]
+
+1. In {{kib}}, go to **Streams > Significant events > Settings**, and connect the Slack app. This starts a Slack OAuth flow and installs the Elastic app into your workspace.
+2. In Slack, invite `@Elastic` to each channel you want to post to.
+3. Back in the settings, connect those channels.
+
+Each connected channel becomes selectable in the rule form and in the workflow YAML editor.
+
+## Available actions [elastic-slack-available-actions]
+
+| Action | Description |
+|--------|-------------|
+| `sendMessage` | Post a message to a connected channel. Parameters: `channel` (required), `text` (required), `threadTs`. |
+| `listChannels` | List the channels connected to this deployment, as `{ id, name }` pairs. No parameters. |
+
+`channel` must be a channel **ID** (for example `C0123456789`), not a channel name — the Relay resolves your deployment's channel binding by ID. Both the rule form channel picker and the YAML editor's channel suggestions write the ID for you.
+
+`sendMessage` returns a `ref` for the posted message; pass it back as `threadTs` to reply in the same thread.
+
+## Use in workflows [elastic-slack-workflows]
+
+```yaml
+- name: notify_slack
+  type: elastic_slack.sendMessage
+  connector-id: elastic-slack
+  with:
+    channel: "C0123456789"
+    text: "Alert fired: {{ event.alerts[0].kibana.alert.reason }}"
+```
+
+## Connector networking configuration [elastic-slack-connector-networking-configuration]
+
+Calls go to the Relay service configured by `xpack.actions.relay`, not directly to Slack. The Relay host must be reachable from {{kib}} and permitted by [`xpack.actions.allowedHosts`](/reference/configuration-reference/alerting-settings.md#action-settings).

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -66,6 +66,7 @@ toc:
           - file: connectors-kibana/servicenow-itom-action-type.md
           - file: connectors-kibana/servicenow-sir-action-type.md
           - file: connectors-kibana/slack-action-type.md
+          - file: connectors-kibana/elastic-slack-action-type.md
           - file: connectors-kibana/swimlane-action-type.md
           - file: connectors-kibana/thehive-action-type.md
           - file: connectors-kibana/tines-action-type.md

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -66,7 +66,7 @@ toc:
           - file: connectors-kibana/servicenow-itom-action-type.md
           - file: connectors-kibana/servicenow-sir-action-type.md
           - file: connectors-kibana/slack-action-type.md
-          - file: connectors-kibana/elastic-slack-action-type.md
+          - file: connectors-kibana/elastic-apps-slack-action-type.md
           - file: connectors-kibana/swimlane-action-type.md
           - file: connectors-kibana/thehive-action-type.md
           - file: connectors-kibana/tines-action-type.md

--- a/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
@@ -31,7 +31,7 @@ export * from './specs/salesforce/salesforce';
 export * from './specs/servicenow_search/servicenow_search';
 export * from './specs/sharepoint_online/sharepoint_online';
 export * from './specs/slack/slack';
-export * from './specs/elastic_slack/elastic_slack';
+export * from './specs/elastic_apps_slack/elastic_apps_slack';
 export * from './specs/azure_blob/azure_blob';
 export * from './specs/gmail/gmail';
 export * from './specs/one_password/one_password';

--- a/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
@@ -31,6 +31,7 @@ export * from './specs/salesforce/salesforce';
 export * from './specs/servicenow_search/servicenow_search';
 export * from './specs/sharepoint_online/sharepoint_online';
 export * from './specs/slack/slack';
+export * from './specs/elastic_slack/elastic_slack';
 export * from './specs/azure_blob/azure_blob';
 export * from './specs/gmail/gmail';
 export * from './specs/one_password/one_password';

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
@@ -123,8 +123,10 @@ export const ConnectorIconsMap: Map<
     lazy(() => import(/* webpackChunkName: "connectorIconSlack2" */ './specs/slack/icon')),
   ],
   [
-    '.elastic_slack',
-    lazy(() => import(/* webpackChunkName: "connectorIconElasticSlack" */ './specs/slack/icon')),
+    '.elastic_apps_slack',
+    lazy(
+      () => import(/* webpackChunkName: "connectorIconElasticAppsSlack" */ './specs/slack/icon')
+    ),
   ],
   ['.gmail', lazy(() => import(/* webpackChunkName: "connectorIconGmail" */ './specs/gmail/icon'))],
   [

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
@@ -122,6 +122,10 @@ export const ConnectorIconsMap: Map<
     '.slack2',
     lazy(() => import(/* webpackChunkName: "connectorIconSlack2" */ './specs/slack/icon')),
   ],
+  [
+    '.elastic_slack',
+    lazy(() => import(/* webpackChunkName: "connectorIconElasticSlack" */ './specs/slack/icon')),
+  ],
   ['.gmail', lazy(() => import(/* webpackChunkName: "connectorIconGmail" */ './specs/gmail/icon'))],
   [
     '.azure-blob',

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -231,12 +231,41 @@ export interface ActionDefinition<TInput = unknown, TOutput = unknown, TError = 
   responseSizeHeader?: string;
 }
 
+/**
+ * Structural view of the Actions plugin's Relay client, for specs that talk to Elastic's
+ * Relay service rather than a third-party API. It is declared here (instead of imported)
+ * so this package stays free of x-pack dependencies; the concrete `RelayClient` satisfies
+ * it by shape.
+ *
+ * Relay calls cannot go through `ActionContext.client`: the Relay base URL and its mTLS
+ * settings come from `xpack.actions.relay`, which only the Actions plugin resolves.
+ */
+export interface RelayActionClient {
+  /** Post an outbound message to a channel bound to this deployment. */
+  trigger(input: {
+    tenantKey: string;
+    channel: string;
+    message: string;
+    threadTs?: string;
+  }): Promise<{ ref: string; tenantKey: string }>;
+  /** Fetch one page of this deployment's channel bindings for a workspace. */
+  listBindings(
+    tenantKey: string,
+    options?: { cursor?: string; limit?: number }
+  ): Promise<{
+    bindings: Array<{ scope_id?: string; display_name?: string }>;
+    nextCursor?: string;
+  }>;
+}
+
 export interface ActionContext {
   client: AxiosInstance;
   config?: Record<string, unknown>;
   connectorUsageCollector?: unknown;
   log: Logger;
   secrets?: Record<string, unknown>;
+  /** Present only when `xpack.actions.relay.url` is configured. */
+  relay?: RelayActionClient;
 }
 
 // ============================================================================

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_apps_slack/elastic_apps_slack.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_apps_slack/elastic_apps_slack.test.ts
@@ -9,9 +9,9 @@
 
 import type { ActionContext, RelayActionClient } from '../../connector_spec';
 import { getConnectorSpec } from '../../..';
-import { ElasticSlack } from './elastic_slack';
+import { ElasticAppsSlack } from './elastic_apps_slack';
 
-describe('ElasticSlack', () => {
+describe('ElasticAppsSlack', () => {
   const trigger = jest.fn();
   const listBindings = jest.fn();
   const relay = { trigger, listBindings } as unknown as RelayActionClient;
@@ -29,15 +29,15 @@ describe('ElasticSlack', () => {
   });
 
   it('is discoverable via getConnectorSpec', () => {
-    const spec = getConnectorSpec('.elastic_slack');
+    const spec = getConnectorSpec('.elastic_apps_slack');
 
-    expect(spec).toBe(ElasticSlack);
+    expect(spec).toBe(ElasticAppsSlack);
     expect(spec?.actions.sendMessage).toBeDefined();
     expect(spec?.actions.listChannels).toBeDefined();
   });
 
   it('declares no auth, since the Relay authenticates the deployment itself', () => {
-    expect(ElasticSlack.auth).toBeUndefined();
+    expect(ElasticAppsSlack.auth).toBeUndefined();
   });
 
   describe('sendMessage', () => {
@@ -45,7 +45,7 @@ describe('ElasticSlack', () => {
       trigger.mockResolvedValue({ ref: 'C123:1700000000.000100', tenantKey: 'team-A' });
 
       await expect(
-        ElasticSlack.actions.sendMessage.handler(createContext(), {
+        ElasticAppsSlack.actions.sendMessage.handler(createContext(), {
           channel: 'C123',
           text: 'alert fired',
         })
@@ -62,7 +62,7 @@ describe('ElasticSlack', () => {
     it('forwards threadTs when replying in a thread', async () => {
       trigger.mockResolvedValue({ ref: 'ref-1', tenantKey: 'team-A' });
 
-      await ElasticSlack.actions.sendMessage.handler(createContext(), {
+      await ElasticAppsSlack.actions.sendMessage.handler(createContext(), {
         channel: 'C123',
         text: 'reply',
         threadTs: '1700000000.000100',
@@ -75,7 +75,7 @@ describe('ElasticSlack', () => {
 
     it('fails with a reconnect hint when the app is no longer connected', async () => {
       await expect(
-        ElasticSlack.actions.sendMessage.handler(createContext({ config: {} }), {
+        ElasticAppsSlack.actions.sendMessage.handler(createContext({ config: {} }), {
           channel: 'C123',
           text: 'alert fired',
         })
@@ -86,7 +86,7 @@ describe('ElasticSlack', () => {
 
     it('fails when the Relay is not configured on the deployment', async () => {
       await expect(
-        ElasticSlack.actions.sendMessage.handler(createContext({ relay: undefined }), {
+        ElasticAppsSlack.actions.sendMessage.handler(createContext({ relay: undefined }), {
           channel: 'C123',
           text: 'alert fired',
         })
@@ -100,15 +100,15 @@ describe('ElasticSlack', () => {
         bindings: [{ scope_id: 'C123', display_name: 'general' }, { scope_id: 'C456' }],
       });
 
-      await expect(ElasticSlack.actions.listChannels.handler(createContext(), {})).resolves.toEqual(
-        {
-          ok: true,
-          channels: [
-            { id: 'C123', name: 'general' },
-            { id: 'C456', name: 'C456' },
-          ],
-        }
-      );
+      await expect(
+        ElasticAppsSlack.actions.listChannels.handler(createContext(), {})
+      ).resolves.toEqual({
+        ok: true,
+        channels: [
+          { id: 'C123', name: 'general' },
+          { id: 'C456', name: 'C456' },
+        ],
+      });
 
       expect(listBindings).toHaveBeenCalledWith('team-A', { cursor: undefined });
     });
@@ -116,9 +116,9 @@ describe('ElasticSlack', () => {
     it('skips entries without a channel id', async () => {
       listBindings.mockResolvedValue({ bindings: [{ display_name: 'orphan' }] });
 
-      await expect(ElasticSlack.actions.listChannels.handler(createContext(), {})).resolves.toEqual(
-        { ok: true, channels: [] }
-      );
+      await expect(
+        ElasticAppsSlack.actions.listChannels.handler(createContext(), {})
+      ).resolves.toEqual({ ok: true, channels: [] });
     });
 
     it('follows the cursor across pages', async () => {
@@ -129,15 +129,15 @@ describe('ElasticSlack', () => {
         })
         .mockResolvedValueOnce({ bindings: [{ scope_id: 'C456', display_name: 'random' }] });
 
-      await expect(ElasticSlack.actions.listChannels.handler(createContext(), {})).resolves.toEqual(
-        {
-          ok: true,
-          channels: [
-            { id: 'C123', name: 'general' },
-            { id: 'C456', name: 'random' },
-          ],
-        }
-      );
+      await expect(
+        ElasticAppsSlack.actions.listChannels.handler(createContext(), {})
+      ).resolves.toEqual({
+        ok: true,
+        channels: [
+          { id: 'C123', name: 'general' },
+          { id: 'C456', name: 'random' },
+        ],
+      });
 
       expect(listBindings).toHaveBeenNthCalledWith(2, 'team-A', { cursor: 'cursor-2' });
     });
@@ -149,7 +149,7 @@ describe('ElasticSlack', () => {
       });
       const ctx = createContext();
 
-      const result = (await ElasticSlack.actions.listChannels.handler(ctx, {})) as {
+      const result = (await ElasticAppsSlack.actions.listChannels.handler(ctx, {})) as {
         channels: unknown[];
       };
 
@@ -163,7 +163,7 @@ describe('ElasticSlack', () => {
     it('reports the number of connected channels', async () => {
       listBindings.mockResolvedValue({ bindings: [{ scope_id: 'C123' }, { scope_id: 'C456' }] });
 
-      await expect(ElasticSlack.test?.handler(createContext())).resolves.toEqual({
+      await expect(ElasticAppsSlack.test?.handler(createContext())).resolves.toEqual({
         ok: true,
         message: expect.stringContaining('2 channels'),
       });

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_apps_slack/elastic_apps_slack.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_apps_slack/elastic_apps_slack.ts
@@ -11,10 +11,10 @@ import { i18n } from '@kbn/i18n';
 import { z, lazySchema } from '@kbn/zod/v4';
 import type { ActionContext, ConnectorSpec, RelayActionClient } from '../../connector_spec';
 import {
-  ElasticSlackListChannelsInputSchema,
-  ElasticSlackSendMessageInputSchema,
-  type ElasticSlackChannel,
-  type ElasticSlackSendMessageInput,
+  ElasticAppsSlackListChannelsInputSchema,
+  ElasticAppsSlackSendMessageInputSchema,
+  type ElasticAppsSlackChannel,
+  type ElasticAppsSlackSendMessageInput,
 } from './types';
 
 /**
@@ -39,7 +39,7 @@ const getRelayConnection = (ctx: ActionContext): RelayConnection => {
   const { relay, config } = ctx;
   if (!relay) {
     throw new Error(
-      i18n.translate('core.kibanaConnectorSpecs.elasticSlack.errors.relayNotConfigured', {
+      i18n.translate('core.kibanaConnectorSpecs.elasticAppsSlack.errors.relayNotConfigured', {
         defaultMessage: 'The Relay service is not configured on this deployment.',
       })
     );
@@ -48,7 +48,7 @@ const getRelayConnection = (ctx: ActionContext): RelayConnection => {
   const tenantKey = config?.tenantKey;
   if (typeof tenantKey !== 'string' || tenantKey.length === 0) {
     throw new Error(
-      i18n.translate('core.kibanaConnectorSpecs.elasticSlack.errors.notConnected', {
+      i18n.translate('core.kibanaConnectorSpecs.elasticAppsSlack.errors.notConnected', {
         defaultMessage:
           'The Elastic Slack app is not connected. Reconnect it from the Significant Events settings.',
       })
@@ -58,10 +58,10 @@ const getRelayConnection = (ctx: ActionContext): RelayConnection => {
   return { relay, tenantKey };
 };
 
-const listConnectedChannels = async (ctx: ActionContext): Promise<ElasticSlackChannel[]> => {
+const listConnectedChannels = async (ctx: ActionContext): Promise<ElasticAppsSlackChannel[]> => {
   const { relay, tenantKey } = getRelayConnection(ctx);
 
-  const channels: ElasticSlackChannel[] = [];
+  const channels: ElasticAppsSlackChannel[] = [];
   let cursor: string | undefined;
 
   for (let page = 0; page < MAX_BINDING_PAGES; page++) {
@@ -92,18 +92,18 @@ const listConnectedChannels = async (ctx: ActionContext): Promise<ElasticSlackCh
  * credentials of its own — the Relay owns the Slack token and enforces that a deployment can
  * only reach the channels it has claimed.
  */
-export const ElasticSlack: ConnectorSpec = {
+export const ElasticAppsSlack: ConnectorSpec = {
   metadata: {
-    id: '.elastic_slack',
+    id: '.elastic_apps_slack',
     displayName: 'Slack (Elastic app)',
-    description: i18n.translate('core.kibanaConnectorSpecs.elasticSlack.metadata.description', {
+    description: i18n.translate('core.kibanaConnectorSpecs.elasticAppsSlack.metadata.description', {
       defaultMessage:
         'Send messages to Slack channels connected to this deployment through the Elastic Slack app',
     }),
     minimumLicense: 'enterprise',
     isTechnicalPreview: true,
     supportedFeatureIds: ['alerting', 'workflows'],
-    docsUrl: `https://www.elastic.co/docs/reference/kibana/connectors-kibana/elastic-slack-action-type`,
+    docsUrl: `https://www.elastic.co/docs/reference/kibana/connectors-kibana/elastic-apps-slack-action-type`,
   },
 
   // The Relay authenticates this deployment at the transport layer (mTLS), so the connector
@@ -120,7 +120,7 @@ export const ElasticSlack: ConnectorSpec = {
       isTool: true,
       description:
         'List the Slack channels connected to this deployment through the Elastic Slack app. Returns each channel id and display name. Use this to discover valid channel ids before sendMessage — messages to channels that are not connected are rejected.',
-      input: ElasticSlackListChannelsInputSchema,
+      input: ElasticAppsSlackListChannelsInputSchema,
       handler: async (ctx) => {
         const channels = await listConnectedChannels(ctx);
         return { ok: true as const, channels };
@@ -131,8 +131,8 @@ export const ElasticSlack: ConnectorSpec = {
       isTool: true,
       description:
         'Send a message to a Slack channel connected to this deployment through the Elastic Slack app. Requires a connected channel id — use listChannels to discover them. Returns the Relay reference for the posted message, which can be used as threadTs to reply in a thread.',
-      input: ElasticSlackSendMessageInputSchema,
-      handler: async (ctx, input: ElasticSlackSendMessageInput) => {
+      input: ElasticAppsSlackSendMessageInputSchema,
+      handler: async (ctx, input: ElasticAppsSlackSendMessageInput) => {
         const { relay, tenantKey } = getRelayConnection(ctx);
         const { channel, text, threadTs } = input;
 
@@ -146,14 +146,14 @@ export const ElasticSlack: ConnectorSpec = {
 
   test: {
     enabled: true,
-    description: i18n.translate('core.kibanaConnectorSpecs.elasticSlack.test.description', {
+    description: i18n.translate('core.kibanaConnectorSpecs.elasticAppsSlack.test.description', {
       defaultMessage: 'Verifies the Elastic Slack app connection by listing connected channels',
     }),
     handler: async (ctx) => {
       const channels = await listConnectedChannels(ctx);
       return {
         ok: true,
-        message: i18n.translate('core.kibanaConnectorSpecs.elasticSlack.test.successMessage', {
+        message: i18n.translate('core.kibanaConnectorSpecs.elasticAppsSlack.test.successMessage', {
           defaultMessage:
             'Connected to Slack through the Elastic app. {count, plural, one {# channel} other {# channels}} connected.',
           values: { count: channels.length },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_apps_slack/types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_apps_slack/types.ts
@@ -9,7 +9,7 @@
 
 import { z, lazySchema } from '@kbn/zod/v4';
 
-export const ElasticSlackSendMessageInputSchema = lazySchema(() =>
+export const ElasticAppsSlackSendMessageInputSchema = lazySchema(() =>
   z.object({
     channel: z
       .string()
@@ -24,13 +24,17 @@ export const ElasticSlackSendMessageInputSchema = lazySchema(() =>
       .describe('Timestamp of another message to reply to (creates a threaded reply)'),
   })
 );
-export type ElasticSlackSendMessageInput = z.infer<typeof ElasticSlackSendMessageInputSchema>;
+export type ElasticAppsSlackSendMessageInput = z.infer<
+  typeof ElasticAppsSlackSendMessageInputSchema
+>;
 
-export const ElasticSlackListChannelsInputSchema = lazySchema(() => z.object({}));
-export type ElasticSlackListChannelsInput = z.infer<typeof ElasticSlackListChannelsInputSchema>;
+export const ElasticAppsSlackListChannelsInputSchema = lazySchema(() => z.object({}));
+export type ElasticAppsSlackListChannelsInput = z.infer<
+  typeof ElasticAppsSlackListChannelsInputSchema
+>;
 
 /** A single connected channel, as surfaced to channel pickers and workflows. */
-export interface ElasticSlackChannel {
+export interface ElasticAppsSlackChannel {
   /** Slack channel id — the value `sendMessage` expects in `channel`. */
   id: string;
   /** Display name from the Relay's persisted snapshot, falling back to the id. */

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_slack/elastic_slack.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_slack/elastic_slack.test.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ActionContext, RelayActionClient } from '../../connector_spec';
+import { getConnectorSpec } from '../../..';
+import { ElasticSlack } from './elastic_slack';
+
+describe('ElasticSlack', () => {
+  const trigger = jest.fn();
+  const listBindings = jest.fn();
+  const relay = { trigger, listBindings } as unknown as RelayActionClient;
+
+  const createContext = (overrides: Partial<ActionContext> = {}): ActionContext =>
+    ({
+      relay,
+      config: { tenantKey: 'team-A' },
+      log: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+      ...overrides,
+    } as unknown as ActionContext);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('is discoverable via getConnectorSpec', () => {
+    const spec = getConnectorSpec('.elastic_slack');
+
+    expect(spec).toBe(ElasticSlack);
+    expect(spec?.actions.sendMessage).toBeDefined();
+    expect(spec?.actions.listChannels).toBeDefined();
+  });
+
+  it('declares no auth, since the Relay authenticates the deployment itself', () => {
+    expect(ElasticSlack.auth).toBeUndefined();
+  });
+
+  describe('sendMessage', () => {
+    it('posts through the Relay using the configured tenant key', async () => {
+      trigger.mockResolvedValue({ ref: 'C123:1700000000.000100', tenantKey: 'team-A' });
+
+      await expect(
+        ElasticSlack.actions.sendMessage.handler(createContext(), {
+          channel: 'C123',
+          text: 'alert fired',
+        })
+      ).resolves.toEqual({ ok: true, channel: 'C123', ref: 'C123:1700000000.000100' });
+
+      expect(trigger).toHaveBeenCalledWith({
+        tenantKey: 'team-A',
+        channel: 'C123',
+        message: 'alert fired',
+        threadTs: undefined,
+      });
+    });
+
+    it('forwards threadTs when replying in a thread', async () => {
+      trigger.mockResolvedValue({ ref: 'ref-1', tenantKey: 'team-A' });
+
+      await ElasticSlack.actions.sendMessage.handler(createContext(), {
+        channel: 'C123',
+        text: 'reply',
+        threadTs: '1700000000.000100',
+      });
+
+      expect(trigger).toHaveBeenCalledWith(
+        expect.objectContaining({ threadTs: '1700000000.000100' })
+      );
+    });
+
+    it('fails with a reconnect hint when the app is no longer connected', async () => {
+      await expect(
+        ElasticSlack.actions.sendMessage.handler(createContext({ config: {} }), {
+          channel: 'C123',
+          text: 'alert fired',
+        })
+      ).rejects.toThrow('The Elastic Slack app is not connected');
+
+      expect(trigger).not.toHaveBeenCalled();
+    });
+
+    it('fails when the Relay is not configured on the deployment', async () => {
+      await expect(
+        ElasticSlack.actions.sendMessage.handler(createContext({ relay: undefined }), {
+          channel: 'C123',
+          text: 'alert fired',
+        })
+      ).rejects.toThrow('The Relay service is not configured');
+    });
+  });
+
+  describe('listChannels', () => {
+    it('maps bindings to channels, falling back to the id when there is no display name', async () => {
+      listBindings.mockResolvedValue({
+        bindings: [{ scope_id: 'C123', display_name: 'general' }, { scope_id: 'C456' }],
+      });
+
+      await expect(ElasticSlack.actions.listChannels.handler(createContext(), {})).resolves.toEqual(
+        {
+          ok: true,
+          channels: [
+            { id: 'C123', name: 'general' },
+            { id: 'C456', name: 'C456' },
+          ],
+        }
+      );
+
+      expect(listBindings).toHaveBeenCalledWith('team-A', { cursor: undefined });
+    });
+
+    it('skips entries without a channel id', async () => {
+      listBindings.mockResolvedValue({ bindings: [{ display_name: 'orphan' }] });
+
+      await expect(ElasticSlack.actions.listChannels.handler(createContext(), {})).resolves.toEqual(
+        { ok: true, channels: [] }
+      );
+    });
+
+    it('follows the cursor across pages', async () => {
+      listBindings
+        .mockResolvedValueOnce({
+          bindings: [{ scope_id: 'C123', display_name: 'general' }],
+          nextCursor: 'cursor-2',
+        })
+        .mockResolvedValueOnce({ bindings: [{ scope_id: 'C456', display_name: 'random' }] });
+
+      await expect(ElasticSlack.actions.listChannels.handler(createContext(), {})).resolves.toEqual(
+        {
+          ok: true,
+          channels: [
+            { id: 'C123', name: 'general' },
+            { id: 'C456', name: 'random' },
+          ],
+        }
+      );
+
+      expect(listBindings).toHaveBeenNthCalledWith(2, 'team-A', { cursor: 'cursor-2' });
+    });
+
+    it('stops and warns when the Relay keeps returning cursors', async () => {
+      listBindings.mockResolvedValue({
+        bindings: [{ scope_id: 'C123' }],
+        nextCursor: 'never-ending',
+      });
+      const ctx = createContext();
+
+      const result = (await ElasticSlack.actions.listChannels.handler(ctx, {})) as {
+        channels: unknown[];
+      };
+
+      expect(listBindings).toHaveBeenCalledTimes(10);
+      expect(result.channels).toHaveLength(10);
+      expect(ctx.log.warn).toHaveBeenCalledWith(expect.stringContaining('stopped after 10 pages'));
+    });
+  });
+
+  describe('test handler', () => {
+    it('reports the number of connected channels', async () => {
+      listBindings.mockResolvedValue({ bindings: [{ scope_id: 'C123' }, { scope_id: 'C456' }] });
+
+      await expect(ElasticSlack.test?.handler(createContext())).resolves.toEqual({
+        ok: true,
+        message: expect.stringContaining('2 channels'),
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_slack/elastic_slack.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_slack/elastic_slack.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import { z, lazySchema } from '@kbn/zod/v4';
+import type { ActionContext, ConnectorSpec, RelayActionClient } from '../../connector_spec';
+import {
+  ElasticSlackListChannelsInputSchema,
+  ElasticSlackSendMessageInputSchema,
+  type ElasticSlackChannel,
+  type ElasticSlackSendMessageInput,
+} from './types';
+
+/**
+ * Number of binding pages to walk when listing connected channels. The Relay pages at 200
+ * entries, so this covers deployments with up to 2000 connected channels — far more than a
+ * picker can usefully display — while bounding the work a single action can do.
+ */
+const MAX_BINDING_PAGES = 10;
+
+interface RelayConnection {
+  relay: RelayActionClient;
+  tenantKey: string;
+}
+
+/**
+ * The Relay client and tenant key are injected by the Actions plugin when the Elastic Slack
+ * app is connected: the connector is registered dynamically at that point, with the workspace
+ * tenant key as its config. Both are therefore expected to be present at execution time, and a
+ * missing one means the connection was torn down between scheduling and execution.
+ */
+const getRelayConnection = (ctx: ActionContext): RelayConnection => {
+  const { relay, config } = ctx;
+  if (!relay) {
+    throw new Error(
+      i18n.translate('core.kibanaConnectorSpecs.elasticSlack.errors.relayNotConfigured', {
+        defaultMessage: 'The Relay service is not configured on this deployment.',
+      })
+    );
+  }
+
+  const tenantKey = config?.tenantKey;
+  if (typeof tenantKey !== 'string' || tenantKey.length === 0) {
+    throw new Error(
+      i18n.translate('core.kibanaConnectorSpecs.elasticSlack.errors.notConnected', {
+        defaultMessage:
+          'The Elastic Slack app is not connected. Reconnect it from the Significant Events settings.',
+      })
+    );
+  }
+
+  return { relay, tenantKey };
+};
+
+const listConnectedChannels = async (ctx: ActionContext): Promise<ElasticSlackChannel[]> => {
+  const { relay, tenantKey } = getRelayConnection(ctx);
+
+  const channels: ElasticSlackChannel[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_BINDING_PAGES; page++) {
+    const { bindings, nextCursor } = await relay.listBindings(tenantKey, { cursor });
+
+    for (const { scope_id: scopeId, display_name: displayName } of bindings) {
+      if (scopeId) {
+        channels.push({ id: scopeId, name: displayName ?? scopeId });
+      }
+    }
+
+    if (!nextCursor) {
+      return channels;
+    }
+    cursor = nextCursor;
+  }
+
+  ctx.log.warn(
+    `Elastic Slack listChannels stopped after ${MAX_BINDING_PAGES} pages of Relay bindings`
+  );
+  return channels;
+};
+
+/**
+ * Posts Slack messages through the Elastic Slack app rather than a workspace token: the
+ * deployment installs the app once (Significant Events settings) and connects individual
+ * channels, and this connector can then post to any of those connected channels. It holds no
+ * credentials of its own — the Relay owns the Slack token and enforces that a deployment can
+ * only reach the channels it has claimed.
+ */
+export const ElasticSlack: ConnectorSpec = {
+  metadata: {
+    id: '.elastic_slack',
+    displayName: 'Slack (Elastic app)',
+    description: i18n.translate('core.kibanaConnectorSpecs.elasticSlack.metadata.description', {
+      defaultMessage:
+        'Send messages to Slack channels connected to this deployment through the Elastic Slack app',
+    }),
+    minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
+    supportedFeatureIds: ['alerting', 'workflows'],
+    docsUrl: `https://www.elastic.co/docs/reference/kibana/connectors-kibana/elastic-slack-action-type`,
+  },
+
+  // The Relay authenticates this deployment at the transport layer (mTLS), so the connector
+  // stores no credentials. `tenantKey` identifies the connected Slack workspace and is set by
+  // the Actions plugin when the connector is registered — never entered by a user.
+  schema: lazySchema(() =>
+    z.object({
+      tenantKey: z.string().min(1).meta({ hidden: true }),
+    })
+  ),
+
+  actions: {
+    listChannels: {
+      isTool: true,
+      description:
+        'List the Slack channels connected to this deployment through the Elastic Slack app. Returns each channel id and display name. Use this to discover valid channel ids before sendMessage — messages to channels that are not connected are rejected.',
+      input: ElasticSlackListChannelsInputSchema,
+      handler: async (ctx) => {
+        const channels = await listConnectedChannels(ctx);
+        return { ok: true as const, channels };
+      },
+    },
+
+    sendMessage: {
+      isTool: true,
+      description:
+        'Send a message to a Slack channel connected to this deployment through the Elastic Slack app. Requires a connected channel id — use listChannels to discover them. Returns the Relay reference for the posted message, which can be used as threadTs to reply in a thread.',
+      input: ElasticSlackSendMessageInputSchema,
+      handler: async (ctx, input: ElasticSlackSendMessageInput) => {
+        const { relay, tenantKey } = getRelayConnection(ctx);
+        const { channel, text, threadTs } = input;
+
+        ctx.log.debug(`Elastic Slack sendMessage request: channel=${channel}`);
+        const { ref } = await relay.trigger({ tenantKey, channel, message: text, threadTs });
+
+        return { ok: true as const, channel, ref };
+      },
+    },
+  },
+
+  test: {
+    enabled: true,
+    description: i18n.translate('core.kibanaConnectorSpecs.elasticSlack.test.description', {
+      defaultMessage: 'Verifies the Elastic Slack app connection by listing connected channels',
+    }),
+    handler: async (ctx) => {
+      const channels = await listConnectedChannels(ctx);
+      return {
+        ok: true,
+        message: i18n.translate('core.kibanaConnectorSpecs.elasticSlack.test.successMessage', {
+          defaultMessage:
+            'Connected to Slack through the Elastic app. {count, plural, one {# channel} other {# channels}} connected.',
+          values: { count: channels.length },
+        }),
+      };
+    },
+  },
+
+  skill: [
+    'This connector can only post to channels that have been connected to this deployment through the Elastic Slack app. It cannot post to arbitrary Slack channels, and it cannot read messages, list users, or search — use the Slack (v2) connector for those.',
+    'Always call listChannels first to get a valid channel id. sendMessage takes the channel id (e.g. C0123456789), never the channel name.',
+    'To connect an additional channel, a user must invite @Elastic to it and connect it from the Significant Events settings in Kibana. There is no action here that can do that.',
+    'The ref returned by sendMessage can be passed back as threadTs to reply in the same thread.',
+  ].join('\n'),
+};

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_slack/types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/elastic_slack/types.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z, lazySchema } from '@kbn/zod/v4';
+
+export const ElasticSlackSendMessageInputSchema = lazySchema(() =>
+  z.object({
+    channel: z
+      .string()
+      .min(1)
+      .describe(
+        'ID of a channel connected to this deployment (e.g. C0123456789). Use listChannels to browse the connected channels. Channels that are not connected are rejected.'
+      ),
+    text: z.string().min(1).describe('The message text to send'),
+    threadTs: z
+      .string()
+      .optional()
+      .describe('Timestamp of another message to reply to (creates a threaded reply)'),
+  })
+);
+export type ElasticSlackSendMessageInput = z.infer<typeof ElasticSlackSendMessageInputSchema>;
+
+export const ElasticSlackListChannelsInputSchema = lazySchema(() => z.object({}));
+export type ElasticSlackListChannelsInput = z.infer<typeof ElasticSlackListChannelsInputSchema>;
+
+/** A single connected channel, as surfaced to channel pickers and workflows. */
+export interface ElasticSlackChannel {
+  /** Slack channel id — the value `sendMessage` expects in `channel`. */
+  id: string;
+  /** Display name from the Relay's persisted snapshot, falling back to the id. */
+  name: string;
+}

--- a/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/connector_channel_selection_handler.test.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/connector_channel_selection_handler.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpStart } from '@kbn/core/public';
+import type { SelectionContext } from '@kbn/workflows/types/latest';
+import {
+  type ConnectorChannelSelectionHandlerServices,
+  getConnectorChannelSelectionHandler,
+} from './connector_channel_selection_handler';
+
+const contextWithConnector = (connectorId?: string): SelectionContext =>
+  ({
+    stepType: 'elastic_slack.sendMessage',
+    scope: 'input',
+    propertyKey: 'channel',
+    values: { config: connectorId ? { 'connector-id': connectorId } : {}, input: {} },
+  } as SelectionContext);
+
+describe('getConnectorChannelSelectionHandler', () => {
+  const post = jest.fn();
+  const services = {
+    http: { post } as unknown as HttpStart,
+  } as ConnectorChannelSelectionHandlerServices;
+
+  const createHandler = () =>
+    getConnectorChannelSelectionHandler(services, { subAction: 'listChannels' });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    post.mockResolvedValue({
+      status: 'ok',
+      data: {
+        ok: true,
+        channels: [
+          { id: 'C001', name: 'general' },
+          { id: 'C002', name: 'alerts' },
+        ],
+      },
+    });
+  });
+
+  it('declares connector-id as a dependency so the step instance is available', () => {
+    expect(createHandler().dependsOnValues).toEqual(['config.connector-id']);
+  });
+
+  describe('search', () => {
+    it('executes the configured sub-action on the step connector', async () => {
+      await createHandler().search('', contextWithConnector('elastic-slack'));
+
+      expect(post).toHaveBeenCalledWith('/api/actions/connector/elastic-slack/_execute', {
+        body: JSON.stringify({ params: { subAction: 'listChannels', subActionParams: {} } }),
+      });
+    });
+
+    it('offers the channel id as the value and the name as the label', async () => {
+      await expect(createHandler().search('', contextWithConnector('c1'))).resolves.toEqual([
+        expect.objectContaining({ value: 'C001', label: '#general' }),
+        expect.objectContaining({ value: 'C002', label: '#alerts' }),
+      ]);
+    });
+
+    it('filters by name or id against the typed query', async () => {
+      const handler = createHandler();
+
+      await expect(handler.search('gen', contextWithConnector('c1'))).resolves.toEqual([
+        expect.objectContaining({ value: 'C001' }),
+      ]);
+      await expect(handler.search('C002', contextWithConnector('c1'))).resolves.toEqual([
+        expect.objectContaining({ value: 'C002' }),
+      ]);
+    });
+
+    it('caps the number of suggestions', async () => {
+      post.mockResolvedValue({
+        status: 'ok',
+        data: {
+          ok: true,
+          channels: Array.from({ length: 30 }, (_, i) => ({ id: `C${i}`, name: `channel-${i}` })),
+        },
+      });
+
+      const options = await getConnectorChannelSelectionHandler(services, {
+        subAction: 'listChannels',
+        maxResults: 5,
+      }).search('', contextWithConnector('c1'));
+
+      expect(options).toHaveLength(5);
+    });
+
+    it('suggests nothing when the step has no connector to ask', async () => {
+      await expect(createHandler().search('', contextWithConnector())).resolves.toEqual([]);
+      expect(post).not.toHaveBeenCalled();
+    });
+
+    it('suggests nothing when the execute call fails', async () => {
+      post.mockRejectedValue(new Error('boom'));
+
+      await expect(createHandler().search('', contextWithConnector('c1'))).resolves.toEqual([]);
+    });
+
+    it('suggests nothing when the connector reports an error', async () => {
+      post.mockResolvedValue({ status: 'error', message: 'not connected' });
+
+      await expect(createHandler().search('', contextWithConnector('c1'))).resolves.toEqual([]);
+    });
+  });
+
+  describe('resolve', () => {
+    it('resolves a known channel id to its option', async () => {
+      await expect(createHandler().resolve('C002', contextWithConnector('c1'))).resolves.toEqual(
+        expect.objectContaining({ value: 'C002', label: '#alerts' })
+      );
+    });
+
+    it('returns null for a channel that is not connected', async () => {
+      await expect(createHandler().resolve('C999', contextWithConnector('c1'))).resolves.toBeNull();
+    });
+
+    it('returns null when there is no connector on the step', async () => {
+      await expect(createHandler().resolve('C001', contextWithConnector())).resolves.toBeNull();
+    });
+  });
+
+  describe('getDetails', () => {
+    it('confirms a resolved channel', async () => {
+      const option = { value: 'C001', label: '#general' };
+
+      await expect(
+        createHandler().getDetails('C001', contextWithConnector('c1'), option)
+      ).resolves.toEqual(expect.objectContaining({ message: expect.stringContaining('#general') }));
+    });
+
+    it('warns that an unresolved channel is rejected at run time', async () => {
+      await expect(
+        createHandler().getDetails('C999', contextWithConnector('c1'), null)
+      ).resolves.toEqual(
+        expect.objectContaining({ message: expect.stringContaining('not a connected channel') })
+      );
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/connector_channel_selection_handler.test.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/connector_channel_selection_handler.test.ts
@@ -16,7 +16,7 @@ import {
 
 const contextWithConnector = (connectorId?: string): SelectionContext =>
   ({
-    stepType: 'elastic_slack.sendMessage',
+    stepType: 'elastic_apps_slack.sendMessage',
     scope: 'input',
     propertyKey: 'channel',
     values: { config: connectorId ? { 'connector-id': connectorId } : {}, input: {} },
@@ -51,9 +51,9 @@ describe('getConnectorChannelSelectionHandler', () => {
 
   describe('search', () => {
     it('executes the configured sub-action on the step connector', async () => {
-      await createHandler().search('', contextWithConnector('elastic-slack'));
+      await createHandler().search('', contextWithConnector('elastic-apps-slack'));
 
-      expect(post).toHaveBeenCalledWith('/api/actions/connector/elastic-slack/_execute', {
+      expect(post).toHaveBeenCalledWith('/api/actions/connector/elastic-apps-slack/_execute', {
         body: JSON.stringify({ params: { subAction: 'listChannels', subActionParams: {} } }),
       });
     });

--- a/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/connector_channel_selection_handler.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/connector_channel_selection_handler.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpStart } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import type { PropertySelectionHandler, SelectionOption } from '@kbn/workflows/types/latest';
+
+export interface ConnectorChannelSelectionHandlerServices {
+  http: HttpStart;
+}
+
+export interface ConnectorChannelSelectionHandlerOptions {
+  /** Sub-action to execute; must return `{ ok: true, channels: [{ id, name }] }`. */
+  subAction: string;
+  /** Maximum number of options to offer. Defaults to 20. */
+  maxResults?: number;
+}
+
+interface Channel {
+  id: string;
+  name: string;
+}
+
+interface ExecuteResponse {
+  status: string;
+  data?: { ok?: boolean; channels?: Channel[] };
+}
+
+const DEFAULT_MAX_RESULTS = 20;
+
+/**
+ * The step's `connector-id` is a sibling root-level property, so the handler must declare it as
+ * a dependency to receive it in `context.values.config`.
+ */
+const DEPENDS_ON_CONNECTOR_ID = ['config.connector-id'] as const;
+
+const toSelectionOption = ({ id, name }: Channel): SelectionOption<string> => ({
+  value: id,
+  label: `#${name}`,
+  description: i18n.translate('workflows.connectorChannelSelection.channelDescription', {
+    defaultMessage: 'Channel #{name}',
+    values: { name },
+  }),
+});
+
+/**
+ * Suggests the channels a connector instance can post to, by executing a channel-listing
+ * sub-action on that instance. The stored value is the channel *id*, since that is what the
+ * corresponding `sendMessage` action resolves against.
+ *
+ * Requires a `connector-id` on the step: without one there is no instance to ask, so the
+ * handler returns no suggestions rather than guessing.
+ */
+export const getConnectorChannelSelectionHandler = (
+  { http }: ConnectorChannelSelectionHandlerServices,
+  { subAction, maxResults = DEFAULT_MAX_RESULTS }: ConnectorChannelSelectionHandlerOptions
+): PropertySelectionHandler<string> => {
+  const listChannels = async (connectorId: string): Promise<Channel[]> => {
+    try {
+      const response = await http.post<ExecuteResponse>(
+        `/api/actions/connector/${encodeURIComponent(connectorId)}/_execute`,
+        { body: JSON.stringify({ params: { subAction, subActionParams: {} } }) }
+      );
+
+      if (response.status !== 'ok' || !response.data?.ok) {
+        return [];
+      }
+      return response.data.channels ?? [];
+    } catch {
+      return [];
+    }
+  };
+
+  const getConnectorId = (context: {
+    values: { config: Record<string, unknown> };
+  }): string | undefined => {
+    const connectorId = context.values.config['connector-id'];
+    return typeof connectorId === 'string' && connectorId.length > 0 ? connectorId : undefined;
+  };
+
+  return {
+    dependsOnValues: [...DEPENDS_ON_CONNECTOR_ID],
+
+    search: async (rawInput, context) => {
+      const connectorId = getConnectorId(context);
+      if (!connectorId) {
+        return [];
+      }
+
+      const query = rawInput.trim().toLowerCase();
+      const channels = await listChannels(connectorId);
+
+      return channels
+        .filter(({ id, name }) =>
+          query ? name.toLowerCase().includes(query) || id.toLowerCase().includes(query) : true
+        )
+        .slice(0, maxResults)
+        .map(toSelectionOption);
+    },
+
+    resolve: async (value, context) => {
+      const connectorId = getConnectorId(context);
+      if (!connectorId || !value) {
+        return null;
+      }
+
+      const channels = await listChannels(connectorId);
+      const match = channels.find(({ id }) => id === value);
+      return match ? toSelectionOption(match) : null;
+    },
+
+    getDetails: async (input, _context, option) => {
+      if (option) {
+        return {
+          message: i18n.translate('workflows.connectorChannelSelection.detailsFound', {
+            defaultMessage: '✓ {label} is connected and can receive messages.',
+            values: { label: option.label ?? input },
+          }),
+          links: [],
+        };
+      }
+
+      return {
+        message: i18n.translate('workflows.connectorChannelSelection.detailsNotFound', {
+          defaultMessage:
+            '`{input}` is not a connected channel. Messages to channels that are not connected are rejected at run time.',
+          values: { input },
+        }),
+        links: [],
+      };
+    },
+  };
+};

--- a/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/lib/steps/editor_handlers/index.ts
@@ -7,4 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+export * from './connector_channel_selection_handler';
 export * from './index_selection_handler';

--- a/src/platform/plugins/shared/workflows_management/public/common/context/internal_steps/editor_handlers/editor_handlers.ts
+++ b/src/platform/plugins/shared/workflows_management/public/common/context/internal_steps/editor_handlers/editor_handlers.ts
@@ -46,7 +46,7 @@ export class InternalStepsEditorHandlers {
     // Connector-derived step types get their contracts from the actions plugin, which cannot
     // carry browser handlers, so their editor handlers are registered here alongside the
     // built-in ones.
-    const elasticSlackChannelSelectionHandler = getConnectorChannelSelectionHandler(services, {
+    const elasticAppsSlackChannelSelectionHandler = getConnectorChannelSelectionHandler(services, {
       subAction: 'listChannels',
     });
 
@@ -63,8 +63,8 @@ export class InternalStepsEditorHandlers {
       'elasticsearch.indices.delete': {
         input: { index: { selection: deleteIndexSelectionHandler } },
       },
-      'elastic_slack.sendMessage': {
-        input: { channel: { selection: elasticSlackChannelSelectionHandler } },
+      'elastic_apps_slack.sendMessage': {
+        input: { channel: { selection: elasticAppsSlackChannelSelectionHandler } },
       },
     };
   };

--- a/src/platform/plugins/shared/workflows_management/public/common/context/internal_steps/editor_handlers/editor_handlers.ts
+++ b/src/platform/plugins/shared/workflows_management/public/common/context/internal_steps/editor_handlers/editor_handlers.ts
@@ -8,7 +8,7 @@
  */
 
 import type { EditorHandlers } from '@kbn/workflows/types/latest';
-import { getIndexSelectionHandler } from '@kbn/workflows-ui';
+import { getConnectorChannelSelectionHandler, getIndexSelectionHandler } from '@kbn/workflows-ui';
 import type { WorkflowsServices } from '../../../../types';
 
 export class InternalStepsEditorHandlers {
@@ -43,6 +43,12 @@ export class InternalStepsEditorHandlers {
       allowWildcard: false,
       showAllIndices: false,
     });
+    // Connector-derived step types get their contracts from the actions plugin, which cannot
+    // carry browser handlers, so their editor handlers are registered here alongside the
+    // built-in ones.
+    const elasticSlackChannelSelectionHandler = getConnectorChannelSelectionHandler(services, {
+      subAction: 'listChannels',
+    });
 
     return {
       'elasticsearch.search': {
@@ -56,6 +62,9 @@ export class InternalStepsEditorHandlers {
       },
       'elasticsearch.indices.delete': {
         input: { index: { selection: deleteIndexSelectionHandler } },
+      },
+      'elastic_slack.sendMessage': {
+        input: { channel: { selection: elasticSlackChannelSelectionHandler } },
       },
     };
   };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/slack_channel_selector.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/slack_channel_selector.test.tsx
@@ -11,7 +11,10 @@ import userEvent from '@testing-library/user-event';
 import { I18nProvider } from '@kbn/i18n-react';
 import React from 'react';
 import { parse } from 'yaml';
-import { ElasticSlackChannelSelectorWrapper, SlackChannelSelector } from './slack_channel_selector';
+import {
+  ElasticAppsSlackChannelSelectorWrapper,
+  SlackChannelSelector,
+} from './slack_channel_selector';
 import { type SlackChannel, useFetchSlackChannels } from '../hooks/use_fetch_slack_channels';
 import type { UseQueryResult } from '@kbn/react-query';
 
@@ -204,17 +207,17 @@ describe('SlackChannelSelector', () => {
   });
 });
 
-describe('ElasticSlackChannelSelectorWrapper', () => {
+describe('ElasticAppsSlackChannelSelectorWrapper', () => {
   const renderWrapper = (params: string) => {
     const onChange = jest.fn();
     render(
       <I18nProvider>
-        <ElasticSlackChannelSelectorWrapper
+        <ElasticAppsSlackChannelSelectorWrapper
           value={{
             id: 'draft-1',
             source: 'inline',
-            stepType: 'elastic_slack.sendMessage',
-            connectorId: 'elastic-slack',
+            stepType: 'elastic_apps_slack.sendMessage',
+            connectorId: 'elastic-apps-slack',
             params,
           }}
           onChange={onChange}
@@ -235,7 +238,7 @@ describe('ElasticSlackChannelSelectorWrapper', () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     const { onChange } = renderWrapper('channel: ""\ntext: "hello"\n');
 
-    expect(screen.getByTestId('elasticSlackChannelSelector')).toBeInTheDocument();
+    expect(screen.getByTestId('elasticAppsSlackChannelSelector')).toBeInTheDocument();
 
     await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByText('#general'));

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/slack_channel_selector.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/slack_channel_selector.test.tsx
@@ -11,7 +11,7 @@ import userEvent from '@testing-library/user-event';
 import { I18nProvider } from '@kbn/i18n-react';
 import React from 'react';
 import { parse } from 'yaml';
-import { SlackChannelSelector } from './slack_channel_selector';
+import { ElasticSlackChannelSelectorWrapper, SlackChannelSelector } from './slack_channel_selector';
 import { type SlackChannel, useFetchSlackChannels } from '../hooks/use_fetch_slack_channels';
 import type { UseQueryResult } from '@kbn/react-query';
 
@@ -152,5 +152,94 @@ describe('SlackChannelSelector', () => {
 
   it('handles missing channel field in params without crashing', () => {
     expect(() => renderSelector({ params: 'text: "hello"\n' })).not.toThrow();
+  });
+
+  describe('when configured to write the channel id', () => {
+    const renderIdSelector = (
+      props: Partial<React.ComponentProps<typeof SlackChannelSelector>> = {}
+    ) => renderSelector({ channelValueField: 'id', ...props });
+
+    it('writes the channel id rather than its name', async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      const { onParamsChange } = renderIdSelector({ params: 'channel: ""\ntext: "hello"\n' });
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('#general'));
+
+      const parsed = parse(onParamsChange.mock.calls[0][0]);
+      expect(parsed.channel).toBe('C001');
+      expect(parsed.text).toBe('hello');
+    });
+
+    it('still labels options by channel name', async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      renderIdSelector();
+
+      await user.click(screen.getByRole('combobox'));
+
+      expect(screen.getByText('#general')).toBeInTheDocument();
+    });
+
+    it('shows the stored id until the channel list resolves its name', () => {
+      renderIdSelector({ params: 'channel: C001\n' });
+      expect(screen.getByDisplayValue('#C001')).toBeInTheDocument();
+    });
+
+    it('resolves the stored id to a channel name once the list is loaded', async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      renderIdSelector({ params: 'channel: C001\n' });
+
+      await user.click(screen.getByRole('combobox'));
+
+      expect(screen.getByDisplayValue('#general')).toBeInTheDocument();
+    });
+  });
+
+  it('requests the channels through the given sub-action', () => {
+    renderSelector({ subAction: 'listConnectedChannels' });
+
+    expect(mockUseFetchSlackChannels).toHaveBeenCalledWith(
+      expect.objectContaining({ subAction: 'listConnectedChannels' })
+    );
+  });
+});
+
+describe('ElasticSlackChannelSelectorWrapper', () => {
+  const renderWrapper = (params: string) => {
+    const onChange = jest.fn();
+    render(
+      <I18nProvider>
+        <ElasticSlackChannelSelectorWrapper
+          value={{
+            id: 'draft-1',
+            source: 'inline',
+            stepType: 'elastic_slack.sendMessage',
+            connectorId: 'elastic-slack',
+            params,
+          }}
+          onChange={onChange}
+        />
+      </I18nProvider>
+    );
+    return { onChange };
+  };
+
+  beforeEach(() => {
+    mockUseFetchSlackChannels.mockReturnValue({
+      data: [{ id: 'C001', name: 'general' }],
+      isFetching: false,
+    } as UseQueryResult<SlackChannel[], Error>);
+  });
+
+  it('writes the channel id, which is what the Relay resolves the binding by', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const { onChange } = renderWrapper('channel: ""\ntext: "hello"\n');
+
+    expect(screen.getByTestId('elasticSlackChannelSelector')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByText('#general'));
+
+    expect(parse(onChange.mock.calls[0][0].params).channel).toBe('C001');
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/slack_channel_selector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/slack_channel_selector.tsx
@@ -17,26 +17,38 @@ interface SlackChannelSelectorProps {
   connectorId: string | null;
   params: string;
   onParamsChange: (params: string) => void;
+  /** Sub-action returning the connector's channels. */
+  subAction?: string;
+  /**
+   * Which channel field to write into the step params. Slack (v2) resolves channels by name,
+   * while the Elastic Slack app resolves the deployment's binding by channel id.
+   */
+  channelValueField?: 'id' | 'name';
+  dataTestSubj?: string;
 }
 
 export const SlackChannelSelector = ({
   connectorId,
   params,
   onParamsChange,
+  subAction,
+  channelValueField = 'name',
+  dataTestSubj = 'slackChannelSelector',
 }: SlackChannelSelectorProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const { data: channels = [], isFetching } = useFetchSlackChannels({
     connectorId,
+    subAction,
     enabled: isOpen,
   });
 
   const options: Array<EuiComboBoxOptionOption<string>> = channels.map((channel) => ({
     label: `#${channel.name}`,
-    value: channel.name,
+    value: channel[channelValueField],
   }));
 
   const handleChange = (selected: Array<EuiComboBoxOptionOption<string>>) => {
-    const channelName = selected[0]?.value ?? '';
+    const channel = selected[0]?.value ?? '';
 
     let parsed: Record<string, unknown> = {};
     try {
@@ -48,16 +60,25 @@ export const SlackChannelSelector = ({
       // leave parsed as empty — the YAML is malformed, we still write the channel
     }
 
-    onParamsChange(stringify({ ...parsed, channel: channelName }));
+    onParamsChange(stringify({ ...parsed, channel }));
   };
 
   const selectedOptions = (() => {
+    let channel: unknown;
     try {
-      const channel = parse(params)?.channel;
-      return channel ? [{ label: `#${channel}`, value: channel }] : [];
+      channel = parse(params)?.channel;
     } catch {
       return [];
     }
+
+    if (!channel || typeof channel !== 'string') {
+      return [];
+    }
+
+    // Channels are only fetched once the combo box is opened, so an id-valued selection shows
+    // its raw id until the list arrives and can resolve the display name.
+    const match = channels.find(({ [channelValueField]: value }) => value === channel);
+    return [{ label: `#${match?.name ?? channel}`, value: channel }];
   })();
 
   return (
@@ -72,7 +93,7 @@ export const SlackChannelSelector = ({
         fullWidth
         compressed
         singleSelection={{ asPlainText: true }}
-        data-test-subj="slackChannelSelector"
+        data-test-subj={dataTestSubj}
         isLoading={isFetching}
         isDisabled={connectorId === null}
         placeholder={i18n.translate(
@@ -100,5 +121,25 @@ export const SlackChannelSelectorWrapper = ({
     connectorId={value.connectorId}
     params={value.params}
     onParamsChange={(params) => onChange({ ...value, params })}
+  />
+);
+
+/**
+ * The Elastic Slack app posts through the Relay, which resolves the deployment's binding by
+ * channel id — a channel name would be rejected as unbound.
+ */
+export const ElasticSlackChannelSelectorWrapper = ({
+  value,
+  onChange,
+}: {
+  value: InlineWorkflowActionDraft;
+  onChange: (value: InlineWorkflowActionDraft) => void;
+}) => (
+  <SlackChannelSelector
+    connectorId={value.connectorId}
+    params={value.params}
+    onParamsChange={(params) => onChange({ ...value, params })}
+    channelValueField="id"
+    dataTestSubj="elasticSlackChannelSelector"
   />
 );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/slack_channel_selector.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/components/slack_channel_selector.tsx
@@ -128,7 +128,7 @@ export const SlackChannelSelectorWrapper = ({
  * The Elastic Slack app posts through the Relay, which resolves the deployment's binding by
  * channel id — a channel name would be rejected as unbound.
  */
-export const ElasticSlackChannelSelectorWrapper = ({
+export const ElasticAppsSlackChannelSelectorWrapper = ({
   value,
   onChange,
 }: {
@@ -140,6 +140,6 @@ export const ElasticSlackChannelSelectorWrapper = ({
     params={value.params}
     onParamsChange={(params) => onChange({ ...value, params })}
     channelValueField="id"
-    dataTestSubj="elasticSlackChannelSelector"
+    dataTestSubj="elasticAppsSlackChannelSelector"
   />
 );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/hooks/use_fetch_slack_channels.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/hooks/use_fetch_slack_channels.ts
@@ -27,22 +27,30 @@ interface ExecuteResponse {
 const connectorExecutePath = (id: string) =>
   `/api/actions/connector/${encodeURIComponent(id)}/_execute`;
 
+/**
+ * Loads the channels a Slack-style connector can post to by executing its channel-listing
+ * sub-action. Shared by the Slack (v2) and Slack (Elastic app) selectors, which expose the
+ * same `{ id, name }` channel shape under different sub-action names.
+ */
 export const useFetchSlackChannels = ({
   connectorId,
+  subAction = 'listChannels',
   enabled = true,
 }: {
   connectorId: string | null;
+  /** Sub-action that returns `{ ok, channels }`. */
+  subAction?: string;
   enabled?: boolean;
 }) => {
   const http = useService(CoreStart('http'));
   const { toasts } = useService(CoreStart('notifications'));
 
   return useQuery<SlackChannel[], Error>({
-    queryKey: ['alertingV2', 'slackChannels', connectorId],
+    queryKey: ['alertingV2', 'slackChannels', connectorId, subAction],
     queryFn: async () => {
       const res = await http.post<ExecuteResponse>(connectorExecutePath(connectorId!), {
         body: JSON.stringify({
-          params: { subAction: 'listChannels', subActionParams: {} },
+          params: { subAction, subActionParams: {} },
         }),
       });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/registry/registry.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/registry/registry.ts
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 import type { InlineActionStepType } from '../types';
 import type { InlineActionStepDefinition } from './types';
 import {
-  ElasticSlackChannelSelectorWrapper,
+  ElasticAppsSlackChannelSelectorWrapper,
   SlackChannelSelectorWrapper,
 } from '../components/slack_channel_selector';
 
@@ -24,7 +24,7 @@ const SLACK2_PARAMS_TEMPLATE = `channel: ""
 text: ""
 `;
 
-const ELASTIC_SLACK_PARAMS_TEMPLATE = `channel: ""
+const ELASTIC_APPS_SLACK_PARAMS_TEMPLATE = `channel: ""
 text: ""
 `;
 
@@ -62,22 +62,22 @@ export const INLINE_ACTION_STEP_DEFINITIONS: readonly InlineActionStepDefinition
     CustomComponent: SlackChannelSelectorWrapper,
   },
   {
-    id: 'elastic_slack.sendMessage',
+    id: 'elastic_apps_slack.sendMessage',
     label: i18n.translate(
-      'xpack.responseOps.alertingV2RuleForm.actionForm.stepType.elasticSlack.label',
+      'xpack.responseOps.alertingV2RuleForm.actionForm.stepType.elasticAppsSlack.label',
       { defaultMessage: 'Slack (Elastic app)' }
     ),
     description: i18n.translate(
-      'xpack.responseOps.alertingV2RuleForm.actionForm.stepType.elasticSlack.description',
+      'xpack.responseOps.alertingV2RuleForm.actionForm.stepType.elasticAppsSlack.description',
       {
         defaultMessage: 'Post a Slack message to a connected channel',
       }
     ),
     iconType: 'logoSlack',
-    connectorTypeId: '.elastic_slack',
+    connectorTypeId: '.elastic_apps_slack',
     connectorTypeSubAction: 'sendMessage',
-    paramsTemplate: ELASTIC_SLACK_PARAMS_TEMPLATE,
-    CustomComponent: ElasticSlackChannelSelectorWrapper,
+    paramsTemplate: ELASTIC_APPS_SLACK_PARAMS_TEMPLATE,
+    CustomComponent: ElasticAppsSlackChannelSelectorWrapper,
   },
 ];
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/registry/registry.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/registry/registry.ts
@@ -8,7 +8,10 @@
 import { i18n } from '@kbn/i18n';
 import type { InlineActionStepType } from '../types';
 import type { InlineActionStepDefinition } from './types';
-import { SlackChannelSelectorWrapper } from '../components/slack_channel_selector';
+import {
+  ElasticSlackChannelSelectorWrapper,
+  SlackChannelSelectorWrapper,
+} from '../components/slack_channel_selector';
 
 const EMAIL_PARAMS_TEMPLATE = `to: 
   - ""
@@ -18,6 +21,10 @@ message: ""
 
 // ToDo: add a channel selector to the Slack (v2) step form
 const SLACK2_PARAMS_TEMPLATE = `channel: ""
+text: ""
+`;
+
+const ELASTIC_SLACK_PARAMS_TEMPLATE = `channel: ""
 text: ""
 `;
 
@@ -53,6 +60,24 @@ export const INLINE_ACTION_STEP_DEFINITIONS: readonly InlineActionStepDefinition
     connectorTypeSubAction: 'sendMessage',
     paramsTemplate: SLACK2_PARAMS_TEMPLATE,
     CustomComponent: SlackChannelSelectorWrapper,
+  },
+  {
+    id: 'elastic_slack.sendMessage',
+    label: i18n.translate(
+      'xpack.responseOps.alertingV2RuleForm.actionForm.stepType.elasticSlack.label',
+      { defaultMessage: 'Slack (Elastic app)' }
+    ),
+    description: i18n.translate(
+      'xpack.responseOps.alertingV2RuleForm.actionForm.stepType.elasticSlack.description',
+      {
+        defaultMessage: 'Post a Slack message to a connected channel',
+      }
+    ),
+    iconType: 'logoSlack',
+    connectorTypeId: '.elastic_slack',
+    connectorTypeSubAction: 'sendMessage',
+    paramsTemplate: ELASTIC_SLACK_PARAMS_TEMPLATE,
+    CustomComponent: ElasticSlackChannelSelectorWrapper,
   },
 ];
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/types.ts
@@ -7,7 +7,10 @@
 
 import { parse } from 'yaml';
 
-export type InlineActionStepType = 'slack2.sendMessage' | 'elastic_slack.sendMessage' | 'email';
+export type InlineActionStepType =
+  | 'slack2.sendMessage'
+  | 'elastic_apps_slack.sendMessage'
+  | 'email';
 export type ActionSource = 'existing' | 'inline';
 
 export interface ExistingWorkflowActionDraft {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/actions_form/types.ts
@@ -7,7 +7,7 @@
 
 import { parse } from 'yaml';
 
-export type InlineActionStepType = 'slack2.sendMessage' | 'email';
+export type InlineActionStepType = 'slack2.sendMessage' | 'elastic_slack.sendMessage' | 'email';
 export type ActionSource = 'existing' | 'inline';
 
 export interface ExistingWorkflowActionDraft {

--- a/x-pack/platform/plugins/shared/actions/server/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/index.ts
@@ -39,11 +39,15 @@ export type { PluginSetupContract, PluginStartContract } from './plugin';
 export { RelayRequestError } from './lib/relay';
 export type {
   RelayBinding,
+  RelayBindingsPage,
   RelayCallbackResponse,
   RelayClaimResponse,
   RelayClientContract,
   RelayInstallRequest,
   RelayInstallResponse,
+  RelayListBindingsOptions,
+  RelayTriggerInput,
+  RelayTriggerResponse,
 } from './lib/relay';
 
 export {

--- a/x-pack/platform/plugins/shared/actions/server/lib/relay/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/relay/index.ts
@@ -9,9 +9,13 @@ export { RelayClient } from './relay_client';
 export { RelayRequestError } from './relay_error';
 export type {
   RelayBinding,
+  RelayBindingsPage,
   RelayCallbackResponse,
   RelayClaimResponse,
   RelayClientContract,
   RelayInstallRequest,
   RelayInstallResponse,
+  RelayListBindingsOptions,
+  RelayTriggerInput,
+  RelayTriggerResponse,
 } from './types';

--- a/x-pack/platform/plugins/shared/actions/server/lib/relay/relay_client.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/relay/relay_client.test.ts
@@ -219,6 +219,65 @@ describe('RelayClient', () => {
     });
   });
 
+  describe('trigger', () => {
+    it('POSTs the outbound message to the trigger endpoint and returns the Relay ref', async () => {
+      requestMock.mockResolvedValue({
+        status: 202,
+        data: { ok: true, surface: 'slack', tenant_key: 'team-A', ref: 'C123:1700000000.000100' },
+      } as never);
+
+      await expect(
+        createClient().trigger({ tenantKey: 'team-A', channel: 'C123', message: 'hello' })
+      ).resolves.toEqual({ ref: 'C123:1700000000.000100', tenantKey: 'team-A' });
+
+      expect(requestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://relay.test/v1/trigger',
+          method: 'post',
+          data: { surface: 'slack', tenant_key: 'team-A', channel: 'C123', message: 'hello' },
+          sslOverrides: relaySSLSettings,
+        })
+      );
+    });
+
+    it('includes thread_ts only when replying in a thread', async () => {
+      requestMock.mockResolvedValue({ status: 202, data: { ref: 'ref-1' } } as never);
+
+      await createClient().trigger({
+        tenantKey: 'team-A',
+        channel: 'C123',
+        message: 'reply',
+        threadTs: '1700000000.000100',
+      });
+
+      expect(requestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ thread_ts: '1700000000.000100' }),
+        })
+      );
+    });
+
+    it.each([
+      [403, 'channel is not bound to this deployment or project', true],
+      [409, 'workspace is not installed', true],
+      [502, 'failed to post outbound message', false],
+    ])('surfaces a %i Relay response as a RelayRequestError', async (status, message, terminal) => {
+      requestMock.mockResolvedValue({ status, data: { message } } as never);
+
+      const error = await createClient()
+        .trigger({ tenantKey: 'team-A', channel: 'C123', message: 'hello' })
+        .then(() => undefined)
+        .catch((cause) => cause);
+
+      expect(error).toBeInstanceOf(RelayRequestError);
+      expect(error).toMatchObject({
+        statusCode: status,
+        relayMessage: message,
+        isTerminal: terminal,
+      });
+    });
+  });
+
   it('preserves Relay errors', async () => {
     requestMock.mockResolvedValue({
       status: 400,

--- a/x-pack/platform/plugins/shared/actions/server/lib/relay/relay_client.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/relay/relay_client.ts
@@ -20,6 +20,8 @@ import type {
   RelayInstallRequest,
   RelayInstallResponse,
   RelayListBindingsOptions,
+  RelayTriggerInput,
+  RelayTriggerResponse,
 } from './types';
 
 export interface RelayClientOptions {
@@ -39,6 +41,12 @@ interface RelayErrorResponse {
 interface RelayBindingsListResponse {
   bindings?: RelayBinding[];
   next_cursor?: string;
+}
+
+/** Raw shape of the `POST /v1/trigger` acknowledgement body. */
+interface RelayTriggerResponseBody {
+  ref?: string;
+  tenant_key?: string;
 }
 
 export class RelayClient implements RelayClientContract {
@@ -138,6 +146,29 @@ export class RelayClient implements RelayClientContract {
         channelId
       )}/unbind`
     );
+  }
+
+  /**
+   * Post an outbound message to a channel bound to this deployment. The Relay resolves the
+   * target binding from the tenant key and channel id, so a channel this deployment does not
+   * own is rejected with a 403 rather than delivered.
+   */
+  async trigger({
+    tenantKey,
+    channel,
+    message,
+    threadTs,
+  }: RelayTriggerInput): Promise<RelayTriggerResponse> {
+    const response = await this.post('/v1/trigger', {
+      surface: 'slack',
+      tenant_key: tenantKey,
+      channel,
+      message,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+    });
+
+    const body = response.data as RelayTriggerResponseBody | undefined;
+    return { ref: body?.ref ?? '', tenantKey: body?.tenant_key ?? tenantKey };
   }
 
   isRelayOrigin(url: string): boolean {

--- a/x-pack/platform/plugins/shared/actions/server/lib/relay/types.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/relay/types.ts
@@ -62,6 +62,28 @@ export interface RelayBindingsPage {
   nextCursor?: string;
 }
 
+/**
+ * Outbound message sent to a bound channel through the Relay's `POST /v1/trigger`
+ * endpoint. The Relay resolves the target binding from `tenantKey` + `channel` and
+ * rejects channels this deployment does not own, so `channel` must be the Slack
+ * channel *id* (as returned by `listBindings`), not its display name.
+ */
+export interface RelayTriggerInput {
+  tenantKey: string;
+  /** Slack channel id, i.e. the `scope_id` of one of this deployment's bindings. */
+  channel: string;
+  message: string;
+  /** Timestamp of the message to reply to, when posting into an existing thread. */
+  threadTs?: string;
+}
+
+/** Acknowledgement of an accepted outbound message. */
+export interface RelayTriggerResponse {
+  /** Relay-side reference for the posted message. */
+  ref: string;
+  tenantKey: string;
+}
+
 export interface RelayClientContract {
   startInstall(body: RelayInstallRequest): Promise<RelayInstallResponse>;
   fetchClaim(claimId: string): Promise<RelayClaimResponse>;
@@ -78,6 +100,11 @@ export interface RelayClientContract {
   bind(tenantKey: string, channelId: string): Promise<void>;
   /** Release a channel binding owned by this deployment (404 if none; 403 if owned by another). */
   unbindChannel(tenantKey: string, channelId: string): Promise<void>;
+  /**
+   * Post an outbound message to a channel bound to this deployment (403 when the channel
+   * is not bound here; 409 when the workspace is no longer installed).
+   */
+  trigger(input: RelayTriggerInput): Promise<RelayTriggerResponse>;
   isRelayOrigin(url: string): boolean;
   postCallback(url: string, body: unknown, signal: AbortSignal): Promise<RelayCallbackResponse>;
 }

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.test.ts
@@ -18,9 +18,12 @@ describe('createConnectorTypeFromSpec', () => {
   const mockGetAxiosInstanceWithAuth = jest.fn();
   const mockActionsConfigUtils = actionsConfigMock.create();
 
+  const mockGetRelayClient = jest.fn();
+
   const mockActionsPlugin: ActionsPluginSetupContract = {
     getActionsConfigurationUtilities: () => mockActionsConfigUtils,
     getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+    getRelayClient: mockGetRelayClient,
   } as unknown as ActionsPluginSetupContract;
 
   const createMockSpec = (overrides: Partial<ConnectorSpec> = {}): ConnectorSpec =>

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
@@ -60,6 +60,7 @@ export const createConnectorTypeFromSpec = (
     ? generateExecutorFunction({
         actions: executableActions,
         getAxiosInstanceWithAuth: actions.getAxiosInstanceWithAuth,
+        getRelayClient: actions.getRelayClient,
       })
     : undefined;
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
@@ -9,7 +9,7 @@ import { loggingSystemMock } from '@kbn/core/server/mocks';
 import type { MockedLogger } from '@kbn/logging-mocks';
 import { generateExecutorFunction } from './generate_executor_function';
 import { setConnectorActionErrorMeta, TEST_CONNECTOR_SUB_ACTION } from '@kbn/connector-specs';
-import type { ConnectorSpec } from '@kbn/connector-specs';
+import type { ConnectorSpec, RelayActionClient } from '@kbn/connector-specs';
 import type { GetAxiosInstanceWithAuthFn } from '../get_axios_instance';
 
 describe('generateExecutorFunction', () => {
@@ -19,6 +19,8 @@ describe('generateExecutorFunction', () => {
   let mockGetAxiosInstanceWithAuth: jest.MockedFunction<GetAxiosInstanceWithAuthFn>;
   let mockAxiosInstance: object;
   let mockHandler: jest.Mock;
+  let mockRelayClient: RelayActionClient;
+  let mockGetRelayClient: jest.MockedFunction<() => RelayActionClient | undefined>;
 
   const makeExecOptions = (params: Record<string, unknown>) =>
     ({
@@ -44,6 +46,8 @@ describe('generateExecutorFunction', () => {
     mockAxiosInstance = { get: jest.fn() };
     mockGetAxiosInstanceWithAuth = jest.fn().mockResolvedValue(mockAxiosInstance);
     mockHandler = jest.fn().mockResolvedValue({ result: 'ok' });
+    mockRelayClient = { trigger: jest.fn(), listBindings: jest.fn() };
+    mockGetRelayClient = jest.fn().mockReturnValue(mockRelayClient);
   });
 
   const makeActions = (handler: jest.Mock = mockHandler): ConnectorSpec['actions'] => ({
@@ -59,6 +63,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -72,6 +77,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const subActionParams = { message: 'hello', count: 3 };
@@ -87,14 +93,32 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const opts = makeExecOptions({ subAction: 'testAction', subActionParams: {} });
       await executor({ ...opts, config, secrets });
 
       expect(mockHandler).toHaveBeenCalledWith(
-        { log: logger, client: mockAxiosInstance, config, secrets },
+        { log: logger, client: mockAxiosInstance, config, secrets, relay: mockRelayClient },
         {}
+      );
+    });
+
+    it('leaves relay undefined in the handler context when no Relay is configured', async () => {
+      mockGetRelayClient.mockReturnValue(undefined);
+
+      const executor = generateExecutorFunction({
+        actions: makeActions(),
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
+      });
+
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+
+      expect(mockHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ relay: undefined }),
+        expect.anything()
       );
     });
 
@@ -104,6 +128,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -119,6 +144,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -138,6 +164,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       await executor({
@@ -164,6 +191,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       await executor(
@@ -187,6 +215,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       await expect(
@@ -202,6 +231,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       await expect(
@@ -219,6 +249,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -242,6 +273,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -273,6 +305,7 @@ describe('generateExecutorFunction', () => {
           },
         },
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -301,6 +334,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -324,6 +358,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
@@ -337,6 +372,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -356,6 +392,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       await expect(
@@ -378,6 +415,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions,
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -404,6 +442,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions,
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result = await executor(
@@ -431,6 +470,7 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions,
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getRelayClient: mockGetRelayClient,
       });
 
       const result1 = await executor(

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ConnectorSpec } from '@kbn/connector-specs';
+import type { ConnectorSpec, RelayActionClient } from '@kbn/connector-specs';
 import {
   getConnectorActionErrorMeta,
   getFinitePositiveNumber,
@@ -65,9 +65,11 @@ const getErrorMeta = ({
 export const generateExecutorFunction = ({
   actions,
   getAxiosInstanceWithAuth,
+  getRelayClient,
 }: {
   actions: ConnectorSpec['actions'];
   getAxiosInstanceWithAuth: GetAxiosInstanceWithAuthFn;
+  getRelayClient: () => RelayActionClient | undefined;
 }) =>
   async function (
     execOptions: ConnectorTypeExecutorOptions<RecordUnknown, RecordUnknown, RecordUnknown>
@@ -112,6 +114,7 @@ export const generateExecutorFunction = ({
       client: axiosInstance,
       secrets,
       config,
+      relay: getRelayClient(),
     };
 
     try {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { InMemoryConnector, PluginStartContract } from '@kbn/actions-plugin/server';
+
+/** Connector type id of the `@kbn/connector-specs` spec backed by the Relay. */
+export const ELASTIC_SLACK_CONNECTOR_TYPE_ID = '.elastic_slack';
+
+/**
+ * Id of the single in-memory connector instance. A deployment installs the Elastic Slack app
+ * once, so there is exactly one instance and its id is stable — rules and workflows reference
+ * it directly, and it must survive restarts and reconnects unchanged.
+ */
+export const ELASTIC_SLACK_CONNECTOR_ID = 'elastic-slack';
+
+const ELASTIC_SLACK_CONNECTOR_NAME = 'Slack (Elastic app)';
+
+const buildConnector = (tenantKey: string): InMemoryConnector => ({
+  id: ELASTIC_SLACK_CONNECTOR_ID,
+  actionTypeId: ELASTIC_SLACK_CONNECTOR_TYPE_ID,
+  name: ELASTIC_SLACK_CONNECTOR_NAME,
+  // The Relay holds the Slack credentials and authenticates this deployment at the transport
+  // layer, so the connector itself has nothing secret to store.
+  config: { tenantKey },
+  secrets: {},
+  isMissingSecrets: false,
+  isPreconfigured: true,
+  isDeprecated: false,
+  isSystemAction: false,
+  isConnectorTypeDeprecated: false,
+});
+
+/**
+ * Publish the connector for a connected Slack workspace.
+ *
+ * In-memory connectors live only for the lifetime of the process, so this runs both on the
+ * connect transition and again at plugin start for a deployment that was already connected.
+ * It always unregisters first: `registerDynamicConnector` is a no-op when the id is taken, so
+ * a reconnect to a different workspace would otherwise keep serving the previous tenant key.
+ */
+export const registerElasticSlackConnector = ({
+  actions,
+  logger,
+  tenantKey,
+}: {
+  actions: Pick<PluginStartContract, 'registerDynamicConnector' | 'unregisterDynamicConnector'>;
+  logger: Logger;
+  tenantKey: string;
+}): void => {
+  actions.unregisterDynamicConnector(ELASTIC_SLACK_CONNECTOR_ID);
+  actions.registerDynamicConnector(buildConnector(tenantKey));
+  logger.debug(`Registered the ${ELASTIC_SLACK_CONNECTOR_ID} connector`);
+};
+
+/** Withdraw the connector once the workspace is no longer connected. */
+export const unregisterElasticSlackConnector = ({
+  actions,
+  logger,
+}: {
+  actions: Pick<PluginStartContract, 'unregisterDynamicConnector'>;
+  logger: Logger;
+}): void => {
+  if (actions.unregisterDynamicConnector(ELASTIC_SLACK_CONNECTOR_ID)) {
+    logger.debug(`Unregistered the ${ELASTIC_SLACK_CONNECTOR_ID} connector`);
+  }
+};

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector.ts
@@ -9,21 +9,21 @@ import type { Logger } from '@kbn/core/server';
 import type { InMemoryConnector, PluginStartContract } from '@kbn/actions-plugin/server';
 
 /** Connector type id of the `@kbn/connector-specs` spec backed by the Relay. */
-export const ELASTIC_SLACK_CONNECTOR_TYPE_ID = '.elastic_slack';
+export const ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID = '.elastic_apps_slack';
 
 /**
  * Id of the single in-memory connector instance. A deployment installs the Elastic Slack app
  * once, so there is exactly one instance and its id is stable — rules and workflows reference
  * it directly, and it must survive restarts and reconnects unchanged.
  */
-export const ELASTIC_SLACK_CONNECTOR_ID = 'elastic-slack';
+export const ELASTIC_APPS_SLACK_CONNECTOR_ID = 'elastic-apps-slack';
 
-const ELASTIC_SLACK_CONNECTOR_NAME = 'Slack (Elastic app)';
+const ELASTIC_APPS_SLACK_CONNECTOR_NAME = 'Slack (Elastic app)';
 
 const buildConnector = (tenantKey: string): InMemoryConnector => ({
-  id: ELASTIC_SLACK_CONNECTOR_ID,
-  actionTypeId: ELASTIC_SLACK_CONNECTOR_TYPE_ID,
-  name: ELASTIC_SLACK_CONNECTOR_NAME,
+  id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+  actionTypeId: ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID,
+  name: ELASTIC_APPS_SLACK_CONNECTOR_NAME,
   // The Relay holds the Slack credentials and authenticates this deployment at the transport
   // layer, so the connector itself has nothing secret to store.
   config: { tenantKey },
@@ -43,7 +43,7 @@ const buildConnector = (tenantKey: string): InMemoryConnector => ({
  * It always unregisters first: `registerDynamicConnector` is a no-op when the id is taken, so
  * a reconnect to a different workspace would otherwise keep serving the previous tenant key.
  */
-export const registerElasticSlackConnector = ({
+export const registerElasticAppsSlackConnector = ({
   actions,
   logger,
   tenantKey,
@@ -52,20 +52,20 @@ export const registerElasticSlackConnector = ({
   logger: Logger;
   tenantKey: string;
 }): void => {
-  actions.unregisterDynamicConnector(ELASTIC_SLACK_CONNECTOR_ID);
+  actions.unregisterDynamicConnector(ELASTIC_APPS_SLACK_CONNECTOR_ID);
   actions.registerDynamicConnector(buildConnector(tenantKey));
-  logger.debug(`Registered the ${ELASTIC_SLACK_CONNECTOR_ID} connector`);
+  logger.debug(`Registered the ${ELASTIC_APPS_SLACK_CONNECTOR_ID} connector`);
 };
 
 /** Withdraw the connector once the workspace is no longer connected. */
-export const unregisterElasticSlackConnector = ({
+export const unregisterElasticAppsSlackConnector = ({
   actions,
   logger,
 }: {
   actions: Pick<PluginStartContract, 'unregisterDynamicConnector'>;
   logger: Logger;
 }): void => {
-  if (actions.unregisterDynamicConnector(ELASTIC_SLACK_CONNECTOR_ID)) {
-    logger.debug(`Unregistered the ${ELASTIC_SLACK_CONNECTOR_ID} connector`);
+  if (actions.unregisterDynamicConnector(ELASTIC_APPS_SLACK_CONNECTOR_ID)) {
+    logger.debug(`Unregistered the ${ELASTIC_APPS_SLACK_CONNECTOR_ID} connector`);
   }
 };

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.test.ts
@@ -13,6 +13,7 @@ import { RELAY_APP_CONNECTION_STATUS } from '../../../common/slack_app/types';
 import { SlackAppService } from './service';
 import { SlackAppUnavailableError } from './errors';
 import { RELAY_APP_CONNECTION_SO_ID, RELAY_APP_CONNECTION_SO_TYPE } from './saved_object';
+import { ELASTIC_SLACK_CONNECTOR_ID, ELASTIC_SLACK_CONNECTOR_TYPE_ID } from './connector';
 
 const request = {} as unknown as KibanaRequest;
 
@@ -51,12 +52,15 @@ function createHarness({ featureFlagEnabled = true, hasRelayClient = true }: Har
   (logger.get as jest.Mock).mockReturnValue(logger);
 
   const getLicense = jest.fn().mockResolvedValue({ type: 'platinum' });
+  const registerDynamicConnector = jest.fn();
+  const unregisterDynamicConnector = jest.fn().mockReturnValue(true);
 
   const server = {
     logger,
     config: {},
     agentBuilder: {},
     kibanaVersion: '9.2.0',
+    actions: { registerDynamicConnector, unregisterDynamicConnector },
     relayClient: hasRelayClient ? { startInstall, fetchClaim, unbind } : undefined,
     core: {
       savedObjects: { getScopedClient: jest.fn().mockReturnValue(soClient) },
@@ -72,7 +76,15 @@ function createHarness({ featureFlagEnabled = true, hasRelayClient = true }: Har
     },
   } as unknown as StreamsServer;
 
-  return { server, soClient, grantAsInternalUser, invalidateAsInternalUser, getBooleanValue };
+  return {
+    server,
+    soClient,
+    grantAsInternalUser,
+    invalidateAsInternalUser,
+    getBooleanValue,
+    registerDynamicConnector,
+    unregisterDynamicConnector,
+  };
 }
 
 describe('SlackAppService', () => {
@@ -749,6 +761,159 @@ describe('SlackAppService', () => {
       await new SlackAppService(server).unbindChannel(request, 'C123');
 
       expect(unbindChannel).toHaveBeenCalledWith('tenant-A', 'C123');
+    });
+  });
+
+  describe('elastic slack connector registration', () => {
+    const connectedConnector = expect.objectContaining({
+      id: ELASTIC_SLACK_CONNECTOR_ID,
+      actionTypeId: ELASTIC_SLACK_CONNECTOR_TYPE_ID,
+      config: { tenantKey: 'tenant-A' },
+    });
+
+    it('registers the connector when the Relay claim completes', async () => {
+      const { server, soClient, registerDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.oauthInProgress,
+          apiKeyId: 'key-1',
+          claimId: 'claim-1',
+        },
+      });
+      fetchClaim.mockResolvedValue({ status: 'complete', tenant_key: 'tenant-A' });
+
+      await new SlackAppService(server).getStatus(request);
+
+      expect(registerDynamicConnector).toHaveBeenCalledWith(connectedConnector);
+    });
+
+    it('does not register while the claim is still pending', async () => {
+      const { server, soClient, registerDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.oauthInProgress,
+          apiKeyId: 'key-1',
+          claimId: 'claim-1',
+        },
+      });
+      fetchClaim.mockResolvedValue({ status: 'pending' });
+
+      await new SlackAppService(server).getStatus(request);
+
+      expect(registerDynamicConnector).not.toHaveBeenCalled();
+    });
+
+    it('unregisters when an in-progress install fails terminally', async () => {
+      const { server, soClient, unregisterDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: { status: RELAY_APP_CONNECTION_STATUS.oauthInProgress, apiKeyId: 'key-1' },
+      });
+
+      await new SlackAppService(server).getStatus(request);
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+    });
+
+    it('withdraws the stale connector when a reconnect starts', async () => {
+      const { server, grantAsInternalUser, unregisterDynamicConnector } = createHarness();
+      grantAsInternalUser.mockResolvedValue({ id: 'key-2', name: 'k', api_key: 'secret' });
+      startInstall.mockResolvedValue({
+        authorize_url: 'https://slack/oauth',
+        claim_id: 'claim-2',
+      });
+
+      await new SlackAppService(server).connect(request);
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+    });
+
+    it('replaces the connector on reconnect so a new tenant key takes effect', async () => {
+      const { server, soClient, registerDynamicConnector, unregisterDynamicConnector } =
+        createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.oauthInProgress,
+          apiKeyId: 'key-1',
+          claimId: 'claim-1',
+        },
+      });
+      fetchClaim.mockResolvedValue({ status: 'complete', tenant_key: 'tenant-B' });
+
+      await new SlackAppService(server).getStatus(request);
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+      expect(registerDynamicConnector).toHaveBeenCalledWith(
+        expect.objectContaining({ config: { tenantKey: 'tenant-B' } })
+      );
+    });
+
+    it('unregisters on disconnect', async () => {
+      const { server, soClient, unregisterDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.connected,
+          apiKeyId: 'key-1',
+          tenantKey: 'tenant-A',
+        },
+      });
+      unbind.mockResolvedValue(undefined);
+
+      await new SlackAppService(server).disconnect(request);
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+    });
+
+    it('still unregisters when the Relay unbind fails and the connection is left in error', async () => {
+      const { server, soClient, unregisterDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.connected,
+          apiKeyId: 'key-1',
+          tenantKey: 'tenant-A',
+        },
+      });
+      unbind.mockRejectedValue(new RelayRequestError('/v1/slack/uninstall', 502));
+
+      await expect(new SlackAppService(server).disconnect(request)).rejects.toThrow();
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+    });
+
+    describe('syncConnector', () => {
+      it('restores the connector for a deployment that is already connected', async () => {
+        const { server, soClient, registerDynamicConnector } = createHarness();
+        soClient.get.mockResolvedValue({
+          attributes: { status: RELAY_APP_CONNECTION_STATUS.connected, tenantKey: 'tenant-A' },
+        });
+
+        await new SlackAppService(server).syncConnector(soClient as never);
+
+        expect(registerDynamicConnector).toHaveBeenCalledWith(connectedConnector);
+      });
+
+      it('registers nothing when there is no connection document', async () => {
+        const { server, soClient, registerDynamicConnector } = createHarness();
+
+        await new SlackAppService(server).syncConnector(soClient as never);
+
+        expect(registerDynamicConnector).not.toHaveBeenCalled();
+      });
+
+      it.each([
+        [RELAY_APP_CONNECTION_STATUS.oauthInProgress, null],
+        [RELAY_APP_CONNECTION_STATUS.error, null],
+        [RELAY_APP_CONNECTION_STATUS.connected, null],
+      ])(
+        'registers nothing for a %s connection without a tenant key',
+        async (status, tenantKey) => {
+          const { server, soClient, registerDynamicConnector } = createHarness();
+          soClient.get.mockResolvedValue({ attributes: { status, tenantKey } });
+
+          await new SlackAppService(server).syncConnector(soClient as never);
+
+          expect(registerDynamicConnector).not.toHaveBeenCalled();
+        }
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.test.ts
@@ -13,7 +13,7 @@ import { RELAY_APP_CONNECTION_STATUS } from '../../../common/slack_app/types';
 import { SlackAppService } from './service';
 import { SlackAppUnavailableError } from './errors';
 import { RELAY_APP_CONNECTION_SO_ID, RELAY_APP_CONNECTION_SO_TYPE } from './saved_object';
-import { ELASTIC_SLACK_CONNECTOR_ID, ELASTIC_SLACK_CONNECTOR_TYPE_ID } from './connector';
+import { ELASTIC_APPS_SLACK_CONNECTOR_ID, ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID } from './connector';
 
 const request = {} as unknown as KibanaRequest;
 
@@ -766,8 +766,8 @@ describe('SlackAppService', () => {
 
   describe('elastic slack connector registration', () => {
     const connectedConnector = expect.objectContaining({
-      id: ELASTIC_SLACK_CONNECTOR_ID,
-      actionTypeId: ELASTIC_SLACK_CONNECTOR_TYPE_ID,
+      id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+      actionTypeId: ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID,
       config: { tenantKey: 'tenant-A' },
     });
 
@@ -811,7 +811,7 @@ describe('SlackAppService', () => {
 
       await new SlackAppService(server).getStatus(request);
 
-      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
     });
 
     it('withdraws the stale connector when a reconnect starts', async () => {
@@ -824,7 +824,7 @@ describe('SlackAppService', () => {
 
       await new SlackAppService(server).connect(request);
 
-      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
     });
 
     it('replaces the connector on reconnect so a new tenant key takes effect', async () => {
@@ -841,7 +841,7 @@ describe('SlackAppService', () => {
 
       await new SlackAppService(server).getStatus(request);
 
-      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
       expect(registerDynamicConnector).toHaveBeenCalledWith(
         expect.objectContaining({ config: { tenantKey: 'tenant-B' } })
       );
@@ -860,7 +860,7 @@ describe('SlackAppService', () => {
 
       await new SlackAppService(server).disconnect(request);
 
-      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
     });
 
     it('still unregisters when the Relay unbind fails and the connection is left in error', async () => {
@@ -876,7 +876,7 @@ describe('SlackAppService', () => {
 
       await expect(new SlackAppService(server).disconnect(request)).rejects.toThrow();
 
-      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_SLACK_CONNECTOR_ID);
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
     });
 
     describe('syncConnector', () => {

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.ts
@@ -24,7 +24,10 @@ import {
 } from './saved_object';
 import { SlackAppUnavailableError } from './errors';
 import { getKibanaUrl } from './get_kibana_url';
-import { registerElasticSlackConnector, unregisterElasticSlackConnector } from './connector';
+import {
+  registerElasticAppsSlackConnector,
+  unregisterElasticAppsSlackConnector,
+} from './connector';
 
 /** Pagination options for a single page of connected channels. */
 export interface ListBindingsOptions {
@@ -69,7 +72,7 @@ export class SlackAppService {
    * plugin start (see `syncConnector`) for a deployment that was already connected.
    */
   private publishConnector(tenantKey: string): void {
-    registerElasticSlackConnector({
+    registerElasticAppsSlackConnector({
       actions: this.server.actions,
       logger: this.logger,
       tenantKey,
@@ -78,7 +81,7 @@ export class SlackAppService {
 
   /** Withdraw the connector whenever the connection stops being usable. */
   private withdrawConnector(): void {
-    unregisterElasticSlackConnector({ actions: this.server.actions, logger: this.logger });
+    unregisterElasticAppsSlackConnector({ actions: this.server.actions, logger: this.logger });
   }
 
   /**

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.ts
@@ -24,6 +24,7 @@ import {
 } from './saved_object';
 import { SlackAppUnavailableError } from './errors';
 import { getKibanaUrl } from './get_kibana_url';
+import { registerElasticSlackConnector, unregisterElasticSlackConnector } from './connector';
 
 /** Pagination options for a single page of connected channels. */
 export interface ListBindingsOptions {
@@ -60,6 +61,37 @@ export class SlackAppService {
     return this.server.core.savedObjects.getScopedClient(request, {
       includedHiddenTypes: [RELAY_APP_CONNECTION_SO_TYPE],
     });
+  }
+
+  /**
+   * Publish the connector that lets rules and workflows post to the connected channels.
+   * The connector is in-memory only, so this runs on every connect transition and again at
+   * plugin start (see `syncConnector`) for a deployment that was already connected.
+   */
+  private publishConnector(tenantKey: string): void {
+    registerElasticSlackConnector({
+      actions: this.server.actions,
+      logger: this.logger,
+      tenantKey,
+    });
+  }
+
+  /** Withdraw the connector whenever the connection stops being usable. */
+  private withdrawConnector(): void {
+    unregisterElasticSlackConnector({ actions: this.server.actions, logger: this.logger });
+  }
+
+  /**
+   * Restore the connector on a deployment that was already connected before this process
+   * started. Called once from plugin start with an internal Saved Objects client, since there
+   * is no request to scope to; the connection document is namespace-agnostic, so a single read
+   * covers the whole deployment.
+   */
+  async syncConnector(soClient: SavedObjectsClientContract): Promise<void> {
+    const connection = await this.readConnection(soClient);
+    if (connection?.status === RELAY_APP_CONNECTION_STATUS.connected && connection.tenantKey) {
+      this.publishConnector(connection.tenantKey);
+    }
   }
 
   private async readConnection(
@@ -218,6 +250,11 @@ export class SlackAppService {
       createdAt: now,
     });
 
+    // The install may land on a different workspace, so any connector left over from the
+    // connection being replaced now carries a stale tenant key. It is republished from the
+    // new tenant key once the claim completes.
+    this.withdrawConnector();
+
     return { authorizeUrl: installResponse.authorize_url };
   }
 
@@ -243,6 +280,7 @@ export class SlackAppService {
       apiKeyId: null,
       error: message,
     });
+    this.withdrawConnector();
 
     return { available: true, status: RELAY_APP_CONNECTION_STATUS.error, error: message };
   }
@@ -298,6 +336,7 @@ export class SlackAppService {
             tenantKey: claim.tenant_key,
             status: RELAY_APP_CONNECTION_STATUS.connected,
           });
+          this.publishConnector(claim.tenant_key);
           return { available: true, status: RELAY_APP_CONNECTION_STATUS.connected };
         }
       } catch (error) {
@@ -406,6 +445,11 @@ export class SlackAppService {
     if (!connection) {
       return { status: 'disconnected' };
     }
+
+    // Withdrawn up front rather than on the success path: a failed Relay unbind below leaves
+    // the connection in `error` state for the user to retry, and rules must not keep posting
+    // through a connection that is being torn down.
+    this.withdrawConnector();
 
     if (connection.apiKeyId) {
       await this.invalidateApiKey(connection.apiKeyId, 'on disconnect');

--- a/x-pack/platform/plugins/shared/significant_events/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/plugin.ts
@@ -13,13 +13,18 @@ import type {
   Plugin,
   PluginInitializerContext,
 } from '@kbn/core/server';
+import { SavedObjectsClient } from '@kbn/core/server';
 import { registerRoutes } from '@kbn/server-route-repository';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
 import type { RulesClientCreateOptions } from '@kbn/alerting-plugin/server';
 import { combineLatest, distinctUntilChanged, filter, skip, switchMap } from 'rxjs';
 import type { Subscription } from 'rxjs';
 import type { StreamsServer } from '@kbn/streams-plugin/server/types';
-import { getRelayAppConnectionSavedObjectType } from './lib/slack_app/saved_object';
+import {
+  getRelayAppConnectionSavedObjectType,
+  RELAY_APP_CONNECTION_SO_TYPE,
+} from './lib/slack_app/saved_object';
+import { SlackAppService } from './lib/slack_app/service';
 import { getSignificantEventsMaintenanceStateSavedObjectType } from './lib/maintenance/saved_object';
 import {
   createSignificantEventsMaintenanceService,
@@ -374,6 +379,8 @@ export class SignificantEventsPlugin
       this.server.agentBuilder = plugins.agentBuilder;
 
       this.server.relayClient = plugins.actions.getRelayClient();
+
+      this.restoreElasticSlackConnector(core, this.server);
     }
 
     // Availability is the same requirement registry that gates requests, so a deployment never gets
@@ -584,6 +591,27 @@ export class SignificantEventsPlugin
     // installed workflows stay enabled during a paused deployment.
     await this.maintenanceService.reassertPausedWorkflows({
       request: createMaintenanceSystemRequest(),
+    });
+  }
+
+  /**
+   * The Elastic Slack connector is an in-memory connector, so it does not survive a restart.
+   * A deployment that was already connected must get it back without the user reconnecting,
+   * which means reading the connection document once here rather than waiting for the settings
+   * UI to poll status. Failures are logged and swallowed: a missing connector degrades Slack
+   * actions but must not take down plugin start.
+   */
+  private restoreElasticSlackConnector(core: CoreStart, server: StreamsServer): void {
+    const soClient = new SavedObjectsClient(
+      core.savedObjects.createInternalRepository([RELAY_APP_CONNECTION_SO_TYPE])
+    );
+
+    new SlackAppService(server).syncConnector(soClient).catch((error) => {
+      this.logger.warn(
+        `significantEvents: failed to restore the Elastic Slack connector: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     });
   }
 

--- a/x-pack/platform/plugins/shared/significant_events/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/plugin.ts
@@ -380,7 +380,7 @@ export class SignificantEventsPlugin
 
       this.server.relayClient = plugins.actions.getRelayClient();
 
-      this.restoreElasticSlackConnector(core, this.server);
+      this.restoreElasticAppsSlackConnector(core, this.server);
     }
 
     // Availability is the same requirement registry that gates requests, so a deployment never gets
@@ -601,7 +601,7 @@ export class SignificantEventsPlugin
    * UI to poll status. Failures are logged and swallowed: a missing connector degrades Slack
    * actions but must not take down plugin start.
    */
-  private restoreElasticSlackConnector(core: CoreStart, server: StreamsServer): void {
+  private restoreElasticAppsSlackConnector(core: CoreStart, server: StreamsServer): void {
     const soClient = new SavedObjectsClient(
       core.savedObjects.createInternalRepository([RELAY_APP_CONNECTION_SO_TYPE])
     );


### PR DESCRIPTION
## Summary

Addresses elastic/nightshift-program#672.

Spike/POC that lets alerts and workflows post Slack messages through the Elastic Slack app a deployment has already connected via the Relay, so users pick a channel from a dropdown instead of provisioning a Slack token or webhook per connector.

The connector holds no credentials of its own. The Relay owns the Slack token and only lets a deployment reach the channels it has connected, so the connector config is just the `tenantKey` (hidden in the UI).

### How it works

- **`.elastic_slack` connector spec** (`@kbn/connector-specs`), technical preview, exposed to `alerting` and `workflows`:
  - `sendMessage({ channel, text, threadTs? })` — posts via the Relay.
  - `listChannels()` — pages the Relay bindings and returns `{ id, name }` per channel, which is what backs the pickers.
- **`RelayClient.trigger()`** (actions plugin) calls `POST /v1/trigger`, reusing the existing `post()` path so `allowedHosts`, proxy settings, and mTLS overrides all still apply.
- **Relay reaches spec handlers through `ActionContext.relay`.** `@kbn/connector-specs` defines a structural `RelayActionClient` interface rather than importing from x-pack, and the actions plugin threads `getRelayClient()` through `createConnectorTypeFromSpec` into the generated executor.
- **No manual creation flow.** `significant_events` registers the connector as a dynamic in-memory connector when the Slack app connects and withdraws it on disconnect, reconnect, or terminal install failure. Because in-memory connectors do not survive a restart, plugin start re-reads the connection saved object and restores it.
- **Channel pickers in both surfaces.** Alerting v2 gets an `elastic_slack.sendMessage` inline step whose selector reuses the generalized Slack channel hook/component; the workflows YAML editor gets a channel selection handler wired through the existing `InternalStepsEditorHandlers` mechanism.

### Notes for reviewers

- **Channel id vs name.** The pickers write the channel **id**, since that is what the Relay resolves the binding by. The existing Slack (v2) selector keeps writing the name — the selector and hook are now parameterized (`subAction`, `channelValueField`) rather than forked.
- **Workflows picker placement.** The channel picker for the YAML editor lives in `InternalStepsEditorHandlers` rather than being merged into the connector contracts in `common/schema.ts`. That file is isomorphic and the picker needs browser-side HTTP to call `_execute`, so this follows the existing pattern used by the Elasticsearch step index pickers.
- **Multi-node deployments.** Dynamic registration happens on the node that serves the connect request; other nodes will not see the connector until they restart and hit the restore path. A periodic poller (like `search_inference_endpoints` does) is the likely follow-up, but is out of scope for this spike.

### Testing

Unit tests added/updated for the Relay `trigger()` method (success, `threadTs`, 403/409/502 handling), the spec handlers (channel mapping, filtering, pagination caps, missing `relay`/`tenantKey`), the dynamic registration lifecycle (connect, reconnect with a new tenant key, disconnect, unbind failure, restore), and both channel pickers.

Jest, type check, lint, and i18n check pass locally on the touched projects. This has not yet been exercised end to end against a live Relay.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.

### Identify risks

- **Connector visibility is per-node.** See the multi-node note above: on a multi-node deployment the connector may be missing on nodes that did not serve the connect request, which would surface as a missing connector in the rule/workflow forms rather than as data loss. Mitigated for restarts by the restore-at-start path; full fix needs a poller.
- **Connector availability tracks the Relay connection.** Disconnecting the Slack app withdraws the connector, so rules or workflows still referencing it will fail to execute until it is reconnected.
- Low blast radius otherwise: the connector is new, gated behind an existing Relay connection, and marked technical preview. Changes to shared code are additive — `ActionContext.relay` is optional, and the Slack selector/hook changes preserve the existing v2 behavior by default.
