### PR TITLE
[Significant events] Flyout design upift

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events_app/public/components/significant_event_details/significant_event_details.tsx
+++ b/x-pack/platform/plugins/shared/significant_events_app/public/components/significant_event_details/significant_event_details.tsx
@@ -5,22 +5,57 @@
  * 2.0.
  */
 
-import React from 'react';
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText, EuiTitle } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import {
+  EuiBadge,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import type { SignificantEvent } from '@kbn/significant-events-schema';
+import type { SignificantEvent, SignificantEventResponse } from '@kbn/significant-events-schema';
+import { InfoPanel } from '../info_panel';
+import { formatTimestamp } from '../../util/formatters';
 
-const CAUSAL_FEATURES_TITLE = i18n.translate(
-  'xpack.significantEventsApp.significantEventsTab.flyout.causalFeatures',
+const DESCRIPTION_TITLE = i18n.translate(
+  'xpack.significantEventsApp.significantEventsTab.flyout.descriptionTitle',
   {
-    defaultMessage: 'Causal Features',
+    defaultMessage: 'Description',
   }
 );
-const STREAMS_TITLE = i18n.translate(
+const GENERAL_INFORMATION_TITLE = i18n.translate(
+  'xpack.significantEventsApp.significantEventsTab.flyout.generalInformationTitle',
+  {
+    defaultMessage: 'General information',
+  }
+);
+const CREATED_AT_LABEL = i18n.translate(
+  'xpack.significantEventsApp.significantEventsTab.flyout.createdAtLabel',
+  {
+    defaultMessage: 'Created at',
+  }
+);
+const CAUSAL_FEATURES_LABEL = i18n.translate(
+  'xpack.significantEventsApp.significantEventsTab.flyout.causalFeatures',
+  {
+    defaultMessage: 'Causal features',
+  }
+);
+const STREAMS_LABEL = i18n.translate(
   'xpack.significantEventsApp.significantEventsTab.flyout.streams',
   {
     defaultMessage: 'Streams',
+  }
+);
+const EMPTY_VALUE = i18n.translate(
+  'xpack.significantEventsApp.significantEventsTab.flyout.emptyValue',
+  {
+    defaultMessage: '—',
   }
 );
 
@@ -28,31 +63,82 @@ const signalPanelCss = css`
   margin-bottom: 4px;
 `;
 
-const BadgeRow = ({ items, color }: { items: string[]; color?: string }) => (
-  <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
-    {items.map((item, idx) => (
-      <EuiFlexItem grow={false} key={`${item}-${idx}`}>
-        <EuiBadge color={color ?? 'default'}>{item}</EuiBadge>
-      </EuiFlexItem>
-    ))}
-  </EuiFlexGroup>
-);
+const BadgeRow = ({ items, color }: { items: string[]; color?: string }) => {
+  if (items.length === 0) {
+    return (
+      <EuiText size="s" color="subdued">
+        {EMPTY_VALUE}
+      </EuiText>
+    );
+  }
+
+  return (
+    <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+      {items.map((item, idx) => (
+        <EuiFlexItem grow={false} key={`${item}-${idx}`}>
+          <EuiBadge color={color ?? 'default'}>{item}</EuiBadge>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGroup>
+  );
+};
 
 interface SignificantEventDetailsProps {
-  event: SignificantEvent;
+  event: SignificantEvent | SignificantEventResponse;
 }
 
 export const SignificantEventDetails = ({ event }: SignificantEventDetailsProps) => {
   const signals = event.signals ?? [];
   const detectionSignals = signals.filter((s) => s.type === 'detection');
+  const createdAt = 'created_at' in event ? event.created_at : event['@timestamp'];
+
+  const generalInfoItems = useMemo(
+    () => [
+      {
+        title: CREATED_AT_LABEL,
+        description: <EuiText size="s">{formatTimestamp(createdAt)}</EuiText>,
+      },
+      {
+        title: STREAMS_LABEL,
+        description: <BadgeRow items={event.stream_names ?? []} color="hollow" />,
+      },
+      {
+        title: CAUSAL_FEATURES_LABEL,
+        description: (
+          <BadgeRow
+            items={(event.causal_features ?? []).map(
+              (f) => `${f.name || '-'}${f.stream_name ? ` (${f.stream_name})` : ''}`
+            )}
+          />
+        ),
+      },
+    ],
+    [createdAt, event.stream_names, event.causal_features]
+  );
 
   return (
     <EuiFlexGroup direction="column" gutterSize="m">
       {event.summary && (
-        <EuiText size="s">
-          <p>{event.summary}</p>
-        </EuiText>
+        <InfoPanel title={DESCRIPTION_TITLE}>
+          <EuiText size="s">
+            <p>{event.summary}</p>
+          </EuiText>
+        </InfoPanel>
       )}
+
+      <InfoPanel title={GENERAL_INFORMATION_TITLE}>
+        {generalInfoItems.map((listItem, index) => (
+          <React.Fragment key={listItem.title}>
+            <EuiDescriptionList
+              type="column"
+              columnWidths={[1, 2]}
+              compressed
+              listItems={[listItem]}
+            />
+            {index < generalInfoItems.length - 1 && <EuiHorizontalRule margin="m" />}
+          </React.Fragment>
+        ))}
+      </InfoPanel>
 
       {detectionSignals.length > 0 && (
         <EuiFlexGroup direction="column" gutterSize="s">
@@ -96,26 +182,6 @@ export const SignificantEventDetails = ({ event }: SignificantEventDetailsProps)
           ))}
         </EuiFlexGroup>
       )}
-
-      {event.causal_features && event.causal_features.length > 0 && (
-        <EuiFlexGroup direction="column" gutterSize="xs">
-          <EuiTitle size="xxs">
-            <h4>{CAUSAL_FEATURES_TITLE}</h4>
-          </EuiTitle>
-          <BadgeRow
-            items={event.causal_features.map(
-              (f) => `${f.name || '-'}${f.stream_name ? ` (${f.stream_name})` : ''}`
-            )}
-          />
-        </EuiFlexGroup>
-      )}
-
-      <EuiFlexGroup direction="column" gutterSize="xs">
-        <EuiTitle size="xxs">
-          <h4>{STREAMS_TITLE}</h4>
-        </EuiTitle>
-        <BadgeRow items={event.stream_names ?? []} color="hollow" />
-      </EuiFlexGroup>
     </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/significant_events_app/public/pages/significant_events/components/significant_events_tab/significant_event_flyout.tsx
+++ b/x-pack/platform/plugins/shared/significant_events_app/public/pages/significant_events/components/significant_events_tab/significant_event_flyout.tsx
@@ -20,27 +20,30 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiHealth,
   EuiHorizontalRule,
   EuiLoadingSpinner,
   EuiPopover,
-  EuiText,
+  EuiSpacer,
   EuiTitle,
   EuiToolTip,
   copyToClipboard,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { getSeverityLabel, type SignificantEventResponse } from '@kbn/significant-events-schema';
+import type { SignificantEventResponse } from '@kbn/significant-events-schema';
 import { useFetchSignificantEventLifecycle } from '../../../../hooks/use_fetch_significant_event_lifecycle';
 import { useKibana } from '../../../../hooks/use_kibana';
 import { useTriggerInvestigation } from '../../../../hooks/use_trigger_investigation';
 import { useUpdateSignificantEvent } from '../../../../hooks/use_update_significant_event';
 import { useBlocksNewActivity } from '../../../../hooks/use_significant_events_maintenance';
+import { FlyoutMetadataCard } from '../../../../components/flyout_components/flyout_metadata_card';
 import { FlyoutToolbarHeader } from '../../../../components/flyout_components/flyout_toolbar_header';
+import { getConfidenceColor } from '../../../../components/knowledge_indicators/utils/get_confidence_color';
 import { LifecycleTimeline } from './lifecycle_timeline';
 import { getSignificantEventStatusColor } from '../shared/status_display';
 import { SIGNIFICANT_EVENT_STATUS_LABELS } from '../shared/translations';
-import { formatTimestamp } from '../../../../util/formatters';
+import { SeverityBadge } from '../severity_badge/severity_badge';
 import { SignificantEventDetails } from '../../../../components/significant_event_details/significant_event_details';
 import { EventInvestigations } from './event_investigations';
 import { hasRunningInvestigation } from '../shared/investigation_status';
@@ -119,6 +122,12 @@ const CONFIDENCE_LABEL = i18n.translate(
   'xpack.significantEventsApp.significantEventsTab.flyout.confidenceLabel',
   {
     defaultMessage: 'Confidence',
+  }
+);
+const STATUS_LABEL = i18n.translate(
+  'xpack.significantEventsApp.significantEventsTab.flyout.statusLabel',
+  {
+    defaultMessage: 'Status',
   }
 );
 
@@ -271,23 +280,35 @@ export const SignificantEventFlyout = ({ event, onClose }: SignificantEventFlyou
       </FlyoutToolbarHeader>
 
       <EuiFlyoutHeader hasBorder>
-        <EuiFlexGroup direction="column" gutterSize="s">
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>
+        <EuiTitle size="s">
+          <h2 id={flyoutTitleId}>{event.title}</h2>
+        </EuiTitle>
+        <EuiSpacer size="m" />
+        <EuiFlexGroup gutterSize="s" responsive={false} wrap>
+          <EuiFlexItem>
+            <FlyoutMetadataCard title={STATUS_LABEL}>
               <EuiBadge color={getSignificantEventStatusColor(event.status)}>
                 {SIGNIFICANT_EVENT_STATUS_LABELS[event.status]}
               </EuiBadge>
+            </FlyoutMetadataCard>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <FlyoutMetadataCard title={SEVERITY_LABEL}>
+              <SeverityBadge score={Number.parseInt(event.severity, 10)} />
+            </FlyoutMetadataCard>
+          </EuiFlexItem>
+          {event.confidence != null && (
+            <EuiFlexItem>
+              <FlyoutMetadataCard title={CONFIDENCE_LABEL}>
+                <EuiHealth
+                  color={getConfidenceColor(Math.round(event.confidence * 100))}
+                  textSize="xs"
+                >
+                  {`${Math.round(event.confidence * 100)}%`}
+                </EuiHealth>
+              </FlyoutMetadataCard>
             </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiTitle size="m">
-            <h2 id={flyoutTitleId}>{event.title}</h2>
-          </EuiTitle>
-          <EuiText size="xs" color="subdued">
-            {formatTimestamp(event.created_at)}
-            {` · ${SEVERITY_LABEL}: ${getSeverityLabel(event.severity)}`}
-            {event.confidence != null &&
-              ` · ${CONFIDENCE_LABEL}: ${Math.round(event.confidence * 100)}%`}
-          </EuiText>
+          )}
         </EuiFlexGroup>
       </EuiFlyoutHeader>
 

--- a/x-pack/platform/plugins/shared/significant_events_app/public/pages/significant_events/components/significant_events_tab/significant_events_tab.test.tsx
+++ b/x-pack/platform/plugins/shared/significant_events_app/public/pages/significant_events/components/significant_events_tab/significant_events_tab.test.tsx
@@ -54,9 +54,6 @@ jest.mock('./lifecycle_timeline', () => ({
 jest.mock('./event_investigations', () => ({
   EventInvestigations: () => null,
 }));
-jest.mock('../../../../components/significant_event_details/significant_event_details', () => ({
-  SignificantEventDetails: () => null,
-}));
 
 const event: SignificantEventResponse = {
   '@timestamp': '2026-01-02T00:00:00.000Z',
@@ -81,14 +78,10 @@ describe('Significant Events timestamp rendering', () => {
     );
   });
 
-  it('renders the lineage creation timestamp in the flyout header', () => {
+  it('renders the lineage creation timestamp in general information', () => {
     render(<SignificantEventFlyout event={event} onClose={jest.fn()} />);
 
-    expect(
-      screen.getByText(
-        (_, element) => element?.textContent?.startsWith(`formatted:${event.created_at}`) ?? false
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText(`formatted:${event.created_at}`)).toBeInTheDocument();
     expect(screen.queryByText(`formatted:${event['@timestamp']}`)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

This is PR improves the way we render some of the data inside a significant flyout. This shouldn't change business logic, but uplift the interface and structure of the flyout.All changes are considered based on what we have for KIs, Rules and Detections.

- Header metadata cards for Status, Severity (SeverityBadge), and Confidence
- Description in an info panel
- General information info panel with a description list for Created at, Streams, and Causal features
- Timestamp moved out of the header into General information

<img width="7848" height="2870" alt="image" src="https://github.com/user-attachments/assets/a29c1341-88f8-4b59-a13e-efb68a11a030" />
