### PR TITLE
Bump undici 6.x to 6.28.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -33470,9 +33470,9 @@ undici@7.29.0, undici@^7.19.1:
   integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 undici@^6.21.1, undici@^6.21.2:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unherit@^1.0.4:
   version "1.1.0"


### PR DESCRIPTION
## Summary

Bumps the transitive **undici 6.x** copy from `6.27.0` → `6.28.0`. This is a lockfile-only change — undici 6.x is pulled in transitively (`^6.21.1` / `^6.21.2`, via `@elastic/transport` / `@elastic/opentelemetry`), and `6.28.0` satisfies those ranges, so there is no `package.json` edit.

The **7.x** copy is already at `7.29.0` on `main`, so this completes the undici remediation on `main` (both slots now on non-vulnerable versions).


<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->