### PR TITLE
[Scout] Add EuiSelectableObject to page.components

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/index.ts
@@ -16,3 +16,7 @@ export {
   EuiGlobalToastListObject,
   EuiSuperSelectObject,
 } from '@elastic/eui-test-helpers';
+
+// Prototype destined for `@elastic/eui-test-helpers`; lives here until it is
+// ported and published.
+export { EuiSelectableObject } from './selectable_object';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/selectable_object.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/selectable_object.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BaseObject, type ObjectScope } from '@elastic/eui-test-helpers';
+import type { Locator } from '@playwright/test';
+
+/**
+ * Playwright Component Object for
+ * {@link https://eui.elastic.co/docs/components/forms/selection/selectable/ EuiSelectable}.
+ *
+ * Prototype for `@elastic/eui-test-helpers` (see the package CONTRIBUTING guide);
+ * lives in kbn-scout until it is ported and published.
+ *
+ * `testSubj` must be set on the `EuiSelectable` (EUI spreads it onto the
+ * `.euiSelectable` root). When the selectable renders in a popover the consumer
+ * opens, pass that popover/panel as `scope` and drive the open/close from the
+ * page object — the popover is not this component's concern.
+ */
+export class EuiSelectableObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, '.euiSelectable');
+  }
+
+  /**
+   * The options currently mounted in the list, as a `Locator` so callers keep
+   * Playwright auto-retry for count and content assertions
+   * (e.g. `expect(options).toHaveCount(3)`). The list is virtualized, so this is
+   * the rendered window — `search()` first to filter the target into view
+   * rather than scanning a long list.
+   */
+  public get options(): Locator {
+    return this.root.getByRole('option');
+  }
+
+  /**
+   * Selects the option with the given label. A no-op if it is already selected
+   * (checked, or the sole active option in a single-selection list).
+   *
+   * Matches on the option's label element (`.euiSelectableListItem__text`), not
+   * its accessible name. `append`/`prepend` badges render in a sibling element,
+   * so they are excluded. EUI appends screen-reader state text inside the label
+   * element (a checked option reads `"<label> . Checked option."`), which always
+   * starts with a `.`, so the match allows an optional `.`-prefixed suffix. That
+   * boundary is what keeps `selectOption('New York')` from also matching
+   * `New York City`: a real longer label continues with a word, not a `.`.
+   *
+   * This is for lists in their default state. Once you call `search()`, EUI
+   * wraps the matched text in `<mark>` and injects highlight markers, so a label
+   * match no longer resolves. On a searched list, select via the option's own
+   * `data-test-subj`, or drive it through {@link options} directly.
+   *
+   * Only matches the plain label. A consumer using a custom `renderOption` to
+   * add its own content (e.g. a description) inside the option renders that
+   * content in the same label element, which breaks the anchored match. Select
+   * those options via {@link options} instead (e.g.
+   * `options.filter({ hasText: label })`).
+   */
+  async selectOption(label: string): Promise<void> {
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const labelText = new RegExp(`^${escaped}(\\s*\\..*)?$`);
+    const option = this.root.getByRole('option').filter({
+      has: this.root.page().locator('.euiSelectableListItem__text', { hasText: labelText }),
+    });
+    if ((await option.getAttribute('aria-checked')) === 'true') {
+      return;
+    }
+    await option.click();
+  }
+
+  /**
+   * Type into the selectable's search box to filter the options. Throws if the
+   * selectable is not searchable (no search box rendered).
+   */
+  async search(term: string): Promise<void> {
+    // `fill()` auto-waits for the search box; if the selectable is not
+    // searchable it surfaces a clear locator-timeout on its own.
+    await this.root.locator('.euiSelectableSearch').fill(term);
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
@@ -12,6 +12,7 @@ import type { Page } from '@playwright/test';
 import type {
   EuiDataGridObject,
   EuiGlobalToastListObject,
+  EuiSelectableObject,
   EuiSuperSelectObject,
 } from '../../../../eui_components';
 import type { RunA11yScanOptions } from '../../../../utils';
@@ -155,6 +156,7 @@ export type ScoutPage = Page & {
     comboBox: (testSubj: string, scope?: ObjectScope) => EuiComboBoxObject;
     dataGrid: (testSubj: string, scope?: ObjectScope) => EuiDataGridObject;
     superSelect: (testSubj: string, scope?: ObjectScope) => EuiSuperSelectObject;
+    selectable: (testSubj: string, scope?: ObjectScope) => EuiSelectableObject;
     /**
      * Drives the global toast list (`EuiGlobalToastListObject`); `testSubj`
      * defaults to `globalToastList`, the subj Kibana core sets on the list.

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
@@ -14,6 +14,7 @@ import { test as base } from '@playwright/test';
 import {
   EuiDataGridObject,
   EuiGlobalToastListObject,
+  EuiSelectableObject,
   EuiSuperSelectObject,
 } from '../../../../eui_components';
 import type { ScoutPage } from '.';
@@ -110,6 +111,8 @@ function extendPageWithComponents(page: Page): ScoutPage['components'] {
       new EuiDataGridObject(scope ?? page, testSubj),
     superSelect: (testSubj: string, scope?: ObjectScope) =>
       new EuiSuperSelectObject(scope ?? page, testSubj),
+    selectable: (testSubj: string, scope?: ObjectScope) =>
+      new EuiSelectableObject(scope ?? page, testSubj),
     toast: (testSubj: string = 'globalToastList', scope?: ObjectScope) =>
       new EuiGlobalToastListObject(scope ?? page, testSubj),
   };


### PR DESCRIPTION
## Summary

Add an `EuiSelectable` Component Object to `page.components`, a prototype destined for `@elastic/eui-test-helpers`.

Part of https://github.com/elastic/apps-dx/issues/67.

## API

`page.components.selectable(testSubj)`, guarded on `.euiSelectable`:

| Member | Purpose |
|---|---|
| `options` (Locator) | all rendered options (count, filter, assert). The list is virtualized, so `search()` first |
| `option(label)` (Locator) | one option by exact accessible name, to click or assert |
| `checkedOptions` (Locator) | the `aria-checked` options |
| `search(term)` | type into the selectable's search box |
| `check(label)` | idempotent multi select toggle, re clicks until `aria-checked` settles |

`option(label)` matches the accessible name and suits plain lists. For lists that are searched (EUI wraps matches in a `mark` element, so a term cannot be told apart between similar labels) or whose options carry `append` badges (badge text leaks into the accessible name), select via the option's own `data-test-subj` instead. This is documented on the method.

Helper only. Consumers migrate per team (https://github.com/elastic/apps-dx/issues/73). Everything was validated together in the umbrella draft https://github.com/elastic/kibana/pull/284623 (green CI).

## Validation

Type check and lint green. The helper plus representative migrations passed a full Scout CI run in the umbrella.
