### PR TITLE
[Agent Builder] Fix SkillInvoked evaluator matching a retired tool name

### DIFF
--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-persona-matrix/src/evaluate_dataset.test.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-persona-matrix/src/evaluate_dataset.test.ts
@@ -235,6 +235,32 @@ describe('createPersonaMatrixSkillInvokedEvaluator', () => {
     expect(result.score).toBeNull();
     expect(result.label).toBe('unavailable');
   });
+
+  it('matches the load_skill tool, not just the retired filestore.read', async () => {
+    // Regression guard. The agent loads skills via the `load_skill` tool:
+    //   {"skill":"/skills/<category>/<name>/SKILL.md"}
+    // A predicate pinned to `filestore.read` can never match, so `skill_invoked`
+    // stays 0 while `total_tool_spans` is non-zero -- meaning the "unavailable"
+    // guard does NOT trip and the evaluator reports a confident false 0 for
+    // every model. Verified against the golden cluster: over 7 days,
+    // filestore.read = 0 spans, load_skill = 7,991 spans.
+    const query = jest.fn().mockResolvedValue({
+      columns: [{ name: 'total_tool_spans' }, { name: 'skill_invoked' }],
+      values: [[2, 1]],
+    });
+    const evaluator = createPersonaMatrixSkillInvokedEvaluator({
+      traceEsClient: { esql: { query } } as unknown as EsClient,
+      log: buildLog(),
+    });
+
+    const result = await evaluator.evaluate(
+      buildEvaluatorArgs(baseExample.metadata, '0af7651916cd43dd8448eb211c80319c')
+    );
+
+    const sent = query.mock.calls[0][0].query as string;
+    expect(sent).toContain('load_skill');
+    expect(result.score).toBe(1);
+  });
 });
 
 describe('task output shape', () => {

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-persona-matrix/src/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-persona-matrix/src/evaluate_dataset.ts
@@ -205,7 +205,7 @@ export const createPersonaMatrixSkillInvokedEvaluator = ({
   ),
   skill_invoked = COUNT(
     CASE(
-      attributes.gen_ai.tool.name == "filestore.read" AND (${skillPredicate}),
+      attributes.gen_ai.tool.name IN ("load_skill", "filestore.read") AND (${skillPredicate}),
       1,
       NULL
     )


### PR DESCRIPTION
## Summary

The persona-matrix `SkillInvoked` evaluator matched only
`attributes.gen_ai.tool.name == "filestore.read"`, but the agent loads skills
via the `load_skill` tool. Verified against the golden cluster over a 7-day
window:

| tool name | spans (7d) |
| --- | --- |
| `filestore.read` | 0 |
| `load_skill` | 7,991 |

Because `total_tool_spans` is still non-zero for these traces, the existing
"no tool spans → `unavailable`" guard does not trip. The evaluator therefore
returned a confident `score: 0` instead of `null` — silently zeroing the
**Skill Invoked** column for every model in every persona-matrix run, not just
for one model.

This surfaced while generating a matrix column for a model that appeared to
never route into any skill. Trace data showed the opposite: it invoked
`load_skill` and called security skills directly. The reported zero was a
measurement artifact, not a model capability result.

## Why only the tool name changed

`load_skill` arguments carry the same `SKILL.md` path the existing predicate
already matches:

```json
{"skill":"/skills/platform/evals/eval-experiment-authoring/SKILL.md"}
```

so only the tool-name check needed widening. No dataset annotations change.
`filestore.read` is retained for backwards compatibility with older traces.

## Verification

Same-trace baseline on real golden-cluster data, holding the trace and skill
predicate fixed and varying only the tool name:

```
OLD (filestore.read only)   total_tool_spans=2  skill_invoked=0
NEW (load_skill accepted)   total_tool_spans=2  skill_invoked=1
```

The added regression test asserts the generated ES|QL includes `load_skill`.
It was confirmed to fail on the pre-fix predicate by reverting the one-line
change and re-running (`1 failed, 13 skipped`), then pass after restoring.

Local gates:

```
tsc     : exited with 0
eslint  : no eslint errors found
jest    : 14 passed, 14 total
```

## Note for reviewers

This changes what the Skill Invoked column reports for **all** models. Existing
persona-matrix results showing `SkillInvoked = 0` should be treated as
unreliable and regenerated rather than compared against post-fix runs.

## Relationship to #283586

This fix is also cherry-picked onto #283586 (`feat/evals-extensions-matrix`), which
generates the security LLM performance matrix, so that PR's generated matrix does not
ship a Skill Invoked column built from the pre-fix predicate. This PR is the standalone
version, based directly on `main`, and can merge independently in either order.
