### PR TITLE
[ESQL Data Federation] Add documentation links to UI + update existing links to use doc links service

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/README.md
+++ b/src/platform/packages/shared/kbn-doc-links/README.md
@@ -1,3 +1,35 @@
 # `@kbn/doc-links` — Kibana documentation links registry
 
-This package contains the service used to access all registered Kibana documentation links
+This package is intended to be the single source of truth for every documentation URL used in the Kibana UI. Instead of hardcoding URLs in components, register them here and access them via `docLinks.links.<section>.<page>`.
+
+When the docs site restructures or the base URL changes, you update one file instead of hunting through dozens of components.
+
+## How to add new links
+
+1. **Register the URLs** in [`src/get_doc_links.ts`](src/get_doc_links.ts). Add a new section or extend an existing one:
+
+   ```ts
+   myPlugin: {
+     overview: `${ELASTIC_DOCS}path/to/overview`,
+     gettingStarted: `${ELASTIC_DOCS}path/to/getting-started`,
+   },
+   ```
+
+2. **Add the types** in [`src/types.ts`](src/types.ts). Add a matching `readonly` block under `DocLinks`:
+
+   ```ts
+   readonly myPlugin: {
+     readonly overview: string;
+     readonly gettingStarted: string;
+   };
+   ```
+
+3. **Use them in your plugin**. Access via the `docLinks` core service:
+
+   ```tsx
+   const { docLinks } = useKibana().services;
+   const link = docLinks.links.myPlugin.overview;
+   ```
+
+> [!IMPORTANT]
+> Never hardcode documentation URLs in components. Always use this service so links stay maintainable.

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -1099,6 +1099,18 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       context: `${ELASTIC_DOCS}solutions/search/rag/playground-context`,
       hiddenFields: `${ELASTIC_DOCS}solutions/search/rag/playground-query#playground-hidden-fields`,
     },
