### PR TITLE
[Context Engine] POC: Verify KI custom workflow step

### DIFF
--- a/x-pack/platform/plugins/shared/context_engine/common/step_types/verify_ki.ts
+++ b/x-pack/platform/plugins/shared/context_engine/common/step_types/verify_ki.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
+import { StepCategory } from '@kbn/workflows';
+import { i18n } from '@kbn/i18n';
+
+/** Step type ID for the Verify KI workflow step. */
+export const VerifyKiStepTypeId = 'context-engine.verifyKi';
+
+export const InputSchema = z.object({
+  index: z
+    .string()
+    .min(1)
+    .max(1024)
+    .describe('Index or alias containing the Knowledge Indicators to verify'),
+  size: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe('Maximum number of KIs to fetch (defaults to 10)'),
+});
+
+export const OutputSchema = z.object({
+  total: z.number(),
+  passed: z.number(),
+  failed: z.number(),
+  results: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string().optional(),
+      passed: z.boolean(),
+      verifierResults: z.array(
+        z.object({
+          verifier: z.string(),
+          passed: z.boolean(),
+          reason: z.string().optional(),
+        })
+      ),
+    })
+  ),
+});
+
+export const ConfigSchema = z.object({
+  verifiers: z
+    .array(z.string().max(256))
+    .max(100)
+    .optional()
+    .describe('Verifier ids to run; omit to run all registered verifiers'),
+});
+
+export type VerifyKiStepInputSchema = typeof InputSchema;
+export type VerifyKiStepOutputSchema = typeof OutputSchema;
+export type VerifyKiStepOutput = z.infer<typeof OutputSchema>;
+
+export const verifyKiStepCommonDefinition: CommonStepDefinition<
+  VerifyKiStepInputSchema,
+  VerifyKiStepOutputSchema,
+  typeof ConfigSchema
+> = {
+  id: VerifyKiStepTypeId,
+  category: StepCategory.Kibana,
+  label: i18n.translate('xpack.contextEngine.verifyKiStep.label', {
+    defaultMessage: 'Verify KI',
+  }),
+  description: i18n.translate('xpack.contextEngine.verifyKiStep.description', {
+    defaultMessage: 'Runs Knowledge Indicator verifiers against KIs in an index',
+  }),
+  documentation: {
+    details: i18n.translate('xpack.contextEngine.verifyKiStep.documentation.details', {
+      defaultMessage:
+        'Fetches Knowledge Indicators from the given index and runs the selected Context Engine verifiers against each one, returning a pass/fail summary per KI.',
+    }),
+    examples: [
+      `## Verify KIs with all registered verifiers
+\`\`\`yaml
+- name: verify_kis
+  type: ${VerifyKiStepTypeId}
+  with:
+    index: "my-ai-index"
+\`\`\``,
+      `## Run selected verifiers against up to 50 KIs
+\`\`\`yaml
+- name: verify_kis
+  type: ${VerifyKiStepTypeId}
+  verifiers:
+    - has-title
+    - min-content
+  with:
+    index: "my-ai-index"
+    size: 50
+\`\`\``,
+    ],
+  },
+  inputSchema: InputSchema,
+  outputSchema: OutputSchema,
+  configSchema: ConfigSchema,
+};

--- a/x-pack/platform/plugins/shared/context_engine/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/context_engine/kibana.jsonc
@@ -8,7 +8,7 @@
     "id": "contextEngine",
     "server": true,
     "browser": true,
-    "requiredPlugins": ["actions", "data", "features", "share", "esql", "triggersActionsUi", "taskManager"],
+    "requiredPlugins": ["actions", "data", "features", "share", "esql", "triggersActionsUi", "taskManager", "workflowsExtensions"],
     "optionalPlugins": ["console", "spaces", "workflowsManagement"],
     "requiredBundles": ["kibanaReact", "actions"]
   }

--- a/x-pack/platform/plugins/shared/context_engine/public/eui_icons.d.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/eui_icons.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+declare module '@elastic/eui/es/components/icon/assets/*' {
+  import type * as React from 'react';
+  import type { SVGProps } from 'react';
+  interface SVGRProps {
+    title?: string;
+    titleId?: string;
+  }
+  export const icon: ({
+    title,
+    titleId,
+    ...props
+  }: SVGProps<SVGSVGElement> & SVGRProps) => React.JSX.Element;
+  export {};
+}

