### PR TITLE
[9.5] [Security Solution] Adjust Attack Discovery "has moved" empty-state copy and layout (#284364)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/attack_discovery_moved/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/attack_discovery_moved/index.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { EuiEmptyPrompt, EuiImage, EuiLink, EuiText } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiImage, EuiLink, EuiSpacer, EuiTextColor } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -86,6 +87,13 @@ const AttackDiscoveryMovedPageComponent: React.FC = () => {
     <>
       <EuiEmptyPrompt
         data-test-subj="attackDiscoveryMovedPage"
+        css={css`
+          // Let each body line sit on a single line on wide screens, while the built-in
+          // 'max-width: max-content' still lets the prompt shrink and wrap on smaller ones.
+          .euiEmptyPrompt__content {
+            max-inline-size: none;
+          }
+        `}
         icon={
           <EuiImage
             url={isDarkMode ? simplifyDarkSvg : simplifyLightSvg}
@@ -96,17 +104,34 @@ const AttackDiscoveryMovedPageComponent: React.FC = () => {
         title={<h2 data-test-subj="attackDiscoveryMovedTitle">{TITLE}</h2>}
         titleSize="m"
         body={
-          <p data-test-subj="attackDiscoveryMovedBody">
-            <FormattedMessage
-              id="xpack.securitySolution.attackDiscovery.moved.description"
-              defaultMessage="{attackDiscovery} now exists as {attacks} and is located under {detections} in the side navigation"
-              values={{
-                attackDiscovery: <em>{ATTACK_DISCOVERY_LABEL}</em>,
-                attacks: <em>{ATTACKS_LABEL}</em>,
-                detections: <strong>{DETECTIONS_LABEL}</strong>,
-              }}
-            />
-          </p>
+          <>
+            <EuiSpacer size="s" />
+            <p data-test-subj="attackDiscoveryMovedBody">
+              <EuiTextColor color="default">
+                <FormattedMessage
+                  id="xpack.securitySolution.attackDiscovery.moved.description"
+                  defaultMessage="{attackDiscovery} now exists as {attacks} and is located under {detections} in the side navigation."
+                  values={{
+                    attackDiscovery: <em>{ATTACK_DISCOVERY_LABEL}</em>,
+                    attacks: <em>{ATTACKS_LABEL}</em>,
+                    detections: <strong>{DETECTIONS_LABEL}</strong>,
+                  }}
+                />
+              </EuiTextColor>
+              <br />
+              <EuiTextColor color="subdued" data-test-subj="attackDiscoveryMovedOptOut">
+                <FormattedMessage
+                  id="xpack.securitySolution.attackDiscovery.moved.optOut"
+                  defaultMessage="Prefer the previous experience? Disable alerts and attacks alignment in {advancedSettingsLink}."
+                  values={{
+                    advancedSettingsLink: (
+                      <EuiLink href={advancedSettingsUrl}>{ADVANCED_SETTINGS_LABEL}</EuiLink>
+                    ),
+                  }}
+                />
+              </EuiTextColor>
+            </p>
+          </>
         }
         actions={
           <SecuritySolutionLinkButton
@@ -117,19 +142,6 @@ const AttackDiscoveryMovedPageComponent: React.FC = () => {
           >
             {GO_TO_ATTACKS_BUTTON}
           </SecuritySolutionLinkButton>
-        }
-        footer={
-          <EuiText size="s" color="subdued" data-test-subj="attackDiscoveryMovedOptOut">
-            <FormattedMessage
-              id="xpack.securitySolution.attackDiscovery.moved.optOut"
-              defaultMessage="Prefer the previous experience? Disable alerts and attacks alignment in {advancedSettingsLink}."
-              values={{
-                advancedSettingsLink: (
-                  <EuiLink href={advancedSettingsUrl}>{ADVANCED_SETTINGS_LABEL}</EuiLink>
-                ),
-              }}
-            />
-          </EuiText>
         }
       />
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Security Solution] Adjust Attack Discovery "has moved" empty-state copy and layout (#284364)](https://github.com/elastic/kibana/pull/284364)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2026-08-11T14:02:42Z","message":"[Security Solution] Adjust Attack Discovery \"has moved\" empty-state copy and layout (#284364)\n\n## Summary\n\nFollow-up copy and layout adjustments to the Attack Discovery \"has\nmoved\" empty state introduced in #281173 (shown when the _alerts and\nattacks alignment_ advanced setting is enabled).\n\nChanges:\n\n- **Copy** — the opt-out note now lives in the description instead of a\nseparate footer:\n  - **Title:** `Attack Discovery has moved`\n- **Description (line 1):** _Attack Discovery_ now exists as _Attacks_\nand is located under **Detections** in the side navigation.\n- **Description (line 2, subdued):** Prefer the previous experience?\nDisable alerts and attacks alignment in [Advanced\nSettings](http://localhost:5601/app/management/kibana/settings?query=alerts%20and%20attacks%20alignment).\n- **Layout**\n- Both lines are now part of the same paragraph; the second line is\nrendered as subdued text.\n  - Added extra spacing between the title and the description.\n- Widened the prompt content so each line fits on a single line on wide\nscreens, while still wrapping/shrinking on smaller screens.\n- Removed the footer entirely.\n\n## Screenshots\n\n\n\n| Before | After |\n| --- | --- |\n| <img width=\"1840\" height=\"1196\" alt=\"Screenshot 2026-08-11 at 12 45\n13\"\nsrc=\"https://github.com/user-attachments/assets/26b84007-d707-4852-ac2d-c688291598df\"\n/> | <img width=\"1840\" height=\"1196\" alt=\"Screenshot 2026-08-11 at 12 38\n19\"\nsrc=\"https://github.com/user-attachments/assets/7b30a437-2ecc-4188-92cc-375fbe512d24\"\n/> |\n\n## Release notes\n\nSkipped — internal copy/layout tweak with no functional change.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### Identify risks\n\n- Presentational-only change to an existing empty state; no functional\nor API impact.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>","sha":"1658b6808dc30a340c8efeb9b351e9f65b672536","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting","backport:version","v9.5.0","v9.6.0"],"title":"[Security Solution] Adjust Attack Discovery \"has moved\" empty-state copy and layout","number":284364,"url":"https://github.com/elastic/kibana/pull/284364","mergeCommit":{"message":"[Security Solution] Adjust Attack Discovery \"has moved\" empty-state copy and layout (#284364)\n\n## Summary\n\nFollow-up copy and layout adjustments to the Attack Discovery \"has\nmoved\" empty state introduced in #281173 (shown when the _alerts and\nattacks alignment_ advanced setting is enabled).\n\nChanges:\n\n- **Copy** — the opt-out note now lives in the description instead of a\nseparate footer:\n  - **Title:** `Attack Discovery has moved`\n- **Description (line 1):** _Attack Discovery_ now exists as _Attacks_\nand is located under **Detections** in the side navigation.\n- **Description (line 2, subdued):** Prefer the previous experience?\nDisable alerts and attacks alignment in [Advanced\nSettings](http://localhost:5601/app/management/kibana/settings?query=alerts%20and%20attacks%20alignment).\n- **Layout**\n- Both lines are now part of the same paragraph; the second line is\nrendered as subdued text.\n  - Added extra spacing between the title and the description.\n- Widened the prompt content so each line fits on a single line on wide\nscreens, while still wrapping/shrinking on smaller screens.\n- Removed the footer entirely.\n\n## Screenshots\n\n\n\n| Before | After |\n| --- | --- |\n| <img width=\"1840\" height=\"1196\" alt=\"Screenshot 2026-08-11 at 12 45\n13\"\nsrc=\"https://github.com/user-attachments/assets/26b84007-d707-4852-ac2d-c688291598df\"\n/> | <img width=\"1840\" height=\"1196\" alt=\"Screenshot 2026-08-11 at 12 38\n19\"\nsrc=\"https://github.com/user-attachments/assets/7b30a437-2ecc-4188-92cc-375fbe512d24\"\n/> |\n\n## Release notes\n\nSkipped — internal copy/layout tweak with no functional change.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### Identify risks\n\n- Presentational-only change to an existing empty state; no functional\nor API impact.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>","sha":"1658b6808dc30a340c8efeb9b351e9f65b672536"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284364","number":284364,"mergeCommit":{"message":"[Security Solution] Adjust Attack Discovery \"has moved\" empty-state copy and layout (#284364)\n\n## Summary\n\nFollow-up copy and layout adjustments to the Attack Discovery \"has\nmoved\" empty state introduced in #281173 (shown when the _alerts and\nattacks alignment_ advanced setting is enabled).\n\nChanges:\n\n- **Copy** — the opt-out note now lives in the description instead of a\nseparate footer:\n  - **Title:** `Attack Discovery has moved`\n- **Description (line 1):** _Attack Discovery_ now exists as _Attacks_\nand is located under **Detections** in the side navigation.\n- **Description (line 2, subdued):** Prefer the previous experience?\nDisable alerts and attacks alignment in [Advanced\nSettings](http://localhost:5601/app/management/kibana/settings?query=alerts%20and%20attacks%20alignment).\n- **Layout**\n- Both lines are now part of the same paragraph; the second line is\nrendered as subdued text.\n  - Added extra spacing between the title and the description.\n- Widened the prompt content so each line fits on a single line on wide\nscreens, while still wrapping/shrinking on smaller screens.\n- Removed the footer entirely.\n\n## Screenshots\n\n\n\n| Before | After |\n| --- | --- |\n| <img width=\"1840\" height=\"1196\" alt=\"Screenshot 2026-08-11 at 12 45\n13\"\nsrc=\"https://github.com/user-attachments/assets/26b84007-d707-4852-ac2d-c688291598df\"\n/> | <img width=\"1840\" height=\"1196\" alt=\"Screenshot 2026-08-11 at 12 38\n19\"\nsrc=\"https://github.com/user-attachments/assets/7b30a437-2ecc-4188-92cc-375fbe512d24\"\n/> |\n\n## Release notes\n\nSkipped — internal copy/layout tweak with no functional change.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### Identify risks\n\n- Presentational-only change to an existing empty state; no functional\nor API impact.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>","sha":"1658b6808dc30a340c8efeb9b351e9f65b672536"}}]}] BACKPORT-->