### PR TITLE
[CI] Fix buildkite unit tests, run buildkite unit tests on CI

### DIFF
--- a/.buildkite/pipelines/evals/llm_evals.yml
+++ b/.buildkite/pipelines/evals/llm_evals.yml
@@ -132,6 +132,7 @@ steps:
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-8
+          diskSizeGb: 130
           preemptible: true
         retry:
           automatic:

--- a/.buildkite/scripts/pipelines/chromium_linux_build/issue_feedback/transform_path_file.test.ts
+++ b/.buildkite/scripts/pipelines/chromium_linux_build/issue_feedback/transform_path_file.test.ts
@@ -12,11 +12,13 @@ import { readFileSync } from 'fs';
 // @ts-expect-error test utils is defined and exists, see https://github.com/facebook/jscodeshift#applytransform
 import { applyTransform } from 'jscodeshift/dist/testUtils';
 
+import { getKibanaDir } from '#pipeline-utils';
+
 import pathFileTransform from './transform_path_file';
 
 // read contents of the path file our transform is built to update
 const pathFileContents = readFileSync(
-  resolve(process.cwd(), 'src/platform/packages/private/kbn-screenshotting-server/src/paths.ts'),
+  resolve(getKibanaDir(), 'src/platform/packages/private/kbn-screenshotting-server/src/paths.ts'),
   'utf8'
 );
 

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.test.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.test.ts
@@ -9,7 +9,9 @@
 
 import { parse as yamlLoad } from 'yaml';
 import { FIPS_GH_LABELS, FIPS_VERSION } from '#pipeline-utils/pr_labels';
+import { getKibanaDir } from '#pipeline-utils/utils';
 
+process.chdir(getKibanaDir());
 const mockAreChangesSkippable = jest.fn();
 const mockDoAnyChangesMatch = jest.fn();
 const mockDoAllChangesMatch = jest.fn();

--- a/.buildkite/scripts/steps/checks/buildkite_unit_tests.sh
+++ b/.buildkite/scripts/steps/checks/buildkite_unit_tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/common/util.sh
+
+echo --- Buildkite Unit Tests
+# Standalone .buildkite npm workspace; deps installed by pre_command → setup_buildkite_deps.sh
+npm test --prefix .buildkite

--- a/.buildkite/scripts/steps/checks/quick_checks.json
+++ b/.buildkite/scripts/steps/checks/quick_checks.json
@@ -86,6 +86,9 @@
     "mayChangeFiles": true
   },
   {
+    "script": ".buildkite/scripts/steps/checks/buildkite_unit_tests.sh"
+  },
+  {
     "script": ".buildkite/scripts/steps/checks/check_scout_config.sh"
   },
   {


### PR DESCRIPTION
## Summary
- Fix failing `.buildkite` unit tests: resolve paths from the kibana root (`getKibanaDir`) instead of assuming `process.cwd()`, and pin `diskSizeGb: 130` on the remaining `llm_evals.yml` suite agent.
- Add `.buildkite` jest (`npm test --prefix .buildkite`) to Quick Checks so the suite runs on every PR, on-merge, and merge-queue as a breaking gate (`CHECK_GATE` on PRs).

Closes elastic/kibana-operations#632

## Why
`.buildkite` is a standalone npm workspace and is not part of the sharded Kibana Jest CI. Without this gate, regressions only show up when someone happens to run those tests locally (or when Local Check happens to touch `.buildkite`).

## Test plan
- [x] Quick Checks runs `buildkite_unit_tests.sh` and passes
- [x] Locally: `npm test --prefix .buildkite`
