### PR TITLE
Add MCP tool annotations framework to Agent Builder

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/builtin.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/builtin.ts
@@ -50,7 +50,6 @@ import type { ToolHandlerFn } from './handler';
  * - Read-only tools should always set idempotentHint: true.
  *
  * See: https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations
- * See: https://claude.com/docs/connectors/building/submission#submission-requirements
  */
 export type McpToolAnnotations = Required<
   Pick<ToolAnnotations, 'title' | 'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/builtin.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/builtin.ts
@@ -20,7 +20,41 @@ import type { IndexSearchToolDefinition } from '@kbn/agent-builder-common/tools/
 import type { WorkflowToolDefinition } from '@kbn/agent-builder-common/tools/types/workflow';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ConfirmPromptDefinition } from '@kbn/agent-builder-common/agents';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolHandlerFn } from './handler';
+
+/**
+ * MCP tool annotations for builtin tools exposed via the Agent Builder MCP server.
+ *
+ * All five fields are required so tool authors must make an explicit classification
+ * choice. The type is derived from the MCP SDK's ToolAnnotations to stay in sync
+ * with the spec — if the SDK renames or removes a field, TypeScript will surface
+ * the break here.
+ *
+ * Annotation guide (copy these values directly):
+ *
+ * Pure read (search, list, get):
+ *   readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false
+ *
+ * Create / upsert (non-destructive write):
+ *   readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false
+ *
+ * Delete / irreversible overwrite:
+ *   readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false
+ *
+ * Calls external API / webhook / email (combine with one of the above):
+ *   openWorldHint: true
+ *
+ * Rules:
+ * - readOnlyHint and destructiveHint must not both be true.
+ * - Read-only tools should always set idempotentHint: true.
+ *
+ * See: https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations
+ * See: https://claude.com/docs/connectors/building/submission#submission-requirements
+ */
+export type McpToolAnnotations = Required<
+  Pick<ToolAnnotations, 'title' | 'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>
+>;
 
 /**
  * Information exposed to the {@link ToolAvailabilityHandler}.
@@ -163,6 +197,12 @@ export interface BuiltinToolDefinition<
    * Refer to {@link ToolAvailabilityConfig}
    */
   availability?: ToolAvailabilityConfig;
+  /**
+   * MCP annotations for this tool. Required for all builtin tools exposed via the MCP server.
+   * Optional during the rollout period — will become required once all tools have been annotated.
+   * See {@link McpToolAnnotations} for the full guide.
+   */
+  annotations?: McpToolAnnotations;
 }
 
 type StaticToolRegistrationMixin<T extends ToolDefinition> = Omit<T, 'readonly' | 'experimental'> &

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/builtin.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/builtin.ts
@@ -52,7 +52,10 @@ import type { ToolHandlerFn } from './handler';
  * See: https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations
  */
 export type McpToolAnnotations = Required<
-  Pick<ToolAnnotations, 'title' | 'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>
+  Pick<
+    ToolAnnotations,
+    'title' | 'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'
+  >
 >;
 
 /**

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/index.ts
@@ -17,6 +17,7 @@ export type {
   ToolAvailabilityConfig,
   ToolReturnSummarizerFn,
   BuiltInToolConfirmationPolicy,
+  McpToolAnnotations,
 } from './builtin';
 export {
   type ToolHandlerFn,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/internal.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/internal.ts
@@ -14,6 +14,7 @@ import type {
   ToolAvailabilityResult,
   ToolReturnSummarizerFn,
   BuiltInToolConfirmationPolicy,
+  McpToolAnnotations,
 } from './builtin';
 import type { LlmDescriptionHandler } from '../runner';
 
@@ -62,6 +63,10 @@ export interface InternalToolDefinition<
    * Tool call policy to control tool call confirmation behavior
    */
   confirmation?: BuiltInToolConfirmationPolicy;