+    dataFederation: {
+      overview: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation`,
+      quickstart: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation-quickstart`,
+      dataSources: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation-sources`,
+      datasets: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation-datasets`,
+      datasetSettings: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation-datasets#dataset-settings`,
+      authentication: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation-sources#authentication`,
+      staticCredentials: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation-static-credentials`,
+      federatedIdentity: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation-federated-identity`,
+      querying: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation-querying`,
+      security: `${ELASTIC_DOCS}reference/query-languages/esql/esql-data-federation-security`,
+    },
     agentBuilder: {
       agentBuilder: `${ELASTIC_DOCS}explore-analyze/ai-features/elastic-agent-builder`,
       getStarted: `${ELASTIC_DOCS}explore-analyze/ai-features/agent-builder/get-started`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -747,6 +747,18 @@ export interface DocLinks {
   readonly datasetQuality: {
     readonly failureStore: string;
   };
+  readonly dataFederation: {
+    readonly overview: string;
+    readonly quickstart: string;
+    readonly dataSources: string;
+    readonly datasets: string;
+    readonly datasetSettings: string;
+    readonly authentication: string;
+    readonly staticCredentials: string;
+    readonly federatedIdentity: string;
+    readonly querying: string;
+    readonly security: string;
+  };
   readonly agentBuilder: {
     readonly agentBuilder: string;
     readonly getStarted: string;

--- a/x-pack/platform/plugins/private/data_federation/moon.yml
+++ b/x-pack/platform/plugins/private/data_federation/moon.yml
@@ -27,6 +27,7 @@ dependsOn:
   - '@kbn/features-plugin'
   - '@kbn/kibana-react-plugin'
   - '@kbn/app-header'
+  - '@kbn/core-doc-links-browser'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout.test.tsx
@@ -10,6 +10,7 @@ import { EuiProvider } from '@elastic/eui';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 
 import type { ToastsStart } from '@kbn/core/public';
+import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type { DataSourcesClient } from '../data_sources_client';
 import type { DatasetsClient } from '../datasets_client';
@@ -37,6 +38,24 @@ const createDatasetsClientMock = (): DatasetsClient =>
     delete: jest.fn().mockResolvedValue(undefined),
   } as unknown as DatasetsClient);
 
+const createDocLinksMock = (): DocLinksStart =>
+  ({
+    links: {
+      dataFederation: {
+        overview: 'https://example.com/data-federation',
+        quickstart: 'https://example.com/data-federation-quickstart',
+        dataSources: 'https://example.com/data-federation-sources',
+        datasets: 'https://example.com/data-federation-datasets',
+        datasetSettings: 'https://example.com/data-federation-datasets#dataset-settings',
+        authentication: 'https://example.com/data-federation-sources#authentication',
+        staticCredentials: 'https://example.com/data-federation-static-credentials',
+        federatedIdentity: 'https://example.com/data-federation-federated-identity',
+        querying: 'https://example.com/data-federation-querying',
+        security: 'https://example.com/data-federation-security',
+      },
+    },
+  } as unknown as DocLinksStart);
+
 describe('CreateDataSourceFlyout', () => {
   it('renders core actions and disables save while saving', async () => {
     const toasts = createToastsMock();
@@ -45,6 +64,7 @@ describe('CreateDataSourceFlyout', () => {
       dataSourcesClient: client,
       datasetsClient: createDatasetsClientMock(),
       toasts,
+      docLinks: createDocLinksMock(),
       featureFlags: {},
     };
     let resolveSave: (value: string | null) => void;
@@ -99,6 +119,7 @@ describe('CreateDataSourceFlyout', () => {
       dataSourcesClient: client,
       datasetsClient: createDatasetsClientMock(),
       toasts,
+      docLinks: createDocLinksMock(),
       featureFlags: {},
     };
     const onSave = jest.fn().mockResolvedValue(null);

--- a/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout.tsx
@@ -21,6 +21,7 @@ import {
   EuiFormRow,
   EuiHorizontalRule,
   EuiIcon,
+  EuiLink,
   EuiSpacer,
   EuiSuperSelect,
   EuiText,
@@ -76,8 +77,10 @@ export const CreateDataSourceFlyout: FunctionComponent<CreateDataSourceFlyoutPro
   onSave,
 }) => {
   const {
-    services: { cloudInfo, featureFlags },
+    services: { cloudInfo, featureFlags, docLinks },
   } = useKibana<DataFederationKibanaServices>();
+
+  const dataFederationLinks = docLinks.links.dataFederation;
 
   const enableFederatedIdentityAuth = featureFlags?.enableFederatedIdentityAuth;
   const enableGoogleCloudStorageDataSourceType =
@@ -247,7 +250,12 @@ export const CreateDataSourceFlyout: FunctionComponent<CreateDataSourceFlyoutPro
           <>
             <EuiSpacer size="s" />
             <EuiText size="s" color="subdued">
-              <p>{createDataSourceFlyoutStrings.createDescription()}</p>
+              <p>
+                {createDataSourceFlyoutStrings.createDescription()}{' '}
+                <EuiLink href={dataFederationLinks.dataSources} target="_blank">
+                  {createDataSourceFlyoutStrings.learnMore()}
+                </EuiLink>
+              </p>
             </EuiText>
           </>
         )}
@@ -320,6 +328,7 @@ export const CreateDataSourceFlyout: FunctionComponent<CreateDataSourceFlyoutPro
             dataSourceType={dataSourceType}
             enableFederatedIdentity={enableFederatedIdentityAuth}
             onAuthenticationModeChange={setAuthenticationMode}
+            authenticationDocsUrl={dataFederationLinks.authentication}
           />
           <CreateDataSourceFlyoutAuthenticationFields
             authenticationMode={authenticationMode}

--- a/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout_authentication_select.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout_authentication_select.tsx
@@ -27,19 +27,18 @@ import {
   type CreateDataSourceAuthenticationMode,
 } from './create_data_source_flyout_authentication';
 
-const DATA_FEDERATION_AUTH_DOCS_URL =
-  'https://www.elastic.co/docs/reference/query-languages/esql/esql-data-federation-sources#authentication';
-
 export function CreateDataSourceFlyoutAuthenticationSelect({
   dataSourceType,
   authenticationMode,
   enableFederatedIdentity,
   onAuthenticationModeChange,
+  authenticationDocsUrl,
 }: {
   dataSourceType: DataSourceType;
   authenticationMode: CreateDataSourceAuthenticationMode;
   enableFederatedIdentity?: boolean;
   onAuthenticationModeChange: (mode: CreateDataSourceAuthenticationMode) => void;
+  authenticationDocsUrl: string;
 }) {
   const options = useMemo(
     () => getCreateDataSourceAuthenticationOptions(dataSourceType, { enableFederatedIdentity }),
@@ -61,7 +60,7 @@ export function CreateDataSourceFlyoutAuthenticationSelect({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiLink
-            href={DATA_FEDERATION_AUTH_DOCS_URL}
+            href={authenticationDocsUrl}
             target="_blank"
             external={false}
             rel="noopener noreferrer"

--- a/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout_i18n.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/create_data_source_flyout/create_data_source_flyout_i18n.ts
@@ -69,4 +69,9 @@ export const createDataSourceFlyoutStrings = {
     i18n.translate('xpack.dataFederation.createFlyout.saveButton', {
       defaultMessage: 'Save',
     }),
+
+  learnMore: () =>
+    i18n.translate('xpack.dataFederation.createFlyout.learnMore', {
+      defaultMessage: 'Learn more',
+    }),
 };

--- a/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout.test.tsx
@@ -45,13 +45,13 @@ const renderFlyout = ({
   render(
     <EuiProvider>
       <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-      <CreateDatasetFlyout
-        initialDataSet={initialDataSet}
-        existingDataSetNames={existingDataSetNames}
-        dataSources={dataSources}
-        onClose={jest.fn()}
-        onSave={onSave}
-      />
+        <CreateDatasetFlyout
+          initialDataSet={initialDataSet}
+          existingDataSetNames={existingDataSetNames}
+          dataSources={dataSources}
+          onClose={jest.fn()}
+          onSave={onSave}
+        />
       </KibanaContextProvider>
     </EuiProvider>
   );

--- a/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout.test.tsx
@@ -9,9 +9,27 @@ import React from 'react';
 import { EuiProvider } from '@elastic/eui';
 import { fireEvent, render } from '@testing-library/react';
 
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type { DataSetWithName } from '../../common';
 import type { DataSource } from '../../common';
 import { CreateDatasetFlyout } from './create_dataset_flyout';
+
+const docLinksMock = {
+  links: {
+    dataFederation: {
+      overview: '',
+      quickstart: '',
+      dataSources: '',
+      datasets: '',
+      datasetSettings: '',
+      authentication: '',
+      staticCredentials: '',
+      federatedIdentity: '',
+      querying: '',
+      security: '',
+    },
+  },
+};
 
 const renderFlyout = ({
   initialDataSet,
@@ -26,6 +44,7 @@ const renderFlyout = ({
 }) =>
   render(
     <EuiProvider>
+      <KibanaContextProvider services={{ docLinks: docLinksMock }}>
       <CreateDatasetFlyout
         initialDataSet={initialDataSet}
         existingDataSetNames={existingDataSetNames}
@@ -33,6 +52,7 @@ const renderFlyout = ({
         onClose={jest.fn()}
         onSave={onSave}
       />
+      </KibanaContextProvider>
     </EuiProvider>
   );
 

--- a/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout.tsx
@@ -19,17 +19,20 @@ import {
   EuiFlyoutHeader,
   EuiForm,
   EuiFormRow,
+  EuiLink,
   EuiSelect,
   EuiSpacer,
   EuiText,
   EuiTextArea,
   EuiTitle,
 } from '@elastic/eui';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useController, useForm } from 'react-hook-form';
 
 import type { DataSetWithName, DataSource } from '../../common';
 import { DATA_SOURCE_TYPES_TO_HELP_TEXT, validateIndexNameRules } from '../../common';
 import { getFlyoutSaveErrorMessage } from '../get_flyout_save_error_message';
+import type { DataFederationKibanaServices } from '../types';
 import {
   buildDatasetSettingsFromFormValues,
   type CreateDatasetFormValues,
@@ -69,6 +72,11 @@ export const CreateDatasetFlyout: FunctionComponent<CreateDatasetFlyoutProps> = 
   onSave,
   dataSources,
 }) => {
+  const {
+    services: { docLinks },
+  } = useKibana<DataFederationKibanaServices>();
+  const dataFederationLinks = docLinks.links.dataFederation;
+
   const isEditMode = initialDataSet !== undefined;
   const initialIdNormalized = initialDataSet?.name?.trim().toLowerCase() ?? '';
   const [saveError, setSaveError] = useState<string | undefined>();
@@ -218,7 +226,12 @@ export const CreateDatasetFlyout: FunctionComponent<CreateDatasetFlyoutProps> = 
           <>
             <EuiSpacer size="s" />
             <EuiText size="s" color="subdued">
-              <p>{createDatasetFlyoutStrings.createDescription()}</p>
+              <p>
+                {createDatasetFlyoutStrings.createDescription()}{' '}
+                <EuiLink href={dataFederationLinks.datasets} target="_blank">
+                  {createDatasetFlyoutStrings.learnMore()}
+                </EuiLink>
+              </p>
             </EuiText>
           </>
         )}

--- a/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout_i18n.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout_i18n.ts
@@ -481,4 +481,14 @@ export const createDatasetFlyoutStrings = {
     i18n.translate('xpack.dataFederation.createDatasetFlyout.saveButton', {
       defaultMessage: 'Save',
     }),
+
+  learnMore: () =>
+    i18n.translate('xpack.dataFederation.createDatasetFlyout.learnMore', {
+      defaultMessage: 'Learn more',
+    }),
+
+  settingsLearnMore: () =>
+    i18n.translate('xpack.dataFederation.createDatasetFlyout.settingsLearnMore', {
+      defaultMessage: 'Learn more about dataset settings',
+    }),
 };

--- a/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout_settings.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout_settings.test.tsx
@@ -10,9 +10,27 @@ import { EuiProvider } from '@elastic/eui';
 import { fireEvent, render } from '@testing-library/react';
 import { useForm, useWatch } from 'react-hook-form';
 
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { CreateDatasetFlyoutSettings } from './create_dataset_flyout_settings';
 import type { CreateDatasetFormValues } from './create_dataset_flyout_form_state';
 import { emptyCreateDatasetSettingsFormValues } from './create_dataset_flyout_form_state';
+
+const docLinksMock = {
+  links: {
+    dataFederation: {
+      overview: '',
+      quickstart: '',
+      dataSources: '',
+      datasets: '',
+      datasetSettings: '',
+      authentication: '',
+      staticCredentials: '',
+      federatedIdentity: '',
+      querying: '',
+      security: '',
+    },
+  },
+};
 
 const renderSettings = () => {
   const Wrapper = () => {
@@ -30,8 +48,10 @@ const renderSettings = () => {
 
     return (
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <CreateDatasetFlyoutSettings control={control} />
         <div data-test-subj="settingsValue">{JSON.stringify(settings)}</div>
+        </KibanaContextProvider>
       </EuiProvider>
     );
   };

--- a/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout_settings.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout_settings.test.tsx
@@ -49,8 +49,8 @@ const renderSettings = () => {
     return (
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <CreateDatasetFlyoutSettings control={control} />
-        <div data-test-subj="settingsValue">{JSON.stringify(settings)}</div>
+          <CreateDatasetFlyoutSettings control={control} />
+          <div data-test-subj="settingsValue">{JSON.stringify(settings)}</div>
         </KibanaContextProvider>
       </EuiProvider>
     );

--- a/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout_settings.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/create_dataset_flyout/create_dataset_flyout_settings.tsx
@@ -11,13 +11,17 @@ import {
   EuiFieldNumber,
   EuiFieldText,
   EuiFormRow,
+  EuiLink,
   EuiSelect,
   EuiSpacer,
+  EuiText,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { Control } from 'react-hook-form';
 import { useController } from 'react-hook-form';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 
+import type { DataFederationKibanaServices } from '../types';
 import { createDatasetFlyoutStrings } from './create_dataset_flyout_i18n';
 import {
   validateMaxErrorRatio,
@@ -105,6 +109,11 @@ export function CreateDatasetFlyoutSettings({
 }: {
   control: Control<CreateDatasetFormValues>;
 }) {
+  const {
+    services: { docLinks },
+  } = useKibana<DataFederationKibanaServices>();
+  const dataFederationLinks = docLinks.links.dataFederation;
+
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
   const advancedId = useGeneratedHtmlId({ prefix: 'createDatasetFlyoutAdvancedSettings' });
 
@@ -159,6 +168,12 @@ export function CreateDatasetFlyoutSettings({
           : createDatasetFlyoutStrings.advancedSettingsShow()}
       </EuiButtonEmpty>
       <div id={advancedId} hidden={!isAdvancedOpen}>
+        <EuiSpacer size="s" />
+        <EuiText size="xs" color="subdued">
+          <EuiLink href={dataFederationLinks.datasetSettings} target="_blank">
+            {createDatasetFlyoutStrings.settingsLearnMore()}
+          </EuiLink>
+        </EuiText>
         <EuiSpacer size="s" />
         {/* Format-independent advanced settings */}
         <UniversalAdvancedSettings control={control} />

--- a/x-pack/platform/plugins/private/data_federation/public/data_sources_tab_content.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/data_sources_tab_content.test.tsx
@@ -113,6 +113,22 @@ const createServicesMock = ({
     dataSourcesClient,
     datasetsClient: { get: jest.fn() },
     toasts: { addDanger: jest.fn(), addSuccess: jest.fn() },
+    docLinks: {
+      links: {
+        dataFederation: {
+          overview: '',
+          quickstart: '',
+          dataSources: '',
+          datasets: '',
+          datasetSettings: '',
+          authentication: '',
+          staticCredentials: '',
+          federatedIdentity: '',
+          querying: '',
+          security: '',
+        },
+      },
+    },
   } as unknown as DataFederationKibanaServices);
 
 const renderComponent = async ({

--- a/x-pack/platform/plugins/private/data_federation/public/data_sources_table.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/data_sources_table.test.tsx
@@ -57,16 +57,16 @@ describe('DataSourcesTable', () => {
     const { getByTestId } = render(
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <DataSourcesTable
-          dataSources={[createDataSource('ds1', 's3')]}
-          selectedDataSources={[]}
-          dataSetsCountByDataSource={new Map()}
-          onSelectionChange={jest.fn()}
-          onCreate={onCreate}
-          onEdit={jest.fn()}
-          onDelete={jest.fn()}
-          onDeleteSelected={jest.fn()}
-        />
+          <DataSourcesTable
+            dataSources={[createDataSource('ds1', 's3')]}
+            selectedDataSources={[]}
+            dataSetsCountByDataSource={new Map()}
+            onSelectionChange={jest.fn()}
+            onCreate={onCreate}
+            onEdit={jest.fn()}
+            onDelete={jest.fn()}
+            onDeleteSelected={jest.fn()}
+          />
         </KibanaContextProvider>
       </EuiProvider>
     );
@@ -81,19 +81,19 @@ describe('DataSourcesTable', () => {
     const { getAllByTestId } = render(
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <DataSourcesTable
-          dataSources={[
-            createDataSource('supported', 's3'),
-            createDataSource('unsupported', 'http'),
-          ]}
-          selectedDataSources={[]}
-          dataSetsCountByDataSource={new Map()}
-          onSelectionChange={jest.fn()}
-          onCreate={jest.fn()}
-          onEdit={onEdit}
-          onDelete={jest.fn()}
-          onDeleteSelected={jest.fn()}
-        />
+          <DataSourcesTable
+            dataSources={[
+              createDataSource('supported', 's3'),
+              createDataSource('unsupported', 'http'),
+            ]}
+            selectedDataSources={[]}
+            dataSetsCountByDataSource={new Map()}
+            onSelectionChange={jest.fn()}
+            onCreate={jest.fn()}
+            onEdit={onEdit}
+            onDelete={jest.fn()}
+            onDeleteSelected={jest.fn()}
+          />
         </KibanaContextProvider>
       </EuiProvider>
     );
@@ -120,16 +120,16 @@ describe('DataSourcesTable', () => {
     const { getAllByTestId, getByText } = render(
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <DataSourcesTable
-          dataSources={[createDataSource('Source A', 's3'), createDataSource('Source B', 's3')]}
-          selectedDataSources={[]}
-          dataSetsCountByDataSource={dataSetsCountByDataSource}
-          onSelectionChange={jest.fn()}
-          onCreate={jest.fn()}
-          onEdit={jest.fn()}
-          onDelete={onDelete}
-          onDeleteSelected={jest.fn()}
-        />
+          <DataSourcesTable
+            dataSources={[createDataSource('Source A', 's3'), createDataSource('Source B', 's3')]}
+            selectedDataSources={[]}
+            dataSetsCountByDataSource={dataSetsCountByDataSource}
+            onSelectionChange={jest.fn()}
+            onCreate={jest.fn()}
+            onEdit={jest.fn()}
+            onDelete={onDelete}
+            onDeleteSelected={jest.fn()}
+          />
         </KibanaContextProvider>
       </EuiProvider>
     );
@@ -164,16 +164,16 @@ describe('DataSourcesTable', () => {
     const { getByTestId } = render(
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <DataSourcesTable
-          dataSources={[...selectedDataSources, createDataSource('other', 's3')]}
-          selectedDataSources={selectedDataSources}
-          dataSetsCountByDataSource={new Map()}
-          onSelectionChange={jest.fn()}
-          onCreate={jest.fn()}
-          onEdit={jest.fn()}
-          onDelete={jest.fn()}
-          onDeleteSelected={onDeleteSelected}
-        />
+          <DataSourcesTable
+            dataSources={[...selectedDataSources, createDataSource('other', 's3')]}
+            selectedDataSources={selectedDataSources}
+            dataSetsCountByDataSource={new Map()}
+            onSelectionChange={jest.fn()}
+            onCreate={jest.fn()}
+            onEdit={jest.fn()}
+            onDelete={jest.fn()}
+            onDeleteSelected={onDeleteSelected}
+          />
         </KibanaContextProvider>
       </EuiProvider>
     );

--- a/x-pack/platform/plugins/private/data_federation/public/data_sources_table.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/data_sources_table.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { EuiProvider } from '@elastic/eui';
 import { fireEvent, render } from '@testing-library/react';
 
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type { DataSource } from '../common';
 import { DataSourcesTable } from './data_sources_table';
 
@@ -20,6 +21,23 @@ const createDataSource = (name: string, type: DataSource['type'] | string): Data
     description: '',
     settings: {},
   } as unknown as DataSource);
+
+const docLinksMock = {
+  links: {
+    dataFederation: {
+      overview: '',
+      quickstart: '',
+      dataSources: '',
+      datasets: '',
+      datasetSettings: '',
+      authentication: '',
+      staticCredentials: '',
+      federatedIdentity: '',
+      querying: '',
+      security: '',
+    },
+  },
+};
 
 describe('DataSourcesTable', () => {
   const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
@@ -38,6 +56,7 @@ describe('DataSourcesTable', () => {
 
     const { getByTestId } = render(
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <DataSourcesTable
           dataSources={[createDataSource('ds1', 's3')]}
           selectedDataSources={[]}
@@ -48,6 +67,7 @@ describe('DataSourcesTable', () => {
           onDelete={jest.fn()}
           onDeleteSelected={jest.fn()}
         />
+        </KibanaContextProvider>
       </EuiProvider>
     );
 
@@ -60,6 +80,7 @@ describe('DataSourcesTable', () => {
 
     const { getAllByTestId } = render(
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <DataSourcesTable
           dataSources={[
             createDataSource('supported', 's3'),
@@ -73,6 +94,7 @@ describe('DataSourcesTable', () => {
           onDelete={jest.fn()}
           onDeleteSelected={jest.fn()}
         />
+        </KibanaContextProvider>
       </EuiProvider>
     );
 
@@ -97,6 +119,7 @@ describe('DataSourcesTable', () => {
 
     const { getAllByTestId, getByText } = render(
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <DataSourcesTable
           dataSources={[createDataSource('Source A', 's3'), createDataSource('Source B', 's3')]}
           selectedDataSources={[]}
@@ -107,6 +130,7 @@ describe('DataSourcesTable', () => {
           onDelete={onDelete}
           onDeleteSelected={jest.fn()}
         />
+        </KibanaContextProvider>
       </EuiProvider>
     );
 
@@ -139,6 +163,7 @@ describe('DataSourcesTable', () => {
 
     const { getByTestId } = render(
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <DataSourcesTable
           dataSources={[...selectedDataSources, createDataSource('other', 's3')]}
           selectedDataSources={selectedDataSources}
@@ -149,6 +174,7 @@ describe('DataSourcesTable', () => {
           onDelete={jest.fn()}
           onDeleteSelected={onDeleteSelected}
         />
+        </KibanaContextProvider>
       </EuiProvider>
     );
 

--- a/x-pack/platform/plugins/private/data_federation/public/data_sources_table.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/data_sources_table.tsx
@@ -8,11 +8,20 @@
 import type { FunctionComponent } from 'react';
 import React, { useMemo } from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiButton, EuiButtonIcon, EuiInMemoryTable, EuiSpacer, EuiToolTip } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiInMemoryTable,
+  EuiLink,
+  EuiSpacer,
+  EuiToolTip,
+} from '@elastic/eui';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 
 import { ALL_DATA_SOURCE_TYPES, type DataSource } from '../common';
 import { getDataSourceTypeVerbose } from './get_data_source_type_label';
 import { mainTranslations } from './main_i18n';
+import type { DataFederationKibanaServices } from './types';
 
 export interface DataSourcesTableProps {
   dataSources: DataSource[];
@@ -35,6 +44,21 @@ export const DataSourcesTable: FunctionComponent<DataSourcesTableProps> = ({
   onDelete,
   onDeleteSelected,
 }) => {
+  const {
+    services: { docLinks },
+  } = useKibana<DataFederationKibanaServices>();
+
+  const emptyMessage = useMemo(
+    () => (
+      <>
+        {mainTranslations.columns.dataSources.noItems}{' '}
+        <EuiLink href={docLinks.links.dataFederation.dataSources} target="_blank">
+          {mainTranslations.docsLink}
+        </EuiLink>
+      </>
+    ),
+    [docLinks.links.dataFederation.dataSources]
+  );
   const columns = useMemo<Array<EuiBasicTableColumn<DataSource>>>(
     () => [
       {
@@ -189,7 +213,7 @@ export const DataSourcesTable: FunctionComponent<DataSourcesTableProps> = ({
         }}
         data-test-subj="dataSetsTable"
         tableCaption={mainTranslations.columns.dataSources.caption}
-        noItemsMessage={mainTranslations.columns.dataSources.noItems}
+        noItemsMessage={emptyMessage}
         tableLayout="auto"
         responsiveBreakpoint={false}
       />

--- a/x-pack/platform/plugins/private/data_federation/public/datasets_tab_content.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/datasets_tab_content.test.tsx
@@ -150,6 +150,22 @@ const createServicesMock = ({
     dataSourcesClient: { get: jest.fn() },
     datasetsClient,
     toasts: { addDanger: jest.fn(), addSuccess: jest.fn() },
+    docLinks: {
+      links: {
+        dataFederation: {
+          overview: '',
+          quickstart: '',
+          dataSources: '',
+          datasets: '',
+          datasetSettings: '',
+          authentication: '',
+          staticCredentials: '',
+          federatedIdentity: '',
+          querying: '',
+          security: '',
+        },
+      },
+    },
   } as unknown as DataFederationKibanaServices);
 
 const renderComponent = async ({

--- a/x-pack/platform/plugins/private/data_federation/public/datasets_table.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/datasets_table.test.tsx
@@ -63,22 +63,22 @@ describe('DatasetsTable', () => {
     const { getByTestId } = render(
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <DatasetsTable
-          filteredItems={[createDataSetRow({ name: 'set1', dataSource: 'ds1' })]}
-          selectedItems={[]}
-          dataSourceFilterOptions={[
-            { value: '', text: 'All' },
-            { value: 'ds1', text: 'ds1' },
-          ]}
-          dataSourceFilter=""
-          isCreateDisabled={true}
-          onSelectionChange={jest.fn()}
-          onDataSourceFilterChange={jest.fn()}
-          onCreate={onCreate}
-          onEdit={jest.fn()}
-          onDelete={jest.fn()}
-          onDeleteSelected={jest.fn()}
-        />
+          <DatasetsTable
+            filteredItems={[createDataSetRow({ name: 'set1', dataSource: 'ds1' })]}
+            selectedItems={[]}
+            dataSourceFilterOptions={[
+              { value: '', text: 'All' },
+              { value: 'ds1', text: 'ds1' },
+            ]}
+            dataSourceFilter=""
+            isCreateDisabled={true}
+            onSelectionChange={jest.fn()}
+            onDataSourceFilterChange={jest.fn()}
+            onCreate={onCreate}
+            onEdit={jest.fn()}
+            onDelete={jest.fn()}
+            onDeleteSelected={jest.fn()}
+          />
         </KibanaContextProvider>
       </EuiProvider>
     );
@@ -96,22 +96,22 @@ describe('DatasetsTable', () => {
     const { getByTestId } = render(
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <DatasetsTable
-          filteredItems={[createDataSetRow({ name: 'set1', dataSource: 'ds1' })]}
-          selectedItems={[]}
-          dataSourceFilterOptions={[
-            { value: '', text: 'All' },
-            { value: 'ds1', text: 'ds1' },
-          ]}
-          dataSourceFilter=""
-          isCreateDisabled={false}
-          onSelectionChange={jest.fn()}
-          onDataSourceFilterChange={jest.fn()}
-          onCreate={onCreate}
-          onEdit={jest.fn()}
-          onDelete={jest.fn()}
-          onDeleteSelected={jest.fn()}
-        />
+          <DatasetsTable
+            filteredItems={[createDataSetRow({ name: 'set1', dataSource: 'ds1' })]}
+            selectedItems={[]}
+            dataSourceFilterOptions={[
+              { value: '', text: 'All' },
+              { value: 'ds1', text: 'ds1' },
+            ]}
+            dataSourceFilter=""
+            isCreateDisabled={false}
+            onSelectionChange={jest.fn()}
+            onDataSourceFilterChange={jest.fn()}
+            onCreate={onCreate}
+            onEdit={jest.fn()}
+            onDelete={jest.fn()}
+            onDeleteSelected={jest.fn()}
+          />
         </KibanaContextProvider>
       </EuiProvider>
     );
@@ -126,22 +126,22 @@ describe('DatasetsTable', () => {
     const { getByTestId } = render(
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <DatasetsTable
-          filteredItems={[createDataSetRow({ name: 'set1', dataSource: 'ds1' })]}
-          selectedItems={[]}
-          dataSourceFilterOptions={[
-            { value: '', text: 'All' },
-            { value: 'ds1', text: 'ds1' },
-          ]}
-          dataSourceFilter=""
-          isCreateDisabled={false}
-          onSelectionChange={jest.fn()}
-          onDataSourceFilterChange={onDataSourceFilterChange}
-          onCreate={jest.fn()}
-          onEdit={jest.fn()}
-          onDelete={jest.fn()}
-          onDeleteSelected={jest.fn()}
-        />
+          <DatasetsTable
+            filteredItems={[createDataSetRow({ name: 'set1', dataSource: 'ds1' })]}
+            selectedItems={[]}
+            dataSourceFilterOptions={[
+              { value: '', text: 'All' },
+              { value: 'ds1', text: 'ds1' },
+            ]}
+            dataSourceFilter=""
+            isCreateDisabled={false}
+            onSelectionChange={jest.fn()}
+            onDataSourceFilterChange={onDataSourceFilterChange}
+            onCreate={jest.fn()}
+            onEdit={jest.fn()}
+            onDelete={jest.fn()}
+            onDeleteSelected={jest.fn()}
+          />
         </KibanaContextProvider>
       </EuiProvider>
     );
@@ -158,25 +158,25 @@ describe('DatasetsTable', () => {
     const { getAllByTestId } = render(
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <DatasetsTable
-          filteredItems={[
-            createDataSetRow({ name: 'set1', dataSource: 'ds1' }),
-            createDataSetRow({ name: 'set2', dataSource: 'ds1' }),
-          ]}
-          selectedItems={[]}
-          dataSourceFilterOptions={[
-            { value: '', text: 'All' },
-            { value: 'ds1', text: 'ds1' },
-          ]}
-          dataSourceFilter=""
-          isCreateDisabled={false}
-          onSelectionChange={jest.fn()}
-          onDataSourceFilterChange={jest.fn()}
-          onCreate={jest.fn()}
-          onEdit={onEdit}
-          onDelete={onDelete}
-          onDeleteSelected={jest.fn()}
-        />
+          <DatasetsTable
+            filteredItems={[
+              createDataSetRow({ name: 'set1', dataSource: 'ds1' }),
+              createDataSetRow({ name: 'set2', dataSource: 'ds1' }),
+            ]}
+            selectedItems={[]}
+            dataSourceFilterOptions={[
+              { value: '', text: 'All' },
+              { value: 'ds1', text: 'ds1' },
+            ]}
+            dataSourceFilter=""
+            isCreateDisabled={false}
+            onSelectionChange={jest.fn()}
+            onDataSourceFilterChange={jest.fn()}
+            onCreate={jest.fn()}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onDeleteSelected={jest.fn()}
+          />
         </KibanaContextProvider>
       </EuiProvider>
     );
@@ -202,22 +202,25 @@ describe('DatasetsTable', () => {
     const { getByTestId } = render(
       <EuiProvider>
         <KibanaContextProvider services={{ docLinks: docLinksMock }}>
-        <DatasetsTable
-          filteredItems={[...selectedItems, createDataSetRow({ name: 'set2', dataSource: 'ds1' })]}
-          selectedItems={selectedItems}
-          dataSourceFilterOptions={[
-            { value: '', text: 'All' },
-            { value: 'ds1', text: 'ds1' },
-          ]}
-          dataSourceFilter=""
-          isCreateDisabled={false}
-          onSelectionChange={jest.fn()}
-          onDataSourceFilterChange={jest.fn()}
-          onCreate={jest.fn()}
-          onEdit={jest.fn()}
-          onDelete={jest.fn()}
-          onDeleteSelected={onDeleteSelected}
-        />
+          <DatasetsTable
+            filteredItems={[
+              ...selectedItems,
+              createDataSetRow({ name: 'set2', dataSource: 'ds1' }),
+            ]}
+            selectedItems={selectedItems}
+            dataSourceFilterOptions={[
+              { value: '', text: 'All' },
+              { value: 'ds1', text: 'ds1' },
+            ]}
+            dataSourceFilter=""
+            isCreateDisabled={false}
+            onSelectionChange={jest.fn()}
+            onDataSourceFilterChange={jest.fn()}
+            onCreate={jest.fn()}
+            onEdit={jest.fn()}
+            onDelete={jest.fn()}
+            onDeleteSelected={onDeleteSelected}
+          />
         </KibanaContextProvider>
       </EuiProvider>
     );

--- a/x-pack/platform/plugins/private/data_federation/public/datasets_table.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/datasets_table.test.tsx
@@ -9,9 +9,27 @@ import React from 'react';
 import { EuiProvider } from '@elastic/eui';
 import { fireEvent, render } from '@testing-library/react';
 
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type { DataSetWithName } from '../common';
 import type { DataSetListRow } from './datasets_table';
 import { DatasetsTable } from './datasets_table';
+
+const docLinksMock = {
+  links: {
+    dataFederation: {
+      overview: '',
+      quickstart: '',
+      dataSources: '',
+      datasets: '',
+      datasetSettings: '',
+      authentication: '',
+      staticCredentials: '',
+      federatedIdentity: '',
+      querying: '',
+      security: '',
+    },
+  },
+};
 
 const createDataSetRow = ({
   name,
@@ -44,6 +62,7 @@ describe('DatasetsTable', () => {
 
     const { getByTestId } = render(
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <DatasetsTable
           filteredItems={[createDataSetRow({ name: 'set1', dataSource: 'ds1' })]}
           selectedItems={[]}
@@ -60,6 +79,7 @@ describe('DatasetsTable', () => {
           onDelete={jest.fn()}
           onDeleteSelected={jest.fn()}
         />
+        </KibanaContextProvider>
       </EuiProvider>
     );
 
@@ -75,6 +95,7 @@ describe('DatasetsTable', () => {
 
     const { getByTestId } = render(
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <DatasetsTable
           filteredItems={[createDataSetRow({ name: 'set1', dataSource: 'ds1' })]}
           selectedItems={[]}
@@ -91,6 +112,7 @@ describe('DatasetsTable', () => {
           onDelete={jest.fn()}
           onDeleteSelected={jest.fn()}
         />
+        </KibanaContextProvider>
       </EuiProvider>
     );
 
@@ -103,6 +125,7 @@ describe('DatasetsTable', () => {
 
     const { getByTestId } = render(
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <DatasetsTable
           filteredItems={[createDataSetRow({ name: 'set1', dataSource: 'ds1' })]}
           selectedItems={[]}
@@ -119,6 +142,7 @@ describe('DatasetsTable', () => {
           onDelete={jest.fn()}
           onDeleteSelected={jest.fn()}
         />
+        </KibanaContextProvider>
       </EuiProvider>
     );
 
@@ -133,6 +157,7 @@ describe('DatasetsTable', () => {
 
     const { getAllByTestId } = render(
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <DatasetsTable
           filteredItems={[
             createDataSetRow({ name: 'set1', dataSource: 'ds1' }),
@@ -152,6 +177,7 @@ describe('DatasetsTable', () => {
           onDelete={onDelete}
           onDeleteSelected={jest.fn()}
         />
+        </KibanaContextProvider>
       </EuiProvider>
     );
 
@@ -175,6 +201,7 @@ describe('DatasetsTable', () => {
 
     const { getByTestId } = render(
       <EuiProvider>
+        <KibanaContextProvider services={{ docLinks: docLinksMock }}>
         <DatasetsTable
           filteredItems={[...selectedItems, createDataSetRow({ name: 'set2', dataSource: 'ds1' })]}
           selectedItems={selectedItems}
@@ -191,6 +218,7 @@ describe('DatasetsTable', () => {
           onDelete={jest.fn()}
           onDeleteSelected={onDeleteSelected}
         />
+        </KibanaContextProvider>
       </EuiProvider>
     );
 

--- a/x-pack/platform/plugins/private/data_federation/public/datasets_table.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/datasets_table.tsx
@@ -13,13 +13,16 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiInMemoryTable,
+  EuiLink,
   EuiSelect,
   EuiSpacer,
 } from '@elastic/eui';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 
 import type { DataSetWithName, DataSource } from '../common';
 import { getDataSourceTypeVerbose } from './get_data_source_type_label';
 import { mainTranslations } from './main_i18n';
+import type { DataFederationKibanaServices } from './types';
 
 /** Data set row in the table; `type` is resolved from the linked data source. */
 export type DataSetListRow = DataSetWithName & { type?: DataSource['type'] };
@@ -51,6 +54,21 @@ export const DatasetsTable: FunctionComponent<DatasetsTableProps> = ({
   onDelete,
   onDeleteSelected,
 }) => {
+  const {
+    services: { docLinks },
+  } = useKibana<DataFederationKibanaServices>();
+
+  const emptyMessage = useMemo(
+    () => (
+      <>
+        {mainTranslations.columns.dataSets.noItems}{' '}
+        <EuiLink href={docLinks.links.dataFederation.datasets} target="_blank">
+          {mainTranslations.docsLink}
+        </EuiLink>
+      </>
+    ),
+    [docLinks.links.dataFederation.datasets]
+  );
   const columns = useMemo<Array<EuiBasicTableColumn<DataSetListRow>>>(
     () => [
       {
@@ -195,7 +213,7 @@ export const DatasetsTable: FunctionComponent<DatasetsTableProps> = ({
         }}
         data-test-subj="dataSetsSetsTable"
         tableCaption={mainTranslations.columns.dataSets.caption}
-        noItemsMessage={mainTranslations.columns.dataSets.noItems}
+        noItemsMessage={emptyMessage}
         tableLayout="auto"
         responsiveBreakpoint={false}
       />

--- a/x-pack/platform/plugins/private/data_federation/public/main.test.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/main.test.tsx
@@ -43,6 +43,22 @@ const createServicesMock = ({
     get: jest.fn().mockResolvedValue(dataSets),
   },
   toasts: createToastsMock(),
+  docLinks: {
+    links: {
+      dataFederation: {
+        overview: '',
+        quickstart: '',
+        dataSources: '',
+        datasets: '',
+        datasetSettings: '',
+        authentication: '',
+        staticCredentials: '',
+        federatedIdentity: '',
+        querying: '',
+        security: '',
+      },
+    },
+  },
 });
 
 describe('Main', () => {

--- a/x-pack/platform/plugins/private/data_federation/public/main.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/main.tsx
@@ -20,16 +20,15 @@ import { DatasetsTabContent } from './datasets_tab_content';
 import type { DataFederationKibanaServices } from './types';
 import { useLoadList } from './use_load_list';
 
-const DOCS_LINK =
-  'https://www.elastic.co/docs/reference/query-languages/esql/esql-data-federation' as const;
-
 const DATASETS_PATH = '/datasets' as const;
 const DATA_SOURCES_PATH = '/data_sources' as const;
 
 export const Main: FunctionComponent = () => {
   const {
-    services: { dataSourcesClient, datasetsClient },
+    services: { dataSourcesClient, datasetsClient, docLinks },
   } = useKibana<DataFederationKibanaServices>();
+
+  const dataFederationLinks = docLinks.links.dataFederation;
 
   const history = useHistory();
   const { pathname } = useLocation();
@@ -108,7 +107,7 @@ export const Main: FunctionComponent = () => {
         badges={[{ label: mainTranslations.experimental }]}
         tabs={tabs}
         spacing="bleed"
-        docLink={DOCS_LINK}
+        docLink={dataFederationLinks.overview}
       />
       <EuiSpacer size="l" />
 

--- a/x-pack/platform/plugins/private/data_federation/public/main.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/main.tsx
@@ -108,6 +108,19 @@ export const Main: FunctionComponent = () => {
         tabs={tabs}
         spacing="bleed"
         docLink={dataFederationLinks.overview}
+        menu={{
+          items: [
+            {
+              id: 'quickstart',
+              label: mainTranslations.quickstartLink,
+              iconType: 'launch',
+              href: dataFederationLinks.quickstart,
+              target: '_blank',
+              overflow: true,
+              order: 3,
+            },
+          ],
+        }}
       />
       <EuiSpacer size="l" />
 

--- a/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/main_i18n.ts
@@ -25,6 +25,10 @@ export const mainTranslations = {
     defaultMessage: 'Learn more',
   }),
 
+  quickstartLink: i18n.translate('xpack.dataFederation.quickstartLink', {
+    defaultMessage: 'Quickstart',
+  }),
+
   columns: {
     dataSources: {
       name: i18n.translate('xpack.dataFederation.table.columnName', {

--- a/x-pack/platform/plugins/private/data_federation/public/mount_management_section.tsx
+++ b/x-pack/platform/plugins/private/data_federation/public/mount_management_section.tsx
@@ -40,6 +40,7 @@ export const mountManagementSection = (
     dataSourcesClient: new DataSourcesClient(coreStart.http),
     datasetsClient: new DatasetsClient(coreStart.http),
     toasts: coreStart.notifications.toasts,
+    docLinks: coreStart.docLinks,
     cloudInfo,
     featureFlags: {
       enableFederatedIdentityAuth,

--- a/x-pack/platform/plugins/private/data_federation/public/types.ts
+++ b/x-pack/platform/plugins/private/data_federation/public/types.ts
@@ -8,6 +8,7 @@
 import type { ManagementSetup } from '@kbn/management-plugin/public';
 import type { CloudSetup } from '@kbn/cloud-plugin/public';
 import type { ToastsStart } from '@kbn/core/public';
+import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 import type { FederatedIdentityClusterInfo } from './create_data_source_flyout/federated_identity_cluster_info';
 import type { DataSourcesClient } from './data_sources_client';
 import type { DatasetsClient } from './datasets_client';
@@ -33,6 +34,7 @@ export interface DataFederationKibanaServices {
   dataSourcesClient: DataSourcesClient;
   datasetsClient: DatasetsClient;
   toasts: ToastsStart;
+  docLinks: DocLinksStart;
   cloudInfo?: FederatedIdentityClusterInfo;
   featureFlags?: FederatedDataFeatureFlags;
 }

--- a/x-pack/platform/plugins/private/data_federation/tsconfig.json
+++ b/x-pack/platform/plugins/private/data_federation/tsconfig.json
@@ -19,7 +19,8 @@
     "@kbn/shared-ux-router",
     "@kbn/features-plugin",
     "@kbn/kibana-react-plugin",
-    "@kbn/app-header"
+    "@kbn/app-header",
+    "@kbn/core-doc-links-browser"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION

## Summary

Adds some new documentation links throughout the ES|QL Data Federation management UI using the centralized `kbn-doc-links` system, replacing existing hardcoded URLs.

---


### ✨ New UI links

- **Data sources tab** empty state: new "Learn more" link → data sources docs
- **Datasets tab** empty state: new "Learn more" link → datasets docs
- **Connect data source flyout**: new "Learn more" link → data sources docs
- **Add dataset flyout**: new "Learn more" link → datasets docs
- **Add dataset advanced settings**: new "Learn more about dataset settings" link → dataset settings docs
- **Page header kebab menu**: new "Quickstart" menu item


### 🔗 Doc links registry (`kbn-doc-links`)

- Register 10 `dataFederation` link entries in `get_doc_links.ts` and `types.ts` covering overview, quickstart, data sources, datasets, settings, authentication, and more
> [!NOTE]
> When adding doc links, don't hardcode. Use the [doc links service](https://github.com/leemthompo/kibana/blob/esql-data-federation-doc-links/src/platform/packages/shared/kbn-doc-links/README.md).


---


### 🧪 Tests

- Updated all test mocks with `docLinks`

## Screenshots

### Kebab menu (new quickstart link )
<img width="947" height="388" alt="kebab-menu-quickstart-and-docs" src="https://github.com/user-attachments/assets/17356397-e3ff-4783-b990-6bdc715c8d69" />

### Datasets tab empty state
<img width="938" height="345" alt="datasets-tab-empty-state" src="https://github.com/user-attachments/assets/72c445b3-a38c-49d6-baae-583d91c07e6c" />

### Add dataset flyout
<img width="1187" height="529" alt="add-dataset-flyout" src="https://github.com/user-attachments/assets/9efe5e75-837d-4f81-a8a4-f8b56423c33f" />

### Data sources tab empty state
<img width="942" height="361" alt="data-sources-tab-empty-state" src="https://github.com/user-attachments/assets/928c3871-e134-4b4e-92f6-bb4a24c3b3e6" />

### Connect data source flyout
<img width="1185" height="603" alt="connect-data-source-flyout" src="https://github.com/user-attachments/assets/7252dbde-901d-4212-a328-50c1bc35790e" />

### Dataset advanced settings
<img width="936" height="600" alt="dataset-advanced-settings" src="https://github.com/user-attachments/assets/8d89cfd2-617d-4e52-bc06-b204e956e227" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->