### PR TITLE
[Discover][Change Point Detection] Add ACTION_FILTERS_NOTIFICATION to DEFAULT_DISABLED_ACTIONS

### DIFF
--- a/src/platform/packages/shared/kbn-change-point-chart-viewer/src/components/change_point_lens_chart.tsx
+++ b/src/platform/packages/shared/kbn-change-point-chart-viewer/src/components/change_point_lens_chart.tsx
@@ -56,6 +56,7 @@ const DEFAULT_DISABLED_ACTIONS = [
   'alertRule',
   'ACTION_OPEN_IN_DISCOVER',
   ACTION_EXPLORE_IN_DISCOVER_TAB,
+  'ACTION_FILTERS_NOTIFICATION',
 ];
 
 const chartContainerCss = css`


### PR DESCRIPTION
## Summary

`ACTION_FILTERS_NOTIFICATION` was not present in the Change point chart menus (built on lens) before https://github.com/elastic/kibana/pull/282386. 

That PR moved the action from `PANEL_NOTIFICATION_TRIGGER` to `ON_OPEN_PANEL_MENU`, a global registration. Since `isCompatible` returns `true` for any ES|QL embeddable, it now appears in every Lens panel context menu, including the metrics grid.

Adds `ACTION_FILTERS_NOTIFICATION` to `DEFAULT_DISABLED_ACTIONS` in `src/platform/packages/shared/kbn-change-point-chart-viewer/src/components/change_point_lens_chart.tsx` ensure it is not shown. 

Before:

<img width="1119" height="814" alt="image" src="https://github.com/user-attachments/assets/02165d7e-ac6e-435a-a86d-da271b83f533" />


After:

<img width="1373" height="723" alt="image" src="https://github.com/user-attachments/assets/011e4b70-93c7-4d81-ac74-9f7d66b9b737" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