+  /**
+   * MCP annotations surfaced to MCP clients. Propagated from BuiltinToolDefinition.
+   */
+  annotations?: McpToolAnnotations;
 }
 
 export type InternalToolAvailabilityHandler = (

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.test.ts
@@ -139,7 +139,23 @@ describe('filterToolsByNamespace', () => {
   });
 });
 
-describe('MCP route — annotation argument logic', () => {
+const mockServerTool = jest.fn();
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: jest.fn().mockImplementation(() => ({
+    tool: mockServerTool,
+    connect: jest.fn(),
+    close: jest.fn(),
+  })),
+}));
+
+jest.mock('../utils/mcp/kibana_mcp_http_transport', () => ({
+  KibanaMcpHttpTransport: jest.fn().mockImplementation(() => ({
+    handleRequest: jest.fn().mockResolvedValue({ status: 200 }),
+    close: jest.fn(),
+  })),
+}));
+
+describe('MCP route — server.tool() positional arguments', () => {
   const mockAnnotations = {
     title: 'List Indices',
     readOnlyHint: true as const,
@@ -148,16 +164,83 @@ describe('MCP route — annotation argument logic', () => {
     openWorldHint: false as const,
   };
 
-  it('resolves tool.annotations when present', () => {
-    const tool = createMockTool('platform.core.list_indices', { annotations: mockAnnotations });
-    const annotationsArg = tool.annotations ?? {};
-    expect(annotationsArg).toEqual(mockAnnotations);
+  let postHandler: Function;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const mockLogger = loggingSystemMock.createLogger();
+
+    const annotatedTool = createMockTool('platform.core.list_indices', {
+      annotations: mockAnnotations,
+    });
+    const unannotatedTool = createMockTool('platform.core.search');
+
+    const mockRegistry = {
+      list: jest.fn().mockResolvedValue([annotatedTool, unannotatedTool]),
+      execute: jest.fn().mockResolvedValue({ results: [{ type: 'other', data: {} }] }),
+    };
+    const getInternalServices = jest.fn().mockReturnValue({
+      tools: { getRegistry: jest.fn().mockResolvedValue(mockRegistry) },
+    });
+
+    const captureVersioned = (method: string) =>
+      jest.fn().mockImplementation((routeConfig: { path: string }) => {
+        const versionedRoute = {
+          addVersion: jest.fn().mockImplementation((_config: any, handler: Function) => {
+            if (method === 'POST') {
+              postHandler = handler;
+            }
+            return versionedRoute;
+          }),
+        };
+        return versionedRoute;
+      });
+
+    const mockRouter = {
+      get: jest.fn(),
+      versioned: { post: captureVersioned('POST') },
+    } as unknown as jest.Mocked<IRouter>;
+
+    registerMCPRoutes({
+      router: mockRouter,
+      getInternalServices,
+      logger: mockLogger,
+    } as unknown as RouteDependencies);
   });
 
-  it('resolves to empty object when annotations are absent', () => {
-    const tool = createMockTool('platform.core.list_indices');
-    const annotationsArg = tool.annotations ?? {};
-    expect(annotationsArg).toEqual({});
+  const createMockRequest = () => ({
+    query: {},
+    events: { aborted$: { subscribe: jest.fn() } },
+  });
+
+  const createMockContext = () => ({
+    core: Promise.resolve({ uiSettings: { client: { get: jest.fn() } } }),
+    licensing: Promise.resolve({
+      license: { status: 'active', hasAtLeast: () => true },
+    }),
+  });
+
+  it('passes annotations as the 4th arg when the tool has them', async () => {
+    await postHandler(createMockContext(), createMockRequest(), { customError: jest.fn() });
+
+    const annotatedCall = mockServerTool.mock.calls.find(
+      (call: any[]) => call[0] === 'platform_core_list_indices'
+    );
+    expect(annotatedCall).toBeDefined();
+    expect(annotatedCall![3]).toEqual(mockAnnotations);
+    expect(typeof annotatedCall![4]).toBe('function');
+  });
+
+  it('passes empty object as the 4th arg when annotations are absent', async () => {
+    await postHandler(createMockContext(), createMockRequest(), { customError: jest.fn() });
+
+    const unannotatedCall = mockServerTool.mock.calls.find(
+      (call: any[]) => call[0] === 'platform_core_search'
+    );
+    expect(unannotatedCall).toBeDefined();
+    expect(unannotatedCall![3]).toEqual({});
+    expect(typeof unannotatedCall![4]).toBe('function');
   });
 });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.test.ts
@@ -139,10 +139,10 @@ describe('filterToolsByNamespace', () => {
   });
 });
 
-const mockServerTool = jest.fn();
+const mockRegisterTool = jest.fn();
 jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   McpServer: jest.fn().mockImplementation(() => ({
-    tool: mockServerTool,
+    registerTool: mockRegisterTool,
     connect: jest.fn(),
     close: jest.fn(),
   })),
@@ -155,7 +155,7 @@ jest.mock('../utils/mcp/kibana_mcp_http_transport', () => ({
   })),
 }));
 