--- a/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/plugin.ts
@@ -20,6 +20,7 @@ import { i18n } from '@kbn/i18n';
 import { CONTEXT_ENGINE_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
 import { from, map, switchMap } from 'rxjs';
 import { CONTEXT_ENGINE_APP_ID, CONTEXT_ENGINE_APP_PATH } from '../common/features';
+import { registerStepDefinitions } from './step_types';
 import type {
   ChatOpener,
   ContextEnginePluginSetup,
@@ -56,8 +57,14 @@ export class ContextEnginePlugin
 
   constructor(_context: PluginInitializerContext) {}
 
-  setup(core: CoreSetup<ContextEngineStartDependencies>): ContextEnginePluginSetup {
+  setup(
+    core: CoreSetup<ContextEngineStartDependencies>,
+    setupDeps: ContextEngineSetupDependencies
+  ): ContextEnginePluginSetup {
     const startServices = core.getStartServices();
+
+    registerStepDefinitions(setupDeps.workflowsExtensions);
+
     // Captured in a closure so `mount` (where `this` is the app config) can read the opener
     // registered on `start`.
     const getChatOpener = () => this.chatOpener;

--- a/x-pack/platform/plugins/shared/context_engine/public/step_types/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/step_types/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+
+export const registerStepDefinitions = (
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup
+): void => {
+  workflowsExtensions.registerStepDefinition(() =>
+    import('./verify_ki').then((module) => module.verifyKiStepDefinition)
+  );
+};

--- a/x-pack/platform/plugins/shared/context_engine/public/step_types/verify_ki.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/step_types/verify_ki.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { createPublicStepDefinition } from '@kbn/workflows-extensions/public';
+import { verifyKiStepCommonDefinition } from '../../common/step_types/verify_ki';
+
+export const verifyKiStepDefinition = createPublicStepDefinition({
+  ...verifyKiStepCommonDefinition,
+  icon: React.lazy(() =>
+    import('@elastic/eui/es/components/icon/assets/check_circle').then(({ icon }) => ({
+      default: icon,
+    }))
+  ),
+});

--- a/x-pack/platform/plugins/shared/context_engine/public/types.ts
+++ b/x-pack/platform/plugins/shared/context_engine/public/types.ts
@@ -10,6 +10,7 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
+import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
 import type { AiIndexHttpItem } from '../common/http_api/ai_indices';
 
 /**
@@ -38,8 +39,9 @@ export interface ContextEnginePluginStart {
   registerChatOpener: (opener: ChatOpener) => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ContextEngineSetupDependencies {}
+export interface ContextEngineSetupDependencies {
+  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup;
+}
 
 export interface ContextEngineStartDependencies {
   data: DataPublicPluginStart;

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/index.ts
@@ -16,3 +16,4 @@ export type {
 } from './types';
 export { KiVerifierRegistry } from './registry';
 export { KiVerificationService } from './service';
+export { pocVerifiers } from './poc_verifiers';

--- a/x-pack/platform/plugins/shared/context_engine/server/ki_verification/poc_verifiers.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/ki_verification/poc_verifiers.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KiVerifier } from './types';
+
+const MIN_CONTENT_LENGTH = 20;
+
+/**
+ * POC verifiers so the Verify KI workflow step has real checks to run; replace with production
+ * verifiers as they land.
+ */
+export const pocVerifiers: KiVerifier[] = [
+  {
+    id: 'has-title',
+    applies: () => true,
+    verify: async (ki) =>
+      ki.title?.trim() ? { passed: true } : { passed: false, reason: 'KI has no title' },
+  },
+  {
+    id: 'min-content',
+    applies: (ki) => ki.content !== undefined,
+    verify: async (ki) =>
+      (ki.content ?? '').trim().length >= MIN_CONTENT_LENGTH
+        ? { passed: true }
+        : {
+            passed: false,
+            reason: `KI content is shorter than ${MIN_CONTENT_LENGTH} characters`,
+          },
+  },
+];

--- a/x-pack/platform/plugins/shared/context_engine/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/plugin.ts
@@ -31,6 +31,8 @@ import { AiIndexRegistry } from './ai_indices/registry';
 import { SignalsService } from './signals/service';
 import type { SignalsServiceApi } from './signals/service';
 import { registerSignalGeneratorTaskDefinition, scheduleSignalGenerator } from './tasks';
+import { KiVerifierRegistry, pocVerifiers } from './ki_verification';
+import { registerStepDefinitions } from './step_types';
 
 export class ContextEnginePlugin
   implements
@@ -47,6 +49,7 @@ export class ContextEnginePlugin
   private esClient?: ElasticsearchClient;
   private isFeedbackLoopEnabled: () => Promise<boolean> = async () => false;
   private readonly aiIndexRegistry = new AiIndexRegistry();
+  private readonly kiVerifierRegistry = new KiVerifierRegistry();
 
   constructor(context: PluginInitializerContext) {
     this.logger = context.logger.get();
@@ -117,6 +120,13 @@ export class ContextEnginePlugin
       },
       // Reads the current value at request time (assigned in start(), after this setup() runs).
       getFeedbackLoopEnabled: () => this.isFeedbackLoopEnabled(),
+    });
+
+    pocVerifiers.forEach((verifier) => this.kiVerifierRegistry.register(verifier));
+    registerStepDefinitions(setupDeps.workflowsExtensions, {
+      coreSetup,
+      registry: this.kiVerifierRegistry,
+      logger: this.logger.get('ki_verification'),
     });
 
     return {

--- a/x-pack/platform/plugins/shared/context_engine/server/step_types/index.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/step_types/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
+import type { VerifyKiStepDeps } from './verify_ki';
+import { getVerifyKiStepDefinition } from './verify_ki';
+
+export const registerStepDefinitions = (
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup,
+  deps: VerifyKiStepDeps
+): void => {
+  workflowsExtensions.registerStepDefinition(getVerifyKiStepDefinition(deps));
+};

--- a/x-pack/platform/plugins/shared/context_engine/server/step_types/verify_ki.test.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/step_types/verify_ki.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
+import { coreMock, elasticsearchServiceMock, uiSettingsServiceMock } from '@kbn/core/server/mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import { KiVerifierRegistry } from '../ki_verification';
+import type { KiVerifier } from '../ki_verification';
+import type { VerifyKiStepDeps } from './verify_ki';
+import { getVerifyKiStepDefinition } from './verify_ki';
+
+const hasTitleVerifier: KiVerifier = {
+  id: 'has-title',
+  applies: () => true,
+  verify: async (ki) =>
+    ki.title ? { passed: true } : { passed: false, reason: 'KI has no title' },
+};
+
+const setupStep = ({ isEnabled = true }: { isEnabled?: boolean } = {}) => {
+  const coreSetup = coreMock.createSetup();
+  const coreStart = coreMock.createStart();
+  const uiSettingsClient = uiSettingsServiceMock.createClient();
+  uiSettingsClient.get.mockResolvedValue(isEnabled);
+  coreStart.uiSettings.asScopedToClient.mockReturnValue(uiSettingsClient);
+  coreSetup.getStartServices.mockResolvedValue([coreStart, {}, {}]);
+
+  const registry = new KiVerifierRegistry();
+  registry.register(hasTitleVerifier);
+
+  const definition = getVerifyKiStepDefinition({
+    coreSetup: coreSetup as unknown as VerifyKiStepDeps['coreSetup'],
+    registry,
+    logger: loggerMock.create(),
+  });
+
+  const esClient = elasticsearchServiceMock.createElasticsearchClient();
+
+  const createContext = ({
+    input,
+    config,
+  }: {
+    input: { index: string; size?: number };
+    config?: { verifiers?: string[] };
+  }) =>
+    ({
+      input,
+      config,
+      rawInput: input,
+      contextManager: {
+        getScopedEsClient: () => esClient,
+        getFakeRequest: () => ({}),
+      },
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+      abortSignal: new AbortController().signal,
+      stepId: 'verify_kis',
+      stepType: 'context-engine.verifyKi',
+    } as unknown as Parameters<typeof definition.handler>[0]);
+
+  return { definition, esClient, createContext };
+};
+
+const searchResponseWith = (hits: Array<{ _id: string; _source?: Record<string, unknown> }>) =>
+  ({
+    hits: { hits: hits.map((hit) => ({ ...hit, _index: 'test-index' })) },
+  } as unknown as SearchResponse);
+
+describe('verify KI workflow step', () => {
+  it('throws a validation error when the Context Engine is disabled', async () => {
+    const { definition, createContext } = setupStep({ isEnabled: false });
+
+    await expect(
+      definition.handler(createContext({ input: { index: 'test-index' } }))
+    ).rejects.toThrow(/Context Engine is disabled/);
+  });
+
+  it('verifies each fetched KI and aggregates pass/fail counts', async () => {
+    const { definition, esClient, createContext } = setupStep();
+    esClient.search.mockResponse(
+      searchResponseWith([
+        { _id: '1', _source: { title: 'A titled KI' } },
+        { _id: '2', _source: {} },
+      ])
+    );
+
+    const result = await definition.handler(createContext({ input: { index: 'test-index' } }));
+
+    expect(result.output).toEqual({
+      total: 2,
+      passed: 1,
+      failed: 1,
+      results: [
+        {
+          id: '1',
+          title: 'A titled KI',
+          passed: true,
+          verifierResults: [{ verifier: 'has-title', passed: true }],
+        },
+        {
+          id: '2',
+          title: undefined,
+          passed: false,
+          verifierResults: [{ verifier: 'has-title', passed: false, reason: 'KI has no title' }],
+        },
+      ],
+    });
+  });
+
+  it('throws a validation error for unknown verifier ids', async () => {
+    const { definition, createContext } = setupStep();
+
+    await expect(
+      definition.handler(
+        createContext({ input: { index: 'test-index' }, config: { verifiers: ['nope'] } })
+      )
+    ).rejects.toThrow(/Unknown KI verifier\(s\): nope/);
+  });
+});

--- a/x-pack/platform/plugins/shared/context_engine/server/step_types/verify_ki.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/step_types/verify_ki.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import { createServerStepDefinition } from '@kbn/workflows-extensions/server';
+import { ExecutionError } from '@kbn/workflows/server';
+import { CONTEXT_ENGINE_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
+import {
+  verifyKiStepCommonDefinition,
+  type VerifyKiStepOutput,
+} from '../../common/step_types/verify_ki';
+import { KiVerifierRegistry, KiVerificationService } from '../ki_verification';
+import type { KiVerifier, KnowledgeIndicator } from '../ki_verification';
+import type { ContextEnginePluginStart, ContextEngineStartDependencies } from '../types';
+
+export interface VerifyKiStepDeps {
+  coreSetup: CoreSetup<ContextEngineStartDependencies, ContextEnginePluginStart>;
+  registry: KiVerifierRegistry;
+  logger: Logger;
+}
+
+const DEFAULT_SIZE = 10;
+
+const selectVerifiers = (registry: KiVerifierRegistry, ids?: string[]): KiVerifier[] => {
+  const all = registry.getAll();
+  if (!ids?.length) {
+    return all;
+  }
+  const byId = new Map(all.map((verifier) => [verifier.id, verifier]));
+  const unknown = ids.filter((id) => !byId.has(id));
+  if (unknown.length > 0) {
+    throw new ExecutionError({
+      type: 'ValidationError',
+      message: `Unknown KI verifier(s): ${unknown.join(', ')}`,
+      details: { registered: all.map((verifier) => verifier.id) },
+    });
+  }
+  return ids.flatMap((id) => byId.get(id) ?? []);
+};
+
+export const getVerifyKiStepDefinition = ({ coreSetup, registry, logger }: VerifyKiStepDeps) =>
+  createServerStepDefinition({
+    ...verifyKiStepCommonDefinition,
+    handler: async (context) => {
+      const { index, size = DEFAULT_SIZE } = context.input;
+
+      const [coreStart] = await coreSetup.getStartServices();
+      const fakeRequest = context.contextManager.getFakeRequest();
+      const uiSettings = coreStart.uiSettings.asScopedToClient(
+        coreStart.savedObjects.getScopedClient(fakeRequest)
+      );
+      const isEnabled = (await uiSettings.get<boolean>(CONTEXT_ENGINE_ENABLED_SETTING_ID)) ?? false;
+      if (!isEnabled) {
+        throw new ExecutionError({
+          type: 'ValidationError',
+          message: `Context Engine is disabled; enable the ${CONTEXT_ENGINE_ENABLED_SETTING_ID} advanced setting to run KI verification`,
+        });
+      }
+
+      const runRegistry = new KiVerifierRegistry();
+      selectVerifiers(registry, context.config?.verifiers).forEach((verifier) =>
+        runRegistry.register(verifier)
+      );
+      const service = new KiVerificationService(runRegistry);
+
+      const esClient = context.contextManager.getScopedEsClient();
+      const response = await esClient.search<KnowledgeIndicator>(
+        { index, size },
+        { signal: context.abortSignal }
+      );
+
+      const results: VerifyKiStepOutput['results'] = [];
+      for (const hit of response.hits.hits) {
+        const ki = hit._source ?? {};
+        const summary = await service.verifyKi(ki, {
+          isEnabled: true,
+          esClient,
+          logger,
+          abortSignal: context.abortSignal,
+        });
+        results.push({
+          id: hit._id ?? '',
+          title: ki.title,
+          passed: summary.passed,
+          verifierResults: summary.results.map((result) =>
+            result.passed
+              ? { verifier: result.verifier, passed: true }
+              : { verifier: result.verifier, passed: false, reason: result.reason }
+          ),
+        });
+      }
+
+      const passed = results.filter((result) => result.passed).length;
+      return {
+        output: { total: results.length, passed, failed: results.length - passed, results },
+      };
+    },
+  });

--- a/x-pack/platform/plugins/shared/context_engine/server/types.ts
+++ b/x-pack/platform/plugins/shared/context_engine/server/types.ts
@@ -12,6 +12,7 @@ import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
+import type { WorkflowsExtensionsServerPluginSetup } from '@kbn/workflows-extensions/server';
 import type { AiIndexProperties } from '../common/http_api/ai_indices';
 import type { SignalsServiceApi } from './signals/service';
 
@@ -27,6 +28,7 @@ export interface ContextEnginePluginStart {
 export interface ContextEngineSetupDependencies {
   features: FeaturesPluginSetup;
   taskManager: TaskManagerSetupContract;
+  workflowsExtensions: WorkflowsExtensionsServerPluginSetup;
 }
 
 export interface ContextEngineStartDependencies {

--- a/x-pack/platform/plugins/shared/context_engine/tsconfig.json
+++ b/x-pack/platform/plugins/shared/context_engine/tsconfig.json
@@ -51,6 +51,9 @@
     "@kbn/index-management-shared-types",
     "@kbn/code-editor",
     "@kbn/ui-callout",
-    "@kbn/logging-mocks"
+    "@kbn/logging-mocks",
+    "@kbn/workflows",
+    "@kbn/workflows-extensions",
+    "@kbn/zod"
   ]
 }


### PR DESCRIPTION
## Summary

**POC — not intended to merge as-is.**

Explores exposing KI verification as a custom workflow step, following up on the discussion about using Workflows as an execution surface for verifiers. The step is a thin consumer of the verifier framework added in #284039: workflows get UI visibility, batch execution, and composability, while the code-based registry remains the core execution primitive (fast, no per-execution cost, usable inline).

Registers a `context-engine.verifyKi` step via the `workflowsExtensions` plugin contract:

```yaml
- name: verify_kis
  type: context-engine.verifyKi
  verifiers:            # optional: subset of registered verifiers
    - has-title
    - min-content
  with:
    index: "my-ai-index"
    size: 50            # optional, default 10, max 500
```

The server handler:
- Fails with a `ValidationError` when the `contextEngine:enabled` advanced setting is off (rather than silently passing)
- Fetches KIs from the given index with the workflow's scoped ES client (abort signal propagated)
- Runs the selected verifiers per KI through `KiVerificationService`
- Returns `{ total, passed, failed, results[] }` with per-verifier pass/fail and failure reasons

### Changes

- `common/step_types/verify_ki.ts` — step id, zod input/output/config schemas, docs/examples
- `server/step_types/` — handler + registration, unit tests
- `server/ki_verification/poc_verifiers.ts` — `has-title` and `min-content` demo verifiers (#284039 intentionally shipped none; the step needs something to run)
- `public/step_types/` — editor definition (lazy EUI icon, async loader registration)
- Plugin wiring: `workflowsExtensions` added to `requiredPlugins`, `KiVerifierRegistry` instantiated and step registered in `setup()`

### Remaining before this could be real

- [ ] Workflows-eng step approval gate (`approved_step_definitions/context-engine.verifyKi.txt` via the Scout API test)
- [ ] Replace POC verifiers with production ones
- [ ] Optional: `getIndexSelectionHandler` editor handler for the `index` input

### Checklist

- [x] Unit tests added (step handler: disabled flag, aggregation, unknown verifier ids)

### Identify risks

No risks; POC gated behind the `contextEngine:enabled` setting, and verification only runs when the step is used in a workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
