### PR TITLE
[Security Solution] Stub getActionForm in flaky EditForm schedule test

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/edit_form/edit_form.test.tsx
@@ -133,6 +133,19 @@ describe('EditForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    // Stub the heavy `triggers_actions_ui` ActionForm that `RuleActionsField`
+    // mounts via `getActionForm` -> `getActionFormLazy` (a `React.lazy`/`Suspense`
+    // subtree). Its first render pays a large one-time lazy-import cost and its
+    // connector/action-type loads never settle under jsdom, which was the
+    // dominant remaining cost that tripped Jest's 5s per-test timeout in CI (see
+    // https://github.com/elastic/kibana/issues/255131). Unlike the sibling
+    // `create_flyout` suite, we cannot blanket-stub `RuleActionsField` here
+    // because tests below assert that `getActionForm` is invoked with specific
+    // props, so we keep `RuleActionsField` live and stub `getActionForm` itself.
+    mockTriggersActionsUi.getActionForm = jest
+      .fn()
+      .mockReturnValue(<div data-test-subj="mockActionForm" />);
+
     mockUseKibana.mockReturnValue({
       services: {
         featureFlags: {
@@ -225,7 +238,7 @@ describe('EditForm', () => {
     await renderComponent();
 
     await waitFor(() => {
-      expect(screen.getByText('Select a connector type')).toBeInTheDocument();
+      expect(screen.getByTestId('mockActionForm')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #283974. Addresses the flakiness reported in #255131 (**not** closing that issue — leaving it open to confirm the fix holds across CI runs).

The `EditForm` schedule Jest suite intermittently trips Jest's 5s per-test timeout on CI (`EditForm should return the schedule editing form`). #282670 already un-skipped the suite by stubbing the heavy `AlertSelection` subtree, but the first test was still slow (~1.2 s locally, slow-test flagged) and the suite kept failing on CI as recently as this week.

The remaining dominant cost is the same heavy subtree #283974 fixed in the sibling `create_flyout` suite — the real `triggers_actions_ui` `ActionForm`, mounted through the actions field:

```
EditForm → RuleActionsField → triggersActionsUi.getActionForm() → getActionFormLazy (React.lazy + Suspense)
```

`triggersActionsUiMock.createStart().getActionForm` delegates to the **real** `getActionFormLazy`, so the mock does not actually spare the test the cost. Two things make it expensive/flaky under jsdom:

1. **First-time lazy mount** — `getActionFormLazy` dynamically imports a large module subtree; the first render in the file pays that one-time cost, attributed to the first `it()` (hence "first test slow, rest fast").
2. **Never-settling async** — `ActionForm` fires connector/action-type loads that never settle in jsdom, which under CI worker contention pushes the render past the 5 s per-test timeout.

Unlike `create_flyout`, this suite can't blanket-stub `RuleActionsField`: two tests assert that `getActionForm` is invoked with specific props (`defaultRuleFrequency`). So this PR keeps `RuleActionsField` live and applies the lighter `getActionForm` stub anticipated in #283974's notes.

## Results (local, `--no-cache`, Node 24.19)

| Config | First test | Slow-test flag |
|---|---|---|
| main (`AlertSelection` stub only) | ~1.2 s | yes |
| this PR (`+ getActionForm` stub) | < 300 ms | no |

## Notes

- `should return the actions field in the schedule editing form` previously matched the real form's "Select a connector type" text; it now asserts the stub's `data-test-subj`. The test only ever verified that the actions section rendered — connector-form behavior is covered by `triggers_actions_ui`'s own tests.
- Stubbing `getActionForm` per-test in `beforeEach` also removes a latent test-ordering leak (one test permanently reassigned `getActionForm` for the rest of the suite).

## Verification

- ✅ `node scripts/jest .../schedule/edit_form/edit_form.test.tsx` — 10/10 pass, no slow-test flag (3 consecutive runs)
- ✅ `node scripts/eslint .../schedule/edit_form/edit_form.test.tsx` — no errors
- ⚠️ `node scripts/type_check` for `security_solution` OOMs locally (as noted in #283073); change is test-only and the stub mirrors the existing `getActionForm = jest.fn()` pattern already in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->