-describe('MCP route — server.tool() positional arguments', () => {
+describe('MCP route — registerTool arguments', () => {
   const mockAnnotations = {
     title: 'List Indices',
     readOnlyHint: true as const,
@@ -221,26 +221,108 @@ describe('MCP route — server.tool() positional arguments', () => {
     }),
   });
 
-  it('passes annotations as the 4th arg when the tool has them', async () => {
+  it('passes annotations in config when the tool has them', async () => {
     await postHandler(createMockContext(), createMockRequest(), { customError: jest.fn() });
 
-    const annotatedCall = mockServerTool.mock.calls.find(
+    const annotatedCall = mockRegisterTool.mock.calls.find(
       (call: any[]) => call[0] === 'platform_core_list_indices'
     );
     expect(annotatedCall).toBeDefined();
-    expect(annotatedCall![3]).toEqual(mockAnnotations);
-    expect(typeof annotatedCall![4]).toBe('function');
+    const [, config, callback] = annotatedCall!;
+    expect(config.annotations).toEqual(mockAnnotations);
+    expect(config.description).toBe('Tool platform.core.list_indices');
+    expect(typeof callback).toBe('function');
   });
 
-  it('passes empty object as the 4th arg when annotations are absent', async () => {
+  it('passes undefined annotations when tool has none', async () => {
     await postHandler(createMockContext(), createMockRequest(), { customError: jest.fn() });
 
-    const unannotatedCall = mockServerTool.mock.calls.find(
+    const unannotatedCall = mockRegisterTool.mock.calls.find(
       (call: any[]) => call[0] === 'platform_core_search'
     );
     expect(unannotatedCall).toBeDefined();
-    expect(unannotatedCall![3]).toEqual({});
-    expect(typeof unannotatedCall![4]).toBe('function');
+    const [, config, callback] = unannotatedCall!;
+    expect(config.annotations).toBeUndefined();
+    expect(typeof callback).toBe('function');
+  });
+});
+
+describe('MCP route — real SDK tool registration', () => {
+  it('registers an unannotated tool without throwing', () => {
+    jest.restoreAllMocks();
+    const { McpServer: RealMcpServer } =
+      jest.requireActual<typeof import('@modelcontextprotocol/sdk/server/mcp.js')>(
+        '@modelcontextprotocol/sdk/server/mcp.js'
+      );
+
+    const server = new RealMcpServer({ name: 'test', version: '0.0.1' });
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text' as const, text: 'ok' }],
+    });
+
+    expect(() => {
+      server.registerTool(
+        'unannotated_tool',
+        { description: 'no annotations', inputSchema: {} },
+        handler
+      );
+    }).not.toThrow();
+  });
+
+  it('registers an annotated tool without throwing', () => {
+    jest.restoreAllMocks();
+    const { McpServer: RealMcpServer } =
+      jest.requireActual<typeof import('@modelcontextprotocol/sdk/server/mcp.js')>(
+        '@modelcontextprotocol/sdk/server/mcp.js'
+      );
+
+    const server = new RealMcpServer({ name: 'test', version: '0.0.1' });
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text' as const, text: 'ok' }],
+    });
+
+    expect(() => {
+      server.registerTool(
+        'annotated_tool',
+        {
+          description: 'with annotations',
+          inputSchema: {},
+          annotations: {
+            title: 'My Tool',
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          },
+        },
+        handler
+      );
+    }).not.toThrow();
+  });
+
+  it('rejects duplicate registration (proves first registration took effect)', () => {
+    jest.restoreAllMocks();
+    const { McpServer: RealMcpServer } =
+      jest.requireActual<typeof import('@modelcontextprotocol/sdk/server/mcp.js')>(
+        '@modelcontextprotocol/sdk/server/mcp.js'
+      );
+
+    const server = new RealMcpServer({ name: 'test', version: '0.0.1' });
+    const handler = jest.fn();
+
+    server.registerTool(
+      'my_tool',
+      { description: 'first', inputSchema: {} },
+      handler
+    );
+
+    expect(() => {
+      server.registerTool(
+        'my_tool',
+        { description: 'duplicate', inputSchema: {} },
+        handler
+      );
+    }).toThrow(/already registered/);
   });
 });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.test.ts
@@ -139,6 +139,28 @@ describe('filterToolsByNamespace', () => {
   });
 });
 
+describe('MCP route — annotation argument logic', () => {
+  const mockAnnotations = {
+    title: 'List Indices',
+    readOnlyHint: true as const,
+    destructiveHint: false as const,
+    idempotentHint: true as const,
+    openWorldHint: false as const,
+  };
+
+  it('resolves tool.annotations when present', () => {
+    const tool = createMockTool('platform.core.list_indices', { annotations: mockAnnotations });
+    const annotationsArg = tool.annotations ?? {};
+    expect(annotationsArg).toEqual(mockAnnotations);
+  });
+
+  it('resolves to empty object when annotations are absent', () => {
+    const tool = createMockTool('platform.core.list_indices');
+    const annotationsArg = tool.annotations ?? {};
+    expect(annotationsArg).toEqual({});
+  });
+});
+
 describe('registerMCPRoutes', () => {
   const routeKey = `POST:${MCP_SERVER_PATH}`;
   const getRouteKey = `GET:${MCP_SERVER_PATH}`;

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.test.ts
@@ -250,10 +250,9 @@ describe('MCP route — registerTool arguments', () => {
 describe('MCP route — real SDK tool registration', () => {
   it('registers an unannotated tool without throwing', () => {
     jest.restoreAllMocks();
-    const { McpServer: RealMcpServer } =
-      jest.requireActual<typeof import('@modelcontextprotocol/sdk/server/mcp.js')>(
-        '@modelcontextprotocol/sdk/server/mcp.js'
-      );
+    const { McpServer: RealMcpServer } = jest.requireActual<
+      typeof import('@modelcontextprotocol/sdk/server/mcp.js')
+    >('@modelcontextprotocol/sdk/server/mcp.js');
 
     const server = new RealMcpServer({ name: 'test', version: '0.0.1' });
     const handler = jest.fn().mockResolvedValue({
@@ -271,10 +270,9 @@ describe('MCP route — real SDK tool registration', () => {
 
   it('registers an annotated tool without throwing', () => {
     jest.restoreAllMocks();
-    const { McpServer: RealMcpServer } =
-      jest.requireActual<typeof import('@modelcontextprotocol/sdk/server/mcp.js')>(
-        '@modelcontextprotocol/sdk/server/mcp.js'
-      );
+    const { McpServer: RealMcpServer } = jest.requireActual<
+      typeof import('@modelcontextprotocol/sdk/server/mcp.js')
+    >('@modelcontextprotocol/sdk/server/mcp.js');
 
     const server = new RealMcpServer({ name: 'test', version: '0.0.1' });
     const handler = jest.fn().mockResolvedValue({
@@ -302,26 +300,17 @@ describe('MCP route — real SDK tool registration', () => {
 
   it('rejects duplicate registration (proves first registration took effect)', () => {
     jest.restoreAllMocks();
-    const { McpServer: RealMcpServer } =
-      jest.requireActual<typeof import('@modelcontextprotocol/sdk/server/mcp.js')>(
-        '@modelcontextprotocol/sdk/server/mcp.js'
-      );
+    const { McpServer: RealMcpServer } = jest.requireActual<
+      typeof import('@modelcontextprotocol/sdk/server/mcp.js')
+    >('@modelcontextprotocol/sdk/server/mcp.js');
 
     const server = new RealMcpServer({ name: 'test', version: '0.0.1' });
     const handler = jest.fn();
 
-    server.registerTool(
-      'my_tool',
-      { description: 'first', inputSchema: {} },
-      handler
-    );
+    server.registerTool('my_tool', { description: 'first', inputSchema: {} }, handler);
 
     expect(() => {
-      server.registerTool(
-        'my_tool',
-        { description: 'duplicate', inputSchema: {} },
-        handler
-      );
+      server.registerTool('my_tool', { description: 'duplicate', inputSchema: {} }, handler);
     }).toThrow(/already registered/);
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.ts
@@ -127,6 +127,7 @@ To learn more about the Agent Builder MCP server, refer to the [MCP documentatio
               idMapping.get(tool.id) ?? tool.id,
               tool.description,
               toolSchema.shape,
+              tool.annotations ?? {},
               async (args: { [x: string]: any }) => {
                 const toolResult = await registry.execute({
                   toolId: tool.id,

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/mcp.ts
@@ -123,11 +123,13 @@ To learn more about the Agent Builder MCP server, refer to the [MCP documentatio
           // Expose tools scoped to the request
           for (const tool of tools) {
             const toolSchema = await tool.getSchema();
-            server.tool(
+            server.registerTool(
               idMapping.get(tool.id) ?? tool.id,
-              tool.description,
-              toolSchema.shape,
-              tool.annotations ?? {},
+              {
+                description: tool.description,
+                inputSchema: toolSchema.shape,
+                annotations: tool.annotations,
+              },
               async (args: { [x: string]: any }) => {
                 const toolResult = await registry.execute({
                   toolId: tool.id,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.ts
@@ -51,6 +51,7 @@ export const convertTool = ({
       getHandler: () => tool.handler,
       summarizeToolReturn: tool.summarizeToolReturn,
       maxResultTokens: tool.maxResultTokens,
+      annotations: tool.annotations,
     };
   }
   if (!isBuiltinDefinition(definition)) {


### PR DESCRIPTION
## Summary

- Adds `McpToolAnnotations` type (derived from `@modelcontextprotocol/sdk` `ToolAnnotations`) to `@kbn/agent-builder-server` — requires all five MCP annotation fields (`title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
- Adds an optional `annotations?` field to `BuiltinToolDefinition` and `InternalToolDefinition`
- Propagates annotations through the builtin tool converter
- Updates the MCP route's `server.tool()` call to the 5-argument overload, passing `tool.annotations ?? {}` (empty = no hints for unannotated tools)
- Adds annotation-related unit tests

This is **Phase 1** of a three-phase rollout:
1. **This PR** — framework plumbing, annotations optional, no behavior change
2. **Follow-up PRs** — per-plugin PRs adding annotation values to each tool (split by domain for team review)
3. **Final PR** — make `annotations` required on `BuiltinToolDefinition`, TypeScript catches stragglers

User-created tool types (`StaticEsqlTool`, `StaticIndexSearchTool`, `StaticWorkflowTool`) are deferred — they need UI form fields and a saved-object migration.

## Test plan

- [x] `node scripts/jest ...mcp.test.ts` — 17 tests pass (2 new annotation tests)
- [x] Type-check: pre-existing errors only, no new errors from these changes
- [ ] CI validation

Generated with [Claude Code](https://claude.com/claude-code)

## Release Note

Introduces MCP Tool Annotations (`readOnlyHint`, `destructiveHint`, etc) to tools exposed by the Agent Builder MCP Server. 
