### PR TITLE
[Entity Analytics] Fix yellow cluster health on single-node ES by adding auto_expand_replicas to EA index settings

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.test.ts
@@ -136,6 +136,7 @@ describe('AssetCriticalityDataClient', () => {
             },
           },
           settings: {
+            auto_expand_replicas: '0-1',
             default_pipeline: 'entity_analytics_create_eventIngest_from_timestamp-pipeline-default',
           },
         },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
@@ -101,6 +101,7 @@ export class AssetCriticalityDataClient {
           },
         },
         settings: {
+          auto_expand_replicas: '0-1',
           default_pipeline: getIngestPipelineName(this.options.namespace),
         },
       },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/indices/lead_index_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/indices/lead_index_service.test.ts
@@ -44,7 +44,7 @@ describe('LeadIndexService', () => {
       expect(indexNames).toContain(scheduledIndex);
 
       const [{ options }] = mockCreateOrUpdateIndex.mock.calls[0];
-      expect(options.settings).toEqual({ hidden: true });
+      expect(options.settings).toEqual({ auto_expand_replicas: '0-1', hidden: true });
       expect(options.mappings.properties).toHaveProperty('id');
       expect(options.mappings.properties).toHaveProperty('observations');
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/indices/lead_index_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/indices/lead_index_service.ts
@@ -40,7 +40,7 @@ export const createLeadIndexService = ({ esClient, logger, spaceId }: LeadIndexS
         options: {
           index: name,
           mappings,
-          settings: { hidden: true },
+          settings: { hidden: true, auto_expand_replicas: '0-1' },
         },
       });
     }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/engine/elasticsearch/indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/engine/elasticsearch/indices.ts
@@ -25,6 +25,7 @@ export const createPrivmonIndexService = (dataClient: PrivilegeMonitoringDataCli
         mappings: generateUserIndexMappings(),
         settings: {
           hidden: true,
+          auto_expand_replicas: '0-1',
           mode: 'lookup',
           default_pipeline: PRIVMON_EVENT_INGEST_PIPELINE_ID,
         },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
@@ -129,7 +129,7 @@ export class WatchlistConfigClient {
       options: {
         index: getIndexForWatchlist(this.deps.namespace),
         mappings: generateWatchlistEntityIndexMappings(),
-        settings: { hidden: true },
+        settings: { hidden: true, auto_expand_replicas: '0-1' },
       },
     });
 


### PR DESCRIPTION
## Summary

Fixes #276861

Four Entity Analytics indices were created with the Elasticsearch default of `number_of_replicas: 1`. On single-node clusters (ECK, dev environments, small self-managed setups), the replica shard can never be allocated because a node cannot hold both a primary and a replica for the same shard. This left the cluster health permanently **yellow**.

The fix adds `auto_expand_replicas: '0-1'` to the index settings for all four affected indices:

| Index creator | File |
|---|---|
| Watchlists | `watchlists/management/watchlist_config.ts` |
| Privilege monitoring | `privilege_monitoring/engine/elasticsearch/indices.ts` |
| Lead generation | `lead_generation/indices/lead_index_service.ts` |
| Asset criticality | `asset_criticality/asset_criticality_data_client.ts` |

## What changed

**Before:** each index was created with only `{ hidden: true }` (or similar minimal) settings, inheriting ES's default of 1 replica.

**After:** each index is created with `auto_expand_replicas: '0-1'`, which instructs Elasticsearch to use 0 replicas when only one data node is available and scale up to 1 replica when a second node joins. This is a standard dynamic setting - no downtime or reindex required.

## Backward compatibility

This change is fully backward compatible and self-healing for existing deployments:

- `auto_expand_replicas` is a **dynamic** Elasticsearch index setting - it can be applied to a live index without closing it or reindexing data.
- The `createOrUpdateIndex` utility already calls `esClient.indices.putSettings()` on existing indices whenever settings are provided. This means the fix will be automatically applied to pre-existing yellow indices on the **next Kibana restart**, recovering cluster health without any manual intervention.
- No data schema changes, no API changes, no feature behaviour changes.

## Additional note

This is the same fix applied to `#261933` (`.workflows-events`) and `#263048` (`.kibana_streams`). The security solution's own `@kbn/index-adapter` package (`resource_installer_utils.ts`) hard-codes `auto_expand_replicas: '0-1'` for all index templates it manages - this PR aligns the four indices that bypass that adapter.


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->