### PR TITLE
[9.5] [ES|QL] Fix time series context in subqueries (#284576)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/validation.ts
@@ -10,7 +10,8 @@
 import { Parser } from '@elastic/esql';
 import type { ESQLCommand } from '@elastic/esql/types';
 import type { ESQLMessage } from '../../commands/definitions/types';
-import type { ESQLColumnData } from '../../commands/registry/types';
+import type { ICommandContext } from '../../commands/registry/types';
+import { isTimeseriesSourceCommand } from '../../commands/definitions/utils/timeseries_check';
 import { mockContext } from './context_fixtures';
 /**
  * This function is used to assert that a query produces the expected errors.
@@ -25,20 +26,17 @@ export const expectErrors = (
   expectedErrors: string[],
   context = mockContext,
   commandName: string,
-  validate: (
-    arg0: ESQLCommand,
-    arg1: ESQLCommand[],
-    arg2: {
-      columns: Map<string, ESQLColumnData>;
-    }
-  ) => ESQLMessage[]
+  validate: (arg0: ESQLCommand, arg1: ESQLCommand[], arg2: ICommandContext) => ESQLMessage[]
 ) => {
   const { root } = Parser.parse(query);
   const command = root.commands.find((cmd) => cmd.name === commandName.toLowerCase());
   if (!command) {
     throw new Error(`${commandName.toUpperCase()} command not found in the parsed query`);
   }
-  const result = validate(command, root.commands, context);
+  const result = validate(command, root.commands, {
+    ...context,
+    isTimeseriesSource: context.isTimeseriesSource ?? isTimeseriesSourceCommand(root.commands),
+  });
 
   const errors: string[] = [];
   result.forEach((error) => {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/commands.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/commands.ts
@@ -13,7 +13,6 @@ import { validateOption } from './option';
 import { validateColumnForCommand } from './column';
 import { errors } from '../errors';
 import type { ICommandCallbacks, ICommandContext } from '../../../registry/types';
-import { isTimeseriesSourceCommand } from '../timeseries_check';
 import { validateInlineCasts } from './inline_cast';
 import type { ESQLMessage } from '../../types';
 
@@ -43,7 +42,7 @@ export const validateCommandArguments = (
       } else if (isColumn(arg) || isIdentifier(arg)) {
         if (command.name === 'stats' || command.name === 'inline stats') {
           // In TS context, bare fields are allowed in STATS (implicitly aggregated)
-          if (!isTimeseriesSourceCommand(ast)) {
+          if (!context.isTimeseriesSource) {
             messages.push(errors.unknownAggFunction(arg));
           }
         } else {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/function.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/function.ts
@@ -27,7 +27,6 @@ import { errors, getFunctionDefinition } from '..';
 import { isTypeConversionFunction } from '../functions';
 import { FunctionDefinitionTypes } from '../../../../..';
 import { getLocationInfo } from '../../../registry/location';
-import { isTimeseriesSourceCommand } from '../timeseries_check';
 import { Location } from '../../../registry/types';
 import type { ICommandCallbacks, ICommandContext } from '../../../registry/types';
 import type {
@@ -123,7 +122,7 @@ class FunctionValidator {
     // Return early so the source-incompatibility error takes priority over the generic
     // "not allowed here" check below — the location may technically match, but the function
     // is invalid regardless because the pipeline source is TS.
-    if (isTimeseriesSourceCommand(this.ast) && this.definition.tsdbCompatible === false) {
+    if (this.isTimeseriesSource && this.definition.tsdbCompatible === false) {
       this.report(errors.tsdbIncompatibleFunction(this.fn));
       return;
     }
@@ -311,7 +310,7 @@ class FunctionValidator {
     if (
       this.definition?.locationsAvailable.includes(Location.STATS_TIMESERIES) &&
       locationId === Location.STATS &&
-      isTimeseriesSourceCommand(this.ast)
+      this.isTimeseriesSource
     ) {
       return true;
     }
@@ -319,11 +318,21 @@ class FunctionValidator {
     return false;
   }
 
+  /** Whether the function belongs to a TS pipeline. */
+  private get isTimeseriesSource(): boolean {
+    return this.context.isTimeseriesSource === true;
+  }
+
   /**
    * Gets information about the location of the current function
    */
   private get location(): { displayName: string; id: Location } {
-    return getLocationInfo(this.fn, this.parentCommand, this.ast, !!this.parentAggFunction);
+    return getLocationInfo(
+      this.fn,
+      this.parentCommand,
+      this.isTimeseriesSource,
+      !!this.parentAggFunction
+    );
   }
 
   /**

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/location.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/location.ts
@@ -9,9 +9,8 @@
 
 import { isFunctionExpression, isOptionNode } from '@elastic/esql';
 import { within, Walker } from '@elastic/esql';
-import type { ESQLAst, ESQLAstAllCommands, ESQLSingleAstItem } from '@elastic/esql/types';
+import type { ESQLAstAllCommands, ESQLSingleAstItem } from '@elastic/esql/types';
 import { Location } from './types';
-import { isTimeseriesSourceCommand } from '../definitions/utils/timeseries_check';
 
 const commandOptionNameToLocation: Record<string, Location> = {
   eval: Location.EVAL,
@@ -68,10 +67,10 @@ export const getLocationFromCommandOrOptionName = (name: string) =>
 export function getLocationInfo(
   position: ESQLSingleAstItem | number,
   parentCommand: ESQLAstAllCommands,
-  ast: ESQLAst,
+  isTimeseriesSource: boolean,
   withinAggFunction: boolean
 ): { id: Location; displayName: string } {
-  if (withinAggFunction && isTimeseriesSourceCommand(ast)) {
+  if (withinAggFunction && isTimeseriesSource) {
     return {
       id: Location.STATS_TIMESERIES,
       displayName: 'agg_function_in_timeseries_context',

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.test.ts
@@ -117,6 +117,8 @@ const statsExpectSuggestions = (
   );
 };
 
+const timeseriesContext = { ...mockContext, isTimeseriesSource: true };
+
 describe('STATS Autocomplete', () => {
   let mockCallbacks: ICommandCallbacks;
   beforeEach(() => {
@@ -127,13 +129,13 @@ describe('STATS Autocomplete', () => {
     (mockCallbacks.getColumnsForQuery as jest.Mock).mockResolvedValue([...lookupIndexFields]);
   });
 
-  const suggest = async (query: string) => {
+  const suggest = async (query: string, context = mockContext) => {
     const cursorPosition = query.length;
     const { innerText, root, command, tokens } = findAutocompleteAstPosition(query, cursorPosition);
     if (!command) {
       throw new Error('Command not found in the parsed query');
     }
-    const contextWithRoot = { ...mockContext, rootAst: root };
+    const contextWithRoot = { ...context, rootAst: root };
     const suggestions = await autocomplete(
       query,
       command,
@@ -360,7 +362,8 @@ describe('STATS Autocomplete', () => {
             ),
             'FUNC($0)',
           ],
-          mockCallbacks
+          mockCallbacks,
+          timeseriesContext
         );
         await statsExpectSuggestions(
           'from a | stats round(avg(',
@@ -925,7 +928,7 @@ describe('STATS Autocomplete', () => {
         test('suggests TBUCKET for TS source command', async () => {
           const expectedCompletionItem = getTimeseriesDateHistogramCompletionItem(50);
 
-          const suggestions = await suggest('TS a | STATS BY ');
+          const suggestions = await suggest('TS a | STATS BY ', timeseriesContext);
 
           expect(suggestions).toContainEqual(expect.objectContaining(expectedCompletionItem));
           expect(suggestions).not.toContainEqual(

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/autocomplete.ts
@@ -70,7 +70,7 @@ export async function autocomplete(
     return [];
   }
   const isInlineStats = command.name === 'inline stats';
-  const isTimeseriesSource = query.trimStart().toLowerCase().startsWith('ts ');
+  const isTimeseriesSource = context?.isTimeseriesSource;
 
   const columnExists = (name: string) => _columnExists(name, context);
 

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.tsdb_compatible.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.tsdb_compatible.test.ts
@@ -48,3 +48,24 @@ describe('tsdbCompatible filtering', () => {
     expect(suggestions).toContain('TS_COMPATIBLE_AGG');
   });
 });
+
+describe('time series source context', () => {
+  it.each([
+    'FROM (TS index | STATS AVG(/))',
+    'FROM index | WHERE 6.9 IN (TS index | STATS AVG(/))',
+  ])('suggests time series aggregations inside a TS subquery: %s', async (query) => {
+    const { suggest } = await setup();
+    const suggestions = (await suggest(query)).map((s) => s.label);
+
+    expect(suggestions).toContain('AVG_OVER_TIME');
+  });
+
+  it('does not suggest time series aggregations inside a non-TS subquery of a TS query', async () => {
+    const { suggest } = await setup();
+    const suggestions = (await suggest('TS index | WHERE 6.9 IN (FROM index | STATS AVG(/))')).map(
+      (s) => s.label
+    );
+
+    expect(suggestions).not.toContain('AVG_OVER_TIME');
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
@@ -9,13 +9,7 @@
 import { ControlTriggerSource, ESQLVariableType, type ESQLCallbacks } from '@kbn/esql-types';
 import type { LicenseType } from '@kbn/licensing-types';
 import { EsqlQuery, isHeaderCommand, Walker } from '@elastic/esql';
-import type {
-  ESQLColumn,
-  ESQLAstItem,
-  ESQLCommandOption,
-  ESQLFunction,
-  ESQLAstAllCommands,
-} from '@elastic/esql/types';
+import type { ESQLColumn, ESQLCommandOption, ESQLAstAllCommands } from '@elastic/esql/types';
 import { esqlCommandRegistry } from '../../commands';
 import { getCommandAutocompleteDefinitions } from '../../commands/registry/complete_items';
 import { SuggestionOrderingEngine } from './utils';
@@ -229,7 +223,7 @@ export async function suggest(
       return columnMapPromise;
     };
 
-    const commands = [...(root.header ?? []), ...root.commands];
+    const commands = [...(root.header ?? []), ...astContext.astForContext.commands];
     const commandsSpecificSuggestions = await getSuggestionsWithinCommandExpression(
       fullText,
       commands,
@@ -263,9 +257,7 @@ async function getSuggestionsWithinCommandExpression(
   commands: ESQLAstAllCommands[],
   astContext: {
     command: ESQLAstAllCommands;
-    node?: ESQLAstItem;
     option?: ESQLCommandOption;
-    containingFunction?: ESQLFunction;
     isCursorInSubquery: boolean;
   },
   getColumnsByType: GetColumnsByTypeFn,

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/subqueries_suite.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/subqueries_suite.ts
@@ -62,6 +62,12 @@ export const runSubqueriesValidationSuite = (setup: Setup) => {
           ['"inference_id" parameter is required for RERANK.']
         );
       });
+
+      it('validates time series functions against the FROM subquery source', async () => {
+        const { expectErrors } = await setup();
+
+        await expectErrors('FROM (TS a_index | STATS col0 = AVG(AVG_OVER_TIME(doubleField)))', []);
+      });
     });
 
     describe('WHERE IN subqueries', () => {
@@ -71,6 +77,20 @@ export const runSubqueriesValidationSuite = (setup: Setup) => {
         await expectErrors(
           'FROM index | WHERE keywordField IN (FROM other_index | KEEP keywordField)',
           []
+        );
+      });
+
+      it('validates time series functions against the IN subquery source', async () => {
+        const { expectErrors } = await setup();
+
+        await expectErrors(
+          'FROM index | WHERE 6.9 IN (TS a_index | STATS col0 = AVG(AVG_OVER_TIME(doubleField)) | KEEP col0)',
+          []
+        );
+
+        await expectErrors(
+          'TS a_index | WHERE 6.9 IN (FROM index | STATS col0 = AVG(AVG_OVER_TIME(doubleField)) | KEEP col0)',
+          ['Function AVG_OVER_TIME not allowed in STATS']
         );
       });
 

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/validation.ts
@@ -20,6 +20,7 @@ import { retrievePolicies, retrieveSources } from './resources';
 import type { ReferenceMaps, ValidationOptions, ValidationResult } from './types';
 import { getSubqueriesToValidate } from './subqueries';
 import { getUnmappedFieldsStrategy } from '../../commands/definitions/utils/settings';
+import { isTimeseriesSourceCommand } from '../../commands/definitions/utils/timeseries_check';
 import { areNewUnmappedFieldsAllowed } from '../../query_columns_service/helpers';
 import type { ESQLMessage } from '../../commands';
 
@@ -92,6 +93,8 @@ async function validateAst(
     ? (minimumLicenseRequired: LicenseType) => license.hasAtLeast(minimumLicenseRequired)
     : undefined;
 
+  const isRootTimeseries = isTimeseriesSourceCommand(rootCommands);
+
   // Validate the header commands
   for (const command of headerCommands) {
     const references: ReferenceMaps = {
@@ -105,7 +108,7 @@ async function validateAst(
       datasets: datasets?.datasets ?? [],
     };
 
-    const commandMessages = validateCommand(command, references, rootCommands, {
+    const commandMessages = validateCommand(command, references, rootCommands, isRootTimeseries, {
       ...callbacks,
       hasMinimumLicenseRequired,
     });
@@ -157,6 +160,7 @@ async function validateAst(
       currentCommand,
       references,
       rootCommands,
+      isTimeseriesSourceCommand(subquery.commands),
       {
         ...callbacks,
         hasMinimumLicenseRequired,
@@ -189,6 +193,7 @@ function validateCommand(
   command: ESQLAstAllCommands,
   references: ReferenceMaps,
   rootCommands: ESQLCommand[],
+  isTimeseriesSource: boolean,
   callbacks?: ICommandCallbacks,
   unmappedFieldsStrategy?: UnmappedFieldsStrategy
 ): ESQLMessage[] {
@@ -230,6 +235,7 @@ function validateCommand(
     views: references.views,
     datasets: references.datasets,
     unmappedFieldsStrategy,
+    isTimeseriesSource,
   };
 
   if (commandDefinition.methods.validate) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[ES|QL] Fix time series context in subqueries (#284576)](https://github.com/elastic/kibana/pull/284576)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Valerio","email":"79913332+bartoval@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-12T10:53:26Z","message":"[ES|QL] Fix time series context in subqueries (#284576)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/284597\n\n- Derive the time-series context from the pipeline containing the\ncurrent command.\n- Reuse `CommandContext.isTimeseriesSource` in autocomplete and\nvalidation.\n- Preserve the root AST passed to command validators.\n- Cover `FROM `and `WHERE IN` subqueries with mixed `FROM/TS` sources.\n\n\n\nhttps://github.com/user-attachments/assets/4f2d425d-f66c-489d-b626-b50f19c5cafd","sha":"59617c0203288edf7b29f39e27943a6eeaf1fe74","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ESQL","backport:version","v9.5.0","v9.6.0"],"title":"[ES|QL] Fix time series context in subqueries","number":284576,"url":"https://github.com/elastic/kibana/pull/284576","mergeCommit":{"message":"[ES|QL] Fix time series context in subqueries (#284576)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/284597\n\n- Derive the time-series context from the pipeline containing the\ncurrent command.\n- Reuse `CommandContext.isTimeseriesSource` in autocomplete and\nvalidation.\n- Preserve the root AST passed to command validators.\n- Cover `FROM `and `WHERE IN` subqueries with mixed `FROM/TS` sources.\n\n\n\nhttps://github.com/user-attachments/assets/4f2d425d-f66c-489d-b626-b50f19c5cafd","sha":"59617c0203288edf7b29f39e27943a6eeaf1fe74"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284576","number":284576,"mergeCommit":{"message":"[ES|QL] Fix time series context in subqueries (#284576)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/284597\n\n- Derive the time-series context from the pipeline containing the\ncurrent command.\n- Reuse `CommandContext.isTimeseriesSource` in autocomplete and\nvalidation.\n- Preserve the root AST passed to command validators.\n- Cover `FROM `and `WHERE IN` subqueries with mixed `FROM/TS` sources.\n\n\n\nhttps://github.com/user-attachments/assets/4f2d425d-f66c-489d-b626-b50f19c5cafd","sha":"59617c0203288edf7b29f39e27943a6eeaf1fe74"}}]}] BACKPORT-->