### PR TITLE
[Streams] Revamped streams UI

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/streams_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/streams_layout/index.tsx
@@ -71,6 +71,10 @@ export function StreamsLayout() {
         title={i18n.translate('xpack.streams.streamsLayout.pageHeaderTitle', {
           defaultMessage: 'Streams',
         })}
+        description={i18n.translate('xpack.streams.streamsLayout.pageHeaderDescription', {
+          defaultMessage:
+            'Route, process, and manage your data streams from source to destination.',
+        })}
         tabs={appHeaderTabs}
       />
       <StreamsAppPageTemplate.Body noPadding={noPadding} paddingSize="m">

--- a/x-pack/platform/plugins/shared/streams_app/public/components/streams_root_redirect/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/streams_root_redirect/index.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { useStreamsPrivileges } from '../../hooks/use_streams_privileges';
+import { RedirectTo } from '../redirect_to';
+import { StreamListView } from '../stream_list_view';
+import { DEFAULT_STREAMS_LAYOUT_TAB } from '../streams_layout/tabs';
+
+/**
+ * Renders the landing view for the app root, which is the tabbed layout when Canvas is enabled and
+ * the stream list otherwise.
+ */
+export function StreamsRootRedirect() {
+  const {
+    features: { canvas },
+  } = useStreamsPrivileges();
+
+  if (canvas.enabled) {
+    return (
+      <RedirectTo
+        path="/new-experience/{tab}"
+        params={{ path: { tab: DEFAULT_STREAMS_LAYOUT_TAB } }}
+      />
+    );
+  }
+
+  return <StreamListView />;
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/routes/config.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/routes/config.tsx
@@ -13,7 +13,7 @@ import { StreamsAppPageTemplate } from '../components/streams_app_page_template'
 import { StreamsAppRouterBreadcrumb } from '../components/streams_app_router_breadcrumb';
 import { RedirectTo } from '../components/redirect_to';
 import { StreamManagementDefaultRedirect } from '../components/stream_management_default_redirect';
-import { StreamListView } from '../components/stream_list_view';
+import { StreamsRootRedirect } from '../components/streams_root_redirect';
 import { StreamDetailRoot } from '../components/stream_root';
 import { StreamDetailManagement } from '../components/stream_management/data_management/stream_detail_management';
 import { SignificantEventsAppRedirect } from '../components/significant_events_app_redirect';
@@ -68,7 +68,7 @@ const streamsAppRoutes = {
     ),
     children: {
       '/': {
-        element: <StreamListView />,
+        element: <StreamsRootRedirect />,
         params: t.partial({
           query: timeRangeQueryParams,
         }),


### PR DESCRIPTION
closes https://github.com/elastic/ingest-dev/issues/9111

## Summary

This PR adds a description line below the Streams header in canvas mode. It also makes the Canvas new experience the default navigation for `Streams` when the FF `observability:streamsEnableCanvas` is enabled, and old experience otherwise.

<img width="553" height="123" alt="Screenshot 2026-08-12 at 13 44 43" src="https://github.com/user-attachments/assets/73a0c398-26d9-4457-915d-2e657ff97f51" />


## Testing

1. Set 
```
uiSettings.overrides:
  observability:streamsEnableCanvas: true
```
2. navigate to streams and make sure you see the canvas experience
3. Set the FF back to false and check to validate the old experience becomes the default nav.