### PR TITLE
[OAS] Align validate-oas skill include-path list with the Buildkite script

### DIFF
--- a/.agents/skills/validate-oas/SKILL.md
+++ b/.agents/skills/validate-oas/SKILL.md
@@ -38,31 +38,28 @@ Refresh flow:
 yarn kbn bootstrap
 ```
 
-2. Regenerate captured OAS snapshots using the same include paths as Buildkite:
+2. Regenerate captured OAS snapshots. Read the include paths from the Buildkite step:
 
 ```bash
-node scripts/capture_oas_snapshot \
-  --include-path /api/status \
-  --include-path /api/alerting/rule/ \
-  --include-path /api/alerting/rules \
-  --include-path /api/actions \
-  --include-path /api/security/role \
-  --include-path /api/spaces \
-  --include-path /api/streams \
-  --include-path /api/fleet \
-  --include-path /api/saved_objects \
-  --include-path /api/maintenance_window \
-  --include-path /api/agent_builder \
-  --include-path /api/workflows \
-  --include-path /api/dashboards \
-  --include-path /api/visualizations \
-  --include-path /api/markdowns \
-  --include-path /api/links \
-  --include-path /api/tags \
-  --include-path /api/security/entity_store
+CI_STEP=.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
+
+INCLUDE_PATHS=$(grep -oE -- '--include-path /api[^ \\"]*' "$CI_STEP" | awk '{print $2}')
+COUNT=$(printf '%s\n' "$INCLUDE_PATHS" | grep -c '^/api/')
+BAD=$(printf '%s\n' "$INCLUDE_PATHS" | grep -cvE '^/api/[A-Za-z0-9._{}/-]+$')
+
+[ "$COUNT" -ge 15 ] || { echo "Only $COUNT include paths read from $CI_STEP. Stop and check that script."; exit 1; }
+[ "$BAD" -eq 0 ] || { echo "$BAD malformed include path(s) in $CI_STEP. Stop."; exit 1; }
+
+printf '%s\n' "$INCLUDE_PATHS" | sed 's|^|--include-path |' | xargs node scripts/capture_oas_snapshot
 ```
 
-A path missing from this list is dropped with no error. It then vanishes from `oas_docs/output/*.yaml` after `make api-docs`, and the API contract check reads it as a removed endpoint. Copy the list from the Buildkite script. Don't edit it by hand.
+CI owns this list. This skill reads it. Never write to `.buildkite/` from here.
+
+Run the block as written. Don't swap it for a literal list of paths. To see the current paths, read `$CI_STEP`.
+
+Why the guards. A path missing from the list is dropped with no error, so a bad read silently narrows the capture. Missing routes then vanish from `oas_docs/output/*.yaml` after `make api-docs`, and the API contract check reads them as removed endpoints. The first guard catches a reformatted or moved script. The second rejects anything that isn't a plain API path, since the paths are split into command arguments.
+
+Two details that look like they could be simplified but can't. `grep -cv` is used instead of `grep -qv` because some grep builds (ugrep) return the wrong status for `-qv`. `xargs` does the argument splitting because zsh and bash disagree on splitting unquoted variables.
 
 3. Run the OpenAPI bundling scripts:
 
@@ -110,25 +107,15 @@ Environment refresh:
 
 ```bash
 yarn kbn bootstrap
-node scripts/capture_oas_snapshot \
-  --include-path /api/status \
-  --include-path /api/alerting/rule/ \
-  --include-path /api/alerting/rules \
-  --include-path /api/actions \
-  --include-path /api/security/role \
-  --include-path /api/spaces \
-  --include-path /api/streams \
-  --include-path /api/fleet \
-  --include-path /api/saved_objects \
-  --include-path /api/maintenance_window \
-  --include-path /api/agent_builder \
-  --include-path /api/workflows \
-  --include-path /api/dashboards \
-  --include-path /api/visualizations \
-  --include-path /api/markdowns \
-  --include-path /api/links \
-  --include-path /api/tags \
-  --include-path /api/security/entity_store
+
+CI_STEP=.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
+INCLUDE_PATHS=$(grep -oE -- '--include-path /api[^ \\"]*' "$CI_STEP" | awk '{print $2}')
+COUNT=$(printf '%s\n' "$INCLUDE_PATHS" | grep -c '^/api/')
+BAD=$(printf '%s\n' "$INCLUDE_PATHS" | grep -cvE '^/api/[A-Za-z0-9._{}/-]+$')
+[ "$COUNT" -ge 15 ] || { echo "Only $COUNT include paths read from $CI_STEP. Stop and check that script."; exit 1; }
+[ "$BAD" -eq 0 ] || { echo "$BAD malformed include path(s) in $CI_STEP. Stop."; exit 1; }
+printf '%s\n' "$INCLUDE_PATHS" | sed 's|^|--include-path |' | xargs node scripts/capture_oas_snapshot
+
 bash .buildkite/scripts/steps/openapi_bundling/security_solution_openapi_bundling.sh
 bash .buildkite/scripts/steps/openapi_bundling/final_merge.sh
 cd oas_docs && make api-docs

--- a/.agents/skills/validate-oas/SKILL.md
+++ b/.agents/skills/validate-oas/SKILL.md
@@ -54,10 +54,15 @@ node scripts/capture_oas_snapshot \
   --include-path /api/maintenance_window \
   --include-path /api/agent_builder \
   --include-path /api/workflows \
-  --include-path /api/security/entity_store \
   --include-path /api/dashboards \
-  --include-path /api/visualizations
+  --include-path /api/visualizations \
+  --include-path /api/markdowns \
+  --include-path /api/links \
+  --include-path /api/tags \
+  --include-path /api/security/entity_store
 ```
+
+A path missing from this list is dropped with no error. It then vanishes from `oas_docs/output/*.yaml` after `make api-docs`, and the API contract check reads it as a removed endpoint. Copy the list from the Buildkite script. Don't edit it by hand.
 
 3. Run the OpenAPI bundling scripts:
 
@@ -118,9 +123,12 @@ node scripts/capture_oas_snapshot \
   --include-path /api/maintenance_window \
   --include-path /api/agent_builder \
   --include-path /api/workflows \
-  --include-path /api/security/entity_store \
   --include-path /api/dashboards \
-  --include-path /api/visualizations
+  --include-path /api/visualizations \
+  --include-path /api/markdowns \
+  --include-path /api/links \
+  --include-path /api/tags \
+  --include-path /api/security/entity_store
 bash .buildkite/scripts/steps/openapi_bundling/security_solution_openapi_bundling.sh
 bash .buildkite/scripts/steps/openapi_bundling/final_merge.sh
 cd oas_docs && make api-docs


### PR DESCRIPTION
## Summary

The `validate-oas` skill hardcods the `capture_oas_snapshot` include-path list. 
As new endpoints are added to `.buildkite/scripts/steps/checks/capture_oas_snapshot.sh` (`/api/markdowns`, `/api/links`, `/api/tags`), the skill's paths get out of sync, and gives misleading information on the validity of Kibana's OAS.

This PR makes the skill read the list from the Buildkite as a single source of truth.

The PR also adds the following guards:

- fewer than 15 paths read means the script moved or changed shape, so stop
- anything that isn't a plain `/api/...` path is rejected, since the paths become command arguments

Tested under bash and zsh.

## Why it drifted

The three paths came from [#274419](https://github.com/elastic/kibana/pull/274419) (2026-06-23), [#268783](https://github.com/elastic/kibana/pull/268783) (2026-07-09) and [#267785](https://github.com/elastic/kibana/pull/267785) (2026-07-14), all part of the "as Code" work.

The skill was last synced on 2026-05-20 in [#270284](https://github.com/elastic/kibana/pull/270284), and before that on 2026-04-28 in [#265881](https://github.com/elastic/kibana/pull/265881). Two of the four PRs that have ever touched this skill were drift fixes.

A team adding a public endpoint has no reason to know a skill file mirrors their CI line. The list only stayed current while someone checked it by hand, so this reads the list instead.

Found while running CI locally for https://github.com/elastic/kibana/pull/284550.

Co-authored with Claude Code
