### PR TITLE
[Significant events] Fixing the UI for EmptyPrompt

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events_app/public/pages/significant_events/components/knowledge_indicators_table/knowledge_indicators_table.tsx
+++ b/x-pack/platform/plugins/shared/significant_events_app/public/pages/significant_events/components/knowledge_indicators_table/knowledge_indicators_table.tsx
@@ -183,8 +183,8 @@ export function KnowledgeIndicatorsTable() {
   });
 
   const generationRow = (
-    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-      <EuiFlexItem>
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} css={{ width: '100%' }}>
+      <EuiFlexItem css={{ minWidth: 0 }}>
         <StreamPicker
           streams={filteredStreams}
           isStreamsLoading={isStreamsLoading}
@@ -241,7 +241,12 @@ export function KnowledgeIndicatorsTable() {
         color="plain"
         css={css`
           && {
-            max-width: 400px;
+            max-width: 560px;
+          }
+
+          .euiEmptyPrompt__actions {
+            width: 100%;
+            max-width: 100%;
           }
         `}
         icon={<AssetImage type="knowledgeIndicatorsEmptyState" size={140} />}


### PR DESCRIPTION
## Summary

The EmptyPrompt for KIs was broken when making a selection, this is fixing that bug. Small css fixes.

<img width="7848" height="2870" alt="image" src="https://github.com/user-attachments/assets/ffb7e81e-b3f7-4db9-ae2f-03ae9760451c" />

