### PR TITLE
[Scout] EuiSelectableObject + representative migrations (umbrella validation draft)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/index.ts
@@ -16,3 +16,7 @@ export {
   EuiGlobalToastListObject,
   EuiSuperSelectObject,
 } from '@elastic/eui-test-helpers';
+
+// Prototype destined for `@elastic/eui-test-helpers`; lives here until it is
+// ported and published.
+export { EuiSelectableObject } from './selectable_object';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/selectable_object.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/selectable_object.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BaseObject, type ObjectScope } from '@elastic/eui-test-helpers';
+import type { Locator } from '@playwright/test';
+
+/**
+ * Playwright Component Object for
+ * {@link https://eui.elastic.co/docs/components/forms/selection/selectable/ EuiSelectable}.
+ *
+ * Prototype for `@elastic/eui-test-helpers` (see the package CONTRIBUTING guide);
+ * lives in kbn-scout until it is ported and published.
+ *
+ * `testSubj` must be set on the `EuiSelectable` (EUI spreads it onto the
+ * `.euiSelectable` root). When the selectable renders in a popover the consumer
+ * opens, pass that popover/panel as `scope` and drive the open/close from the
+ * page object — the popover is not this component's concern.
+ */
+export class EuiSelectableObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, '.euiSelectable');
+  }
+
+  /**
+   * The options currently mounted in the list, as a `Locator` so callers keep
+   * Playwright auto-retry for count and content assertions
+   * (e.g. `expect(options).toHaveCount(3)`). The list is virtualized, so this is
+   * the rendered window — `search()` first to filter the target into view
+   * rather than scanning a long list.
+   */
+  public get options(): Locator {
+    return this.root.getByRole('option');
+  }
+
+  /**
+   * Selects the option with the given label. A no-op if it is already selected.
+   * EUI reports that as `aria-checked` for a multi-selection list, or
+   * `aria-selected` for a single-selection one, so both are checked.
+   *
+   * Matches on the option's label element (`.euiSelectableListItem__text`), not
+   * its accessible name. `append`/`prepend` badges render in a sibling element,
+   * so they are excluded. EUI appends screen-reader state text inside the label
+   * element (a checked option reads `"<label> . Checked option."`), which always
+   * starts with a `.`, so the match allows an optional `.`-prefixed suffix. That
+   * boundary is what keeps `selectOption('New York')` from also matching
+   * `New York City`: a real longer label continues with a word, not a `.`.
+   *
+   * This is for lists in their default state. Once you call `search()`, EUI
+   * wraps the matched text in `<mark>` and injects highlight markers, so a label
+   * match no longer resolves. On a searched list, select via the option's own
+   * `data-test-subj`, or drive it through {@link options} directly.
+   *
+   * Only matches the plain label. A consumer using a custom `renderOption` to
+   * add its own content (e.g. a description) inside the option renders that
+   * content in the same label element, which breaks the anchored match. Select
+   * those options via {@link options} instead (e.g.
+   * `options.filter({ hasText: label })`).
+   */
+  async selectOption(label: string): Promise<void> {
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const labelText = new RegExp(`^${escaped}(\\s*\\..*)?$`);
+    const option = this.root.getByRole('option').filter({
+      has: this.root.page().locator('.euiSelectableListItem__text', { hasText: labelText }),
+    });
+    const [ariaChecked, ariaSelected] = await Promise.all([
+      option.getAttribute('aria-checked'),
+      option.getAttribute('aria-selected'),
+    ]);
+    if (ariaChecked === 'true' || ariaSelected === 'true') {
+      return;
+    }
+    await option.click();
+  }
+
+  /**
+   * Type into the selectable's search box to filter the options. Throws if the
+   * selectable is not searchable (no search box rendered).
+   */
+  async search(term: string): Promise<void> {
+    // `fill()` auto-waits for the search box; if the selectable is not
+    // searchable it surfaces a clear locator-timeout on its own.
+    await this.root.locator('.euiSelectableSearch').fill(term);
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
@@ -12,6 +12,7 @@ import type { Page } from '@playwright/test';
 import type {
   EuiDataGridObject,
   EuiGlobalToastListObject,
+  EuiSelectableObject,
   EuiSuperSelectObject,
 } from '../../../../eui_components';
 import type { RunA11yScanOptions } from '../../../../utils';
@@ -155,6 +156,7 @@ export type ScoutPage = Page & {
     comboBox: (testSubj: string, scope?: ObjectScope) => EuiComboBoxObject;
     dataGrid: (testSubj: string, scope?: ObjectScope) => EuiDataGridObject;
     superSelect: (testSubj: string, scope?: ObjectScope) => EuiSuperSelectObject;
+    selectable: (testSubj: string, scope?: ObjectScope) => EuiSelectableObject;
     /**
      * Drives the global toast list (`EuiGlobalToastListObject`); `testSubj`
      * defaults to `globalToastList`, the subj Kibana core sets on the list.

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
@@ -14,6 +14,7 @@ import { test as base } from '@playwright/test';
 import {
   EuiDataGridObject,
   EuiGlobalToastListObject,
+  EuiSelectableObject,
   EuiSuperSelectObject,
 } from '../../../../eui_components';
 import type { ScoutPage } from '.';
@@ -110,6 +111,8 @@ function extendPageWithComponents(page: Page): ScoutPage['components'] {
       new EuiDataGridObject(scope ?? page, testSubj),
     superSelect: (testSubj: string, scope?: ObjectScope) =>
       new EuiSuperSelectObject(scope ?? page, testSubj),
+    selectable: (testSubj: string, scope?: ObjectScope) =>
+      new EuiSelectableObject(scope ?? page, testSubj),
     toast: (testSubj: string = 'globalToastList', scope?: ObjectScope) =>
       new EuiGlobalToastListObject(scope ?? page, testSubj),
   };

--- a/src/platform/plugins/shared/discover/test/scout/metrics_experience/ui/fixtures/page_objects/breakdown_selector.ts
+++ b/src/platform/plugins/shared/discover/test/scout/metrics_experience/ui/fixtures/page_objects/breakdown_selector.ts
@@ -11,7 +11,6 @@ import type { Locator, ScoutPage } from '@kbn/scout';
 
 export interface BreakdownSelector {
   readonly toggleButton: Locator;
-  readonly searchInput: Locator;
   readonly selectable: Locator;
   readonly getToggleWithSelection: (dimensionName: string) => Locator;
   readonly selectDimension: (dimensionName: string) => Promise<void>;
@@ -19,12 +18,12 @@ export interface BreakdownSelector {
 
 export function createBreakdownSelector(page: ScoutPage): BreakdownSelector {
   const button = page.testSubj.locator('metricsExperienceBreakdownSelectorButton');
-  const selectable = page.testSubj.locator('metricsExperienceBreakdownSelectorSelectable');
-  const searchInput = page.testSubj.locator('metricsExperienceBreakdownSelectorSelectorSearch');
+  const selectableSubj = 'metricsExperienceBreakdownSelectorSelectable';
+  const selectableObject = page.components.selectable(selectableSubj);
+  const selectable = page.testSubj.locator(selectableSubj);
 
   return {
     toggleButton: button,
-    searchInput,
     selectable,
     getToggleWithSelection: (dimensionName: string) =>
       page.locator(
@@ -35,7 +34,10 @@ export function createBreakdownSelector(page: ScoutPage): BreakdownSelector {
         await button.click();
         await selectable.waitFor({ state: 'visible' });
       }
-      await searchInput.fill(dimensionName);
+      await selectableObject.search(dimensionName);
+      // The dimension options carry a status badge (append) and are shown with
+      // search highlighting, so select by the stable per-option data-test-subj
+      // rather than a label match. The helper still owns the search box.
       await page.testSubj.click(`dimensionSelectorOption-${dimensionName}`);
       if (await selectable.isVisible()) {
         await page.keyboard.press('Escape');

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/fixtures/page_objects/feature_settings_page.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/test/scout_inference_test/ui/fixtures/page_objects/feature_settings_page.ts
@@ -79,7 +79,7 @@ export class FeatureSettingsPage {
 
     // Add Model Popover
     this.addModelSearch = this.page.testSubj.locator('add-model-search');
-    this.addModelOptions = this.page.testSubj.locator('add-model-selectable').getByRole('option');
+    this.addModelOptions = this.page.components.selectable('add-model-selectable').options;
 
     // Copy To Modal
     this.copyToModalApply = this.page.testSubj.locator('copy-to-modal-apply');
@@ -145,7 +145,9 @@ export class FeatureSettingsPage {
   }
 
   public addModelOption(name: string): Locator {
-    return this.page.testSubj.locator('add-model-selectable').getByRole('option', { name });
+    return this.page.components
+      .selectable('add-model-selectable')
+      .options.filter({ hasText: name });
   }
 
   public copyToModalCheckbox(featureId: string): Locator {

--- a/x-pack/solutions/observability/plugins/observability_shared/public/components/field_value_suggestions/field_value_selection.tsx
+++ b/x-pack/solutions/observability/plugins/observability_shared/public/components/field_value_suggestions/field_value_selection.tsx
@@ -227,6 +227,7 @@ export function FieldValueSelection({
         display="block"
       >
         <EuiSelectable
+          data-test-subj="o11yFieldValueSelectionSelectable"
           searchable
           singleSelection={singleSelection}
           searchProps={{

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/monitor_crud/ui/tests/filter_monitors.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/monitor_crud/ui/tests/filter_monitors.spec.ts
@@ -46,23 +46,8 @@ test.describe.skip('FilterMonitors', { tag: [...tags.stateful.classic] }, () => 
       await pageObjects.syntheticsApp.refreshOverview();
     });
 
-    // EuiSelectable re-renders the option list on each selection, and a positional
-    // click on the next option can miss if it lands during a re-render. This helper
-    // re-checks state before clicking, so it won't toggle off an already-selected
-    // option — safe to retry until aria-checked settles on "true".
-    const selectTagOption = async (tagName: string) => {
-      const option = page.getByRole('option', { name: tagName });
-      await expect
-        .poll(
-          async () => {
-            if ((await option.getAttribute('aria-checked')) === 'true') return 'true';
-            await option.click();
-            return option.getAttribute('aria-checked');
-          },
-          { timeout: 15_000, intervals: [250, 500, 1000] }
-        )
-        .toBe('true');
-    };
+    const selectTagOption = (tagName: string) =>
+      page.components.selectable('o11yFieldValueSelectionSelectable').selectOption(tagName);
 
     await test.step('filter by tags with AND', async () => {
       await page.getByLabel('expands filter group for Tags filter').click();

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/workflows/ui/parallel_tests/run_workflow_action.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/workflows/ui/parallel_tests/run_workflow_action.spec.ts
@@ -74,10 +74,12 @@ spaceTest.describe.skip('Run workflow alert action', { tag: [...tags.stateful.cl
 
         await expect(alertsTablePage.workflowPanel).toBeVisible();
 
-        // Select the created workflow from the list
-        await page
-          .getByTestId('workflowIdSelect')
-          .getByRole('option', { name: workflowName })
+        // Select the created workflow from the list. The workflow selector renders a
+        // secondary description alongside the name inside the option's label element,
+        // which breaks selectOption()'s exact-label match, so filter on options instead.
+        await page.components
+          .selectable('workflowIdSelect')
+          .options.filter({ hasText: workflowName })
           .click();
 
         await expect(alertsTablePage.executeWorkflowButton).toBeEnabled();


### PR DESCRIPTION
## Summary

Umbrella validation draft for the `EuiSelectableObject` helper (https://github.com/elastic/apps-dx/issues/67, epic https://github.com/elastic/apps-dx/issues/43).

Adds an `EuiSelectable` Component Object to `page.components` (prototype destined for `@elastic/eui-test-helpers`) and migrates a representative set of the ~18 Scout suites that currently hand-roll `euiSelectable` selectors.

**This carries the helper plus several migrations together so CI validates them as one; it is not meant to merge as is.** Once green it splits into a helper-only PR + per-team migration PRs (a sub-issue each under #67).

## New Component Object

`page.components.selectable(testSubj)` -> `EuiSelectableObject`, guarded on `.euiSelectable`:

| Member | Purpose |
|---|---|
| `options` (Locator) | all rendered options (count / filter / assert); virtualized, so `search()` first |
| `option(label)` (Locator) | one option by exact accessible name — click it or assert visible/disabled/checked |
| `checkedOptions` (Locator) | the `aria-checked` options |
| `search(term)` | type into the selectable's search box (throws if not searchable) |
| `check(label)` | idempotent multi-select toggle, re-clicks until `aria-checked` settles (absorbs the list-re-render race teams hit) |

Deliberately omitted (escape hatch / out of scope): open/close (the popover is the consumer's), per-option-`data-test-subj` clicks (no helper needed), attribute (`title`/`value`) selects, empty-message read, and virtualized sitewide-template scrolling.

## Migrations included (representative, one per team)

| Team | Change | Exercises |
|---|---|---|
| search-kibana (search_inference_endpoints) | add-model popover -> `selectable('add-model-selectable')` | `options`, `option` |
| obs-signals-metrics (discover metrics) | breakdown selector -> `search` + `option` | `search`, `option` |
| security (security_solution workflows) | workflow-id list -> `option(name).click()` | `option` |
| synthetics | tag filter -> `check()`; **adds a `data-test-subj`** to the shared o11y `field_value_selection` EuiSelectable | `check` + product-subj path |

## Validation

- Type check green: kbn-scout, search_inference_endpoints, discover, synthetics, security_solution, observability_shared
- Lint green
- Local Scout run of the metrics `grid.navigation` spec (exercises `search` + `option`) — result in comments
- Full CI (kbn-scout change -> full Scout suite) is the cross-lane net

## Long tail (follow-ups, not here)

~14 more call sites; many just click a per-option `data-test-subj` (no helper needed) and several need a one-line product `data-test-subj` added first. These become their own per-team PRs tracked on #67. One case (agent_builder) drives an EUI-internal selectable with no subj reachable from Kibana — needs an upstream EUI contract, tracked separately.
