### PR TITLE
[CI] Prevent gate steps from canceling themselves on failure

### DIFF
--- a/.buildkite/scripts/steps/gate_failure/cancel.test.ts
+++ b/.buildkite/scripts/steps/gate_failure/cancel.test.ts
@@ -1,0 +1,267 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const mockGetMetadataKeys = jest.fn();
+const mockGetMetadata = jest.fn();
+const mockCancelStep = jest.fn();
+const mockSetAnnotation = jest.fn();
+
+jest.mock('#pipeline-utils', () => ({
+  BuildkiteClient: jest.fn().mockImplementation(() => ({
+    getMetadataKeys: mockGetMetadataKeys,
+    getMetadata: mockGetMetadata,
+    cancelStep: mockCancelStep,
+    setAnnotation: mockSetAnnotation,
+  })),
+}));
+
+const ORIGINAL_ENV = process.env;
+
+const runCancelModule = () => {
+  jest.isolateModules(() => {
+    require('./cancel');
+  });
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  jest.resetModules();
+  jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  process.env = {
+    ...ORIGINAL_ENV,
+    BUILDKITE_STEP_KEY: 'check_oas_snapshot',
+    BUILDKITE_LABEL: 'Check OAS Snapshot',
+  };
+  mockGetMetadataKeys.mockReturnValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('cancel-on-gate-failure', () => {
+  describe('when no cancel keys are registered', () => {
+    it('does nothing', () => {
+      mockGetMetadataKeys.mockReturnValue([]);
+      runCancelModule();
+      expect(mockCancelStep).not.toHaveBeenCalled();
+      expect(mockSetAnnotation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('self-cancellation prevention', () => {
+    it('does not cancel the running gate step even when it is in the batch', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(
+        JSON.stringify(['check_oas_snapshot', 'scout_test_lane_1', 'jest'])
+      );
+
+      runCancelModule();
+
+      expect(mockCancelStep).not.toHaveBeenCalledWith('check_oas_snapshot');
+      expect(mockCancelStep).toHaveBeenCalledWith('scout_test_lane_1');
+      expect(mockCancelStep).toHaveBeenCalledWith('jest');
+    });
+
+    it('includes a was-not-canceled note in both annotations when self is in the batch', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['check_oas_snapshot', 'jest']));
+
+      runCancelModule();
+
+      expect(mockSetAnnotation).toHaveBeenNthCalledWith(
+        1,
+        'cancel-on-gate-failure:check_oas_snapshot',
+        'info',
+        expect.stringContaining('was not canceled')
+      );
+      expect(mockSetAnnotation).toHaveBeenNthCalledWith(
+        2,
+        'cancel-on-gate-failure:check_oas_snapshot',
+        'info',
+        expect.stringContaining('was not canceled')
+      );
+    });
+
+    it('writes the initial annotation before calling cancelStep', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['check_oas_snapshot', 'jest']));
+
+      const callOrder: string[] = [];
+      mockSetAnnotation.mockImplementation(() => callOrder.push('annotate'));
+      mockCancelStep.mockImplementation(() => callOrder.push('cancel'));
+
+      runCancelModule();
+
+      expect(callOrder).toEqual(['annotate', 'cancel', 'annotate']);
+    });
+
+    it('returns early without annotation when the gate step is the only registered key', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['check_oas_snapshot']));
+
+      runCancelModule();
+
+      expect(mockCancelStep).not.toHaveBeenCalled();
+      expect(mockSetAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('does not filter any key when BUILDKITE_STEP_KEY is unset', () => {
+      delete process.env.BUILDKITE_STEP_KEY;
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['jest', 'ftr_configs_1']));
+
+      runCancelModule();
+
+      expect(mockCancelStep).toHaveBeenCalledWith('jest');
+      expect(mockCancelStep).toHaveBeenCalledWith('ftr_configs_1');
+    });
+  });
+
+  describe('annotation behavior', () => {
+    it('writes an initial annotation before the cancel loop then overwrites with the final summary', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['jest']));
+
+      const callOrder: string[] = [];
+      mockSetAnnotation.mockImplementation(() => callOrder.push('annotate'));
+      mockCancelStep.mockImplementation(() => callOrder.push('cancel'));
+
+      runCancelModule();
+
+      expect(callOrder).toEqual(['annotate', 'cancel', 'annotate']);
+    });
+
+    it('uses the gate step key in the annotation context', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['jest']));
+
+      runCancelModule();
+
+      expect(mockSetAnnotation).toHaveBeenCalledWith(
+        'cancel-on-gate-failure:check_oas_snapshot',
+        expect.any(String),
+        expect.any(String)
+      );
+    });
+
+    it('uses warning style when some cancels fail', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['jest']));
+      mockCancelStep.mockImplementation(() => {
+        throw new Error('some unexpected failure');
+      });
+
+      runCancelModule();
+
+      expect(process.exit).toHaveBeenCalledWith(1);
+      const finalCall = mockSetAnnotation.mock.calls[mockSetAnnotation.mock.calls.length - 1];
+      expect(finalCall[1]).toBe('warning');
+    });
+
+    it('uses info style when all cancels succeed', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['jest']));
+
+      runCancelModule();
+
+      expect(process.exit).not.toHaveBeenCalled();
+      const finalCall = mockSetAnnotation.mock.calls[mockSetAnnotation.mock.calls.length - 1];
+      expect(finalCall[1]).toBe('info');
+    });
+  });
+
+  describe('already-finished step handling', () => {
+    it('skips steps that are already finished without exiting', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['jest', 'ftr_configs_1']));
+      mockCancelStep.mockImplementation((key) => {
+        if (key === 'jest') throw new Error('already finished');
+      });
+
+      runCancelModule();
+
+      expect(process.exit).not.toHaveBeenCalled();
+      const finalCall = mockSetAnnotation.mock.calls[mockSetAnnotation.mock.calls.length - 1];
+      expect(finalCall[2]).toContain('Already finished: jest');
+    });
+
+    it('exits with 1 when a non-already-finished cancel fails', () => {
+      mockGetMetadataKeys.mockReturnValue(['cancel_on_gate_failure_batch:pipeline']);
+      mockGetMetadata.mockReturnValue(JSON.stringify(['jest']));
+      mockCancelStep.mockImplementation(() => {
+        throw new Error('network error');
+      });
+
+      runCancelModule();
+
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('multiple batch keys', () => {
+    it('collects step keys from all cancel_on_gate_failure_batch:* metadata keys', () => {
+      mockGetMetadataKeys.mockReturnValue([
+        'cancel_on_gate_failure_batch:pipeline',
+        'cancel_on_gate_failure_batch:scout',
+      ]);
+      mockGetMetadata.mockImplementation((key: string) => {
+        if (key === 'cancel_on_gate_failure_batch:pipeline') return JSON.stringify(['jest']);
+        if (key === 'cancel_on_gate_failure_batch:scout') return JSON.stringify(['scout_lane_1']);
+        return null;
+      });
+
+      runCancelModule();
+
+      expect(mockCancelStep).toHaveBeenCalledWith('jest');
+      expect(mockCancelStep).toHaveBeenCalledWith('scout_lane_1');
+    });
+
+    it('deduplicates step keys that appear in multiple batches', () => {
+      mockGetMetadataKeys.mockReturnValue([
+        'cancel_on_gate_failure_batch:pipeline',
+        'cancel_on_gate_failure_batch:scout',
+      ]);
+      mockGetMetadata.mockImplementation((key: string) => {
+        if (key === 'cancel_on_gate_failure_batch:pipeline')
+          return JSON.stringify(['jest', 'shared_step']);
+        if (key === 'cancel_on_gate_failure_batch:scout')
+          return JSON.stringify(['scout_lane_1', 'shared_step']);
+        return null;
+      });
+
+      runCancelModule();
+
+      const cancelCalls = mockCancelStep.mock.calls.map(([k]: [string]) => k);
+      expect(cancelCalls.filter((k) => k === 'shared_step')).toHaveLength(1);
+    });
+
+    it('falls back to [] when a metadata value is malformed JSON', () => {
+      mockGetMetadataKeys.mockReturnValue([
+        'cancel_on_gate_failure_batch:pipeline',
+        'cancel_on_gate_failure_batch:bad',
+      ]);
+      mockGetMetadata.mockImplementation((key: string) => {
+        if (key === 'cancel_on_gate_failure_batch:pipeline') return JSON.stringify(['jest']);
+        if (key === 'cancel_on_gate_failure_batch:bad') return 'not-valid-json';
+        return null;
+      });
+
+      runCancelModule();
+
+      expect(mockCancelStep).toHaveBeenCalledWith('jest');
+      expect(mockCancelStep).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/.buildkite/scripts/steps/gate_failure/cancel.ts
+++ b/.buildkite/scripts/steps/gate_failure/cancel.ts
@@ -12,23 +12,59 @@ import { BuildkiteClient } from '#pipeline-utils';
 const BATCH_PREFIX = 'cancel_on_gate_failure_batch:';
 
 function run(): void {
+  // Separate the raw env value from the display fallback: selfKey drives the
+  // filter predicate, so 'unknown' must not silently spare a step keyed that way.
+  const selfKey = process.env.BUILDKITE_STEP_KEY;
+  const gateStepKey = selfKey ?? 'unknown';
+  const gateLabel = process.env.BUILDKITE_LABEL ?? gateStepKey;
+  // Include the gate step key in the annotation context so multiple gate failures
+  // each get their own annotation instead of overwriting each other.
+  const annotationContext = `cancel-on-gate-failure:${gateStepKey}`;
+
   const bk = new BuildkiteClient();
 
-  const stepKeys = bk
-    .getMetadataKeys()
-    .filter((key) => key.startsWith(BATCH_PREFIX))
-    .flatMap((key) => {
-      const value = bk.getMetadata(key);
-      try {
-        return value ? (JSON.parse(value) as string[]) : [];
-      } catch {
-        return [];
-      }
-    });
+  const allStepKeys = [
+    ...new Set(
+      bk
+        .getMetadataKeys()
+        .filter((key) => key.startsWith(BATCH_PREFIX))
+        .flatMap((key) => {
+          const value = bk.getMetadata(key);
+          try {
+            return value ? (JSON.parse(value) as string[]) : [];
+          } catch {
+            return [];
+          }
+        })
+    ),
+  ];
+
+  // Never cancel the step that is running this cascade. Doing so kills the
+  // post-command hook mid-loop, changes the step's recorded state from
+  // "failed" to "canceled" (hiding the real failure), and prevents the final
+  // annotation from being written.
+  // check_oas_snapshot is registered this way today via pipeline.ts: it should
+  // be cancelable by other gate failures, but must not cancel itself.
+  const skipsSelf = Boolean(selfKey) && allStepKeys.includes(selfKey!);
+  const stepKeys = selfKey ? allStepKeys.filter((k) => k !== selfKey) : allStepKeys;
 
   if (stepKeys.length === 0) {
     return;
   }
+
+  const selfNote = skipsSelf
+    ? `**Note:** **${gateStepKey}** was registered as cancelable but was not canceled to preserve its exit status.`
+    : '';
+
+  // Write an initial annotation before the loop so that even a truncated run
+  // (e.g., from an unrelated signal) leaves a readable breadcrumb in the build UI.
+  bk.setAnnotation(
+    annotationContext,
+    'info',
+    [`Check gate **${gateLabel}** failed. Canceling ${stepKeys.length} step(s)...`, selfNote]
+      .filter(Boolean)
+      .join('\n\n')
+  );
 
   const canceled: string[] = [];
   const skipped: string[] = [];
@@ -56,18 +92,14 @@ function run(): void {
     }
   }
 
-  const gateStepKey = process.env.BUILDKITE_STEP_KEY ?? 'unknown';
-  const gateLabel = process.env.BUILDKITE_LABEL ?? gateStepKey;
   const summary = [
     `Check gate **${gateLabel}** failed.`,
     `Canceled ${canceled.length} step(s): ${canceled.length ? canceled.join(', ') : 'none'}`,
     ...(skipped.length ? [`Already finished: ${skipped.join(', ')}`] : []),
     ...(failures.length ? ['Failed to cancel:', ...failures.map((line) => `- ${line}`)] : []),
+    ...(selfNote ? [selfNote] : []),
   ].join('\n');
 
-  // Include the gate step key in the annotation context so multiple gate failures
-  // each get their own annotation instead of overwriting each other.
-  const annotationContext = `cancel-on-gate-failure:${gateStepKey}`;
   bk.setAnnotation(annotationContext, failures.length ? 'warning' : 'info', summary);
 
   if (failures.length > 0) {


### PR DESCRIPTION
When check_oas_snapshot failed it triggered the cancel cascade, which canceled itself turning its state from "failed" to "canceled", hiding the real failure, killing the post-command hook mid-loop, and leaving no annotation explaining why 88 steps were killed.

Fix: cancel.ts now skips its own BUILDKITE_STEP_KEY, writes an initial annotation before the loop (breadcrumb if truncated), deduplicates keys across batches, and separates the raw env value from the 'unknown' display fallback so the filter predicate is correct when the var is unset.

Reproduces on: https://buildkite.com/elastic/kibana-pull-request/builds/484172

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->