### PR TITLE
[Cloud Connect] Rewrite AutoOps URL to deployment scope on ECE

### DIFF
--- a/packages/kbn-rspack-optimizer/limits.yml
+++ b/packages/kbn-rspack-optimizer/limits.yml
@@ -21,7 +21,7 @@ pageLoadAssetSize:
   charts: 1188
   clientApps: 1017
   cloud: 8477
-  cloudConnect: 4998
+  cloudConnect: 5575
   cloudDataMigration: 1755
   cloudDefend: 3060
   cloudExperiments: 67356

--- a/x-pack/platform/plugins/shared/cloud_connect/public/hooks/use_cloud_connect_status.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/hooks/use_cloud_connect_status.test.ts
@@ -108,6 +108,39 @@ describe('useCloudConnectStatus', () => {
     expect(result.current.autoOpsDocsUrl).toBe('https://www.elastic.co/docs/current/en/autoops');
   });
 
+  it('should rewrite autoOpsServiceUrl to a deployment-scoped URL when deploymentId is provided', async () => {
+    const clusterDetails = createMockClusterDetails({
+      services: {
+        auto_ops: {
+          enabled: true,
+          metadata: {
+            service_url:
+              'https://app.auto-ops.cloud.elastic.co/regions/aws-us-east-1/organizations/198583657190/clusters/abcdef1234567890abcdef1234567890/cluster',
+            documentation_url: 'https://www.elastic.co/docs/current/en/autoops',
+          },
+        },
+      },
+    });
+    const mockGet = jest.fn().mockResolvedValue(clusterDetails);
+    const http = createMockHttp(mockGet);
+    const useCloudConnectStatus = createUseCloudConnectStatusHook({
+      http,
+      deploymentId: 'ed211902155ba60ebf36df819054704e',
+    });
+
+    const { result } = renderHook(() => useCloudConnectStatus());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.autoOpsServiceUrl).toBe(
+      'https://app.auto-ops.cloud.elastic.co/regions/aws-us-east-1/organizations/198583657190/deployments/ed211902155ba60ebf36df819054704e/deployment'
+    );
+    // docs url is unaffected
+    expect(result.current.autoOpsDocsUrl).toBe('https://www.elastic.co/docs/current/en/autoops');
+  });
+
   it('should return undefined autoOpsServiceUrl and autoOpsDocsUrl when AutoOps metadata is absent', async () => {
     const clusterDetails = createMockClusterDetails({
       services: {

--- a/x-pack/platform/plugins/shared/cloud_connect/public/hooks/use_cloud_connect_status.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/hooks/use_cloud_connect_status.ts
@@ -10,12 +10,17 @@ import useAsyncFn from 'react-use/lib/useAsyncFn';
 import type { HttpSetup } from '@kbn/core/public';
 import { API_BASE_PATH } from '../../common/constants';
 import type { ClusterDetails } from '../types';
+import { toAutoOpsDeploymentUrl } from '../lib/autoops_url';
 
 export interface UseCloudConnectStatusResult {
   isCloudConnected: boolean;
   isCloudConnectEisEnabled: boolean;
   isCloudConnectAutoopsEnabled: boolean;
-  /** The URL to the AutoOps service page for this cluster, from `metadata.service_url`. */
+  /**
+   * The URL to the AutoOps service page for this cluster. On ECE this is rewritten to a
+   * deployment-scoped URL using `cloud.deploymentId`; on self-managed clusters it is the raw
+   * `metadata.service_url` from the Cloud Connect API response.
+   */
   autoOpsServiceUrl?: string;
   /** The URL to the AutoOps documentation, from `metadata.documentation_url`. */
   autoOpsDocsUrl?: string;
@@ -27,8 +32,12 @@ export type UseCloudConnectStatusHook = () => UseCloudConnectStatusResult;
 
 export const createUseCloudConnectStatusHook = ({
   http,
+  deploymentId,
 }: {
   http: HttpSetup;
+  /** The ECE deployment id (`cloud.deploymentId`). When present the AutoOps link is rewritten
+   * from the cluster-scoped `/clusters/{id}/cluster` path to `/deployments/{id}/deployment`. */
+  deploymentId?: string;
 }): UseCloudConnectStatusHook => {
   return () => {
     const [{ error, loading, value }, load] = useAsyncFn(async () => {
@@ -51,7 +60,10 @@ export const createUseCloudConnectStatusHook = ({
       isCloudConnected: value != null,
       isCloudConnectEisEnabled: value?.services?.eis?.enabled ?? false,
       isCloudConnectAutoopsEnabled: value?.services?.auto_ops?.enabled ?? false,
-      autoOpsServiceUrl: value?.services?.auto_ops?.metadata?.service_url,
+      autoOpsServiceUrl: toAutoOpsDeploymentUrl(
+        value?.services?.auto_ops?.metadata?.service_url,
+        deploymentId
+      ),
       autoOpsDocsUrl: value?.services?.auto_ops?.metadata?.documentation_url,
       isLoading: loading,
       error: error ?? null,

--- a/x-pack/platform/plugins/shared/cloud_connect/public/lib/autoops_url.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/lib/autoops_url.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { toAutoOpsDeploymentUrl } from './autoops_url';
+
+const SERVICE_URL =
+  'https://app.auto-ops.cloud.elastic.co/regions/aws-us-east-1/organizations/198583657190/clusters/abcdef1234567890abcdef1234567890/cluster';
+const DEPLOYMENT_ID = 'ed211902155ba60ebf36df819054704e';
+const EXPECTED =
+  'https://app.auto-ops.cloud.elastic.co/regions/aws-us-east-1/organizations/198583657190/deployments/ed211902155ba60ebf36df819054704e/deployment';
+
+describe('toAutoOpsDeploymentUrl', () => {
+  it('rewrites a cluster-scoped service_url to a deployment-scoped URL', () => {
+    expect(toAutoOpsDeploymentUrl(SERVICE_URL, DEPLOYMENT_ID)).toBe(EXPECTED);
+  });
+
+  it('returns service_url unchanged when deploymentId is undefined', () => {
+    expect(toAutoOpsDeploymentUrl(SERVICE_URL, undefined)).toBe(SERVICE_URL);
+  });
+
+  it('returns service_url unchanged when deploymentId is an empty string', () => {
+    expect(toAutoOpsDeploymentUrl(SERVICE_URL, '')).toBe(SERVICE_URL);
+  });
+
+  it('returns undefined when serviceUrl is undefined', () => {
+    expect(toAutoOpsDeploymentUrl(undefined, DEPLOYMENT_ID)).toBeUndefined();
+  });
+
+  it('returns service_url unchanged for a malformed URL', () => {
+    expect(toAutoOpsDeploymentUrl('not-a-url', DEPLOYMENT_ID)).toBe('not-a-url');
+  });
+
+  it('returns service_url unchanged when the pathname has no organizations segment', () => {
+    const noOrg = 'https://app.auto-ops.cloud.elastic.co/regions/aws-us-east-1';
+    expect(toAutoOpsDeploymentUrl(noOrg, DEPLOYMENT_ID)).toBe(noOrg);
+  });
+
+  it('returns service_url unchanged when organizations segment has no following id', () => {
+    const truncated =
+      'https://app.auto-ops.cloud.elastic.co/regions/aws-us-east-1/organizations';
+    expect(toAutoOpsDeploymentUrl(truncated, DEPLOYMENT_ID)).toBe(truncated);
+  });
+
+  it('preserves the origin exactly — does not hardcode the host', () => {
+    const stagingUrl =
+      'https://staging.auto-ops.cloud.elastic.co/regions/aws-us-east-1/organizations/198583657190/clusters/abcdef1234567890abcdef1234567890/cluster';
+    const result = toAutoOpsDeploymentUrl(stagingUrl, DEPLOYMENT_ID);
+    expect(result?.startsWith('https://staging.auto-ops.cloud.elastic.co')).toBe(true);
+  });
+
+  it('preserves the region segment exactly', () => {
+    const result = toAutoOpsDeploymentUrl(SERVICE_URL, DEPLOYMENT_ID);
+    expect(result).toContain('/regions/aws-us-east-1/');
+  });
+
+  it('preserves the organization id segment', () => {
+    const result = toAutoOpsDeploymentUrl(SERVICE_URL, DEPLOYMENT_ID);
+    expect(result).toContain('/organizations/198583657190/');
+  });
+});

--- a/x-pack/platform/plugins/shared/cloud_connect/public/lib/autoops_url.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/lib/autoops_url.test.ts
@@ -40,8 +40,7 @@ describe('toAutoOpsDeploymentUrl', () => {
   });
 
   it('returns service_url unchanged when organizations segment has no following id', () => {
-    const truncated =
-      'https://app.auto-ops.cloud.elastic.co/regions/aws-us-east-1/organizations';
+    const truncated = 'https://app.auto-ops.cloud.elastic.co/regions/aws-us-east-1/organizations';
     expect(toAutoOpsDeploymentUrl(truncated, DEPLOYMENT_ID)).toBe(truncated);
   });
 

--- a/x-pack/platform/plugins/shared/cloud_connect/public/lib/autoops_url.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/lib/autoops_url.ts
@@ -43,6 +43,8 @@ export function toAutoOpsDeploymentUrl(
   }
 
   // Rebuild the pathname up to and including the org id, then append the deployment tail.
-  parsed.pathname = `${parts.slice(0, orgIdx + 2).join('/')}/deployments/${deploymentId}/deployment`;
+  parsed.pathname = `${parts
+    .slice(0, orgIdx + 2)
+    .join('/')}/deployments/${deploymentId}/deployment`;
   return parsed.toString();
 }

--- a/x-pack/platform/plugins/shared/cloud_connect/public/lib/autoops_url.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/lib/autoops_url.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Rewrites an AutoOps cluster-scoped `service_url` to a deployment-scoped URL when a
+ * `deploymentId` is available (ECE only), so the link lands on the correct page:
+ *
+ *   in:  .../organizations/{orgId}/clusters/{clusterId}/cluster
+ *   out: .../organizations/{orgId}/deployments/{deploymentId}/deployment
+ *
+ * Falls back to returning `serviceUrl` unchanged when `deploymentId` is absent (self-managed
+ * clusters don't have one), when the URL doesn't have the expected shape, or when parsing fails.
+ * Returns `undefined` when `serviceUrl` is absent.
+ */
+export function toAutoOpsDeploymentUrl(
+  serviceUrl?: string,
+  deploymentId?: string
+): string | undefined {
+  if (!serviceUrl) {
+    return undefined;
+  }
+  if (!deploymentId) {
+    return serviceUrl;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(serviceUrl);
+  } catch {
+    return serviceUrl;
+  }
+
+  const parts = parsed.pathname.split('/');
+  const orgIdx = parts.findIndex((part) => part === 'organizations');
+
+  // Need 'organizations' followed by a non-empty org id segment.
+  if (orgIdx === -1 || orgIdx + 1 >= parts.length || !parts[orgIdx + 1]) {
+    return serviceUrl;
+  }
+
+  // Rebuild the pathname up to and including the org id, then append the deployment tail.
+  parsed.pathname = `${parts.slice(0, orgIdx + 2).join('/')}/deployments/${deploymentId}/deployment`;
+  return parsed.toString();
+}

--- a/x-pack/platform/plugins/shared/cloud_connect/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/plugin.tsx
@@ -42,6 +42,7 @@ export class CloudConnectedPlugin
   private readonly telemetry = new CloudConnectTelemetryService();
   private homeSetup?: HomePublicPluginSetup;
   private managementSetup?: ManagementSetup;
+  private deploymentId?: string;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.config = initializerContext.config.get<CloudConnectConfig>();
@@ -60,6 +61,7 @@ export class CloudConnectedPlugin
     // Store plugin setup references for registering hooks in start()
     this.homeSetup = plugins.home;
     this.managementSetup = plugins.management;
+    this.deploymentId = plugins.cloud?.deploymentId;
 
     // Setup telemetry
     this.telemetry.setup(core.analytics);
@@ -95,7 +97,10 @@ export class CloudConnectedPlugin
   }
 
   public start(core: CoreStart): CloudConnectedPluginStart {
-    const useCloudConnectStatus = createUseCloudConnectStatusHook({ http: core.http });
+    const useCloudConnectStatus = createUseCloudConnectStatusHook({
+      http: core.http,
+      deploymentId: this.deploymentId,
+    });
 
     // Register the hook with home plugin if available.
     // We use this registration pattern instead of having home depend on cloudConnect


### PR DESCRIPTION
## Summary

The AutoOps enabled callout's "Open AutoOps" button previously linked to the cluster-scoped URL from `services.auto_ops.metadata.service_url`. On ECE, we want the marketing banners for AutoOps to open a deployment-scoped URL instead (`.../deployments/{deploymentId}/deployment`).

This change adds a `toAutoOpsDeploymentUrl` helper that rewrites the path when `cloud.deploymentId` is available (ECE only), reusing the origin, region, and organisation from the existing `service_url`. Self-managed clusters have no deployment id so they receive the original URL unchanged.

### How to test

* Startup kibana and elasticsearch
* apply the following patch with `git apply ~/path/to/file.txt` [test.diff.txt](https://github.com/user-attachments/files/30973671/test.diff.txt)
* Verify that the cloud connect autoops url is still cluster scoped
* Verify that the `welcome to stack management` promo banner for autoops shows the link scoped to deployment id


PS: You might need to edit your `config/kibana.dev.yml` file to simulate you are on cloud:

```yaml
xpack.cloud.id: 'test'
xpack.cloud.base_url: "https://cloud.elastic.co"
xpack.cloud.deployment_url: "/deployments/deploymentId"
xpack.cloud.organization_id: "org-test1234"
xpack.cloud.region: "us-east-1"
xpack.cloud.csp: "aws"
xpack.cloud_connect.cloudUrl: 'https://console.qa.cld.elstc.co
```

