### PR TITLE
Saved objects with semantic search POC

### DIFF
--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_create.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_create.ts
@@ -75,6 +75,7 @@ export const performBulkCreate = async <T>(
     common: commonHelper,
     validation: validationHelper,
     encryption: encryptionHelper,
+    embedding: embeddingHelper,
     preflight: preflightHelper,
     serializer: serializerHelper,
     migration: migrationHelper,
@@ -328,10 +329,23 @@ export const performBulkCreate = async <T>(
           });
         }
 
+        // Populate shadow semantic fields AFTER migration and schema validation.
+        // Shadow keys must not enter migration transforms (they may silently drop unknown keys)
+        // and must not be seen by validateObjectForCreate (strict model-version schemas reject
+        // unknown keys, failing every bulkCreate for opted-in types that register a create schema).
+        const migratedWithSemantics: SavedObjectSanitizedDoc<T> = {
+          ...migrated,
+          attributes: embeddingHelper.populateSemanticFields(
+            object.type,
+            migrated.attributes,
+            options.deferEmbeddings
+          ),
+        };
+
         const expectedResult = {
           esRequestIndex: bulkRequestIndexCounter++,
           requestedId: object.id,
-          rawMigratedDoc: serializer.savedObjectToRaw(migrated),
+          rawMigratedDoc: serializer.savedObjectToRaw(migratedWithSemantics),
         };
 
         bulkCreateParams.push(

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_update.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_update.ts
@@ -87,6 +87,7 @@ export const performBulkUpdate = async <T>(
   const {
     common: commonHelper,
     encryption: encryptionHelper,
+    embedding: embeddingHelper,
     migration: migrationHelper,
     user: userHelper,
   } = helpers;
@@ -315,11 +316,16 @@ export const performBulkUpdate = async <T>(
 
         const typeDefinition = registry.getType(type)!;
 
+        // Do NOT add shadow semantic keys to the partial before encryption/merge: migration
+        // transforms may silently drop unknown keys.  Instead, compute shadow keys from the
+        // original partial attributes and overlay them after migrateInputDocument.
+        // No per-request deferEmbeddings override for bulk updates — use per-type default.
+        const partialAttrs = documentToSave[type];
         const encryptedUpdatedAttributes = await encryptionHelper.optionallyEncryptAttributes(
           type,
           id,
           objectNamespace || namespace,
-          documentToSave[type]
+          partialAttrs
         );
 
         const updatedAttributes = mergeAttributes
@@ -346,9 +352,24 @@ export const performBulkUpdate = async <T>(
             references: documentToSave.references,
           }),
         });
-        const updatedMigratedDocumentToSave = serializer.savedObjectToRaw(
-          migratedUpdatedSavedObjectDoc as SavedObjectSanitizedDoc
-        );
+
+        // Overlay shadow semantic fields derived from the ORIGINAL partial attributes, after
+        // merge and migration.  Only fields present in the partial update get a shadow key;
+        // absent fields preserve the stored shadow that survived mergeForUpdate.
+        const shadowOverlay = embeddingHelper.shadowFieldsForUpdate(type, partialAttrs);
+        const docForSerialization =
+          Object.keys(shadowOverlay).length > 0
+            ? ({
+                ...migratedUpdatedSavedObjectDoc,
+                attributes: {
+                  ...((migratedUpdatedSavedObjectDoc as SavedObjectSanitizedDoc)
+                    .attributes as Record<string, unknown>),
+                  ...shadowOverlay,
+                },
+              } as SavedObjectSanitizedDoc)
+            : (migratedUpdatedSavedObjectDoc as SavedObjectSanitizedDoc);
+
+        const updatedMigratedDocumentToSave = serializer.savedObjectToRaw(docForSerialization);
 
         const namespaces =
           savedObjectNamespaces ?? (savedObjectNamespace ? [savedObjectNamespace] : []);

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/create.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/create.ts
@@ -49,6 +49,7 @@ export const performCreate = async <T>(
     common: commonHelper,
     validation: validationHelper,
     encryption: encryptionHelper,
+    embedding: embeddingHelper,
     preflight: preflightHelper,
     serializer: serializerHelper,
     migration: migrationHelper,
@@ -188,7 +189,19 @@ export const performCreate = async <T>(
    */
   validationHelper.validateObjectForCreate(type, migrated as SavedObjectSanitizedDoc<T>);
 
-  const raw = serializer.savedObjectToRaw(migrated as SavedObjectSanitizedDoc<T>);
+  // Populate shadow semantic fields AFTER migration and schema validation.
+  // Shadow keys must not enter migration transforms (they may silently drop unknown keys)
+  // and must not be seen by validateObjectForCreate (strict model-version schemas reject
+  // unknown keys, failing every create for opted-in types that register a create schema).
+  const migratedDoc = migrated as SavedObjectSanitizedDoc<T>;
+  const raw = serializer.savedObjectToRaw({
+    ...migratedDoc,
+    attributes: embeddingHelper.populateSemanticFields(
+      type,
+      migratedDoc.attributes,
+      options.deferEmbeddings
+    ),
+  });
 
   const requestParams: IndexRequest | CreateRequest = {
     id: raw._id,

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/find.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/find.test.ts
@@ -243,6 +243,173 @@ describe('find', () => {
         expect(mockGetSearchDsl).not.toHaveBeenCalled();
         expect(client.search).not.toHaveBeenCalled();
       });
+
+      describe('semanticSearch option', () => {
+        // Spy helper: makes the module-level registry report that `type` (='index-pattern')
+        // has a semanticSearch definition, so validation checks that fire AFTER the
+        // registration check can be reached.
+        const withSemanticType = () =>
+          jest
+            .spyOn(registry, 'getSemanticSearchDefinition')
+            .mockImplementation((typeName) =>
+              typeName === type
+                ? { fields: ['title'], inferenceId: '.elser-2-elasticsearch', embedding: 'sync' }
+                : undefined
+            );
+
+        afterEach(() => {
+          jest.restoreAllMocks();
+        });
+
+        it(`throws when semanticSearch.query is an empty string`, async () => {
+          await expect(
+            repository.find({ type, semanticSearch: { query: '' } })
+          ).rejects.toThrowError('options.semanticSearch.query must be a non-empty string');
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when semanticSearch.query is a whitespace-only string`, async () => {
+          await expect(
+            repository.find({ type, semanticSearch: { query: '   ' } })
+          ).rejects.toThrowError('options.semanticSearch.query must be a non-empty string');
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when semanticSearch is combined with searchAfter`, async () => {
+          await expect(
+            repository.find({
+              type,
+              semanticSearch: { query: 'test' },
+              searchAfter: ['1', 'a'],
+            })
+          ).rejects.toThrowError(
+            'options.semanticSearch cannot be combined with options.searchAfter'
+          );
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when semanticSearch is combined with pit`, async () => {
+          await expect(
+            repository.find({
+              type,
+              semanticSearch: { query: 'test' },
+              pit: { id: 'abc123' },
+            })
+          ).rejects.toThrowError('options.semanticSearch cannot be combined with options.pit');
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when semanticSearch is combined with sortField`, async () => {
+          await expect(
+            repository.find({
+              type,
+              semanticSearch: { query: 'test' },
+              sortField: 'updated_at',
+            })
+          ).rejects.toThrowError(
+            'options.semanticSearch cannot be combined with options.sortField'
+          );
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when rankWindowSize is 0`, async () => {
+          await expect(
+            repository.find({ type, semanticSearch: { query: 'test', rankWindowSize: 0 } })
+          ).rejects.toThrowError(
+            'options.semanticSearch.rankWindowSize must be a positive integer between 1 and 1000'
+          );
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when rankWindowSize exceeds 1000`, async () => {
+          await expect(
+            repository.find({ type, semanticSearch: { query: 'test', rankWindowSize: 1001 } })
+          ).rejects.toThrowError(
+            'options.semanticSearch.rankWindowSize must be a positive integer between 1 and 1000'
+          );
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when rankWindowSize is a non-integer`, async () => {
+          await expect(
+            repository.find({ type, semanticSearch: { query: 'test', rankWindowSize: 1.5 } })
+          ).rejects.toThrowError(
+            'options.semanticSearch.rankWindowSize must be a positive integer between 1 and 1000'
+          );
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when rankConstant is 0`, async () => {
+          await expect(
+            repository.find({ type, semanticSearch: { query: 'test', rankConstant: 0 } })
+          ).rejects.toThrowError(
+            'options.semanticSearch.rankConstant must be a positive integer (minimum 1)'
+          );
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when rankConstant is negative`, async () => {
+          await expect(
+            repository.find({ type, semanticSearch: { query: 'test', rankConstant: -1 } })
+          ).rejects.toThrowError(
+            'options.semanticSearch.rankConstant must be a positive integer (minimum 1)'
+          );
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws when no requested type has semanticSearch in registration`, async () => {
+          // registry has no semantic types by default — no spy needed
+          await expect(
+            repository.find({ type, semanticSearch: { query: 'find dashboards' } })
+          ).rejects.toThrowError(
+            'options.semanticSearch requires at least one of the requested types to have semanticSearch declared in registration'
+          );
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws in hybrid mode when perPage exceeds rankWindowSize`, async () => {
+          withSemanticType();
+          await expect(
+            repository.find({
+              type,
+              perPage: 50,
+              semanticSearch: { query: 'test', mode: 'hybrid', rankWindowSize: 20 },
+            })
+          ).rejects.toThrowError(
+            'options.perPage (50) must not exceed rankWindowSize (20) in hybrid semantic search mode'
+          );
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws in hybrid mode when page offset reaches the rank window boundary`, async () => {
+          withSemanticType();
+          // perPage=10, page=11, rankWindowSize=100 → from=100 >= rws=100 → reject
+          await expect(
+            repository.find({
+              type,
+              perPage: 10,
+              page: 11,
+              semanticSearch: { query: 'test', mode: 'hybrid', rankWindowSize: 100 },
+            })
+          ).rejects.toThrowError('options.page (11) with perPage 10 exceeds the rank window (100)');
+          expect(client.search).not.toHaveBeenCalled();
+        });
+
+        it(`throws in hybrid mode when page offset exceeds default rank window`, async () => {
+          withSemanticType();
+          // perPage=20 (default), page=6, effectiveRws=max(200,100)=200 → from=100 < 200 OK
+          // perPage=20, page=11, effectiveRws=200 → from=200 >= 200 → reject
+          await expect(
+            repository.find({
+              type,
+              perPage: 20,
+              page: 11,
+              semanticSearch: { query: 'test' }, // mode defaults to hybrid
+            })
+          ).rejects.toThrowError('options.page (11) with perPage 20 exceeds the rank window (200)');
+          expect(client.search).not.toHaveBeenCalled();
+        });
+      });
     });
 
     describe('returns', () => {
@@ -544,6 +711,76 @@ describe('find', () => {
             type: ['config', 'index-pattern'],
           })
         );
+      });
+
+      describe('semanticSearch option', () => {
+        afterEach(() => {
+          jest.restoreAllMocks();
+        });
+
+        it(`passes semanticSearch option to getSearchDsl with resolved rankWindowSize`, async () => {
+          // Make the registry report that `type` (='index-pattern') has semanticSearch
+          // so the registration check passes.
+          jest
+            .spyOn(registry, 'getSemanticSearchDefinition')
+            .mockImplementation((typeName) =>
+              typeName === type
+                ? { fields: ['title'], inferenceId: '.elser-2-elasticsearch', embedding: 'sync' }
+                : undefined
+            );
+
+          const semanticSearch = {
+            query: 'find relevant dashboards',
+            mode: 'hybrid' as const,
+            rankConstant: 30,
+          };
+
+          await findSuccess(client, repository, { type, semanticSearch });
+
+          // The option must be forwarded with the effective rankWindowSize resolved:
+          // perPage=FIND_DEFAULT_PER_PAGE (20), effectiveRws=max(200,100)=200.
+          expect(mockGetSearchDsl).toHaveBeenCalledWith(
+            mappings,
+            registry,
+            expect.objectContaining({
+              semanticSearch: expect.objectContaining({
+                query: 'find relevant dashboards',
+                mode: 'hybrid',
+                rankConstant: 30,
+                rankWindowSize: 200, // resolved from max(perPage*10, 100)
+              }),
+            })
+          );
+        });
+
+        it(`passes explicit rankWindowSize to getSearchDsl unchanged`, async () => {
+          jest
+            .spyOn(registry, 'getSemanticSearchDefinition')
+            .mockImplementation((typeName) =>
+              typeName === type
+                ? { fields: ['title'], inferenceId: '.elser-2-elasticsearch', embedding: 'sync' }
+                : undefined
+            );
+
+          const semanticSearch = {
+            query: 'find relevant dashboards',
+            mode: 'semantic' as const,
+            rankWindowSize: 500,
+          };
+
+          await findSuccess(client, repository, { type, semanticSearch });
+
+          expect(mockGetSearchDsl).toHaveBeenCalledWith(
+            mappings,
+            registry,
+            expect.objectContaining({
+              semanticSearch: expect.objectContaining({
+                mode: 'semantic',
+                rankWindowSize: 500,
+              }),
+            })
+          );
+        });
       });
     });
   });

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/find.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/find.ts
@@ -92,6 +92,7 @@ export const performFind = async <T = unknown, A = unknown>(
     preference,
     aggs,
     migrationVersionCompatibility,
+    semanticSearch,
   } = options;
 
   if (!type) {
@@ -116,6 +117,86 @@ export const performFind = async <T = unknown, A = unknown>(
 
   if (fields && !Array.isArray(fields)) {
     throw SavedObjectsErrorHelpers.createBadRequestError('options.fields must be an array');
+  }
+
+  // semanticSearch option validation — all checks are pre-flight to avoid a round-trip
+  // to ES for options that are structurally incompatible with retriever DSL.
+  let resolvedSemanticSearch = semanticSearch;
+  if (semanticSearch) {
+    if (!semanticSearch.query?.trim()) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        'options.semanticSearch.query must be a non-empty string'
+      );
+    }
+    if (searchAfter) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        'options.semanticSearch cannot be combined with options.searchAfter'
+      );
+    }
+    if (pit) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        'options.semanticSearch cannot be combined with options.pit'
+      );
+    }
+    if (sortField) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        'options.semanticSearch cannot be combined with options.sortField (ES rejects top-level sort with a retriever)'
+      );
+    }
+    if (
+      semanticSearch.rankWindowSize !== undefined &&
+      (!Number.isInteger(semanticSearch.rankWindowSize) ||
+        semanticSearch.rankWindowSize < 1 ||
+        semanticSearch.rankWindowSize > 1000)
+    ) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        'options.semanticSearch.rankWindowSize must be a positive integer between 1 and 1000'
+      );
+    }
+    if (
+      semanticSearch.rankConstant !== undefined &&
+      (!Number.isInteger(semanticSearch.rankConstant) || semanticSearch.rankConstant < 1)
+    ) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        'options.semanticSearch.rankConstant must be a positive integer (minimum 1)'
+      );
+    }
+    // At least one requested type must declare semanticSearch in its registration.
+    const typesWithSemantic = allowedTypes.filter(
+      (t) => registry.getSemanticSearchDefinition(t) !== undefined
+    );
+    if (typesWithSemantic.length === 0) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        `options.semanticSearch requires at least one of the requested types to have semanticSearch ` +
+          `declared in registration; none of [${allowedTypes.join(
+            ', '
+          )}] have semanticSearch configured`
+      );
+    }
+    // Resolve the effective rank_window_size so pagination validation and the ES query agree.
+    // The perPage-relative default (max(perPage*10, 100)) is resolved here and passed
+    // to getSearchDsl so it uses the same value.
+    const effectiveRankWindowSize =
+      semanticSearch.rankWindowSize ?? Math.min(Math.max(perPage * 10, 100), 1000);
+    resolvedSemanticSearch = { ...semanticSearch, rankWindowSize: effectiveRankWindowSize };
+    // Hybrid mode: validate that from/size fall inside the rank window.
+    // ES silently returns empty results when from >= rank_window_size (no 400), so we
+    // pre-flight reject to avoid confusing silent empty pages.
+    const semanticMode = semanticSearch.mode ?? 'hybrid';
+    if (semanticMode === 'hybrid') {
+      if (perPage > effectiveRankWindowSize) {
+        throw SavedObjectsErrorHelpers.createBadRequestError(
+          `options.perPage (${perPage}) must not exceed rankWindowSize (${effectiveRankWindowSize}) in hybrid semantic search mode`
+        );
+      }
+      const from = perPage * (page - 1);
+      if (from >= effectiveRankWindowSize) {
+        throw SavedObjectsErrorHelpers.createBadRequestError(
+          `options.page (${page}) with perPage ${perPage} exceeds the rank window (${effectiveRankWindowSize}); ` +
+            `start offset ${from} must be less than rankWindowSize in hybrid semantic search mode`
+        );
+      }
+    }
   }
 
   let kueryNode;
@@ -214,6 +295,7 @@ export const performFind = async <T = unknown, A = unknown>(
       hasNoReference,
       hasNoReferenceOperator,
       kueryNode,
+      semanticSearch: resolvedSemanticSearch,
     }),
   };
 

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/embedding.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/embedding.test.ts
@@ -1,0 +1,279 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ISavedObjectTypeRegistry } from '@kbn/core-saved-objects-server';
+import { EmbeddingHelper } from './embedding';
+
+/** Minimal registry mock for embedding helper tests. */
+const createRegistryMock = (
+  definitions: Record<
+    string,
+    { fields: readonly string[]; inferenceId: string; embedding: 'sync' | 'deferred' } | undefined
+  > = {}
+): jest.Mocked<ISavedObjectTypeRegistry> => {
+  return {
+    getSemanticSearchDefinition: jest.fn((typeName: string) => definitions[typeName] ?? undefined),
+  } as unknown as jest.Mocked<ISavedObjectTypeRegistry>;
+};
+
+describe('EmbeddingHelper.populateSemanticFields', () => {
+  let helper: EmbeddingHelper;
+
+  // ── Not opted-in types ──────────────────────────────────────────────────────
+
+  describe('when the type does not declare semanticSearch', () => {
+    beforeEach(() => {
+      helper = new EmbeddingHelper({ registry: createRegistryMock() });
+    });
+
+    it('returns the exact same attributes reference (hot path, zero allocation)', () => {
+      const attrs = { title: 'Hello' };
+      expect(helper.populateSemanticFields('no-search-type', attrs)).toBe(attrs);
+    });
+
+    it('does not alter any attribute values', () => {
+      const attrs = { a: 1, b: 'text' };
+      expect(helper.populateSemanticFields('no-search-type', attrs)).toEqual({ a: 1, b: 'text' });
+    });
+  });
+
+  // ── Sync mode (default) ─────────────────────────────────────────────────────
+
+  describe('when the type declares semanticSearch with embedding: "sync" (default)', () => {
+    const syncDef = {
+      fields: ['title', 'description'] as readonly string[],
+      inferenceId: '.elser-2-elasticsearch',
+      embedding: 'sync' as const,
+    };
+
+    beforeEach(() => {
+      helper = new EmbeddingHelper({
+        registry: createRegistryMock({ 'my-type': syncDef }),
+      });
+    });
+
+    it('returns a NEW object (not the same reference)', () => {
+      const attrs = { title: 'Hello', description: 'World' };
+      const result = helper.populateSemanticFields('my-type', attrs);
+      expect(result).not.toBe(attrs);
+    });
+
+    it('copies source field text into shadow keys for non-empty string values', () => {
+      const attrs = { title: 'Dashboard A', description: 'Shows metrics' };
+      const result = helper.populateSemanticFields('my-type', attrs) as Record<string, unknown>;
+      expect(result.title_semantic).toBe('Dashboard A');
+      expect(result.description_semantic).toBe('Shows metrics');
+    });
+
+    it('preserves non-declared attributes unchanged', () => {
+      const attrs = { title: 'Hello', otherField: 'value', nested: { x: 1 } };
+      const result = helper.populateSemanticFields('my-type', attrs) as Record<string, unknown>;
+      expect(result.otherField).toBe('value');
+      expect(result.nested).toEqual({ x: 1 });
+    });
+
+    it('does NOT mutate the input attributes object', () => {
+      const attrs = { title: 'Hello', description: 'World' };
+      const original = { ...attrs };
+      helper.populateSemanticFields('my-type', attrs);
+      expect(attrs).toEqual(original);
+    });
+
+    describe('present-but-cleared field values emit null (Finding #3)', () => {
+      // When a declared field KEY is present in the input but its value is not a non-empty
+      // string, we emit `null` for the shadow key.  This ensures that on the update path,
+      // mergeForUpdate overwrites any stale stored shadow with null (ES then skips inference).
+      // On the create path, emitting null is harmless (there is no stored shadow to clear).
+
+      it('emits null shadow key for a null value', () => {
+        const attrs = { title: null as unknown as string, description: 'World' };
+        const result = helper.populateSemanticFields('my-type', attrs) as Record<string, unknown>;
+        expect(result.title_semantic).toBeNull();
+        expect(result.description_semantic).toBe('World');
+      });
+
+      it('emits null shadow key for an undefined value (key present, value undefined)', () => {
+        const attrs = { title: undefined as unknown as string, description: 'World' };
+        const result = helper.populateSemanticFields('my-type', attrs) as Record<string, unknown>;
+        expect(result.title_semantic).toBeNull();
+      });
+
+      it('emits null shadow key for an empty string value', () => {
+        const attrs = { title: '', description: 'World' };
+        const result = helper.populateSemanticFields('my-type', attrs) as Record<string, unknown>;
+        expect(result.title_semantic).toBeNull();
+      });
+
+      it('emits null shadow key for a numeric value (type mismatch)', () => {
+        const attrs = { title: 42 as unknown as string, description: 'World' };
+        const result = helper.populateSemanticFields('my-type', attrs) as Record<string, unknown>;
+        expect(result.title_semantic).toBeNull();
+      });
+
+      it('skips a declared field that is ABSENT from the attributes — no shadow key emitted', () => {
+        // Only `title` present; `description` is not a key in the input at all.
+        // This preserves the stored shadow via mergeForUpdate (staleness rule).
+        const attrs = { title: 'Hello' };
+        const result = helper.populateSemanticFields('my-type', attrs) as Record<string, unknown>;
+        expect(result.title_semantic).toBe('Hello');
+        expect(result).not.toHaveProperty('description_semantic');
+      });
+    });
+
+    describe('stripping caller-supplied shadow keys', () => {
+      it('strips keys ending with _semantic from the input', () => {
+        const attrs = { title: 'Hello', title_semantic: 'stale value', description: 'World' };
+        const result = helper.populateSemanticFields('my-type', attrs) as Record<string, unknown>;
+        // The helper re-derives title_semantic from the source; the stale value is gone.
+        expect(result.title_semantic).toBe('Hello');
+        expect(result.description_semantic).toBe('World');
+      });
+
+      it('strips shadow keys for non-declared fields too (defense-in-depth)', () => {
+        const attrs = { title: 'Hello', some_other_field_semantic: 'caller-injected' };
+        const result = helper.populateSemanticFields('my-type', attrs) as Record<string, unknown>;
+        expect(result).not.toHaveProperty('some_other_field_semantic');
+      });
+    });
+  });
+
+  // ── Deferred mode via per-type default ──────────────────────────────────────
+
+  describe('when the type declares semanticSearch with embedding: "deferred"', () => {
+    const deferredDef = {
+      fields: ['title'] as readonly string[],
+      inferenceId: '.elser-2-elasticsearch',
+      embedding: 'deferred' as const,
+    };
+
+    beforeEach(() => {
+      helper = new EmbeddingHelper({
+        registry: createRegistryMock({ 'deferred-type': deferredDef }),
+      });
+    });
+
+    it('returns a new object with no shadow keys added', () => {
+      const attrs = { title: 'Hello', extra: 'value' };
+      const result = helper.populateSemanticFields('deferred-type', attrs) as Record<
+        string,
+        unknown
+      >;
+      expect(result).not.toHaveProperty('title_semantic');
+    });
+
+    it('strips caller-supplied shadow keys even in deferred mode', () => {
+      const attrs = { title: 'Hello', title_semantic: 'stale caller value' };
+      const result = helper.populateSemanticFields('deferred-type', attrs) as Record<
+        string,
+        unknown
+      >;
+      expect(result).not.toHaveProperty('title_semantic');
+      // Source field is untouched
+      expect(result.title).toBe('Hello');
+    });
+
+    it('preserves non-shadow attributes', () => {
+      const attrs = { title: 'Hello', other: 42 };
+      const result = helper.populateSemanticFields('deferred-type', attrs) as Record<
+        string,
+        unknown
+      >;
+      expect(result.title).toBe('Hello');
+      expect(result.other).toBe(42);
+    });
+  });
+
+  // ── Per-request override: deferEmbeddings flag ──────────────────────────────
+
+  describe('per-request deferEmbeddings override', () => {
+    const syncDef = {
+      fields: ['title'] as readonly string[],
+      inferenceId: '.elser-2-elasticsearch',
+      embedding: 'sync' as const,
+    };
+    const deferredDef = {
+      fields: ['title'] as readonly string[],
+      inferenceId: '.elser-2-elasticsearch',
+      embedding: 'deferred' as const,
+    };
+
+    it('deferEmbeddings=true overrides a sync-default type (no shadow keys emitted)', () => {
+      helper = new EmbeddingHelper({
+        registry: createRegistryMock({ 'sync-type': syncDef }),
+      });
+      const attrs = { title: 'Hello' };
+      const result = helper.populateSemanticFields('sync-type', attrs, true) as Record<
+        string,
+        unknown
+      >;
+      expect(result).not.toHaveProperty('title_semantic');
+    });
+
+    it('deferEmbeddings=false overrides a deferred-default type (shadow keys emitted)', () => {
+      helper = new EmbeddingHelper({
+        registry: createRegistryMock({ 'deferred-type': deferredDef }),
+      });
+      const attrs = { title: 'Hello' };
+      const result = helper.populateSemanticFields('deferred-type', attrs, false) as Record<
+        string,
+        unknown
+      >;
+      expect(result.title_semantic).toBe('Hello');
+    });
+
+    it('deferEmbeddings=undefined falls back to per-type default (sync emits, deferred does not)', () => {
+      helper = new EmbeddingHelper({
+        registry: createRegistryMock({ 'sync-type': syncDef, 'deferred-type': deferredDef }),
+      });
+      const attrs = { title: 'Hello' };
+
+      const syncResult = helper.populateSemanticFields('sync-type', attrs, undefined) as Record<
+        string,
+        unknown
+      >;
+      expect(syncResult.title_semantic).toBe('Hello');
+
+      const deferredResult = helper.populateSemanticFields(
+        'deferred-type',
+        attrs,
+        undefined
+      ) as Record<string, unknown>;
+      expect(deferredResult).not.toHaveProperty('title_semantic');
+    });
+  });
+
+  // ── Update staleness rule ────────────────────────────────────────────────────
+
+  describe('partial-update semantics (update staleness rule)', () => {
+    const syncDef = {
+      fields: ['title', 'description'] as readonly string[],
+      inferenceId: '.elser-2-elasticsearch',
+      embedding: 'sync' as const,
+    };
+
+    beforeEach(() => {
+      helper = new EmbeddingHelper({
+        registry: createRegistryMock({ 'my-type': syncDef }),
+      });
+    });
+
+    it('only emits a shadow key for declared fields that are present in the partial attributes', () => {
+      // Partial update: only `title` is being updated.
+      const partialAttrs = { title: 'Updated Title' };
+      const result = helper.populateSemanticFields('my-type', partialAttrs) as Record<
+        string,
+        unknown
+      >;
+      expect(result.title_semantic).toBe('Updated Title');
+      // `description` is absent from the partial update, so its shadow key is not emitted.
+      // The stored doc's existing `description_semantic` is preserved by mergeForUpdate.
+      expect(result).not.toHaveProperty('description_semantic');
+    });
+  });
+});

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/embedding.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/embedding.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { ISavedObjectTypeRegistry } from '@kbn/core-saved-objects-server';
+import {
+  SEMANTIC_FIELD_SUFFIX,
+  getSemanticFieldName,
+} from '@kbn/core-saved-objects-base-server-internal';
+
+export type IEmbeddingHelper = PublicMethodsOf<EmbeddingHelper>;
+
+/**
+ * Populates or suppresses shadow semantic fields on the write path (Mechanism B, ADR-6).
+ *
+ * Incompatibility note: a type must not declare both {@link SavedObjectsType.semanticSearch} and
+ * use the ESO encryption extension (i.e. be registered as an encryptable type).  Shadow keys are
+ * added after validation and migration but before `savedObjectToRaw`; if the ESO extension also
+ * operates on the same attributes the AAD computed at write time will include shadow keys while
+ * the read path strips them before decryption, producing AAD mismatches.  Nothing enforces this
+ * at registration time because core cannot see ESO registrations — type authors are responsible
+ * for not combining the two options.
+ */
+export class EmbeddingHelper {
+  private readonly registry: ISavedObjectTypeRegistry;
+
+  constructor({ registry }: { registry: ISavedObjectTypeRegistry }) {
+    this.registry = registry;
+  }
+
+  /**
+   * Returns attributes with shadow `{field}_semantic` keys populated for types that declare
+   * {@link SavedObjectsType.semanticSearch | semanticSearch}, or the same reference when the type
+   * is not opted in (hot path, zero allocation).
+   *
+   * Behavior:
+   * - **Not opted in**: returns the original `attributes` reference unchanged.
+   * - **Deferred mode** (`deferEmbeddings ?? definition.embedding === 'deferred'`): strips any
+   *   caller-supplied `*_semantic` keys and returns a new object with no shadow fields.
+   *   Elasticsearch performs no inference; the object is eventually embedded by the reconciler.
+   * - **Sync mode**: strips caller-supplied `*_semantic` keys (callers must never write shadow
+   *   fields directly), then for each declared field that is **present in the input**:
+   *   - non-empty string → copies the value as `{field}_semantic` (ES embeds synchronously);
+   *   - present but cleared (null, empty string, non-string) → emits `null` so ES skips
+   *     inference (S7) and any stale stored shadow is overwritten.
+   *   Fields **absent** from the input are skipped — for partial updates this preserves the
+   *   stored shadow value via `mergeForUpdate`; for creates there is no stored shadow.
+   *
+   * This function is synchronous and performs no I/O; Elasticsearch runs inference at index time
+   * when the shadow key is present in the raw document.
+   */
+  readonly populateSemanticFields = <T>(
+    type: string,
+    attributes: T,
+    deferEmbeddings?: boolean
+  ): T => {
+    const definition = this.registry.getSemanticSearchDefinition(type);
+    if (!definition) {
+      // Hot path: type is not opted in — return the same reference, zero allocation.
+      return attributes;
+    }
+
+    const isDeferred = deferEmbeddings ?? definition.embedding === 'deferred';
+
+    // Build a new object: copy all non-shadow keys, then (sync mode only) append shadow copies
+    // of declared source fields that carry a non-empty string value.
+    // Stripping caller-supplied shadow keys is always done — even in deferred mode — because
+    // callers must never write shadow fields directly; the helper is the sole writer.
+    const raw = attributes as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(raw)) {
+      if (!key.endsWith(SEMANTIC_FIELD_SUFFIX)) {
+        result[key] = raw[key];
+      }
+    }
+
+    if (!isDeferred) {
+      for (const field of definition.fields) {
+        if (!Object.hasOwn(raw, field)) {
+          // Field absent from this input — skip entirely.
+          // For partial updates the stored shadow survives mergeForUpdate unchanged.
+          // For creates there is no stored shadow to preserve.
+          continue;
+        }
+        const value = raw[field];
+        if (typeof value === 'string' && value.length > 0) {
+          result[getSemanticFieldName(field)] = value;
+        } else {
+          // Field is present but cleared (empty string, null, non-string).
+          // Emit null: ES skips inference (S7 spike finding) and mergeForUpdate overwrites
+          // any stale shadow from the stored document.
+          result[getSemanticFieldName(field)] = null;
+        }
+      }
+    }
+
+    return result as T;
+  };
+
+  /**
+   * Returns only the shadow field entries derived from a partial update's `attributes`, for
+   * overlay onto the post-merge, post-migration document.  Only fields explicitly present in the
+   * input produce an entry; absent fields are omitted so that the stored shadow value (preserved
+   * by `mergeForUpdate`) is left intact.  Returns an empty record for non-opted-in types or when
+   * the per-type default is `'deferred'` (the reconciler handles embedding in that case).
+   *
+   * Use this in the update write path AFTER `migrateInputDocument`, so that shadow keys never
+   * pass through migration transforms that may rebuild attributes from scratch.
+   */
+  readonly shadowFieldsForUpdate = <T>(type: string, attributes: T): Record<string, unknown> => {
+    const definition = this.registry.getSemanticSearchDefinition(type);
+    if (!definition || definition.embedding === 'deferred') {
+      return {};
+    }
+    const raw = attributes as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const field of definition.fields) {
+      if (!Object.hasOwn(raw, field)) {
+        continue; // Absent from partial — preserve the stored shadow via mergeForUpdate.
+      }
+      const value = raw[field];
+      result[getSemanticFieldName(field)] =
+        typeof value === 'string' && value.length > 0 ? value : null;
+    }
+    return result;
+  };
+}

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/index.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/index.ts
@@ -9,6 +9,7 @@
 
 import type { ICommonHelper } from './common';
 import type { IEncryptionHelper } from './encryption';
+import type { IEmbeddingHelper } from './embedding';
 import type { IValidationHelper } from './validation';
 import type { IPreflightCheckHelper } from './preflight_check';
 import type { ISerializerHelper } from './serializer';
@@ -17,6 +18,7 @@ import type { UserHelper } from './user';
 
 export { CommonHelper, type ICommonHelper } from './common';
 export { EncryptionHelper, type IEncryptionHelper } from './encryption';
+export { EmbeddingHelper, type IEmbeddingHelper } from './embedding';
 export { ValidationHelper, type IValidationHelper } from './validation';
 export { SerializerHelper, type ISerializerHelper } from './serializer';
 export { MigrationHelper, type IMigrationHelper } from './migration';
@@ -35,6 +37,7 @@ export {
 export interface RepositoryHelpers {
   common: ICommonHelper;
   encryption: IEncryptionHelper;
+  embedding: IEmbeddingHelper;
   validation: IValidationHelper;
   preflight: IPreflightCheckHelper;
   serializer: ISerializerHelper;

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/search.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/search.test.ts
@@ -115,6 +115,58 @@ describe('search', () => {
     }
   );
 
+  describe('forbidden esOptions that bypass namespace filtering', () => {
+    // Each key in this list introduces an independent ES retrieval branch that is not governed by
+    // the namespace/type bool filter. Allowing them would be a silent cross-namespace data leak.
+    it.each(['knn', 'retriever', 'rank', 'sub_searches'])(
+      'should throw a 400 bad request error when esOptions contains "%s"',
+      async (forbiddenKey) => {
+        const badOptions = {
+          ...options,
+          [forbiddenKey]: { some: 'value' },
+        } as SavedObjectsSearchOptions;
+
+        await expect(repository.search(badOptions)).rejects.toMatchObject({
+          output: {
+            statusCode: 400,
+            payload: expect.objectContaining({
+              message: expect.stringContaining(forbiddenKey),
+            }),
+          },
+        });
+        expect(client.search).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should include all offending keys in the error message when multiple forbidden keys are present', async () => {
+      const badOptions = {
+        ...options,
+        knn: { field: 'embedding', query_vector: [1, 2, 3], k: 10, num_candidates: 100 },
+        retriever: { standard: { query: { match_all: {} } } },
+      } as SavedObjectsSearchOptions;
+
+      await expect(repository.search(badOptions)).rejects.toMatchObject({
+        output: {
+          statusCode: 400,
+          payload: expect.objectContaining({
+            message: expect.stringMatching(/knn/),
+          }),
+        },
+      });
+      expect(client.search).not.toHaveBeenCalled();
+    });
+
+    it('should not throw for collapse, which operates on the already-filtered result set', async () => {
+      const collapseOptions = {
+        ...options,
+        collapse: { field: 'type' },
+      } as SavedObjectsSearchOptions;
+
+      await expect(repository.search(collapseOptions)).resolves.toEqual(EMPTY_SEARCH_RESPONSE);
+      expect(client.search).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('should return an empty response if the search returns 404', async () => {
     client.search.mockResolvedValueOnce(
       elasticsearchClientMock.createSuccessTransportRequestPromise(

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/search.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/search.ts
@@ -75,6 +75,31 @@ export async function performSearch<T extends SavedObjectsRawDocSource, A = unkn
     );
   }
 
+  // Guard: 'knn', 'retriever', 'rank', and 'sub_searches' introduce independent ES retrieval
+  // branches that are NOT governed by the namespace/type bool filter injected by
+  // mergeUserQueryWithNamespacesBool. An under-filtered branch is a silent cross-namespace data
+  // leak (S5 finding). Even when TypeScript forbids these keys for typed callers, runtime callers
+  // can spread untyped options — that is the entire bug class this guard addresses.
+  //
+  // 'collapse' is intentionally excluded: it performs field collapsing on the already-filtered
+  // result set and cannot retrieve documents that did not match the namespace filter in the query.
+  //
+  // 'sub_searches' is not present in the current @elastic/elasticsearch type definitions but is
+  // guarded here as a defense-in-depth measure against untyped callers on future ES API versions.
+  const FORBIDDEN_ES_OPTIONS = ['knn', 'retriever', 'rank', 'sub_searches'] as const;
+  const esOptionsRecord = esOptions as Record<string, unknown>;
+  const presentForbiddenOptions = FORBIDDEN_ES_OPTIONS.filter(
+    (key) => esOptionsRecord[key] != null
+  );
+  if (presentForbiddenOptions.length > 0) {
+    throw SavedObjectsErrorHelpers.createBadRequestError(
+      `esOptions contains keys that bypass namespace filtering: ${presentForbiddenOptions.join(
+        ', '
+      )}. ` +
+        `These options introduce independent retrieval branches outside the namespace/type bool filter.`
+    );
+  }
+
   const types = castArray(type).filter((t) => allowedTypes.includes(t));
   if (types.length === 0) {
     return createEmptySearchResponse();

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/semantic_search_write_path.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/semantic_search_write_path.test.ts
@@ -1,0 +1,672 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Tests that the write-path embedding helper populates (or omits) shadow semantic fields in the
+ * raw Elasticsearch document for opted-in types.  These tests exercise the full repository stack
+ * (real EmbeddingHelper, real serializer, mocked ES client) so that assertions target the exact
+ * `document` body sent to `client.create` / `client.index` / `client.bulk`.
+ */
+
+import {
+  pointInTimeFinderMock,
+  mockGetCurrentTime,
+  mockPreflightCheckForCreate,
+  mockGetSearchDsl,
+} from '../repository.test.mock';
+
+import type { estypes } from '@elastic/elasticsearch';
+import { schema } from '@kbn/config-schema';
+import { SavedObjectsRepository } from '../repository';
+import { loggerMock } from '@kbn/logging-mocks';
+import type { SavedObjectsSerializer } from '@kbn/core-saved-objects-base-server-internal';
+import type { SavedObjectsRawDocSource } from '@kbn/core-saved-objects-server';
+import { SavedObjectTypeRegistry } from '@kbn/core-saved-objects-base-server-internal';
+import { kibanaMigratorMock } from '../../mocks';
+import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+
+import {
+  mockVersionProps,
+  mockTimestamp,
+  createDocumentMigrator,
+  createSpySerializer,
+} from '../../test_helpers/repository.test.common';
+
+// ── Type names ──────────────────────────────────────────────────────────────
+
+const SYNC_TYPE = 'semanticSyncType';
+const DEFERRED_TYPE = 'semanticDeferredType';
+const PLAIN_TYPE = 'plainType';
+// SCHEMA_TYPE has a strict modelVersion create schema AND semanticSearch — regression for
+// Finding #1 (shadow keys must not be visible to validateObjectForCreate).
+const SCHEMA_TYPE = 'semanticSchemaType';
+
+// ── Registry with semantic-search types ──────────────────────────────────────
+
+const createSemanticRegistry = () => {
+  const registry = new SavedObjectTypeRegistry();
+
+  registry.registerType({
+    name: PLAIN_TYPE,
+    hidden: false,
+    namespaceType: 'single',
+    mappings: { properties: { title: { type: 'text' }, count: { type: 'integer' } } },
+  });
+
+  registry.registerType({
+    name: SYNC_TYPE,
+    hidden: false,
+    namespaceType: 'single',
+    mappings: {
+      properties: {
+        title: { type: 'text' },
+        description: { type: 'text' },
+        count: { type: 'integer' },
+      },
+    },
+    semanticSearch: {
+      fields: ['title', 'description'],
+      // no inferenceId — uses platform default
+      // no embedding — defaults to 'sync'
+    },
+  });
+
+  registry.registerType({
+    name: DEFERRED_TYPE,
+    hidden: false,
+    namespaceType: 'single',
+    mappings: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+    semanticSearch: {
+      fields: ['title'],
+      embedding: 'deferred',
+    },
+  });
+
+  // Type with a strict model-version create schema AND semanticSearch.  The schema only
+  // allows `title` and `count`; shadow keys must never reach validateObjectForCreate or it
+  // would throw an "Unknown key" error (blocker Finding #1 regression guard).
+  registry.registerType({
+    name: SCHEMA_TYPE,
+    hidden: false,
+    namespaceType: 'single',
+    mappings: {
+      properties: {
+        title: { type: 'text' },
+        count: { type: 'integer' },
+      },
+    },
+    modelVersions: {
+      '1': {
+        changes: [],
+        schemas: {
+          create: schema.object({ title: schema.string(), count: schema.number() }),
+        },
+      },
+    },
+    semanticSearch: {
+      fields: ['title'],
+    },
+  });
+
+  return registry;
+};
+
+// ── Shared test mappings ─────────────────────────────────────────────────────
+
+const testMappings = {
+  properties: {
+    [PLAIN_TYPE]: { properties: {} },
+    [SYNC_TYPE]: { properties: {} },
+    [DEFERRED_TYPE]: { properties: {} },
+    [SCHEMA_TYPE]: { properties: {} },
+  },
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Extracts the raw `_source` from the first `client.create` call. */
+const getCreateBody = (
+  client: ReturnType<typeof elasticsearchClientMock.createElasticsearchClient>
+) => (client.create.mock.calls[0][0] as estypes.CreateRequest).document as Record<string, unknown>;
+
+/** Extracts the raw `_source` from the first `client.index` call. */
+const getIndexBody = (
+  client: ReturnType<typeof elasticsearchClientMock.createElasticsearchClient>
+) => (client.index.mock.calls[0][0] as estypes.IndexRequest).document as Record<string, unknown>;
+
+/** Extracts the raw `_source` of the first bulk write item (the body after the action). */
+const getBulkBody = (
+  client: ReturnType<typeof elasticsearchClientMock.createElasticsearchClient>
+) => {
+  // bulk params are [{action}, {body}, {action}, {body}, ...]
+  const params = client.bulk.mock.calls[0][0] as { operations: unknown[] };
+  return params.operations[1] as Record<string, unknown>;
+};
+
+describe('Semantic search write path (EmbeddingHelper integration)', () => {
+  let client: ReturnType<typeof elasticsearchClientMock.createElasticsearchClient>;
+  let repository: SavedObjectsRepository;
+  let migrator: ReturnType<typeof kibanaMigratorMock.create>;
+  let logger: ReturnType<typeof loggerMock.create>;
+  let serializer: jest.Mocked<SavedObjectsSerializer>;
+
+  const registry = createSemanticRegistry();
+  const documentMigrator = createDocumentMigrator(registry);
+
+  beforeEach(() => {
+    pointInTimeFinderMock.mockClear();
+    client = elasticsearchClientMock.createElasticsearchClient();
+    migrator = kibanaMigratorMock.create();
+    documentMigrator.prepareMigrations();
+    migrator.migrateDocument = jest.fn().mockImplementation(documentMigrator.migrate);
+    migrator.runMigrations = jest.fn().mockResolvedValue([{ status: 'skipped' }]);
+    logger = loggerMock.create();
+    serializer = createSpySerializer(registry);
+    mockGetSearchDsl.mockClear();
+
+    const allTypes = registry.getAllTypes().map((t) => t.name);
+    const allowedTypes = [...new Set(allTypes.filter((t) => !registry.isHidden(t)))];
+
+    // @ts-expect-error must use the private constructor to use the mocked serializer
+    repository = new SavedObjectsRepository({
+      index: '.kibana-test',
+      mappings: testMappings,
+      client,
+      migrator,
+      typeRegistry: registry,
+      serializer,
+      allowedTypes,
+      logger,
+    });
+
+    mockGetCurrentTime.mockReturnValue(mockTimestamp);
+
+    // Default: preflight resolves with no conflicts
+    mockPreflightCheckForCreate.mockReset();
+    mockPreflightCheckForCreate.mockImplementation(({ objects }) =>
+      Promise.resolve(objects.map(({ type, id }) => ({ type, id })))
+    );
+
+    // Default: create/index respond with success
+    client.create.mockResponseImplementation((params) => ({
+      body: { _id: params.id, ...mockVersionProps } as estypes.CreateResponse,
+    }));
+    client.index.mockResponseImplementation((params) => ({
+      body: { _id: params.id, ...mockVersionProps } as estypes.CreateResponse,
+    }));
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // create()
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('create()', () => {
+    it('does NOT add shadow keys for a type without semanticSearch', async () => {
+      await repository.create(PLAIN_TYPE, { title: 'Hello', count: 3 });
+      const body = getCreateBody(client);
+      const typeAttrs = body[PLAIN_TYPE] as Record<string, unknown>;
+      expect(typeAttrs).not.toHaveProperty('title_semantic');
+    });
+
+    it('adds shadow key for a declared text field with a non-empty string value (sync mode)', async () => {
+      await repository.create(SYNC_TYPE, {
+        title: 'Dashboard A',
+        description: 'Shows metrics',
+        count: 5,
+      });
+      const body = getCreateBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.title_semantic).toBe('Dashboard A');
+      expect(typeAttrs.description_semantic).toBe('Shows metrics');
+    });
+
+    it('emits null shadow key for a declared field with a non-string value (clears stale shadow)', async () => {
+      // Null field is present in the input — we emit null so any stale shadow on an update path
+      // is cleared by mergeForUpdate, and so ES skips inference (S7).  On a create there is no
+      // stale shadow to clear, but emitting null is harmless.
+      await repository.create(SYNC_TYPE, {
+        title: null as unknown as string,
+        description: 'Desc',
+        count: 0,
+      });
+      const body = getCreateBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.title_semantic).toBeNull();
+      expect(typeAttrs.description_semantic).toBe('Desc');
+    });
+
+    it('emits null shadow key for a declared field with an empty string value', async () => {
+      // Empty string is present in the input — emit null so stale shadow is cleared (Finding #3).
+      await repository.create(SYNC_TYPE, { title: '', description: 'Desc' });
+      const body = getCreateBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.title_semantic).toBeNull();
+    });
+
+    it('strips any caller-supplied shadow keys from the stored document', async () => {
+      // Caller tries to inject a stale shadow value — it must be replaced with the derived one.
+      await repository.create(SYNC_TYPE, {
+        title: 'New Title',
+        title_semantic: 'stale caller value',
+        description: 'Desc',
+      } as any);
+      const body = getCreateBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.title_semantic).toBe('New Title');
+    });
+
+    it('does NOT add shadow keys when deferEmbeddings=true (even for a sync-default type)', async () => {
+      await repository.create(
+        SYNC_TYPE,
+        { title: 'Hello', description: 'World' },
+        { deferEmbeddings: true }
+      );
+      const body = getCreateBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs).not.toHaveProperty('title_semantic');
+      expect(typeAttrs).not.toHaveProperty('description_semantic');
+    });
+
+    it('does NOT add shadow keys for a deferred-default type (no per-request override)', async () => {
+      await repository.create(DEFERRED_TYPE, { title: 'Hello' });
+      const body = getCreateBody(client);
+      const typeAttrs = body[DEFERRED_TYPE] as Record<string, unknown>;
+      expect(typeAttrs).not.toHaveProperty('title_semantic');
+    });
+
+    it('DOES add shadow keys when deferEmbeddings=false overrides a deferred-default type', async () => {
+      await repository.create(DEFERRED_TYPE, { title: 'Hello' }, { deferEmbeddings: false });
+      const body = getCreateBody(client);
+      const typeAttrs = body[DEFERRED_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.title_semantic).toBe('Hello');
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // bulkCreate()
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('bulkCreate()', () => {
+    /** Build a minimal but well-shaped bulk response so bulk_create.ts can parse it. */
+    const makeBulkResponse = (types: string[], ids: string[]): estypes.BulkResponse =>
+      ({
+        errors: false,
+        took: 1,
+        items: types.map((type, i) => ({
+          create: {
+            _id: `${type}:${ids[i]}`,
+            ...mockVersionProps,
+            result: 'created',
+            _index: '.kibana-test',
+          },
+        })),
+      } as unknown as estypes.BulkResponse);
+
+    it('adds shadow keys for a sync-default type in bulk create', async () => {
+      client.bulk.mockResponseOnce(makeBulkResponse([SYNC_TYPE], ['id-1']));
+      await repository.bulkCreate([
+        { type: SYNC_TYPE, id: 'id-1', attributes: { title: 'Rule A', description: 'Desc A' } },
+      ]);
+      const params = client.bulk.mock.calls[0][0] as { operations: unknown[] };
+      const body = params.operations[1] as Record<string, unknown>;
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.title_semantic).toBe('Rule A');
+      expect(typeAttrs.description_semantic).toBe('Desc A');
+    });
+
+    it('does NOT add shadow keys when deferEmbeddings=true at the options level', async () => {
+      client.bulk.mockResponseOnce(makeBulkResponse([SYNC_TYPE], ['id-2']));
+      await repository.bulkCreate(
+        [{ type: SYNC_TYPE, id: 'id-2', attributes: { title: 'Rule A', description: 'Desc A' } }],
+        { deferEmbeddings: true }
+      );
+      const params = client.bulk.mock.calls[0][0] as { operations: unknown[] };
+      const body = params.operations[1] as Record<string, unknown>;
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs).not.toHaveProperty('title_semantic');
+      expect(typeAttrs).not.toHaveProperty('description_semantic');
+    });
+
+    it('does NOT add shadow keys for the non-semantic type in a mixed bulk', async () => {
+      client.bulk.mockResponseOnce(makeBulkResponse([PLAIN_TYPE, SYNC_TYPE], ['id-3', 'id-4']));
+      await repository.bulkCreate([
+        { type: PLAIN_TYPE, id: 'id-3', attributes: { title: 'Plain Doc', count: 1 } },
+        { type: SYNC_TYPE, id: 'id-4', attributes: { title: 'Semantic Doc', description: 'Desc' } },
+      ]);
+      const params = client.bulk.mock.calls[0][0] as { operations: unknown[] };
+      // First item: plain type (action at [0], body at [1])
+      const plainBody = params.operations[1] as Record<string, unknown>;
+      const plainAttrs = plainBody[PLAIN_TYPE] as Record<string, unknown>;
+      expect(plainAttrs).not.toHaveProperty('title_semantic');
+
+      // Second item: semantic type (action at [2], body at [3])
+      const semanticBody = params.operations[3] as Record<string, unknown>;
+      const semanticAttrs = semanticBody[SYNC_TYPE] as Record<string, unknown>;
+      expect(semanticAttrs.title_semantic).toBe('Semantic Doc');
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // update()
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('update()', () => {
+    const existingId = 'existing-doc-id';
+
+    beforeEach(() => {
+      // update() does a GET first (to get the existing doc), then an index.
+      // Stored doc has NO pre-existing shadow keys (simulates a doc written before the feature).
+      client.get.mockResponseOnce({
+        found: true,
+        _id: `${SYNC_TYPE}:${existingId}`,
+        _index: '.kibana-test',
+        ...mockVersionProps,
+        _source: {
+          type: SYNC_TYPE,
+          [SYNC_TYPE]: { title: 'Old Title', description: 'Old Desc' },
+          references: [],
+          updated_at: mockTimestamp,
+        },
+      } as estypes.GetResponse<SavedObjectsRawDocSource>);
+      client.index.mockResponseImplementation((params) => ({
+        body: { _id: params.id, ...mockVersionProps } as estypes.CreateResponse,
+      }));
+    });
+
+    it('adds shadow key for a declared field present in the partial update (sync mode)', async () => {
+      await repository.update(SYNC_TYPE, existingId, { title: 'New Title' });
+      const body = getIndexBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.title_semantic).toBe('New Title');
+    });
+
+    it('does NOT emit shadow key for a declared field absent from the partial update (staleness rule)', async () => {
+      // Only updating `description` — `title` is not in the partial update.
+      // Because the stored doc has no pre-existing `title_semantic`, the merged doc also has none.
+      // When the stored doc DOES have a `title_semantic`, mergeForUpdate preserves it (stale until
+      // the reconciler re-touches the doc); that staleness behavior is by design (see ADR-6).
+      await repository.update(SYNC_TYPE, existingId, { description: 'New Desc' });
+      const body = getIndexBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.description_semantic).toBe('New Desc');
+      // `title` was not in the partial update → no `title_semantic` emitted from the helper;
+      // the stored doc had no `title_semantic` to preserve either → absent in the merged result.
+      expect(typeAttrs).not.toHaveProperty('title_semantic');
+    });
+
+    it('strips caller-supplied shadow keys from the partial update', async () => {
+      await repository.update(SYNC_TYPE, existingId, {
+        title: 'New Title',
+        title_semantic: 'caller-injected stale',
+      } as any);
+      const body = getIndexBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      // Helper strips the caller-supplied value and derives the correct one from `title`
+      expect(typeAttrs.title_semantic).toBe('New Title');
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // bulkUpdate()
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('bulkUpdate()', () => {
+    const existingId = 'existing-bulk-update-id';
+
+    beforeEach(() => {
+      // bulkUpdate() does an mget, then a bulk index
+      client.mget.mockResponseOnce({
+        docs: [
+          {
+            found: true,
+            _id: `${SYNC_TYPE}:${existingId}`,
+            _index: '.kibana-test',
+            ...mockVersionProps,
+            _source: {
+              type: SYNC_TYPE,
+              [SYNC_TYPE]: { title: 'Old Title', description: 'Old Desc' },
+              references: [],
+              updated_at: mockTimestamp,
+            },
+          },
+        ],
+      } as estypes.MgetResponse<SavedObjectsRawDocSource>);
+
+      client.bulk.mockResponseImplementation(() => ({
+        body: {
+          errors: false,
+          took: 1,
+          items: [
+            {
+              index: { _id: `${SYNC_TYPE}:${existingId}`, result: 'updated', ...mockVersionProps },
+            },
+          ],
+        } as unknown as estypes.BulkResponse,
+      }));
+    });
+
+    it('adds shadow key for a declared field present in the bulk partial update', async () => {
+      await repository.bulkUpdate([
+        { type: SYNC_TYPE, id: existingId, attributes: { title: 'Bulk New Title' } },
+      ]);
+      const body = getBulkBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.title_semantic).toBe('Bulk New Title');
+    });
+
+    it('does NOT emit shadow key for a declared field absent from the bulk partial update', async () => {
+      await repository.bulkUpdate([
+        { type: SYNC_TYPE, id: existingId, attributes: { description: 'Bulk New Desc' } },
+      ]);
+      const body = getBulkBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.description_semantic).toBe('Bulk New Desc');
+      expect(typeAttrs).not.toHaveProperty('title_semantic');
+    });
+
+    it('emits null shadow key when a declared field is cleared in bulk update', async () => {
+      // The stored doc has title_semantic; the partial update sets title to empty string.
+      // The helper must emit title_semantic=null to clear the stale shadow (Finding #3).
+      // Override the mget to return a doc that has a stored title_semantic.
+      client.mget.mockReset();
+      client.mget.mockResponseOnce({
+        docs: [
+          {
+            found: true,
+            _id: `${SYNC_TYPE}:${existingId}`,
+            _index: '.kibana-test',
+            ...mockVersionProps,
+            _source: {
+              type: SYNC_TYPE,
+              [SYNC_TYPE]: {
+                title: 'Old Title',
+                description: 'Old Desc',
+                title_semantic: 'Old Title',
+              },
+              references: [],
+              updated_at: mockTimestamp,
+            },
+          },
+        ],
+      } as estypes.MgetResponse<SavedObjectsRawDocSource>);
+      client.bulk.mockResponseImplementation(() => ({
+        body: {
+          errors: false,
+          took: 1,
+          items: [
+            {
+              index: { _id: `${SYNC_TYPE}:${existingId}`, result: 'updated', ...mockVersionProps },
+            },
+          ],
+        } as unknown as estypes.BulkResponse,
+      }));
+
+      await repository.bulkUpdate([{ type: SYNC_TYPE, id: existingId, attributes: { title: '' } }]);
+      const body = getBulkBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      // title_semantic must be null (not the stale 'Old Title')
+      expect(typeAttrs.title_semantic).toBeNull();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // create() with strict modelVersion create schema — regression for Finding #1
+  // Shadow keys must not reach validateObjectForCreate or schema validation rejects them.
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('create() with a strict modelVersion create schema (Finding #1 regression)', () => {
+    it('succeeds and writes shadow keys when the type has a strict schema plus semanticSearch', async () => {
+      // SCHEMA_TYPE has a schema.object({ title, count }) that forbids unknown keys.
+      // Shadow keys must be added AFTER validation — if they were added before, this call
+      // would throw "Unknown key(s): title_semantic".
+      await repository.create(SCHEMA_TYPE, { title: 'Rule name', count: 42 });
+      const body = getCreateBody(client);
+      const typeAttrs = body[SCHEMA_TYPE] as Record<string, unknown>;
+      // Shadow key present in the stored document
+      expect(typeAttrs.title_semantic).toBe('Rule name');
+      // Original attributes preserved
+      expect(typeAttrs.title).toBe('Rule name');
+      expect(typeAttrs.count).toBe(42);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // update() clearing a field — Finding #3 (stale shadow text)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('update() clearing a declared field (Finding #3)', () => {
+    const existingId = 'clear-field-id';
+
+    beforeEach(() => {
+      // Stored doc has a non-null title_semantic from a previous sync-mode write.
+      client.get.mockResponseOnce({
+        found: true,
+        _id: `${SYNC_TYPE}:${existingId}`,
+        _index: '.kibana-test',
+        ...mockVersionProps,
+        _source: {
+          type: SYNC_TYPE,
+          [SYNC_TYPE]: { title: 'Old Title', description: 'Old Desc', title_semantic: 'Old Title' },
+          references: [],
+          updated_at: mockTimestamp,
+        },
+      } as estypes.GetResponse<SavedObjectsRawDocSource>);
+      client.index.mockResponseImplementation((params) => ({
+        body: { _id: params.id, ...mockVersionProps } as estypes.CreateResponse,
+      }));
+    });
+
+    it('emits null shadow key when a declared field is set to empty string', async () => {
+      await repository.update(SYNC_TYPE, existingId, { title: '' });
+      const body = getIndexBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      // null clears the stale shadow in the stored doc; ES skips inference (S7).
+      expect(typeAttrs.title_semantic).toBeNull();
+    });
+
+    it('emits null shadow key when a declared field is set to null', async () => {
+      await repository.update(SYNC_TYPE, existingId, { title: null as unknown as string });
+      const body = getIndexBody(client);
+      const typeAttrs = body[SYNC_TYPE] as Record<string, unknown>;
+      expect(typeAttrs.title_semantic).toBeNull();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // get() and bulkGet() read path — Finding #2
+  // getSavedObjectFromSource must strip shadow keys so they never leak to consumers.
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('get() / bulkGet() strip shadow keys from returned attributes (Finding #2)', () => {
+    const storedId = 'get-strip-id';
+
+    it('get() returns attributes without shadow keys even when _source[type] contains them', async () => {
+      // Simulate a raw ES document that contains shadow keys in _source[type].
+      client.get.mockResponseOnce({
+        found: true,
+        _id: `${SYNC_TYPE}:${storedId}`,
+        _index: '.kibana-test',
+        ...mockVersionProps,
+        _source: {
+          type: SYNC_TYPE,
+          [SYNC_TYPE]: {
+            title: 'Hello',
+            description: 'World',
+            title_semantic: 'Hello',
+            description_semantic: 'World',
+          },
+          references: [],
+          updated_at: mockTimestamp,
+        },
+      } as estypes.GetResponse<SavedObjectsRawDocSource>);
+
+      const result = await repository.get(SYNC_TYPE, storedId);
+      const attrs = result.attributes as Record<string, unknown>;
+      expect(attrs.title).toBe('Hello');
+      expect(attrs.description).toBe('World');
+      expect(attrs).not.toHaveProperty('title_semantic');
+      expect(attrs).not.toHaveProperty('description_semantic');
+    });
+
+    it('bulkGet() returns attributes without shadow keys for each opted-in object', async () => {
+      client.mget.mockResponseOnce({
+        docs: [
+          {
+            found: true,
+            _id: `${SYNC_TYPE}:${storedId}`,
+            _index: '.kibana-test',
+            ...mockVersionProps,
+            _source: {
+              type: SYNC_TYPE,
+              [SYNC_TYPE]: {
+                title: 'Bulk Hello',
+                title_semantic: 'Bulk Hello',
+                description_semantic: 'some stale shadow',
+              },
+              references: [],
+              updated_at: mockTimestamp,
+            },
+          },
+        ],
+      } as estypes.MgetResponse<SavedObjectsRawDocSource>);
+
+      const result = await repository.bulkGet([{ type: SYNC_TYPE, id: storedId }]);
+      const soResult = result.saved_objects[0] as { attributes?: unknown; error?: unknown };
+      expect(soResult.error).toBeUndefined();
+      const attrs = soResult.attributes as Record<string, unknown>;
+      expect(attrs.title).toBe('Bulk Hello');
+      expect(attrs).not.toHaveProperty('title_semantic');
+      expect(attrs).not.toHaveProperty('description_semantic');
+    });
+
+    it('get() for a non-opted-in type preserves _source[type] as-is', async () => {
+      client.get.mockResponseOnce({
+        found: true,
+        _id: `${PLAIN_TYPE}:${storedId}`,
+        _index: '.kibana-test',
+        ...mockVersionProps,
+        _source: {
+          type: PLAIN_TYPE,
+          [PLAIN_TYPE]: { title: 'Plain', count: 7 },
+          references: [],
+          updated_at: mockTimestamp,
+        },
+      } as estypes.GetResponse<SavedObjectsRawDocSource>);
+
+      const result = await repository.get(PLAIN_TYPE, storedId);
+      const attrs = result.attributes as Record<string, unknown>;
+      expect(attrs.title).toBe('Plain');
+      expect(attrs.count).toBe(7);
+    });
+  });
+});

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/update.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/update.ts
@@ -82,6 +82,7 @@ export const executeUpdate = async <T>(
   const {
     common: commonHelper,
     encryption: encryptionHelper,
+    embedding: embeddingHelper,
     preflight: preflightHelper,
     migration: migrationHelper,
     validation: validationHelper,
@@ -204,7 +205,14 @@ export const executeUpdate = async <T>(
       ...(savedObjectNamespace && { namespace: savedObjectNamespace }),
       ...(savedObjectNamespaces && { namespaces: savedObjectNamespaces }),
       attributes: {
-        ...(await encryptionHelper.optionallyEncryptAttributes(type, id, namespace, upsert)),
+        ...(await encryptionHelper.optionallyEncryptAttributes(
+          type,
+          id,
+          namespace,
+          // Do NOT include shadow semantic keys here: they must be added after migration and
+          // validation so they never enter transform functions or schema validation.
+          upsert
+        )),
       },
       created_at: time,
       updated_at: time,
@@ -213,7 +221,15 @@ export const executeUpdate = async <T>(
       ...(accessControlToWrite && { accessControl: accessControlToWrite }),
     }) as SavedObjectSanitizedDoc<T>;
     validationHelper.validateObjectForCreate(type, migratedUpsert);
-    const rawUpsert = serializer.savedObjectToRaw(migratedUpsert);
+
+    // Populate shadow semantic fields AFTER migration and schema validation.
+    // Upsert uses full attributes; embedding mode from the per-type default (no per-request
+    // deferEmbeddings on update — foundation decision).
+    const migratedUpsertWithSemantics: SavedObjectSanitizedDoc<T> = {
+      ...migratedUpsert,
+      attributes: embeddingHelper.populateSemanticFields(type, migratedUpsert.attributes),
+    };
+    const rawUpsert = serializer.savedObjectToRaw(migratedUpsertWithSemantics);
 
     const createRequestParams: CreateRequest = {
       id: rawUpsert._id,
@@ -282,6 +298,10 @@ export const executeUpdate = async <T>(
     // therefor we can safely process with the "standard" update sequence.
 
     const mergeAttributes = options.mergeAttributes ?? true;
+    // Do NOT add shadow semantic keys to the partial before encryption/merge: migration
+    // transforms may silently drop unknown keys, and including them here would also cause
+    // mergeForUpdate to conflict with the stored shadow on the target doc.  Instead, compute
+    // shadow keys from the original partial attributes and overlay them after migrateInputDocument.
     const encryptedUpdatedAttributes = await encryptionHelper.optionallyEncryptAttributes(
       type,
       id,
@@ -313,9 +333,28 @@ export const executeUpdate = async <T>(
       ...(Array.isArray(references) && { references }),
     });
 
-    const docToSend = serializer.savedObjectToRaw(
-      migratedUpdatedSavedObjectDoc as SavedObjectSanitizedDoc
-    );
+    // Overlay shadow semantic fields derived from the ORIGINAL partial attributes, after
+    // merge and migration.  Using the original partial (not the merged/migrated doc) ensures
+    // the staleness rule: only fields present in THIS partial update get a shadow key;
+    // absent fields preserve the stored shadow value that survived mergeForUpdate, or get
+    // re-populated by the reconciler if a transform dropped them.
+    // No per-request deferEmbeddings override for updates — the per-type default applies.
+    const shadowOverlay = embeddingHelper.shadowFieldsForUpdate(type, attributes);
+    const docForSerialization =
+      Object.keys(shadowOverlay).length > 0
+        ? ({
+            ...migratedUpdatedSavedObjectDoc,
+            attributes: {
+              ...((migratedUpdatedSavedObjectDoc as SavedObjectSanitizedDoc).attributes as Record<
+                string,
+                unknown
+              >),
+              ...shadowOverlay,
+            },
+          } as SavedObjectSanitizedDoc)
+        : (migratedUpdatedSavedObjectDoc as SavedObjectSanitizedDoc);
+
+    const docToSend = serializer.savedObjectToRaw(docForSerialization);
 
     // implement creating the call params
     const indexRequestParams: IndexRequest = {

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/utils/internal_utils.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/utils/internal_utils.ts
@@ -22,6 +22,7 @@ import { SavedObjectsUtils, ALL_NAMESPACES_STRING } from '@kbn/core-saved-object
 import {
   decodeRequestVersion,
   encodeHitVersion,
+  SEMANTIC_FIELD_SUFFIX,
 } from '@kbn/core-saved-objects-base-server-internal';
 
 export interface GetBulkOperationErrorRawResponse {
@@ -130,6 +131,18 @@ export function getSavedObjectFromSource<T>(
     ];
   }
 
+  // Strip shadow semantic keys for opted-in types so that the platform-internal
+  // `{field}_semantic` convention never leaks through get() / bulkGet() / resolve().
+  // This mirrors the strip in rawToSavedObject() for find() / create() responses.
+  const rawTypeAttrs = doc._source[type];
+  const attributes: T =
+    rawTypeAttrs !== null &&
+    rawTypeAttrs !== undefined &&
+    typeof rawTypeAttrs === 'object' &&
+    registry.getSemanticSearchDefinition(type) !== undefined
+      ? (stripSemanticAttributes(rawTypeAttrs as Record<string, unknown>) as T)
+      : (rawTypeAttrs as T);
+
   return {
     id,
     type,
@@ -143,7 +156,7 @@ export function getSavedObjectFromSource<T>(
     ...(createdBy && { created_by: createdBy }),
     ...(updatedBy && { updated_by: updatedBy }),
     version: encodeHitVersion(doc),
-    attributes: doc._source[type],
+    attributes,
     references: doc._source.references || [],
     managed,
     accessControl,
@@ -315,4 +328,17 @@ export function setAccessControl({
         accessMode: accessMode ?? 'default',
       }
     : undefined;
+}
+
+// Returns a shallow copy of attrs with every key ending in SEMANTIC_FIELD_SUFFIX removed.
+// Used in getSavedObjectFromSource to keep the platform-internal shadow-field convention
+// from leaking through get() / bulkGet() / resolve() responses.
+function stripSemanticAttributes(attrs: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(attrs)) {
+    if (!key.endsWith(SEMANTIC_FIELD_SUFFIX)) {
+      result[key] = attrs[key];
+    }
+  }
+  return result;
 }

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/index.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/index.ts
@@ -7,5 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { getSearchDsl } from './search_dsl';
-export { getNamespacesBoolFilter } from './query_params';
+export { getSearchDsl, type GetSearchDslOptions } from './search_dsl';
+export { getNamespacesBoolFilter, getSemanticClause } from './query_params';

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/query_params.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/query_params.test.ts
@@ -18,7 +18,7 @@ import {
   SavedObjectTypeRegistry,
   type IndexMapping,
 } from '@kbn/core-saved-objects-base-server-internal';
-import { getQueryParams } from './query_params';
+import { getQueryParams, getSemanticClause } from './query_params';
 import type {
   SavedObjectsType,
   SavedObjectsTypeMappingDefinition,
@@ -1035,6 +1035,179 @@ describe('#getQueryParams', () => {
           })
         ).toThrowError('cannot specify empty namespaces array');
       });
+    });
+  });
+});
+
+// ─── getSemanticClause ────────────────────────────────────────────────────────
+
+describe('#getSemanticClause', () => {
+  let semanticRegistry: SavedObjectTypeRegistry;
+
+  beforeEach(() => {
+    semanticRegistry = new SavedObjectTypeRegistry();
+
+    // typeA: declares two semantic fields
+    semanticRegistry.registerType({
+      name: 'typeA',
+      hidden: false,
+      namespaceType: 'single',
+      mappings: {
+        properties: {
+          title: { type: 'text' },
+          description: { type: 'text' },
+        },
+      },
+      semanticSearch: { fields: ['title', 'description'] },
+    });
+
+    // typeB: single semantic field, different name
+    semanticRegistry.registerType({
+      name: 'typeB',
+      hidden: false,
+      namespaceType: 'single',
+      mappings: {
+        properties: {
+          name: { type: 'text' },
+        },
+      },
+      semanticSearch: { fields: ['name'] },
+    });
+
+    // typeC: no semanticSearch declaration
+    semanticRegistry.registerType({
+      name: 'typeC',
+      hidden: false,
+      namespaceType: 'single',
+      mappings: {
+        properties: {
+          body: { type: 'text' },
+        },
+      },
+    });
+  });
+
+  describe('shadow field name mapping', () => {
+    it('maps source field to {type}.{field}_semantic shadow path', () => {
+      const result = getSemanticClause(semanticRegistry, ['typeA'], 'my query');
+      const should: any[] = (result as any).bool.should;
+      expect(should).toEqual(
+        expect.arrayContaining([
+          { semantic: { field: 'typeA.title_semantic', query: 'my query' } },
+          { semantic: { field: 'typeA.description_semantic', query: 'my query' } },
+        ])
+      );
+    });
+  });
+
+  describe('field resolution', () => {
+    it('uses all declared fields when fields option is undefined', () => {
+      const result = getSemanticClause(semanticRegistry, ['typeA'], 'q');
+      const should: any[] = (result as any).bool.should;
+      expect(should).toHaveLength(2);
+      expect(should.map((c: any) => c.semantic.field)).toEqual(
+        expect.arrayContaining(['typeA.title_semantic', 'typeA.description_semantic'])
+      );
+    });
+
+    it('uses all declared fields when fields option is an empty array', () => {
+      const result = getSemanticClause(semanticRegistry, ['typeA'], 'q', []);
+      const should: any[] = (result as any).bool.should;
+      expect(should).toHaveLength(2);
+    });
+
+    it('restricts to the intersection of requested and declared fields', () => {
+      const result = getSemanticClause(semanticRegistry, ['typeA'], 'q', ['title']);
+      const should: any[] = (result as any).bool.should;
+      expect(should).toHaveLength(1);
+      expect(should[0]).toEqual({ semantic: { field: 'typeA.title_semantic', query: 'q' } });
+    });
+
+    it('throws Boom.badRequest when a requested field is not declared on any type', () => {
+      expect(() =>
+        getSemanticClause(semanticRegistry, ['typeA', 'typeB'], 'q', ['nonExistent'])
+      ).toThrow("semanticSearch.fields contains 'nonExistent'");
+    });
+
+    it('throws when a field is declared on one type but not on any of the requested types', () => {
+      // 'name' is only on typeB; requesting it against typeA alone is invalid
+      expect(() => getSemanticClause(semanticRegistry, ['typeA'], 'q', ['name'])).toThrow(
+        "semanticSearch.fields contains 'name'"
+      );
+    });
+
+    it('does not throw when a requested field is declared on at least one requested type', () => {
+      // 'name' is declared on typeB — should succeed when typeB is included
+      expect(() =>
+        getSemanticClause(semanticRegistry, ['typeA', 'typeB'], 'q', ['name'])
+      ).not.toThrow();
+    });
+  });
+
+  describe('multi-type', () => {
+    it('combines clauses from multiple types with semanticSearch', () => {
+      const result = getSemanticClause(semanticRegistry, ['typeA', 'typeB'], 'hello');
+      const should: any[] = (result as any).bool.should;
+      // typeA contributes title + description; typeB contributes name => 3 clauses total
+      expect(should).toHaveLength(3);
+      expect(should.map((c: any) => c.semantic.field)).toEqual(
+        expect.arrayContaining([
+          'typeA.title_semantic',
+          'typeA.description_semantic',
+          'typeB.name_semantic',
+        ])
+      );
+    });
+
+    it('skips types without a semanticSearch declaration', () => {
+      const result = getSemanticClause(semanticRegistry, ['typeA', 'typeC'], 'hello');
+      const should: any[] = (result as any).bool.should;
+      // typeC has no semanticSearch — only typeA's fields
+      expect(should.every((c: any) => c.semantic.field.startsWith('typeA.'))).toBe(true);
+    });
+
+    it('produces only the intersection of requested fields across types', () => {
+      // 'title' exists on typeA only; typeB has 'name' only => intersection for typeB is empty
+      const result = getSemanticClause(semanticRegistry, ['typeA', 'typeB'], 'q', ['title']);
+      const should: any[] = (result as any).bool.should;
+      expect(should).toHaveLength(1);
+      expect(should[0]).toEqual({ semantic: { field: 'typeA.title_semantic', query: 'q' } });
+    });
+  });
+
+  describe('multi-field', () => {
+    it('returns bool.should with minimum_should_match: 1', () => {
+      const result = getSemanticClause(semanticRegistry, ['typeA'], 'q') as any;
+      expect(result.bool.minimum_should_match).toBe(1);
+      expect(Array.isArray(result.bool.should)).toBe(true);
+    });
+
+    it('creates one clause per declared field', () => {
+      const result = getSemanticClause(semanticRegistry, ['typeA'], 'search text');
+      const should: any[] = (result as any).bool.should;
+      expect(should).toHaveLength(2);
+      should.forEach((clause: any) => {
+        expect(clause.semantic.query).toBe('search text');
+        expect(typeof clause.semantic.field).toBe('string');
+        expect(clause.semantic.field).toMatch(/_semantic$/);
+      });
+    });
+  });
+
+  describe('defense-in-depth: empty should guard', () => {
+    it('throws Boom.badRequest when no requested type declares semanticSearch (only non-semantic types)', () => {
+      // typeC has no semanticSearch declaration; the resulting should[] would be empty.
+      // performFind already rejects before this point, but getSemanticClause must also throw
+      // to prevent a `bool.should: []` clause (ES match-all) from ever being emitted.
+      expect(() => getSemanticClause(semanticRegistry, ['typeC'], 'q')).toThrow(
+        /semanticSearch was requested but none of the requested types declare semanticSearch/
+      );
+    });
+
+    it('throws Boom.badRequest when all requested types are unknown to the registry', () => {
+      expect(() => getSemanticClause(semanticRegistry, ['nonExistentType'], 'q')).toThrow(
+        /semanticSearch was requested but none of the requested types declare semanticSearch/
+      );
     });
   });
 });

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/query_params.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/query_params.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import Boom from '@hapi/boom';
 import * as esKuery from '@kbn/es-query';
 import type { SavedObjectTypeIdTuple } from '@kbn/core-saved-objects-common';
 import type { ISavedObjectTypeRegistry } from '@kbn/core-saved-objects-server';
@@ -14,7 +15,11 @@ import {
   ALL_NAMESPACES_STRING,
   DEFAULT_NAMESPACE_STRING,
 } from '@kbn/core-saved-objects-utils-server';
-import { getProperty, type IndexMapping } from '@kbn/core-saved-objects-base-server-internal';
+import {
+  getProperty,
+  getSemanticFieldName,
+  type IndexMapping,
+} from '@kbn/core-saved-objects-base-server-internal';
 import type { estypes } from '@elastic/elasticsearch';
 import { getReferencesFilter } from './references_filter';
 
@@ -485,4 +490,70 @@ const getSimpleQueryStringClause = ({
       },
     },
   ];
+};
+
+/**
+ * Builds an ES `semantic` bool-should clause for the given types, query text, and optional field
+ * subset. Shadow field paths follow the platform convention `{type}.{field}_semantic` (never
+ * exposed to callers — field names here are source attribute names resolved via the registry).
+ *
+ * @throws Boom.badRequest when `fields` contains a name not declared on any of the requested types.
+ */
+export const getSemanticClause = (
+  registry: ISavedObjectTypeRegistry,
+  types: string[],
+  queryText: string,
+  fields?: string[]
+): estypes.QueryDslQueryContainer => {
+  // Collect all declared semantic fields across all requested types that have semanticSearch enabled.
+  const allDeclaredFields = new Set<string>();
+  for (const typeName of types) {
+    const def = registry.getSemanticSearchDefinition(typeName);
+    if (def) {
+      for (const f of def.fields) {
+        allDeclaredFields.add(f);
+      }
+    }
+  }
+
+  // Validate: every caller-supplied field must be declared on at least one of the requested types.
+  if (fields && fields.length > 0) {
+    for (const f of fields) {
+      if (!allDeclaredFields.has(f)) {
+        throw Boom.badRequest(
+          `semanticSearch.fields contains '${f}', which is not declared as a semantic search ` +
+            `field on any of the requested types`
+        );
+      }
+    }
+  }
+
+  // Build one `semantic` query per type×field combination using the platform shadow field name.
+  const should: estypes.QueryDslQueryContainer[] = [];
+  for (const typeName of types) {
+    const def = registry.getSemanticSearchDefinition(typeName);
+    if (!def) continue;
+
+    // Intersection of requested fields with this type's declared fields; default: all declared.
+    const effectiveFields =
+      fields && fields.length > 0 ? def.fields.filter((f) => fields.includes(f)) : def.fields;
+
+    for (const field of effectiveFields) {
+      should.push({
+        semantic: { field: `${typeName}.${getSemanticFieldName(field)}`, query: queryText },
+      });
+    }
+  }
+
+  // Defense-in-depth: performFind already rejects when no type declares semanticSearch, but guard
+  // here too so the caller can never accidentally receive a `bool.should: []` clause which ES
+  // treats as match-all (namespace-filtered, so not a security leak — but a latent correctness trap).
+  if (should.length === 0) {
+    throw Boom.badRequest(
+      `semanticSearch was requested but none of the requested types declare semanticSearch — ` +
+        `types: [${types.join(', ')}]`
+    );
+  }
+
+  return { bool: { should, minimum_should_match: 1 } };
 };

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/search_dsl.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/search_dsl.test.ts
@@ -19,15 +19,44 @@ import * as sortParamsNS from './sorting_params';
 
 const getPitParams = pitParamsNS.getPitParams as jest.Mock;
 const getQueryParams = queryParamsNS.getQueryParams as jest.Mock;
+const getNamespacesBoolFilter = queryParamsNS.getNamespacesBoolFilter as jest.Mock;
+const getSemanticClause = queryParamsNS.getSemanticClause as jest.Mock;
 const getSortingParams = sortParamsNS.getSortingParams as jest.Mock;
 
 const registry = typeRegistryMock.create();
 const mappings = { properties: {} };
 
+/**
+ * Recursively walks the retriever tree (standard + rrf leaves) and returns the `query` object
+ * from every standard-retriever leaf. Used by the S5 invariant test to verify the namespace/type
+ * filter is present in every leaf regardless of tree depth.
+ *
+ * Throws for any unrecognized retriever node type so that a future addition of a new leaf kind
+ * (e.g. `knn`, `linear`) causes a clear failure rather than silently bypassing the invariant check.
+ */
+const collectLeafQueries = (retriever: any): any[] => {
+  if (retriever.standard) {
+    return [retriever.standard.query];
+  }
+  if (retriever.rrf && Array.isArray(retriever.rrf.retrievers)) {
+    return retriever.rrf.retrievers.flatMap((entry: any) => {
+      // RRFRetrieverComponent wraps the child in a `retriever` key; plain RetrieverContainer does not.
+      return collectLeafQueries(entry.retriever ?? entry);
+    });
+  }
+  throw new Error(
+    `collectLeafQueries: unrecognized retriever node type — keys: [${Object.keys(retriever).join(
+      ', '
+    )}]. Extend this helper to handle the new node type and verify the namespace filter is applied.`
+  );
+};
+
 describe('getSearchDsl', () => {
   afterEach(() => {
     getQueryParams.mockReset();
     getSortingParams.mockReset();
+    getNamespacesBoolFilter.mockReset();
+    getSemanticClause.mockReset();
   });
 
   describe('validation', () => {
@@ -141,6 +170,253 @@ describe('getSearchDsl', () => {
         b: 'b',
         pit: { id: 'abc123' },
         search_after: ['1', 'bar'],
+      });
+    });
+  });
+
+  // ─── semanticSearch option ─────────────────────────────────────────────────
+
+  describe('semanticSearch', () => {
+    // A concrete namespace/type filter shape used as the mock return value for
+    // getNamespacesBoolFilter so the leaf-walking assertion can check for it by identity.
+    const mockNsTypeFilter = {
+      bool: {
+        should: [{ bool: { must: [{ term: { type: 'mytype' } }] } }],
+        minimum_should_match: 1,
+      },
+    };
+    // A concrete semantic clause returned by the mocked getSemanticClause.
+    const mockSemanticClause = {
+      bool: {
+        should: [{ semantic: { field: 'mytype.title_semantic', query: 'find me' } }],
+        minimum_should_match: 1,
+      },
+    };
+    // A BM25 query that already embeds the namespace filter (as getQueryParams does in production).
+    const mockBm25Query = {
+      bool: {
+        filter: [mockNsTypeFilter],
+        must: [{ simple_query_string: { query: 'find me', fields: ['*'] } }],
+      },
+    };
+
+    beforeEach(() => {
+      getNamespacesBoolFilter.mockReturnValue(mockNsTypeFilter);
+      getSemanticClause.mockReturnValue(mockSemanticClause);
+      getQueryParams.mockReturnValue({ query: mockBm25Query });
+      getSortingParams.mockReturnValue({});
+    });
+
+    describe('non-semantic path is unchanged when semanticSearch is absent', () => {
+      it('does not call getNamespacesBoolFilter or getSemanticClause', () => {
+        getSearchDsl(mappings, registry, { type: 'mytype' });
+        expect(getNamespacesBoolFilter).not.toHaveBeenCalled();
+        expect(getSemanticClause).not.toHaveBeenCalled();
+      });
+
+      it('calls getQueryParams and getSortingParams as before', () => {
+        getSearchDsl(mappings, registry, { type: 'mytype' });
+        expect(getQueryParams).toHaveBeenCalledTimes(1);
+        expect(getSortingParams).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('mode: semantic', () => {
+      const semanticOpts = {
+        type: 'mytype',
+        namespaces: ['default'],
+        semanticSearch: { query: 'find me', mode: 'semantic' as const },
+      };
+
+      it('returns a retriever instead of a bare query', () => {
+        const result = getSearchDsl(mappings, registry, semanticOpts) as any;
+        expect(result.retriever).toBeDefined();
+        expect(result.query).toBeUndefined();
+      });
+
+      it('emits a standard retriever wrapping the semantic clause', () => {
+        const result = getSearchDsl(mappings, registry, semanticOpts) as any;
+        expect(result.retriever.standard).toBeDefined();
+        expect(result.retriever.standard.query.bool.must).toContainEqual(mockSemanticClause);
+      });
+
+      it('does not include top-level sort or search_after', () => {
+        const result = getSearchDsl(mappings, registry, semanticOpts) as any;
+        expect(result.sort).toBeUndefined();
+        expect(result.search_after).toBeUndefined();
+      });
+
+      it('does not call getQueryParams for the BM25 query in semantic-only mode', () => {
+        getSearchDsl(mappings, registry, semanticOpts);
+        expect(getQueryParams).not.toHaveBeenCalled();
+      });
+
+      it('calls getSemanticClause with the correct arguments', () => {
+        getSearchDsl(mappings, registry, semanticOpts);
+        expect(getSemanticClause).toHaveBeenCalledWith(registry, ['mytype'], 'find me', undefined);
+      });
+
+      // ── S5 LEAF-WALKING TEST (semantic mode) ──────────────────────────────
+      // Walks the retriever tree and asserts the namespace/type bool filter appears in EVERY
+      // leaf.  This test must fail if a future change adds an unfiltered leaf.
+      it('(S5) namespace/type filter is present in every leaf (semantic mode)', () => {
+        const result = getSearchDsl(mappings, registry, semanticOpts) as any;
+        const leafQueries = collectLeafQueries(result.retriever);
+        expect(leafQueries.length).toBeGreaterThan(0);
+        for (const query of leafQueries) {
+          const filter: unknown[] = Array.isArray(query?.bool?.filter)
+            ? query.bool.filter
+            : [query?.bool?.filter];
+          expect(filter).toContainEqual(mockNsTypeFilter);
+        }
+      });
+    });
+
+    describe('mode: hybrid (default)', () => {
+      const hybridOpts = {
+        type: 'mytype',
+        namespaces: ['default'],
+        semanticSearch: { query: 'find me' }, // mode omitted → defaults to 'hybrid'
+      };
+
+      it('returns a retriever instead of a bare query', () => {
+        const result = getSearchDsl(mappings, registry, hybridOpts) as any;
+        expect(result.retriever).toBeDefined();
+        expect(result.query).toBeUndefined();
+      });
+
+      it('emits an rrf retriever with two leaves', () => {
+        const result = getSearchDsl(mappings, registry, hybridOpts) as any;
+        expect(result.retriever.rrf).toBeDefined();
+        expect(result.retriever.rrf.retrievers).toHaveLength(2);
+      });
+
+      it('applies default rank_window_size (100) and rank_constant (60)', () => {
+        const result = getSearchDsl(mappings, registry, hybridOpts) as any;
+        expect(result.retriever.rrf.rank_window_size).toBe(100);
+        expect(result.retriever.rrf.rank_constant).toBe(60);
+      });
+
+      it('respects caller-supplied rankWindowSize and rankConstant', () => {
+        const result = getSearchDsl(mappings, registry, {
+          ...hybridOpts,
+          semanticSearch: { query: 'find me', rankWindowSize: 500, rankConstant: 20 },
+        }) as any;
+        expect(result.retriever.rrf.rank_window_size).toBe(500);
+        expect(result.retriever.rrf.rank_constant).toBe(20);
+      });
+
+      it('does not include top-level sort or search_after', () => {
+        const result = getSearchDsl(mappings, registry, hybridOpts) as any;
+        expect(result.sort).toBeUndefined();
+        expect(result.search_after).toBeUndefined();
+      });
+
+      it('calls getQueryParams once for the BM25 leaf', () => {
+        getSearchDsl(mappings, registry, hybridOpts);
+        expect(getQueryParams).toHaveBeenCalledTimes(1);
+      });
+
+      it('calls getSemanticClause with the correct arguments', () => {
+        getSearchDsl(mappings, registry, {
+          ...hybridOpts,
+          semanticSearch: { query: 'find me', fields: ['title'] },
+        });
+        expect(getSemanticClause).toHaveBeenCalledWith(registry, ['mytype'], 'find me', ['title']);
+      });
+
+      it('wraps the BM25 query (including its embedded nsTypeFilter) in the first leaf', () => {
+        const result = getSearchDsl(mappings, registry, hybridOpts) as any;
+        const bm25Leaf = result.retriever.rrf.retrievers[0];
+        expect(bm25Leaf.standard.query).toEqual(mockBm25Query);
+      });
+
+      it('puts the semantic clause in the second leaf', () => {
+        const result = getSearchDsl(mappings, registry, hybridOpts) as any;
+        const semanticLeaf = result.retriever.rrf.retrievers[1];
+        expect(semanticLeaf.standard.query.bool.must).toContainEqual(mockSemanticClause);
+      });
+
+      // ── S5 LEAF-WALKING TEST (hybrid mode) ────────────────────────────────
+      // Recursively walks the rrf retriever tree and asserts the namespace/type bool filter
+      // is present in EVERY leaf independently.  If a future change adds an unfiltered leaf
+      // (e.g. a third retriever without the filter), this test must fail loudly.
+      it('(S5) namespace/type filter is present in every leaf (hybrid mode)', () => {
+        const result = getSearchDsl(mappings, registry, hybridOpts) as any;
+        const leafQueries = collectLeafQueries(result.retriever);
+        expect(leafQueries).toHaveLength(2);
+        for (const query of leafQueries) {
+          const filter: unknown[] = Array.isArray(query?.bool?.filter)
+            ? query.bool.filter
+            : [query?.bool?.filter];
+          expect(filter).toContainEqual(mockNsTypeFilter);
+        }
+      });
+
+      it('(S5) leaf-walking test fails when a leaf lacks the nsTypeFilter', () => {
+        // Sanity-check that the helper actually detects a missing filter.
+        const fakeResult = {
+          retriever: {
+            rrf: {
+              retrievers: [
+                { standard: { query: { bool: { filter: [mockNsTypeFilter] } } } },
+                // Second leaf intentionally has NO filter.
+                { standard: { query: { bool: {} } } },
+              ],
+            },
+          },
+        };
+        const leafQueries = collectLeafQueries(fakeResult.retriever);
+        const allFiltered = leafQueries.every((query) => {
+          const f: unknown[] = Array.isArray(query?.bool?.filter)
+            ? query.bool.filter
+            : [query?.bool?.filter];
+          return f.includes(mockNsTypeFilter);
+        });
+        expect(allFiltered).toBe(false);
+      });
+
+      it('(S5) leaf-walker throws on an unrecognized retriever node type (fail-closed guard)', () => {
+        // Proves that adding a new retriever kind (e.g. `knn`, `linear`) does NOT silently bypass
+        // the invariant — the helper throws so the developer must explicitly handle and verify it.
+        const unknownRetriever = { knn: { field: 'some_vector', num_candidates: 100 } };
+        expect(() => collectLeafQueries(unknownRetriever)).toThrow(
+          /unrecognized retriever node type.*knn/
+        );
+      });
+
+      describe('with multiple namespaces', () => {
+        it('passes namespaces to getNamespacesBoolFilter', () => {
+          const multiNsOpts = {
+            type: 'mytype',
+            namespaces: ['ns1', 'ns2'],
+            semanticSearch: { query: 'q' },
+          };
+          getSearchDsl(mappings, registry, multiNsOpts);
+          expect(getNamespacesBoolFilter).toHaveBeenCalledWith(
+            expect.objectContaining({ namespaces: ['ns1', 'ns2'] })
+          );
+        });
+      });
+
+      describe('with typeToNamespacesMap', () => {
+        it('derives the types array from typeToNamespacesMap keys', () => {
+          const map = new Map([
+            ['typeX', ['ns1']],
+            ['typeY', ['ns2']],
+          ]);
+          getSearchDsl(mappings, registry, {
+            type: 'ignored',
+            typeToNamespacesMap: map,
+            semanticSearch: { query: 'q' },
+          });
+          expect(getSemanticClause).toHaveBeenCalledWith(
+            registry,
+            expect.arrayContaining(['typeX', 'typeY']),
+            'q',
+            undefined
+          );
+        });
       });
     });
   });

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/search_dsl.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/search_dsl.ts
@@ -14,13 +14,19 @@ import type { SavedObjectsPitParams } from '@kbn/core-saved-objects-api-server';
 import type { ISavedObjectTypeRegistry } from '@kbn/core-saved-objects-server';
 import type { IndexMapping } from '@kbn/core-saved-objects-base-server-internal';
 import type { SavedObjectTypeIdTuple } from '@kbn/core-saved-objects-common';
-import { getQueryParams, type SearchOperator } from './query_params';
+import {
+  getQueryParams,
+  getSemanticClause,
+  getNamespacesBoolFilter,
+  type SearchOperator,
+} from './query_params';
 import { getPitParams } from './pit_params';
 import { getSortingParams } from './sorting_params';
 
 type KueryNode = any;
 
-interface GetSearchDslOptions {
+/** Options accepted by {@link getSearchDsl}. */
+export interface GetSearchDslOptions {
   type: string | string[];
   search?: string;
   defaultSearchOperator?: SearchOperator;
@@ -37,6 +43,25 @@ interface GetSearchDslOptions {
   hasNoReference?: SavedObjectTypeIdTuple | SavedObjectTypeIdTuple[];
   hasNoReferenceOperator?: SearchOperator;
   kueryNode?: KueryNode;
+  /**
+   * When present, emits an ES `retriever` instead of a bare `query`.
+   * Server-side only — never expose over the public HTTP route.
+   */
+  semanticSearch?: {
+    /** Natural-language query text forwarded to the `semantic` query. */
+    query: string;
+    /** Source attribute names to target; defaults to all declared semantic fields per type. */
+    fields?: string[];
+    /**
+     * `'semantic'` wraps the semantic query in a single `standard` retriever.
+     * `'hybrid'` (default) uses RRF over BM25 + semantic leaves.
+     */
+    mode?: 'semantic' | 'hybrid';
+    /** RRF `rank_window_size` (positive integer, 1–1000; default 100). */
+    rankWindowSize?: number;
+    /** RRF `rank_constant` (positive integer ≥ 1; default 60). */
+    rankConstant?: number;
+  };
 }
 
 export function getSearchDsl(
@@ -61,6 +86,7 @@ export function getSearchDsl(
     hasNoReference,
     hasNoReferenceOperator,
     kueryNode,
+    semanticSearch,
   } = options;
 
   if (!type) {
@@ -71,6 +97,95 @@ export function getSearchDsl(
     throw Boom.notAcceptable('sortOrder requires a sortField');
   }
 
+  // When semanticSearch is present, emit a `retriever` instead of the plain `query`.
+  // Top-level sort, search_after, and pit are rejected by performFind before reaching here.
+  if (semanticSearch) {
+    // Resolve the types array the same way getQueryParams does internally.
+    const types: string[] = typeToNamespacesMap
+      ? Array.from(typeToNamespacesMap.keys())
+      : Array.isArray(type)
+      ? type
+      : [type];
+
+    // Build the namespace/type bool filter ONCE; inject into every leaf independently (S5).
+    const nsTypeFilter = getNamespacesBoolFilter({
+      namespaces,
+      registry,
+      types,
+      typeToNamespacesMap,
+    });
+
+    const semanticClause = getSemanticClause(
+      registry,
+      types,
+      semanticSearch.query,
+      semanticSearch.fields
+    );
+
+    const mode = semanticSearch.mode ?? 'hybrid';
+
+    if (mode === 'semantic') {
+      // Single standard retriever: semantic query gated by the namespace/type filter.
+      return {
+        retriever: {
+          standard: {
+            query: {
+              bool: {
+                must: [semanticClause],
+                filter: [nsTypeFilter],
+              },
+            },
+          },
+        },
+      };
+    }
+
+    // hybrid (default): RRF over BM25 leaf and semantic leaf.
+    // The BM25 leaf is today's getQueryParams output (already contains nsTypeFilter in its
+    // query.bool.filter).  The semantic leaf independently carries a copy of nsTypeFilter.
+    const { query: bm25Query } = getQueryParams({
+      registry,
+      namespaces,
+      type,
+      typeToNamespacesMap,
+      search,
+      searchFields,
+      rootSearchFields,
+      defaultSearchOperator,
+      hasReference,
+      hasReferenceOperator,
+      hasNoReference,
+      hasNoReferenceOperator,
+      kueryNode,
+      mappings,
+    });
+
+    return {
+      retriever: {
+        rrf: {
+          retrievers: [
+            // BM25 leaf: nsTypeFilter already embedded in query.bool.filter via getQueryParams.
+            { standard: { query: bm25Query } },
+            // Semantic leaf: nsTypeFilter independently injected (S5 invariant).
+            {
+              standard: {
+                query: {
+                  bool: {
+                    must: [semanticClause],
+                    filter: [nsTypeFilter],
+                  },
+                },
+              },
+            },
+          ],
+          rank_window_size: semanticSearch.rankWindowSize ?? 100,
+          rank_constant: semanticSearch.rankConstant ?? 60,
+        },
+      },
+    };
+  }
+
+  // Non-semantic path: byte-identical to the pre-change behaviour.
   return {
     ...getQueryParams({
       registry,

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/utils/create_helpers.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/utils/create_helpers.ts
@@ -20,6 +20,7 @@ import type { RepositoryHelpers } from '../apis/helpers';
 import {
   CommonHelper,
   EncryptionHelper,
+  EmbeddingHelper,
   ValidationHelper,
   PreflightCheckHelper,
   SerializerHelper,
@@ -62,6 +63,7 @@ export const createRepositoryHelpers = ({
     encryptionExtension: extensions?.encryptionExtension,
     securityExtension: extensions?.securityExtension,
   });
+  const embeddingHelper = new EmbeddingHelper({ registry: typeRegistry });
   const validationHelper = new ValidationHelper({
     registry: typeRegistry,
     logger,
@@ -91,6 +93,7 @@ export const createRepositoryHelpers = ({
     preflight: preflightCheckHelper,
     validation: validationHelper,
     encryption: encryptionHelper,
+    embedding: embeddingHelper,
     serializer: serializerHelper,
     migration: migrationHelper,
     user: userHelper,

--- a/src/core/packages/saved-objects/api-server-internal/src/mocks/api_helpers.mocks.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/mocks/api_helpers.mocks.ts
@@ -12,6 +12,7 @@ import type { PublicMethodsOf } from '@kbn/utility-types';
 import type {
   CommonHelper,
   EncryptionHelper,
+  EmbeddingHelper,
   ValidationHelper,
   PreflightCheckHelper,
   SerializerHelper,
@@ -68,6 +69,17 @@ const createEncryptionHelperMock = (): EncryptionHelperMock => {
   return mock;
 };
 
+export type EmbeddingHelperMock = jest.Mocked<PublicMethodsOf<EmbeddingHelper>>;
+
+const createEmbeddingHelperMock = (): EmbeddingHelperMock => {
+  const mock: EmbeddingHelperMock = {
+    populateSemanticFields: jest.fn().mockImplementation((_type, attributes) => attributes),
+    shadowFieldsForUpdate: jest.fn().mockReturnValue({}),
+  };
+
+  return mock;
+};
+
 export type ValidationHelperMock = jest.Mocked<PublicMethodsOf<ValidationHelper>>;
 
 const createValidationHelperMock = (): ValidationHelperMock => {
@@ -119,6 +131,7 @@ const createUserHelperMock = (): UserHelperMock => {
 export interface RepositoryHelpersMock {
   common: CommonHelperMock;
   encryption: EncryptionHelperMock;
+  embedding: EmbeddingHelperMock;
   validation: ValidationHelperMock;
   preflight: PreflightCheckHelperMock;
   serializer: SerializerHelperMock;
@@ -130,6 +143,7 @@ const createRepositoryHelpersMock = (): RepositoryHelpersMock => {
   return {
     common: createCommonHelperMock(),
     encryption: createEncryptionHelperMock(),
+    embedding: createEmbeddingHelperMock(),
     validation: createValidationHelperMock(),
     preflight: createPreflightCheckHelperMock(),
     serializer: createSerializerHelperMock(),
@@ -142,6 +156,7 @@ export const apiHelperMocks = {
   create: createRepositoryHelpersMock,
   createCommonHelper: createCommonHelperMock,
   createEncryptionHelper: createEncryptionHelperMock,
+  createEmbeddingHelper: createEmbeddingHelperMock,
   createValidationHelper: createValidationHelperMock,
   createSerializerHelper: createSerializerHelperMock,
   createPreflightCheckHelper: createPreflightCheckHelperMock,

--- a/src/core/packages/saved-objects/api-server-internal/src/mocks/saved_objects_extensions.mock.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/mocks/saved_objects_extensions.mock.ts
@@ -8,12 +8,19 @@
  */
 
 import type {
+  ISavedObjectsEmbeddingExtension,
   ISavedObjectsEncryptionExtension,
   ISavedObjectsSecurityExtension,
   ISavedObjectsSpacesExtension,
 } from '@kbn/core-saved-objects-server';
 import type { Either } from '@kbn/core-saved-objects-api-server';
 import type { Payload } from '@hapi/boom';
+
+const createEmbeddingExtension = (): jest.Mocked<ISavedObjectsEmbeddingExtension> => ({
+  isEmbeddableType: jest.fn(),
+  embedAttributes: jest.fn(),
+  acceptsPrecomputedEmbeddings: jest.fn(),
+});
 
 const createEncryptionExtension = (): jest.Mocked<ISavedObjectsEncryptionExtension> => ({
   isEncryptableType: jest.fn(),
@@ -68,6 +75,7 @@ const createSpacesExtension = (): jest.Mocked<ISavedObjectsSpacesExtension> => (
 });
 
 const create = () => ({
+  embeddingExtension: createEmbeddingExtension(),
   encryptionExtension: createEncryptionExtension(),
   securityExtension: createSecurityExtension(),
   spacesExtension: createSpacesExtension(),
@@ -75,6 +83,7 @@ const create = () => ({
 
 export const savedObjectsExtensionsMock = {
   create,
+  createEmbeddingExtension,
   createEncryptionExtension,
   createSecurityExtension,
   createSpacesExtension,

--- a/src/core/packages/saved-objects/api-server-mocks/src/saved_objects_extensions.mock.ts
+++ b/src/core/packages/saved-objects/api-server-mocks/src/saved_objects_extensions.mock.ts
@@ -8,12 +8,20 @@
  */
 
 import type {
+  ISavedObjectsEmbeddingExtension,
   ISavedObjectsEncryptionExtension,
   ISavedObjectsSecurityExtension,
   ISavedObjectsSpacesExtension,
   SavedObjectsExtensions,
 } from '@kbn/core-saved-objects-server';
 import { lazyObject } from '@kbn/lazy-object';
+
+const createEmbeddingExtension = (): jest.Mocked<ISavedObjectsEmbeddingExtension> =>
+  lazyObject({
+    isEmbeddableType: jest.fn(),
+    embedAttributes: jest.fn(),
+    acceptsPrecomputedEmbeddings: jest.fn(),
+  });
 
 const createEncryptionExtension = (): jest.Mocked<ISavedObjectsEncryptionExtension> =>
   lazyObject({
@@ -61,6 +69,7 @@ const createSpacesExtension = (): jest.Mocked<ISavedObjectsSpacesExtension> =>
 
 const create = (): jest.Mocked<SavedObjectsExtensions> =>
   lazyObject({
+    embeddingExtension: createEmbeddingExtension(),
     encryptionExtension: createEncryptionExtension(),
     securityExtension: createSecurityExtension(),
     spacesExtension: createSpacesExtension(),
@@ -68,6 +77,7 @@ const create = (): jest.Mocked<SavedObjectsExtensions> =>
 
 export const savedObjectsExtensionsMock = {
   create,
+  createEmbeddingExtension,
   createEncryptionExtension,
   createSecurityExtension,
   createSpacesExtension,

--- a/src/core/packages/saved-objects/api-server/index.ts
+++ b/src/core/packages/saved-objects/api-server/index.ts
@@ -36,6 +36,7 @@ export type {
   SavedObjectsCheckConflictsResponse,
   SavedObjectsBulkUpdateOptions,
   SavedObjectsFindOptionsReference,
+  SavedObjectsFindOptionsSemanticSearch,
   SavedObjectsFindResult,
   SavedObjectsRemoveReferencesToOptions,
   SavedObjectsDeleteOptions,

--- a/src/core/packages/saved-objects/api-server/src/apis/create.ts
+++ b/src/core/packages/saved-objects/api-server/src/apis/create.ts
@@ -81,4 +81,19 @@ export interface SavedObjectsCreateOptions extends SavedObjectsBaseOptions {
    * as that is set during the operation using the current user's profile ID.
    */
   accessControl?: Pick<SavedObjectAccessControl, 'accessMode'>;
+  /**
+   * Per-request override for the embedding timing declared by the type's
+   * {@link SavedObjectsTypeSemanticSearchDefinition.embedding | semanticSearch.embedding} setting.
+   *
+   * When `true`, shadow semantic fields are omitted from the raw document so that Elasticsearch
+   * performs no inference during indexing. The object is immediately findable via `find()`/BM25
+   * and becomes semantically searchable only after a background reconciliation cycle (eventual
+   * consistency for semantic search only). Only meaningful for types that declare
+   * {@link SavedObjectsType.semanticSearch | semanticSearch}; silently ignored for all other types.
+   *
+   * Typical use: pass `deferEmbeddings: true` from bulk-install code paths (e.g. prebuilt-rule
+   * import, package installation) to keep write latency independent of ML capacity, even when the
+   * type's default is `'sync'`.
+   */
+  deferEmbeddings?: boolean;
 }

--- a/src/core/packages/saved-objects/api-server/src/apis/find.ts
+++ b/src/core/packages/saved-objects/api-server/src/apis/find.ts
@@ -42,6 +42,60 @@ export interface SavedObjectsPitParams {
 }
 
 /**
+ * Semantic (vector) search options for {@link SavedObjectsFindOptions}.
+ *
+ * **Server-side only** — never expose over the public `/api/saved_objects/_find`
+ * HTTP route; doing so would be a compatibility commitment to make deliberately later.
+ *
+ * @remarks
+ * - `mode` defaults to `'hybrid'` (RRF over BM25 + semantic leaves).
+ * - `fields` are **source attribute names** (e.g., `'title'`, `'description'`), never
+ *   internal shadow field names. The platform maps them to shadow fields via the type
+ *   registry.
+ * - Types without a `semanticSearch` declaration in their registration contribute no
+ *   semantic clause. If *no* requested type has `semanticSearch` configured, `find()`
+ *   rejects with a bad-request error naming the types.
+ *
+ * **Paging semantics (hybrid mode)**:
+ * ES enforces `rank_window_size >= size`, so `perPage` must not exceed `rankWindowSize`.
+ * Additionally, `(page - 1) * perPage` must be less than `rankWindowSize`; pages beyond
+ * this range silently return no results (ES 200 with empty hits). `find()` pre-validates
+ * both constraints and rejects violating requests with a bad-request error.
+ *
+ * Semantic mode uses standard `from`/`size` pagination and has no window constraint.
+ *
+ * @public
+ */
+export interface SavedObjectsFindOptionsSemanticSearch {
+  /** Natural-language query text forwarded to the ES `semantic` query. */
+  query: string;
+  /**
+   * Subset of the type's declared semantic fields to target (source attribute names).
+   * Defaults to all declared semantic fields across the requested types.
+   */
+  fields?: string[];
+  /**
+   * Search mode:
+   * - `'semantic'`: a single standard retriever wrapping the semantic query (normal
+   *   `from`/`size` pagination; no rank-window constraint).
+   * - `'hybrid'` (default): RRF over BM25 + semantic leaves, with pagination bounded
+   *   by `rankWindowSize`.
+   */
+  mode?: 'semantic' | 'hybrid';
+  /**
+   * RRF `rank_window_size` — positive integer, 1–1000.
+   * Defaults to `Math.min(Math.max(perPage * 10, 100), 1000)`.
+   * Only meaningful in hybrid mode.
+   */
+  rankWindowSize?: number;
+  /**
+   * RRF `rank_constant` — positive integer ≥ 1 (default 60).
+   * Only meaningful in hybrid mode.
+   */
+  rankConstant?: number;
+}
+
+/**
  * Options for finding saved objects
  *
  * @public
@@ -172,6 +226,23 @@ export interface SavedObjectsFindOptions {
   pit?: SavedObjectsPitParams;
   /** {@link SavedObjectsRawDocParseOptions.migrationVersionCompatibility} */
   migrationVersionCompatibility?: 'compatible' | 'raw';
+  /**
+   * Semantic (vector) search options. When present, `find()` emits an ES `retriever`
+   * instead of a bare `query` and routes through the platform's semantic-search layer.
+   *
+   * **Server-side only** — do not pass this option over the public HTTP route.
+   *
+   * **Filter scoping in hybrid mode**: in `mode: 'hybrid'` the KQL `filter`,
+   * `hasReference`, and `hasNoReference` options are applied only to the BM25 leaf of the
+   * RRF retriever — they do NOT narrow the semantic leaf. The semantic leaf carries only
+   * the namespace/type filter that is always injected. As a result, documents matched
+   * solely by the semantic leaf may appear in results even when they would be excluded by
+   * a KQL filter. Callers that require both filters to apply must use `mode: 'semantic'`
+   * (single leaf, no BM25) or add the equivalent clause to `semanticSearch.query` text.
+   *
+   * {@link SavedObjectsFindOptionsSemanticSearch}
+   */
+  semanticSearch?: SavedObjectsFindOptionsSemanticSearch;
 }
 
 /**

--- a/src/core/packages/saved-objects/api-server/src/apis/index.ts
+++ b/src/core/packages/saved-objects/api-server/src/apis/index.ts
@@ -50,6 +50,7 @@ export type { SavedObjectsDeleteByNamespaceOptions } from './delete_by_namespace
 export type {
   SavedObjectsFindOptions,
   SavedObjectsFindOptionsReference,
+  SavedObjectsFindOptionsSemanticSearch,
   SavedObjectsFindResponse,
   SavedObjectsFindResult,
   SavedObjectsPitParams,

--- a/src/core/packages/saved-objects/base-server-internal/index.ts
+++ b/src/core/packages/saved-objects/base-server-internal/index.ts
@@ -38,6 +38,13 @@ export {
 } from './src/saved_objects_config';
 export type { ISavedObjectTypeRegistryInternal } from './src/saved_objects_type_registry';
 export { SavedObjectTypeRegistry } from './src/saved_objects_type_registry';
+export {
+  DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID,
+  SEMANTIC_FIELD_SUFFIX,
+  MAX_SEMANTIC_SEARCH_FIELDS,
+  getSemanticFieldName,
+  resolveSemanticInferenceId,
+} from './src/semantic_search';
 export type {
   IKibanaMigrator,
   KibanaMigratorStatus,

--- a/src/core/packages/saved-objects/base-server-internal/src/model_version/version_map.test.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/model_version/version_map.test.ts
@@ -190,6 +190,71 @@ describe('ModelVersion map utilities', () => {
         )
       ).toEqual('10.1.0');
     });
+
+    it('returns at least 10.1.0 when a type declares semanticSearch with no model versions (useModelVersionsOnly=true)', () => {
+      // Simulates the ZDT mapping-version check: a type opting into semanticSearch for the first
+      // time must be detected as changed against an existing index at 10.0.0.
+      expect(
+        getCurrentVirtualVersion(
+          buildType({
+            mappings: { properties: { title: { type: 'text' } } },
+            semanticSearch: { fields: ['title'] },
+          }),
+          true
+        )
+      ).toEqual('10.1.0');
+    });
+
+    it('returns the migration version (not bumped) for semanticSearch with no modelVersions when useModelVersionsOnly=false', () => {
+      // Only the model-version branch is bumped; the legacy-migration branch is not, so
+      // outdated-document queries for types with no modelVersions are unaffected.
+      expect(
+        getCurrentVirtualVersion(
+          buildType({
+            migrations: { '8.6.0': dummyMigration },
+            mappings: { properties: { title: { type: 'text' } } },
+            semanticSearch: { fields: ['title'] },
+          }),
+          false
+        )
+      ).toEqual('8.6.0');
+    });
+
+    it('bumps a type with existing model versions by +1 when semanticSearch is declared', () => {
+      // This is the key case that the Math.max(n,1) semantics missed: a type already at
+      // model version 3 gets max(3,1)=3 (no-op). The +1 semantics produce 3+1=4=10.4.0,
+      // which is detectable against a stored 10.3.0.
+      expect(
+        getCurrentVirtualVersion(
+          buildType({
+            modelVersions: {
+              1: dummyModelVersion(),
+              2: dummyModelVersion(),
+              3: dummyModelVersion(),
+            },
+            mappings: { properties: { title: { type: 'text' } } },
+            semanticSearch: { fields: ['title'] },
+          }),
+          true
+        )
+      ).toEqual('10.4.0');
+    });
+
+    it('returns the natural latest version (no bump) for the same type without semanticSearch', () => {
+      expect(
+        getCurrentVirtualVersion(
+          buildType({
+            modelVersions: {
+              1: dummyModelVersion(),
+              2: dummyModelVersion(),
+              3: dummyModelVersion(),
+            },
+            mappings: { properties: { title: { type: 'text' } } },
+          }),
+          true
+        )
+      ).toEqual('10.3.0');
+    });
   });
 
   describe('getVirtualVersionMap', () => {
@@ -295,6 +360,68 @@ describe('ModelVersion map utilities', () => {
       ).toEqual(2);
     });
 
+    it('returns at least 1 for a type that declares semanticSearch with no model versions', () => {
+      expect(
+        getLatestMappingsVersionNumber(
+          buildType({
+            mappings: { properties: { title: { type: 'text' } } },
+            semanticSearch: { fields: ['title'] },
+          })
+        )
+      ).toEqual(1);
+    });
+
+    it('bumps a type with existing mappings versions by +1 when semanticSearch is declared', () => {
+      // This mirrors the getCurrentVirtualVersion fix: Math.max(3,1)=3 was a no-op.
+      // The +1 semantics produce 3+1=4, detectable against a stored 10.3.0.
+      expect(
+        getLatestMappingsVersionNumber(
+          buildType({
+            mappings: { properties: { title: { type: 'text' } } },
+            modelVersions: {
+              '1': dummyModelVersion(),
+              '2': dummyModelVersion(),
+              '3': dummyModelVersionWithMappingsChanges(),
+            },
+            semanticSearch: { fields: ['title'] },
+          })
+        )
+      ).toEqual(4);
+    });
+
+    it('returns the natural latest version (no bump) for the same type without semanticSearch', () => {
+      expect(
+        getLatestMappingsVersionNumber(
+          buildType({
+            mappings: { properties: { title: { type: 'text' } } },
+            modelVersions: {
+              '1': dummyModelVersion(),
+              '2': dummyModelVersion(),
+              '3': dummyModelVersionWithMappingsChanges(),
+            },
+          })
+        )
+      ).toEqual(3);
+    });
+
+    it('agrees with getCurrentVirtualVersion on the effective version, preventing an infinite mapping-update loop', () => {
+      // After a migration stamps the bumped version via getCurrentVirtualVersion, on the next
+      // boot getLatestMappingsVersionNumber must return the same effective number so the type
+      // is not re-detected as needing a mapping update.
+      const type = buildType({
+        modelVersions: {
+          '1': dummyModelVersion(),
+          '2': dummyModelVersion(),
+          '3': dummyModelVersionWithMappingsChanges(),
+        },
+        mappings: { properties: { title: { type: 'text' } } },
+        semanticSearch: { fields: ['title'] },
+      });
+      const mappingsVersion = getLatestMappingsVersionNumber(type); // 3+1=4
+      const virtualVersion = getCurrentVirtualVersion(type, true); // 10.4.0
+      expect(virtualVersion).toEqual(`10.${mappingsVersion}.0`);
+    });
+
     it('accepts provider functions', () => {
       expect(
         getLatestMappingsVersionNumber(
@@ -390,6 +517,26 @@ describe('ModelVersion map utilities', () => {
         foo: '10.1.0',
         bar: '10.0.0',
         dolly: '10.0.0',
+      });
+    });
+
+    it('returns at least 10.1.0 for a type that declares semanticSearch without explicit model versions', () => {
+      // This is the key property that makes v2 change-detection fire when an existing type
+      // opts into semanticSearch against an already-migrated index (stored at 10.0.0).
+      expect(
+        getLatestMappingsVirtualVersionMap([
+          buildType({
+            name: 'withSemantic',
+            mappings: { properties: { title: { type: 'text' } } },
+            semanticSearch: { fields: ['title'] },
+          }),
+          buildType({
+            name: 'noSemantic',
+          }),
+        ])
+      ).toEqual({
+        withSemantic: '10.1.0',
+        noSemantic: '10.0.0',
       });
     });
   });

--- a/src/core/packages/saved-objects/base-server-internal/src/model_version/version_map.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/model_version/version_map.ts
@@ -74,6 +74,21 @@ export const getModelVersionMapForTypes = (types: SavedObjectsType[]): ModelVers
  * - if the type does NOT define model versions =>
  *   - the initialModelVersion aka 10.0.0 (if useModelVersionsOnly is set to true)
  *   - the latest migration version for the type (if useModelVersionsOnly is set to false)
+ *
+ * Types declaring {@link SavedObjectsType.semanticSearch} are bumped by exactly +1 over
+ * their natural latest model version so that change-detection fires on existing indexes that
+ * predate the opt-in, regardless of how many model versions the type already has (the shadow
+ * field addition is a platform-managed mapping change). Using `Math.max(n, 1)` was a no-op
+ * for any type already at model version ≥ 1.
+ *
+ * This bump must stay consistent with {@link getLatestMappingsVersionNumber}, which applies
+ * the same +1, so that stored mapping metadata is never mismatched against the comparison
+ * value — a mismatch in opposite directions would cause an infinite mapping-update loop.
+ *
+ * @remarks GA hazard: the synthetic +1 version is renumbered if the type author later adds
+ * a real model version. Documents stamped with the synthetic version will skip that new
+ * version's transform. GA requires pinned synthetic versions; for the POC this is a
+ * documented limitation.
  */
 export const getCurrentVirtualVersion = (
   type: SavedObjectsType,
@@ -81,7 +96,11 @@ export const getCurrentVirtualVersion = (
 ): string => {
   if (type.modelVersions || useModelVersionsOnly) {
     const versionNumber = getLatestModelVersion(type);
-    return modelVersionToVirtualVersion(versionNumber);
+    // A semanticSearch declaration synthesizes a shadow semantic_text field; bump by exactly
+    // +1 over the natural latest so mapping-change detection fires on any existing type,
+    // including those already at model version ≥ 1 (Math.max(n,1) was a no-op for those).
+    const effectiveVersion = type.semanticSearch ? versionNumber + 1 : versionNumber;
+    return modelVersionToVirtualVersion(effectiveVersion);
   } else {
     return getLatestMigrationVersion(type);
   }
@@ -108,18 +127,34 @@ export const getVirtualVersionMap = ({
 
 /**
  * Returns the latest version number that includes changes in the mappings, for the given type.
- * If none of the versions are updating the mappings, it will return 0
+ * If none of the versions are updating the mappings, it will return 0.
+ *
+ * Types declaring {@link SavedObjectsType.semanticSearch} are bumped by exactly +1 over their
+ * natural latest mappings version because the platform synthesizes shadow fields as a mapping
+ * change. Using `Math.max(n, 1)` was a no-op for any type whose latest mappings version was
+ * already ≥ 1, causing change-detection to miss the opt-in on existing indexes.
+ *
+ * This bump must stay consistent with {@link getCurrentVirtualVersion}, which applies the same
+ * +1, so that stored mapping metadata is never mismatched against the comparison value — a
+ * mismatch in opposite directions would cause an infinite mapping-update loop.
+ *
+ * @remarks GA hazard: the synthetic +1 version is renumbered if the type author later adds
+ * a real model version. Documents stamped with the synthetic version will skip that new
+ * version's transform. GA requires pinned synthetic versions; for the POC this is a
+ * documented limitation.
  */
 export const getLatestMappingsVersionNumber = (type: SavedObjectsType): number => {
   const versionMap =
     typeof type.modelVersions === 'function' ? type.modelVersions() : type.modelVersions ?? {};
-  return Object.entries(versionMap)
-    .filter(([version, info]) =>
-      info.changes?.some((change) => change.type === 'mappings_addition')
-    )
+  const fromModelVersions = Object.entries(versionMap)
+    .filter(([, info]) => info.changes?.some((change) => change.type === 'mappings_addition'))
     .reduce<number>((memo, [current]) => {
       return Math.max(memo, assertValidModelVersion(current));
     }, 0);
+  // A semanticSearch declaration synthesizes shadow semantic_text fields; bump by exactly
+  // +1 over the natural latest so getNewAndUpdatedTypes fires on any existing type, including
+  // those whose latest mappings version was already ≥ 1 (Math.max(n,1) was a no-op for those).
+  return type.semanticSearch ? fromModelVersions + 1 : fromModelVersions;
 };
 
 /**

--- a/src/core/packages/saved-objects/base-server-internal/src/saved_objects_type_registry.test.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/saved_objects_type_registry.test.ts
@@ -7,7 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+import type {
+  SavedObjectsType,
+  SavedObjectsMappingProperties,
+} from '@kbn/core-saved-objects-server';
 import { SavedObjectTypeRegistry } from './saved_objects_type_registry';
 
 const createType = (type: Partial<SavedObjectsType>): SavedObjectsType => ({
@@ -294,6 +297,314 @@ describe('SavedObjectTypeRegistry', () => {
     });
 
     // TODO: same test with 'onImport'
+
+    describe('semanticSearch validation', () => {
+      it('allows a valid semanticSearch declaration', () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeWithSemantic',
+              mappings: {
+                properties: {
+                  title: { type: 'text' },
+                  description: { type: 'text' },
+                },
+              },
+              semanticSearch: { fields: ['title', 'description'] },
+            })
+          );
+        }).not.toThrow();
+      });
+
+      it('allows a semanticSearch declaration with an explicit inferenceId override', () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeWithSemantic',
+              mappings: { properties: { title: { type: 'text' } } },
+              semanticSearch: { fields: ['title'], inferenceId: '.my-custom-endpoint' },
+            })
+          );
+        }).not.toThrow();
+      });
+
+      it('throws when semanticSearch.fields is empty', () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeEmpty',
+              mappings: { properties: { title: { type: 'text' } } },
+              semanticSearch: { fields: [] },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type typeEmpty: 'semanticSearch.fields' must contain at least one field name"`
+        );
+      });
+
+      it('throws when semanticSearch.fields exceeds MAX_SEMANTIC_SEARCH_FIELDS', () => {
+        const manyFields = ['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9'];
+        const properties = Object.fromEntries(
+          manyFields.map((f) => [f, { type: 'text' as const }])
+        ) as SavedObjectsMappingProperties;
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeTooMany',
+              mappings: { properties },
+              semanticSearch: { fields: manyFields },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type typeTooMany: 'semanticSearch.fields' exceeds the maximum of 8 fields"`
+        );
+      });
+
+      it('throws when semanticSearch.fields contains duplicates', () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeDup',
+              mappings: { properties: { title: { type: 'text' } } },
+              semanticSearch: { fields: ['title', 'title'] },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type typeDup: 'semanticSearch.fields' contains duplicate field 'title'"`
+        );
+      });
+
+      it('throws when a declared field does not exist in mappings.properties', () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeMissing',
+              mappings: { properties: { title: { type: 'text' } } },
+              semanticSearch: { fields: ['missing'] },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type typeMissing: semanticSearch field 'missing' does not exist in mappings.properties"`
+        );
+      });
+
+      it('throws when a declared field has a non-text mapping type', () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeKeyword',
+              mappings: { properties: { title: { type: 'keyword' } } },
+              semanticSearch: { fields: ['title'] },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type typeKeyword: semanticSearch field 'title' must have mapping type 'text', got 'keyword'"`
+        );
+      });
+
+      it("throws when a mapping property name ends with '_semantic' (reserved suffix)", () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeReserved',
+              mappings: {
+                properties: {
+                  title: { type: 'text' },
+                  title_semantic: { type: 'keyword' },
+                },
+              },
+              semanticSearch: { fields: ['title'] },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type typeReserved: mapping property 'title_semantic' uses the reserved suffix '_semantic'"`
+        );
+      });
+
+      it("throws when a mapping property has type 'semantic_text' for a type declaring semanticSearch", () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeManualSemantic',
+              mappings: {
+                properties: {
+                  title: { type: 'text' },
+                  embeddings: { type: 'semantic_text' },
+                },
+              },
+              semanticSearch: { fields: ['title'] },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type typeManualSemantic: mapping property 'embeddings' uses type 'semantic_text', which is reserved for platform-managed shadow fields; remove it and use 'semanticSearch.fields' instead"`
+        );
+      });
+
+      it("throws when a mapping property has type 'dense_vector' for a type declaring semanticSearch", () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'typeDenseVec',
+              mappings: {
+                properties: {
+                  title: { type: 'text' },
+                  vec: { type: 'dense_vector' },
+                },
+              },
+              semanticSearch: { fields: ['title'] },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type typeDenseVec: mapping property 'vec' uses type 'dense_vector', which is reserved for platform-managed shadow fields; remove it and use 'semanticSearch.fields' instead"`
+        );
+      });
+
+      it('accepts a hyphenated type name with semanticSearch (hyphens are safe in bracket-notation Painless)', () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'index-pattern',
+              mappings: { properties: { title: { type: 'text' } } },
+              semanticSearch: { fields: ['title'] },
+            })
+          );
+        }).not.toThrow();
+      });
+
+      it('rejects a type name containing a single quote (would break Painless string literal)', () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: "bad'type",
+              mappings: { properties: { title: { type: 'text' } } },
+              semanticSearch: { fields: ['title'] },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type bad'type: type name must match /^[a-zA-Z0-9_-]+$/ to be used with semanticSearch (got 'bad'type')"`
+        );
+      });
+
+      it('rejects a type name containing a backslash (would break Painless string literal)', () => {
+        expect(() => {
+          registry.registerType(
+            createType({
+              name: 'bad\\type',
+              mappings: { properties: { title: { type: 'text' } } },
+              semanticSearch: { fields: ['title'] },
+            })
+          );
+        }).toThrowErrorMatchingInlineSnapshot(
+          `"Type bad\\\\type: type name must match /^[a-zA-Z0-9_-]+$/ to be used with semanticSearch (got 'bad\\\\type')"`
+        );
+      });
+    });
+  });
+
+  describe('#getSemanticSearchDefinition', () => {
+    it('returns undefined for a type that does not declare semanticSearch', () => {
+      registry.registerType(createType({ name: 'noSemantic' }));
+      expect(registry.getSemanticSearchDefinition('noSemantic')).toBeUndefined();
+    });
+
+    it('returns undefined for an unregistered type name', () => {
+      expect(registry.getSemanticSearchDefinition('unregistered')).toBeUndefined();
+    });
+
+    it('returns the resolved definition with the default inferenceId when none is declared', () => {
+      registry.registerType(
+        createType({
+          name: 'typeA',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        })
+      );
+      expect(registry.getSemanticSearchDefinition('typeA')).toEqual({
+        fields: ['title'],
+        inferenceId: '.elser-2-elasticsearch',
+        embedding: 'sync',
+      });
+    });
+
+    it('returns the resolved definition with the overridden inferenceId', () => {
+      registry.registerType(
+        createType({
+          name: 'typeB',
+          mappings: { properties: { title: { type: 'text' }, body: { type: 'text' } } },
+          semanticSearch: { fields: ['title', 'body'], inferenceId: '.custom-endpoint' },
+        })
+      );
+      expect(registry.getSemanticSearchDefinition('typeB')).toEqual({
+        fields: ['title', 'body'],
+        inferenceId: '.custom-endpoint',
+        embedding: 'sync',
+      });
+    });
+
+    it('does not expose the definition for a different type name', () => {
+      registry.registerType(
+        createType({
+          name: 'typeC',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        })
+      );
+      expect(registry.getSemanticSearchDefinition('typeD')).toBeUndefined();
+    });
+
+    it("defaults embedding to 'sync' when not declared", () => {
+      registry.registerType(
+        createType({
+          name: 'typeSync',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        })
+      );
+      expect(registry.getSemanticSearchDefinition('typeSync')).toMatchObject({
+        embedding: 'sync',
+      });
+    });
+
+    it("preserves embedding: 'sync' when explicitly declared", () => {
+      registry.registerType(
+        createType({
+          name: 'typeSyncExplicit',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'], embedding: 'sync' },
+        })
+      );
+      expect(registry.getSemanticSearchDefinition('typeSyncExplicit')).toMatchObject({
+        embedding: 'sync',
+      });
+    });
+
+    it("resolves embedding: 'deferred' when declared", () => {
+      registry.registerType(
+        createType({
+          name: 'typeDeferred',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'], embedding: 'deferred' },
+        })
+      );
+      expect(registry.getSemanticSearchDefinition('typeDeferred')).toEqual({
+        fields: ['title'],
+        inferenceId: '.elser-2-elasticsearch',
+        embedding: 'deferred',
+      });
+    });
+
+    it('returns a frozen definition that callers cannot mutate', () => {
+      registry.registerType(
+        createType({
+          name: 'typeFrozen',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'], embedding: 'deferred' },
+        })
+      );
+      const def = registry.getSemanticSearchDefinition('typeFrozen')!;
+      expect(Object.isFrozen(def)).toBe(true);
+      expect(Object.isFrozen(def.fields)).toBe(true);
+    });
   });
 
   describe('#getType', () => {

--- a/src/core/packages/saved-objects/base-server-internal/src/saved_objects_type_registry.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/saved_objects_type_registry.ts
@@ -9,6 +9,11 @@
 
 import { deepFreeze } from '@kbn/std';
 import type { SavedObjectsType, ISavedObjectTypeRegistry } from '@kbn/core-saved-objects-server';
+import {
+  MAX_SEMANTIC_SEARCH_FIELDS,
+  SEMANTIC_FIELD_SUFFIX,
+  resolveSemanticInferenceId,
+} from './semantic_search';
 
 export interface SavedObjectTypeRegistryConfig {
   legacyTypes?: string[];
@@ -36,6 +41,13 @@ export interface ISavedObjectTypeRegistryInternal extends ISavedObjectTypeRegist
   isAccessControlEnabled(): boolean;
 }
 
+/** Resolved semantic-search metadata stored outside the frozen type object (flag C). */
+interface ResolvedSemanticDefinition {
+  readonly fields: readonly string[];
+  readonly inferenceId: string;
+  readonly embedding: 'sync' | 'deferred';
+}
+
 /**
  * Core internal implementation of {@link ISavedObjectTypeRegistry}.
  *
@@ -44,6 +56,7 @@ export interface ISavedObjectTypeRegistryInternal extends ISavedObjectTypeRegist
 export class SavedObjectTypeRegistry implements ISavedObjectTypeRegistryInternal {
   private readonly types = new Map<string, SavedObjectsType>();
   private readonly legacyTypesMap: Set<string>;
+  private readonly resolvedSemanticDefinitions = new Map<string, ResolvedSemanticDefinition>();
 
   private accessControlEnabled: boolean = true;
 
@@ -77,6 +90,20 @@ export class SavedObjectTypeRegistry implements ISavedObjectTypeRegistryInternal
     const typeWithAccessControl = { ...type, supportsAccessControl };
 
     validateType(type);
+
+    // Compute and cache derived semantic state before the type object is frozen.
+    // Copy the fields array so the stored definition is independent of the frozen type object;
+    // freeze the definition to prevent callers from mutating the registry's cached state.
+    if (type.semanticSearch) {
+      this.resolvedSemanticDefinitions.set(
+        type.name,
+        Object.freeze({
+          fields: Object.freeze([...type.semanticSearch.fields]) as readonly string[],
+          inferenceId: resolveSemanticInferenceId(type),
+          embedding: type.semanticSearch.embedding ?? 'sync',
+        })
+      );
+    }
 
     if (process.env.NODE_ENV !== 'production') {
       deepFreeze(typeWithAccessControl);
@@ -164,6 +191,11 @@ export class SavedObjectTypeRegistry implements ISavedObjectTypeRegistryInternal
     return this.types.get(type)?.supportsAccessControl ?? false;
   }
 
+  /** {@inheritDoc ISavedObjectTypeRegistry.getSemanticSearchDefinition} */
+  public getSemanticSearchDefinition(typeName: string): ResolvedSemanticDefinition | undefined {
+    return this.resolvedSemanticDefinitions.get(typeName);
+  }
+
   /** {@inheritDoc ISavedObjectTypeRegistryInternal.setAccessControlEnabled} */
   public setAccessControlEnabled(enabled: boolean) {
     this.accessControlEnabled = enabled;
@@ -175,7 +207,14 @@ export class SavedObjectTypeRegistry implements ISavedObjectTypeRegistryInternal
   }
 }
 
-const validateType = ({ name, management, hidden, hiddenFromHttpApis }: SavedObjectsType) => {
+const validateType = ({
+  name,
+  management,
+  hidden,
+  hiddenFromHttpApis,
+  semanticSearch,
+  mappings,
+}: SavedObjectsType) => {
   if (management) {
     if (management.onExport && !management.importableAndExportable) {
       throw new Error(
@@ -193,5 +232,93 @@ const validateType = ({ name, management, hidden, hiddenFromHttpApis }: SavedObj
     throw new Error(
       `Type ${name}: 'hiddenFromHttpApis' cannot be 'false' when specifying 'hidden' as 'true'`
     );
+  }
+
+  if (semanticSearch) {
+    validateSemanticSearch(name, semanticSearch.fields, mappings.properties ?? {});
+  }
+};
+
+/**
+ * Alphanumerics, underscores, and hyphens are allowed in type names and field names used in
+ * Painless scripts. Hyphens are safe because the builder uses single-quoted bracket notation
+ * (e.g. ctx._source.get('index-pattern')), which is inert for hyphens. The characters that
+ * would actually break a Painless script — quotes, backslashes, braces — remain excluded.
+ */
+const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9_-]+$/;
+
+const validateSemanticSearch = (
+  typeName: string,
+  fields: string[],
+  properties: Record<string, { type?: string }>
+): void => {
+  // Type name safety: the type name is interpolated into Painless scripts. Reject any
+  // character that could break the script (quotes, backslashes, etc.).
+  if (!SAFE_IDENTIFIER_RE.test(typeName)) {
+    throw new Error(
+      `Type ${typeName}: type name must match /^[a-zA-Z0-9_-]+$/ to be used with semanticSearch (got '${typeName}')`
+    );
+  }
+
+  if (fields.length === 0) {
+    throw new Error(
+      `Type ${typeName}: 'semanticSearch.fields' must contain at least one field name`
+    );
+  }
+  if (fields.length > MAX_SEMANTIC_SEARCH_FIELDS) {
+    throw new Error(
+      `Type ${typeName}: 'semanticSearch.fields' exceeds the maximum of ${MAX_SEMANTIC_SEARCH_FIELDS} fields`
+    );
+  }
+
+  const seen = new Set<string>();
+  for (const field of fields) {
+    if (seen.has(field)) {
+      throw new Error(
+        `Type ${typeName}: 'semanticSearch.fields' contains duplicate field '${field}'`
+      );
+    }
+    seen.add(field);
+
+    // Field name safety: field names are also interpolated into Painless scripts.
+    if (!SAFE_IDENTIFIER_RE.test(field)) {
+      throw new Error(
+        `Type ${typeName}: semanticSearch field '${field}' must match /^[a-zA-Z0-9_-]+$/ (got '${field}')`
+      );
+    }
+
+    const mapping = properties[field];
+    if (!mapping) {
+      throw new Error(
+        `Type ${typeName}: semanticSearch field '${field}' does not exist in mappings.properties`
+      );
+    }
+    if (mapping.type !== 'text') {
+      throw new Error(
+        `Type ${typeName}: semanticSearch field '${field}' must have mapping type 'text', got '${mapping.type}'`
+      );
+    }
+  }
+
+  // Reserve the '_semantic' suffix: no hand-written property name may end with it.
+  // POC limitation: only top-level properties are scanned; nested `properties` and
+  // multi-field `fields` are not recursed into. Track as a Phase 2 hardening item.
+  for (const propName of Object.keys(properties)) {
+    if (propName.endsWith(SEMANTIC_FIELD_SUFFIX)) {
+      throw new Error(
+        `Type ${typeName}: mapping property '${propName}' uses the reserved suffix '${SEMANTIC_FIELD_SUFFIX}'`
+      );
+    }
+  }
+
+  // Reject hand-written 'semantic_text' or 'dense_vector' field types for types declaring
+  // semanticSearch — the platform must remain in control of shadow-field creation (flag F).
+  // POC limitation: same as above — only top-level properties are checked.
+  for (const [propName, mapping] of Object.entries(properties)) {
+    if (mapping.type === 'semantic_text' || mapping.type === 'dense_vector') {
+      throw new Error(
+        `Type ${typeName}: mapping property '${propName}' uses type '${mapping.type}', which is reserved for platform-managed shadow fields; remove it and use 'semanticSearch.fields' instead`
+      );
+    }
   }
 };

--- a/src/core/packages/saved-objects/base-server-internal/src/semantic_search.test.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/semantic_search.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+import {
+  DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID,
+  SEMANTIC_FIELD_SUFFIX,
+  MAX_SEMANTIC_SEARCH_FIELDS,
+  getSemanticFieldName,
+  resolveSemanticInferenceId,
+} from './semantic_search';
+
+const createType = (overrides: Partial<SavedObjectsType> = {}): SavedObjectsType => ({
+  name: 'test',
+  hidden: false,
+  namespaceType: 'single',
+  mappings: { properties: {} },
+  ...overrides,
+});
+
+describe('semantic_search constants', () => {
+  it('DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID is the ELSER endpoint', () => {
+    expect(DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID).toBe('.elser-2-elasticsearch');
+  });
+
+  it('SEMANTIC_FIELD_SUFFIX is _semantic', () => {
+    expect(SEMANTIC_FIELD_SUFFIX).toBe('_semantic');
+  });
+
+  it('MAX_SEMANTIC_SEARCH_FIELDS is 8', () => {
+    expect(MAX_SEMANTIC_SEARCH_FIELDS).toBe(8);
+  });
+});
+
+describe('getSemanticFieldName', () => {
+  it('appends the suffix to the field name', () => {
+    expect(getSemanticFieldName('title')).toBe('title_semantic');
+    expect(getSemanticFieldName('description')).toBe('description_semantic');
+  });
+});
+
+describe('resolveSemanticInferenceId', () => {
+  it('returns the default inference ID when no inferenceId is declared', () => {
+    const type = createType({ semanticSearch: { fields: ['title'] } });
+    expect(resolveSemanticInferenceId(type)).toBe(DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID);
+  });
+
+  it('returns the override inferenceId when declared', () => {
+    const type = createType({
+      semanticSearch: { fields: ['title'], inferenceId: '.my-custom-endpoint' },
+    });
+    expect(resolveSemanticInferenceId(type)).toBe('.my-custom-endpoint');
+  });
+
+  it('returns the default when semanticSearch has no inferenceId property', () => {
+    const type = createType({ semanticSearch: { fields: ['title'], inferenceId: undefined } });
+    expect(resolveSemanticInferenceId(type)).toBe(DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID);
+  });
+});

--- a/src/core/packages/saved-objects/base-server-internal/src/semantic_search.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/semantic_search.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+
+/** The platform-default ELSER inference endpoint used when no override is declared. */
+export const DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID = '.elser-2-elasticsearch';
+
+/** Suffix appended to source field names to form the shadow semantic field name. */
+export const SEMANTIC_FIELD_SUFFIX = '_semantic';
+
+/** Maximum number of fields a type may declare in {@link SavedObjectsType.semanticSearch}. */
+export const MAX_SEMANTIC_SEARCH_FIELDS = 8;
+
+/** Returns the shadow `semantic_text` field name for a given source attribute name. */
+export const getSemanticFieldName = (field: string): string => `${field}${SEMANTIC_FIELD_SUFFIX}`;
+
+/**
+ * Resolves the inference endpoint ID for a type — the single authoritative resolver (ADR-7).
+ * All subsystems must call this function; no code may read `inferenceId` from a registration directly.
+ */
+export const resolveSemanticInferenceId = (type: SavedObjectsType): string =>
+  type.semanticSearch?.inferenceId ?? DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID;

--- a/src/core/packages/saved-objects/base-server-internal/src/serialization/serializer.test.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/serialization/serializer.test.ts
@@ -31,6 +31,7 @@ const createMockedTypeRegistry = ({
     isMultiNamespace: jest.fn().mockReturnValue(isMultiNamespace),
     setAccessControlEnabled: jest.fn(),
     isAccessControlEnabled: jest.fn().mockReturnValue(accessControlEnabled),
+    getSemanticSearchDefinition: jest.fn().mockReturnValue(undefined),
   };
   return typeRegistry as ISavedObjectTypeRegistryInternal;
 };
@@ -1500,6 +1501,93 @@ describe('#generateRawLegacyUrlAliasId', () => {
     test(`for namespace-agnostic types`, () => {
       const id = namespaceAgnosticSerializer.generateRawLegacyUrlAliasId('foo', 'bar', 'baz');
       expect(id).toEqual(expected);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Semantic search stripping tests
+// Verifies that rawToSavedObject strips *_semantic shadow keys only for types
+// that opt in to semanticSearch (Mechanism B, ADR-6).
+// ---------------------------------------------------------------------------
+
+const createSemanticRegistry = (semanticTypeName: string): ISavedObjectTypeRegistryInternal => {
+  const registry: Partial<ISavedObjectTypeRegistryInternal> = {
+    isNamespaceAgnostic: jest.fn().mockReturnValue(false),
+    isSingleNamespace: jest.fn().mockReturnValue(true),
+    isMultiNamespace: jest.fn().mockReturnValue(false),
+    setAccessControlEnabled: jest.fn(),
+    isAccessControlEnabled: jest.fn().mockReturnValue(false),
+    getSemanticSearchDefinition: jest
+      .fn()
+      .mockImplementation((typeName: string) =>
+        typeName === semanticTypeName
+          ? { fields: ['description'], inferenceId: '.elser-2-elasticsearch' }
+          : undefined
+      ),
+  };
+  return registry as ISavedObjectTypeRegistryInternal;
+};
+
+describe('#rawToSavedObject — semantic search stripping', () => {
+  const SEMANTIC_TYPE = 'mytype';
+  const semanticSerializer = new SavedObjectsSerializer(createSemanticRegistry(SEMANTIC_TYPE));
+
+  test('strips *_semantic shadow keys from attributes of an opted-in type', () => {
+    const actual = semanticSerializer.rawToSavedObject({
+      _id: `${SEMANTIC_TYPE}:doc1`,
+      _source: {
+        type: SEMANTIC_TYPE,
+        [SEMANTIC_TYPE]: {
+          title: 'Hello',
+          description: 'World',
+          description_semantic: { text: 'World', inference: { chunks: [] } },
+        },
+      },
+    });
+    expect(actual.attributes).toEqual({ title: 'Hello', description: 'World' });
+    expect(actual.attributes).not.toHaveProperty('description_semantic');
+  });
+
+  test('returns attributes unchanged (equal) when no shadow keys are present for opted-in type', () => {
+    const actual = semanticSerializer.rawToSavedObject({
+      _id: `${SEMANTIC_TYPE}:doc2`,
+      _source: {
+        type: SEMANTIC_TYPE,
+        [SEMANTIC_TYPE]: { title: 'Hello', description: 'World' },
+      },
+    });
+    expect(actual.attributes).toEqual({ title: 'Hello', description: 'World' });
+  });
+
+  test('does NOT strip *_semantic keys from a non-opted-in type', () => {
+    // 'other' is not registered with semanticSearch — its foo_semantic key is legitimate.
+    const actual = singleNamespaceSerializer.rawToSavedObject({
+      _id: 'other:doc3',
+      _source: {
+        type: 'other',
+        other: { foo: 'bar', foo_semantic: 'legitimate value' },
+      },
+    });
+    expect(actual.attributes).toEqual({ foo: 'bar', foo_semantic: 'legitimate value' });
+  });
+
+  test('round-trip savedObjectToRaw -> rawToSavedObject preserves non-opted-in type attributes with _semantic suffix', () => {
+    // Confirms a non-opted-in type's attributes are never accidentally stripped.
+    const saved = singleNamespaceSerializer.rawToSavedObject({
+      _id: 'other:doc4',
+      _source: {
+        type: 'other',
+        namespace: undefined,
+        other: { normal: 'value', custom_semantic: 'also legitimate' },
+        references: [],
+      },
+    });
+    const raw = singleNamespaceSerializer.savedObjectToRaw(saved);
+    const roundTripped = singleNamespaceSerializer.rawToSavedObject(raw);
+    expect(roundTripped.attributes).toEqual({
+      normal: 'value',
+      custom_semantic: 'also legitimate',
     });
   });
 });

--- a/src/core/packages/saved-objects/base-server-internal/src/serialization/serializer.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/serialization/serializer.ts
@@ -16,6 +16,7 @@ import type {
 } from '@kbn/core-saved-objects-server';
 import { SavedObjectsUtils } from '@kbn/core-saved-objects-utils-server';
 import { LEGACY_URL_ALIAS_TYPE } from '../legacy_alias';
+import { SEMANTIC_FIELD_SUFFIX } from '../semantic_search';
 import { decodeVersion, encodeVersion } from '../version';
 import type {
   ISavedObjectTypeRegistryInternal,
@@ -113,13 +114,31 @@ export class SavedObjectsSerializer implements ISavedObjectsSerializer {
       namespace && (namespaceTreatment === 'lax' || this.registry.isSingleNamespace(type));
     const includeNamespaces = this.registry.isMultiNamespace(type);
 
+    // Introduce intermediate variable (flag D).
+    // Strip shadow semantic keys only for opted-in types — non-opted-in types return
+    // the same reference with zero extra work (this is a hot path).
+    //
+    // Phase 1 / Phase 2 consequence (accepted): during reindex migrations or outdated-doc
+    // transforms, rawToSavedObject strips *_semantic values, and savedObjectToRaw does not
+    // restore them.  Any Mechanism-B embeddings stored in _source[type] are therefore
+    // silently dropped on each migration pass and must be re-populated by the reconciler.
+    // Phase 4 must account for this re-embedding cost in the backfill design.
+    const rawAttributes = _source[type];
+    const attributes: T =
+      rawAttributes !== null &&
+      rawAttributes !== undefined &&
+      typeof rawAttributes === 'object' &&
+      this.registry.getSemanticSearchDefinition(type) !== undefined
+        ? (stripSemanticAttributes(rawAttributes as Record<string, unknown>) as T)
+        : (rawAttributes as T);
+
     return {
       type,
       id,
       ...(includeNamespace && { namespace }),
       ...(includeNamespaces && { namespaces }),
       ...(originId && { originId }),
-      attributes: _source[type],
+      attributes,
       references: references || [], // adds references default
       ...(managed != null ? { managed } : {}),
       ...(migrationVersion && { migrationVersion }),
@@ -269,6 +288,19 @@ export class SavedObjectsSerializer implements ISavedObjectsSerializer {
 
 function checkIdMatchesPrefix(id: string, prefix: string) {
   return id.startsWith(prefix) && id.length > prefix.length;
+}
+
+// Returns a shallow copy of attrs with every key ending in SEMANTIC_FIELD_SUFFIX removed.
+// Called only for types that declare semanticSearch; safe because Mechanism B writes shadow
+// keys into _source[type] alongside the original attribute values.
+function stripSemanticAttributes(attrs: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(attrs)) {
+    if (!key.endsWith(SEMANTIC_FIELD_SUFFIX)) {
+      result[key] = attrs[key];
+    }
+  }
+  return result;
 }
 
 function assertNonEmptyString(value: string, name: string) {

--- a/src/core/packages/saved-objects/base-server-mocks/src/saved_objects_type_registry.mock.ts
+++ b/src/core/packages/saved-objects/base-server-mocks/src/saved_objects_type_registry.mock.ts
@@ -33,6 +33,7 @@ const createRegistryMock = (): jest.Mocked<ISavedObjectTypeRegistryInternal> => 
     supportsAccessControl: jest.fn(),
     isAccessControlEnabled: jest.fn(),
     setAccessControlEnabled: jest.fn(),
+    getSemanticSearchDefinition: jest.fn(),
   });
 
   mock.getVisibleTypes.mockReturnValue([]);
@@ -54,6 +55,7 @@ const createRegistryMock = (): jest.Mocked<ISavedObjectTypeRegistryInternal> => 
   mock.getNameAttribute.mockReturnValue(undefined);
   mock.supportsAccessControl.mockReturnValue(false);
   mock.isAccessControlEnabled.mockReturnValue(true);
+  mock.getSemanticSearchDefinition.mockReturnValue(undefined);
 
   return mock;
 };

--- a/src/core/packages/saved-objects/import-export-server-internal/src/import/import_saved_objects.ts
+++ b/src/core/packages/saved-objects/import-export-server-internal/src/import/import_saved_objects.ts
@@ -61,6 +61,12 @@ export interface ImportSavedObjectsOptions {
    * If provided, Kibana will apply the given option to the `managed` property.
    */
   managed?: boolean;
+  /**
+   * When `true`, shadow semantic fields are omitted from the raw documents written by `bulkCreate`,
+   * so that Elasticsearch performs no inference during indexing. See
+   * {@link SavedObjectsImportOptions.deferEmbeddings} for full semantics.
+   */
+  deferEmbeddings?: boolean;
   /** The factory function for creating the access control import transforms */
   createAccessControlImportTransforms?: AccessControlImportTransformsFactory;
   /** The logger to use during the import operation */
@@ -85,6 +91,7 @@ export async function importSavedObjectsFromStream({
   refresh,
   compatibilityMode,
   managed,
+  deferEmbeddings,
   log,
   createAccessControlImportTransforms,
 }: ImportSavedObjectsOptions): Promise<SavedObjectsImportResponse> {
@@ -180,6 +187,7 @@ export async function importSavedObjectsFromStream({
     refresh,
     compatibilityMode,
     managed,
+    deferEmbeddings,
   };
   const createSavedObjectsResult = await createSavedObjects(createSavedObjectsParams);
   errorAccumulator = [...errorAccumulator, ...createSavedObjectsResult.errors];

--- a/src/core/packages/saved-objects/import-export-server-internal/src/import/lib/create_saved_objects.test.ts
+++ b/src/core/packages/saved-objects/import-export-server-internal/src/import/lib/create_saved_objects.test.ts
@@ -434,4 +434,29 @@ describe('#createSavedObjects', () => {
       await testReturnValue({ namespace, compatibilityMode: true });
     });
   });
+
+  describe('deferEmbeddings option', () => {
+    test('passes deferEmbeddings: true to bulkCreate when set', async () => {
+      const baseOptions = setupParams({ objects: [obj1] });
+      const options = { ...baseOptions, deferEmbeddings: true as const };
+      bulkCreate.mockResolvedValue({ saved_objects: [getResultMock.success(obj1, baseOptions)] });
+
+      await createSavedObjects(options);
+      expect(bulkCreate).toHaveBeenCalledTimes(1);
+      expect(bulkCreate).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ deferEmbeddings: true })
+      );
+    });
+
+    test('does not pass deferEmbeddings: true when omitted from params', async () => {
+      const options = setupParams({ objects: [obj1] });
+      bulkCreate.mockResolvedValue({ saved_objects: [getResultMock.success(obj1, options)] });
+
+      await createSavedObjects(options);
+      expect(bulkCreate).toHaveBeenCalledTimes(1);
+      const callOptions = bulkCreate.mock.calls[0][1];
+      expect(callOptions).not.toHaveProperty('deferEmbeddings', true);
+    });
+  });
 });

--- a/src/core/packages/saved-objects/import-export-server-internal/src/import/lib/create_saved_objects.ts
+++ b/src/core/packages/saved-objects/import-export-server-internal/src/import/lib/create_saved_objects.ts
@@ -43,6 +43,12 @@ export interface CreateSavedObjectsParams<T> {
    * make their edits to the copy.
    */
   managed?: boolean;
+  /**
+   * When `true`, shadow semantic fields are omitted from the raw documents written by `bulkCreate`,
+   * so that Elasticsearch performs no inference during indexing. Only meaningful for types that
+   * declare {@link SavedObjectsType.semanticSearch | semanticSearch}; silently ignored otherwise.
+   */
+  deferEmbeddings?: boolean;
 }
 
 export interface CreateSavedObjectsResult<T> {
@@ -64,6 +70,7 @@ export const createSavedObjects = async <T>({
   refresh,
   compatibilityMode,
   managed,
+  deferEmbeddings,
 }: CreateSavedObjectsParams<T>): Promise<CreateSavedObjectsResult<T>> => {
   // filter out any objects that resulted in errors
   const errorSet = accumulatedErrors.reduce(
@@ -129,6 +136,7 @@ export const createSavedObjects = async <T>({
       namespace,
       overwrite,
       refresh,
+      deferEmbeddings,
     });
     expectedResults = bulkCreateResponse.saved_objects;
   }

--- a/src/core/packages/saved-objects/import-export-server-internal/src/import/resolve_import_errors.test.ts
+++ b/src/core/packages/saved-objects/import-export-server-internal/src/import/resolve_import_errors.test.ts
@@ -94,6 +94,7 @@ describe('#importSavedObjectsFromStream', () => {
       } as any),
     importHooks = {},
     managed,
+    deferEmbeddings,
   }: {
     retries?: SavedObjectsImportRetry[];
     createNewCopies?: boolean;
@@ -101,6 +102,7 @@ describe('#importSavedObjectsFromStream', () => {
     getTypeImpl?: (name: string) => any;
     importHooks?: Record<string, SavedObjectsImportHook[]>;
     managed?: boolean;
+    deferEmbeddings?: boolean;
   } = {}): ResolveSavedObjectsImportErrorsOptions => {
     readStream = new Readable();
     savedObjectsClient = savedObjectsClientMock.create();
@@ -119,6 +121,7 @@ describe('#importSavedObjectsFromStream', () => {
       createNewCopies,
       compatibilityMode,
       managed,
+      deferEmbeddings,
     };
   };
 
@@ -492,6 +495,34 @@ describe('#importSavedObjectsFromStream', () => {
           importStateMap: new Map(),
           namespace,
           compatibilityMode: true,
+        };
+        expect(mockCreateSavedObjects).toHaveBeenNthCalledWith(1, {
+          ...partialCreateSavedObjectsParams,
+          objects: objectsToOverwrite,
+          overwrite: true,
+        });
+        expect(mockCreateSavedObjects).toHaveBeenNthCalledWith(2, {
+          ...partialCreateSavedObjectsParams,
+          objects: objectsToNotOverwrite,
+        });
+      });
+
+      test('passes `deferEmbeddings` to both createSavedObjects calls when specified', async () => {
+        const objectsToOverwrite = [createObject()];
+        const objectsToNotOverwrite = [createObject()];
+        mockSplitOverwrites.mockReturnValue({ objectsToOverwrite, objectsToNotOverwrite });
+        mockCreateSavedObjects.mockResolvedValueOnce({
+          errors: [],
+          createdObjects: [],
+        });
+
+        await resolveSavedObjectsImportErrors(setupOptions({ deferEmbeddings: true }));
+        const partialCreateSavedObjectsParams = {
+          accumulatedErrors: [],
+          savedObjectsClient,
+          importStateMap: new Map(),
+          namespace,
+          deferEmbeddings: true,
         };
         expect(mockCreateSavedObjects).toHaveBeenNthCalledWith(1, {
           ...partialCreateSavedObjectsParams,

--- a/src/core/packages/saved-objects/import-export-server-internal/src/import/resolve_import_errors.ts
+++ b/src/core/packages/saved-objects/import-export-server-internal/src/import/resolve_import_errors.ts
@@ -66,6 +66,12 @@ export interface ResolveSavedObjectsImportErrorsOptions {
    * This property allows plugin authors to implement read-only UI's
    */
   managed?: boolean;
+  /**
+   * When `true`, shadow semantic fields are omitted from the raw documents written by `bulkCreate`,
+   * so that Elasticsearch performs no inference during indexing. See
+   * {@link SavedObjectsResolveImportErrorsOptions.deferEmbeddings} for full semantics.
+   */
+  deferEmbeddings?: boolean;
   /** The factory function for creating the access control import transforms */
   createAccessControlImportTransforms?: AccessControlImportTransformsFactory;
 }
@@ -87,6 +93,7 @@ export async function resolveSavedObjectsImportErrors({
   createNewCopies,
   compatibilityMode,
   managed,
+  deferEmbeddings,
   createAccessControlImportTransforms,
 }: ResolveSavedObjectsImportErrorsOptions): Promise<SavedObjectsImportResponse> {
   // throw a BadRequest error if we see invalid retries
@@ -227,6 +234,7 @@ export async function resolveSavedObjectsImportErrors({
       overwrite,
       compatibilityMode,
       managed,
+      deferEmbeddings,
     };
     const { createdObjects, errors: bulkCreateErrors } = await createSavedObjects(
       createSavedObjectsParams

--- a/src/core/packages/saved-objects/import-export-server-internal/src/import/saved_objects_importer.ts
+++ b/src/core/packages/saved-objects/import-export-server-internal/src/import/saved_objects_importer.ts
@@ -66,6 +66,7 @@ export class SavedObjectsImporter implements ISavedObjectsImporter {
     refresh,
     compatibilityMode,
     managed,
+    deferEmbeddings,
   }: SavedObjectsImportOptions): Promise<SavedObjectsImportResponse> {
     return importSavedObjectsFromStream({
       readStream,
@@ -79,6 +80,7 @@ export class SavedObjectsImporter implements ISavedObjectsImporter {
       typeRegistry: this.#typeRegistry,
       importHooks: this.#importHooks,
       managed,
+      deferEmbeddings,
       log: this.#log,
       createAccessControlImportTransforms: this.#createAccessControlImportTransforms,
     });
@@ -91,6 +93,7 @@ export class SavedObjectsImporter implements ISavedObjectsImporter {
     namespace,
     retries,
     managed,
+    deferEmbeddings,
   }: SavedObjectsResolveImportErrorsOptions): Promise<SavedObjectsImportResponse> {
     this.#log.debug('Resolving import errors');
     return resolveSavedObjectsImportErrors({
@@ -104,6 +107,7 @@ export class SavedObjectsImporter implements ISavedObjectsImporter {
       typeRegistry: this.#typeRegistry,
       importHooks: this.#importHooks,
       managed,
+      deferEmbeddings,
       createAccessControlImportTransforms: this.#createAccessControlImportTransforms,
     });
   }

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/ensure_inference_endpoints.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/ensure_inference_endpoints.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { errors as EsErrors } from '@elastic/elasticsearch';
+import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+import { ensureInferenceEndpoints } from './ensure_inference_endpoints';
+
+const createResponseError = (statusCode: number) =>
+  new EsErrors.ResponseError(
+    elasticsearchClientMock.createApiResponse({
+      statusCode,
+      body: { error: { type: 'es_type', reason: 'es_reason' } },
+    })
+  );
+
+describe('ensureInferenceEndpoints', () => {
+  let client: ReturnType<typeof elasticsearchClientMock.createInternalClient>;
+
+  beforeEach(() => {
+    client = elasticsearchClientMock.createInternalClient();
+  });
+
+  it('returns an empty report and makes no ES calls when inferenceIds is empty', async () => {
+    const report = await ensureInferenceEndpoints(client, []);
+
+    expect(client.inference.get).not.toHaveBeenCalled();
+    expect(report).toEqual({ checked: [], missing: [], errors: [] });
+  });
+
+  it('adds endpoint to checked when inference.get resolves', async () => {
+    client.inference.get.mockResolvedValueOnce({ endpoints: [] } as any);
+
+    const report = await ensureInferenceEndpoints(client, ['.elser-2-elasticsearch']);
+
+    expect(client.inference.get).toHaveBeenCalledWith({
+      inference_id: '.elser-2-elasticsearch',
+    });
+    expect(report.checked).toEqual(['.elser-2-elasticsearch']);
+    expect(report.missing).toEqual([]);
+    expect(report.errors).toEqual([]);
+  });
+
+  it('adds endpoint to missing when inference.get rejects with 404', async () => {
+    client.inference.get.mockRejectedValueOnce(createResponseError(404));
+
+    const report = await ensureInferenceEndpoints(client, ['.elser-2-elasticsearch']);
+
+    expect(report.checked).toEqual([]);
+    expect(report.missing).toEqual(['.elser-2-elasticsearch']);
+    expect(report.errors).toEqual([]);
+  });
+
+  it('adds endpoint to errors when inference.get rejects with a non-404 error', async () => {
+    client.inference.get.mockRejectedValueOnce(createResponseError(503));
+
+    const report = await ensureInferenceEndpoints(client, ['.elser-2-elasticsearch']);
+
+    expect(report.checked).toEqual([]);
+    expect(report.missing).toEqual([]);
+    expect(report.errors).toHaveLength(1);
+    expect(report.errors[0].inferenceId).toBe('.elser-2-elasticsearch');
+    expect(typeof report.errors[0].error).toBe('string');
+  });
+
+  it('adds endpoint to errors when inference.get rejects with a plain Error', async () => {
+    client.inference.get.mockRejectedValueOnce(new Error('network timeout'));
+
+    const report = await ensureInferenceEndpoints(client, ['custom-endpoint']);
+
+    expect(report.errors).toEqual([{ inferenceId: 'custom-endpoint', error: 'network timeout' }]);
+  });
+
+  it('adds endpoint to errors when inference.get rejects with a non-Error value', async () => {
+    client.inference.get.mockRejectedValueOnce('unexpected string rejection');
+
+    const report = await ensureInferenceEndpoints(client, ['custom-endpoint']);
+
+    expect(report.errors[0].inferenceId).toBe('custom-endpoint');
+    expect(report.errors[0].error).toBe('unexpected string rejection');
+  });
+
+  it('handles multiple endpoints independently: checked + missing + error in one call', async () => {
+    client.inference.get
+      .mockResolvedValueOnce({ endpoints: [] } as any) // first: exists
+      .mockRejectedValueOnce(createResponseError(404)) // second: missing
+      .mockRejectedValueOnce(new Error('permission denied')); // third: error
+
+    const report = await ensureInferenceEndpoints(client, [
+      '.elser-2-elasticsearch',
+      '.multilingual-e5-small-elasticsearch',
+      'custom-endpoint',
+    ]);
+
+    expect(report.checked).toEqual(['.elser-2-elasticsearch']);
+    expect(report.missing).toEqual(['.multilingual-e5-small-elasticsearch']);
+    expect(report.errors).toEqual([{ inferenceId: 'custom-endpoint', error: 'permission denied' }]);
+  });
+
+  it('never throws even when multiple endpoints fail', async () => {
+    client.inference.get
+      .mockRejectedValueOnce(createResponseError(404))
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockRejectedValueOnce(createResponseError(503));
+
+    await expect(ensureInferenceEndpoints(client, ['a', 'b', 'c'])).resolves.toEqual({
+      checked: [],
+      missing: ['a'],
+      errors: [
+        { inferenceId: 'b', error: 'boom' },
+        { inferenceId: 'c', error: expect.any(String) },
+      ],
+    });
+  });
+});

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/ensure_inference_endpoints.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/ensure_inference_endpoints.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+
+/** Outcome of the per-boot inference-endpoint preflight check. */
+export interface InferenceEndpointPreflightReport {
+  /** Inference IDs whose endpoints were confirmed to exist. */
+  checked: string[];
+  /** Inference IDs whose endpoints returned 404. Semantic search will be degraded for types using these. */
+  missing: string[];
+  /** Inference IDs whose endpoints could not be verified due to a non-404 error. */
+  errors: Array<{ inferenceId: string; error: string }>;
+}
+
+const is404 = (err: unknown): boolean =>
+  typeof err === 'object' &&
+  err !== null &&
+  (err as { meta?: { statusCode?: number } }).meta?.statusCode === 404;
+
+/**
+ * Checks whether each given inference endpoint exists in ES.
+ * Resolves with a structured report and never throws — all failures are captured in the report.
+ */
+export const ensureInferenceEndpoints = async (
+  client: ElasticsearchClient,
+  inferenceIds: ReadonlyArray<string>
+): Promise<InferenceEndpointPreflightReport> => {
+  const report: InferenceEndpointPreflightReport = {
+    checked: [],
+    missing: [],
+    errors: [],
+  };
+
+  for (const inferenceId of inferenceIds) {
+    try {
+      await client.inference.get({ inference_id: inferenceId });
+      report.checked.push(inferenceId);
+    } catch (err) {
+      if (is404(err)) {
+        report.missing.push(inferenceId);
+      } else {
+        const message = err instanceof Error ? err.message : String(err);
+        report.errors.push({ inferenceId, error: message });
+      }
+    }
+  }
+
+  return report;
+};

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/index.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/index.ts
@@ -106,6 +106,9 @@ export { checkForUnknownDocs } from './check_for_unknown_docs';
 
 export { waitForPickupUpdatedMappingsTask } from './wait_for_pickup_updated_mappings_task';
 
+export type { InferenceEndpointPreflightReport } from './ensure_inference_endpoints';
+export { ensureInferenceEndpoints } from './ensure_inference_endpoints';
+
 export type { BulkOverwriteTransformedDocumentsParams } from './bulk_overwrite_transformed_documents';
 export { bulkOverwriteTransformedDocuments } from './bulk_overwrite_transformed_documents';
 

--- a/src/core/packages/saved-objects/migration-server-internal/src/core/build_types_mappings.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/core/build_types_mappings.test.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+import { DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID } from '@kbn/core-saved-objects-base-server-internal';
+import { buildTypesMappings } from './build_types_mappings';
+
+const createType = (overrides: Partial<SavedObjectsType> = {}): SavedObjectsType => ({
+  name: 'test',
+  hidden: false,
+  namespaceType: 'single',
+  mappings: { properties: {} },
+  ...overrides,
+});
+
+describe('buildTypesMappings', () => {
+  describe('types without semanticSearch', () => {
+    it('emits mappings unchanged for a plain type', () => {
+      const type = createType({
+        name: 'plain',
+        mappings: { properties: { title: { type: 'text' }, count: { type: 'long' } } },
+      });
+      const result = buildTypesMappings([type]);
+      expect(result).toEqual({ plain: type.mappings });
+    });
+
+    it('emits the same mapping object reference when no semanticSearch is declared', () => {
+      const type = createType({ name: 'plain' });
+      const result = buildTypesMappings([type]);
+      expect(result.plain).toBe(type.mappings);
+    });
+  });
+
+  describe('shadow field emission', () => {
+    it('emits a shadow semantic_text field with the platform default inference id', () => {
+      const type = createType({
+        name: 'dashboard',
+        mappings: { properties: { title: { type: 'text' } } },
+        semanticSearch: { fields: ['title'] },
+      });
+      const result = buildTypesMappings([type]);
+      expect(result.dashboard.properties.title_semantic).toEqual({
+        type: 'semantic_text',
+        inference_id: DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID,
+      });
+    });
+
+    it('uses the declared inferenceId override instead of the default', () => {
+      const customId = '.my-custom-endpoint';
+      const type = createType({
+        name: 'rule',
+        mappings: { properties: { name: { type: 'text' } } },
+        semanticSearch: { fields: ['name'], inferenceId: customId },
+      });
+      const result = buildTypesMappings([type]);
+      expect(result.rule.properties.name_semantic).toEqual({
+        type: 'semantic_text',
+        inference_id: customId,
+      });
+    });
+
+    it('emits a shadow field for each declared field when multiple fields are listed', () => {
+      const type = createType({
+        name: 'dashboard',
+        mappings: {
+          properties: {
+            title: { type: 'text' },
+            description: { type: 'text' },
+            notes: { type: 'text' },
+          },
+        },
+        semanticSearch: { fields: ['title', 'description', 'notes'] },
+      });
+      const result = buildTypesMappings([type]);
+      const props = result.dashboard.properties;
+      expect(props.title_semantic).toEqual({
+        type: 'semantic_text',
+        inference_id: DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID,
+      });
+      expect(props.description_semantic).toEqual({
+        type: 'semantic_text',
+        inference_id: DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID,
+      });
+      expect(props.notes_semantic).toEqual({
+        type: 'semantic_text',
+        inference_id: DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID,
+      });
+    });
+  });
+
+  describe('Mechanism B invariant: source field mapping untouched', () => {
+    it('preserves the source field mapping byte-for-byte — no copy_to added', () => {
+      const sourceFieldMapping = { type: 'text' as const };
+      const type = createType({
+        name: 'dashboard',
+        mappings: { properties: { title: sourceFieldMapping } },
+        semanticSearch: { fields: ['title'] },
+      });
+      const result = buildTypesMappings([type]);
+      // The source field must be deep-equal to the original — no modification whatsoever.
+      expect(result.dashboard.properties.title).toEqual(sourceFieldMapping);
+      // Specifically, no copy_to must have been injected.
+      expect(
+        (result.dashboard.properties.title as Record<string, unknown>).copy_to
+      ).toBeUndefined();
+    });
+
+    it('preserves all source field properties including extra fields', () => {
+      const type = createType({
+        name: 'search',
+        mappings: {
+          properties: {
+            body: {
+              type: 'text',
+              analyzer: 'english',
+              index_options: 'offsets',
+            },
+          },
+        },
+        semanticSearch: { fields: ['body'] },
+      });
+      const result = buildTypesMappings([type]);
+      expect(result.search.properties.body).toEqual({
+        type: 'text',
+        analyzer: 'english',
+        index_options: 'offsets',
+      });
+    });
+  });
+
+  describe('frozen input safety', () => {
+    it('does not throw when the type object is frozen', () => {
+      const type = Object.freeze(
+        createType({
+          name: 'frozen',
+          mappings: Object.freeze({
+            properties: Object.freeze({
+              title: Object.freeze({ type: 'text' as const }),
+            }),
+          }) as SavedObjectsType['mappings'],
+          semanticSearch: Object.freeze({ fields: Object.freeze(['title']) as string[] }),
+        })
+      ) as SavedObjectsType;
+
+      expect(() => buildTypesMappings([type])).not.toThrow();
+      const result = buildTypesMappings([type]);
+      expect(result.frozen.properties.title_semantic).toEqual({
+        type: 'semantic_text',
+        inference_id: DEFAULT_SEMANTIC_SEARCH_INFERENCE_ID,
+      });
+    });
+  });
+
+  describe('types without semanticSearch are unaffected by semantic types in the same call', () => {
+    it('emits a clean mapping for a plain type when a semantic type is also registered', () => {
+      const plainType = createType({
+        name: 'plain',
+        mappings: { properties: { title: { type: 'keyword' } } },
+      });
+      const semanticType = createType({
+        name: 'semantic',
+        mappings: { properties: { body: { type: 'text' } } },
+        semanticSearch: { fields: ['body'] },
+      });
+      const result = buildTypesMappings([plainType, semanticType]);
+      // plain type: exact same mapping, no shadow fields
+      expect(result.plain).toEqual(plainType.mappings);
+      expect(Object.keys(result.plain.properties)).toEqual(['title']);
+      // semantic type: shadow field added, source field unchanged
+      expect(Object.keys(result.semantic.properties).sort()).toEqual(['body', 'body_semantic']);
+    });
+  });
+
+  describe('duplicate type names', () => {
+    it('throws when two types share the same name', () => {
+      const type1 = createType({ name: 'dup' });
+      const type2 = createType({ name: 'dup' });
+      expect(() => buildTypesMappings([type1, type2])).toThrow('Type dup is already defined.');
+    });
+  });
+});

--- a/src/core/packages/saved-objects/migration-server-internal/src/core/build_types_mappings.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/core/build_types_mappings.ts
@@ -7,21 +7,54 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+import type {
+  SavedObjectsType,
+  SavedObjectsMappingProperties,
+} from '@kbn/core-saved-objects-server';
 import type { SavedObjectsTypeMappingDefinitions } from '@kbn/core-saved-objects-base-server-internal';
+import {
+  getSemanticFieldName,
+  resolveSemanticInferenceId,
+} from '@kbn/core-saved-objects-base-server-internal';
 
 /**
- * Merge mappings from all registered saved object types.
+ * Merge mappings from all registered saved object types, synthesizing shadow `semantic_text`
+ * fields for any type that declares {@link SavedObjectsType.semanticSearch}.
  */
 export const buildTypesMappings = (
   types: SavedObjectsType[]
 ): SavedObjectsTypeMappingDefinitions => {
-  return types.reduce<SavedObjectsTypeMappingDefinitions>((acc, { name: type, mappings }) => {
-    const duplicate = Object.hasOwn(acc, type);
+  return types.reduce<SavedObjectsTypeMappingDefinitions>((acc, type) => {
+    const { name: typeName, mappings, semanticSearch } = type;
+    const duplicate = Object.hasOwn(acc, typeName);
     if (duplicate) {
-      throw new Error(`Type ${type} is already defined.`);
+      throw new Error(`Type ${typeName} is already defined.`);
     }
-    acc[type] = mappings;
+
+    if (!semanticSearch) {
+      acc[typeName] = mappings;
+      return acc;
+    }
+
+    // ADR-6 / Mechanism B: emit shadow semantic_text fields alongside the author's mappings.
+    // Source field mappings are byte-identical to what the author wrote — no copy_to is added.
+    const inferenceId = resolveSemanticInferenceId(type);
+    const shadowProperties: SavedObjectsMappingProperties = {};
+    for (const field of semanticSearch.fields) {
+      shadowProperties[getSemanticFieldName(field)] = {
+        type: 'semantic_text',
+        inference_id: inferenceId,
+      };
+    }
+
+    acc[typeName] = {
+      ...mappings,
+      properties: {
+        ...mappings.properties,
+        ...shadowProperties,
+      },
+    };
+
     return acc;
   }, {});
 };

--- a/src/core/packages/saved-objects/migration-server-internal/src/core/compare_mappings.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/core/compare_mappings.test.ts
@@ -113,6 +113,89 @@ describe('getNewAndUpdatedTypes', () => {
   });
 });
 
+describe('getNewAndUpdatedTypes — semanticSearch version bump', () => {
+  test('detects a type as updated when semanticSearch bumps latestMappingsVersions above the stored version', () => {
+    // Simulates an existing deployment: the stored mappingVersions reflect the type before
+    // it declared semanticSearch (10.0.0). The platform now returns 10.1.0 via
+    // getLatestMappingsVirtualVersionMap because semanticSearch is present.
+    // getNewAndUpdatedTypes must classify the type as 'updated' so
+    // UPDATE_TARGET_MAPPINGS_PROPERTIES fires and the shadow field is added.
+    const indexMeta: IndexMappingMeta = {
+      mappingVersions: {
+        myType: '10.0.0',
+      },
+    };
+
+    const { newTypes, updatedTypes } = getNewAndUpdatedTypes({
+      indexTypes: ['myType'],
+      indexMeta,
+      latestMappingsVersions: { myType: '10.1.0' },
+    });
+
+    expect(newTypes).toEqual([]);
+    expect(updatedTypes).toEqual(['myType']);
+  });
+
+  test('leaves a type unchanged after a migration stamps the bumped version in the index', () => {
+    // After UPDATE_TARGET_MAPPINGS_PROPERTIES the index stores 10.1.0.
+    // On the next boot the type is still at 10.1.0 — no spurious re-migration.
+    const indexMeta: IndexMappingMeta = {
+      mappingVersions: {
+        myType: '10.1.0',
+      },
+    };
+
+    const { newTypes, updatedTypes } = getNewAndUpdatedTypes({
+      indexTypes: ['myType'],
+      indexMeta,
+      latestMappingsVersions: { myType: '10.1.0' },
+    });
+
+    expect(newTypes).toEqual([]);
+    expect(updatedTypes).toEqual([]);
+  });
+
+  test('detects a type with existing model versions as updated when semanticSearch bumps the version above stored', () => {
+    // Simulates the dashboard case: type already at model version 3 (stored 10.3.0),
+    // semanticSearch is then declared. getLatestMappingsVirtualVersionMap now returns
+    // 10.4.0 (3+1). The type must be classified as 'updated' so the shadow field is added.
+    // Math.max(3,1)=3 produced 10.3.0 — a no-op that let this bug ship.
+    const indexMeta: IndexMappingMeta = {
+      mappingVersions: {
+        myVersionedType: '10.3.0',
+      },
+    };
+
+    const { newTypes, updatedTypes } = getNewAndUpdatedTypes({
+      indexTypes: ['myVersionedType'],
+      indexMeta,
+      latestMappingsVersions: { myVersionedType: '10.4.0' },
+    });
+
+    expect(newTypes).toEqual([]);
+    expect(updatedTypes).toEqual(['myVersionedType']);
+  });
+
+  test('leaves a model-versioned type unchanged after a migration stamps the +1 bumped version', () => {
+    // After UPDATE_TARGET_MAPPINGS_PROPERTIES the index stores 10.4.0. On the next boot
+    // the type is still at 10.4.0 — no spurious re-migration.
+    const indexMeta: IndexMappingMeta = {
+      mappingVersions: {
+        myVersionedType: '10.4.0',
+      },
+    };
+
+    const { newTypes, updatedTypes } = getNewAndUpdatedTypes({
+      indexTypes: ['myVersionedType'],
+      indexMeta,
+      latestMappingsVersions: { myVersionedType: '10.4.0' },
+    });
+
+    expect(newTypes).toEqual([]);
+    expect(updatedTypes).toEqual([]);
+  });
+});
+
 describe('getUpdatedRootFields', () => {
   it('deep compares provided indexMappings against the current baseMappings()', () => {
     const updatedFields = getUpdatedRootFields({

--- a/src/core/packages/saved-objects/migration-server-internal/src/kibana_migrator.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/kibana_migrator.ts
@@ -39,6 +39,7 @@ import { DocumentMigrator } from './document_migrator';
 import { runZeroDowntimeMigration } from './zdt';
 import { ALLOWED_CONVERT_VERSION } from './kibana_migrator_constants';
 import { runV2Migration } from './run_v2_migration';
+import { ensureInferenceEndpoints } from './actions';
 
 export interface KibanaMigratorOptions {
   client: ElasticsearchClient;
@@ -182,6 +183,12 @@ export class KibanaMigrator implements IKibanaMigrator {
     process.on('uncaughtExceptionMonitor', dumpLogs);
 
     try {
+      // Use this.log (the real logger) so preflight degradation errors are always
+      // emitted immediately, even when the cumulative logger is active (serverless/ZDT).
+      // The cumulative logger buffers all calls and clears them on success, which
+      // would silently drop the missing-endpoint error that operators need to act on.
+      await this.runInferenceEndpointPreflight(this.log);
+
       const migrationAlgorithm = this.soMigrationsConfig.algorithm;
       if (migrationAlgorithm === 'zdt') {
         return await runZeroDowntimeMigration({
@@ -223,6 +230,60 @@ export class KibanaMigrator implements IKibanaMigrator {
     } finally {
       process.removeListener('uncaughtExceptionMonitor', dumpLogs);
       logger.clear?.();
+    }
+  }
+
+  /** Checks inference endpoints for all types that declare semanticSearch and logs results. Never throws. */
+  private async runInferenceEndpointPreflight(logger: Logger): Promise<void> {
+    // Build a map of inferenceId → type names so we can produce context-rich log messages.
+    const inferenceIdToTypes = new Map<string, string[]>();
+    for (const type of this.typeRegistry.getAllTypes()) {
+      const def = this.typeRegistry.getSemanticSearchDefinition(type.name);
+      if (def) {
+        const existing = inferenceIdToTypes.get(def.inferenceId);
+        if (existing) {
+          existing.push(type.name);
+        } else {
+          inferenceIdToTypes.set(def.inferenceId, [type.name]);
+        }
+      }
+    }
+
+    const inferenceIds = [...inferenceIdToTypes.keys()];
+    if (inferenceIds.length === 0) {
+      // No types declare semanticSearch — skip entirely (zero ES calls, zero log noise).
+      return;
+    }
+
+    logger.debug(
+      `Semantic search preflight: checking ${
+        inferenceIds.length
+      } inference endpoint(s): ${inferenceIds.join(', ')}`
+    );
+
+    const report = await ensureInferenceEndpoints(this.client, inferenceIds);
+
+    for (const inferenceId of report.checked) {
+      logger.debug(`Semantic search preflight: inference endpoint '${inferenceId}' confirmed.`);
+    }
+
+    for (const inferenceId of report.missing) {
+      const types = inferenceIdToTypes.get(inferenceId) ?? [];
+      logger.error(
+        `Inference endpoint '${inferenceId}' was not found. ` +
+          `Semantic search for type(s) [${types.join(
+            ', '
+          )}] will be degraded until the endpoint is available.`
+      );
+    }
+
+    for (const { inferenceId, error } of report.errors) {
+      const types = inferenceIdToTypes.get(inferenceId) ?? [];
+      logger.error(
+        `Could not verify inference endpoint '${inferenceId}' (type(s): [${types.join(
+          ', '
+        )}]): ${error}. ` + `Semantic search availability is unknown; proceeding.`
+      );
     }
   }
 

--- a/src/core/packages/saved-objects/migration-server-internal/src/kibana_migrator_inference_preflight.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/kibana_migrator_inference_preflight.test.ts
@@ -1,0 +1,373 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Tests for the inference-endpoint preflight wiring in KibanaMigrator.runMigrationsInternal.
+ * Verifies that:
+ *   - the preflight is skipped entirely (zero ES calls) when no type declares semanticSearch;
+ *   - missing endpoints are logged as errors naming the type(s) and inference ID;
+ *   - non-404 errors are logged as "could not verify" without blocking migration;
+ *   - migration always proceeds regardless of preflight outcome.
+ */
+
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+import {
+  type MigrationResult,
+  SavedObjectTypeRegistry,
+} from '@kbn/core-saved-objects-base-server-internal';
+import { ByteSizeValue } from '@kbn/config-schema';
+import { docLinksServiceMock } from '@kbn/core-doc-links-server-mocks';
+import { errors as EsErrors } from '@elastic/elasticsearch';
+import { KibanaMigrator, type KibanaMigratorOptions } from './kibana_migrator';
+
+const SUCCESSFUL_MIGRATION_RESULT: MigrationResult[] = [
+  { destIndex: '.my_index_8.2.3_001', elapsedMs: 1, status: 'patched' },
+];
+
+jest.mock('./run_v2_migration', () => ({
+  runV2Migration: jest.fn(
+    (): Promise<MigrationResult[]> => Promise.resolve(SUCCESSFUL_MIGRATION_RESULT)
+  ),
+}));
+
+jest.mock('./zdt', () => ({
+  runZeroDowntimeMigration: jest.fn(
+    (): Promise<MigrationResult[]> => Promise.resolve(SUCCESSFUL_MIGRATION_RESULT)
+  ),
+}));
+
+const createRegistry = (types: Array<Partial<SavedObjectsType>>) => {
+  const registry = new SavedObjectTypeRegistry();
+  types.forEach((type) =>
+    registry.registerType({
+      name: 'unknown',
+      hidden: false,
+      namespaceType: 'single',
+      mappings: { properties: {} },
+      migrations: {},
+      ...type,
+    })
+  );
+  return registry;
+};
+
+const createResponseError = (statusCode: number) =>
+  new EsErrors.ResponseError(
+    elasticsearchClientMock.createApiResponse({
+      statusCode,
+      body: { error: { type: 'es_type', reason: 'es_reason' } },
+    })
+  );
+
+const mockOptions = (
+  typeRegistry: SavedObjectTypeRegistry,
+  algorithm: 'v2' | 'zdt' = 'v2'
+): KibanaMigratorOptions => {
+  const mockedClient = elasticsearchClientMock.createElasticsearchClient();
+  (mockedClient as any).child = jest.fn().mockImplementation(() => mockedClient);
+
+  return {
+    logger: loggingSystemMock.create().get(),
+    kibanaVersion: '8.2.3',
+    waitForMigrationCompletion: false,
+    hashToVersionMap: {},
+    typeRegistry,
+    kibanaIndex: '.my_index',
+    soMigrationsConfig: {
+      algorithm,
+      batchSize: 20,
+      maxBatchSizeBytes: ByteSizeValue.parse('20mb'),
+      maxReadBatchSizeBytes: new ByteSizeValue(536870888),
+      pollInterval: 20000,
+      scrollDuration: '10m',
+      skip: false,
+      retryAttempts: 20,
+      zdt: {
+        metaPickupSyncDelaySec: 120,
+        runOnRoles: ['migrator'],
+      },
+      // Use false so logger calls are real (not deferred) — lets us assert on them directly.
+      useCumulativeLogger: false,
+    },
+    client: mockedClient,
+    docLinks: docLinksServiceMock.createSetupContract(),
+    nodeRoles: { backgroundTasks: true, ui: true, migrator: true },
+    esCapabilities: elasticsearchServiceMock.createCapabilities(),
+  };
+};
+
+describe('KibanaMigrator — inference endpoint preflight', () => {
+  describe('when no registered type declares semanticSearch', () => {
+    it('makes no inference.get calls and runs migration normally', async () => {
+      const registry = createRegistry([
+        { name: 'plain-type', mappings: { properties: { title: { type: 'keyword' } } } },
+      ]);
+      const options = mockOptions(registry);
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      const result = await migrator.runMigrations();
+
+      expect((options.client as any).inference.get).not.toHaveBeenCalled();
+      expect(result).toEqual(SUCCESSFUL_MIGRATION_RESULT);
+    });
+
+    it('logs no inference-preflight messages', async () => {
+      const registry = createRegistry([
+        { name: 'plain-type', mappings: { properties: { title: { type: 'keyword' } } } },
+      ]);
+      const options = mockOptions(registry);
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      await migrator.runMigrations();
+
+      const errorCalls = (options.logger.error as jest.Mock).mock.calls;
+      const inferenceRelatedErrors = errorCalls.filter(
+        ([msg]: [string]) => typeof msg === 'string' && msg.includes('inference endpoint')
+      );
+      expect(inferenceRelatedErrors).toHaveLength(0);
+    });
+  });
+
+  describe('when a type declares semanticSearch and the endpoint exists', () => {
+    it('logs no error and migration proceeds', async () => {
+      const registry = createRegistry([
+        {
+          name: 'my-type',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        },
+      ]);
+      const options = mockOptions(registry);
+      (options.client as any).inference.get.mockResolvedValue({ endpoints: [] });
+
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      const result = await migrator.runMigrations();
+
+      expect((options.client as any).inference.get).toHaveBeenCalledWith({
+        inference_id: '.elser-2-elasticsearch',
+      });
+      expect((options.logger.error as jest.Mock).mock.calls).toHaveLength(0);
+      expect(result).toEqual(SUCCESSFUL_MIGRATION_RESULT);
+    });
+  });
+
+  describe('when a type declares semanticSearch and the endpoint is missing (404)', () => {
+    it('logs an error naming the type, inference ID, and degraded state', async () => {
+      const registry = createRegistry([
+        {
+          name: 'my-type',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        },
+      ]);
+      const options = mockOptions(registry);
+      (options.client as any).inference.get.mockRejectedValue(createResponseError(404));
+
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      const result = await migrator.runMigrations();
+
+      const errorCalls: string[] = (options.logger.error as jest.Mock).mock.calls.map(
+        ([msg]: [string]) => msg
+      );
+      const preflightError = errorCalls.find((msg) =>
+        msg.toLowerCase().includes('inference endpoint')
+      );
+      expect(preflightError).toBeDefined();
+      // Must name the inference ID.
+      expect(preflightError).toContain('.elser-2-elasticsearch');
+      // Must name the type(s).
+      expect(preflightError).toContain('my-type');
+      // Must communicate degradation.
+      expect(preflightError?.toLowerCase()).toContain('degraded');
+      // Migration must still complete.
+      expect(result).toEqual(SUCCESSFUL_MIGRATION_RESULT);
+    });
+
+    it('proceeds unconditionally — migration is not blocked', async () => {
+      const registry = createRegistry([
+        {
+          name: 'my-type',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        },
+      ]);
+      const options = mockOptions(registry);
+      (options.client as any).inference.get.mockRejectedValue(createResponseError(404));
+
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      await expect(migrator.runMigrations()).resolves.toEqual(SUCCESSFUL_MIGRATION_RESULT);
+    });
+  });
+
+  describe('when inference.get throws a non-404 error', () => {
+    it('logs a "could not verify" error and proceeds', async () => {
+      const registry = createRegistry([
+        {
+          name: 'my-type',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        },
+      ]);
+      const options = mockOptions(registry);
+      (options.client as any).inference.get.mockRejectedValue(new Error('network failure'));
+
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      const result = await migrator.runMigrations();
+
+      const errorCalls: string[] = (options.logger.error as jest.Mock).mock.calls.map(
+        ([msg]: [string]) => msg
+      );
+      const preflightError = errorCalls.find((msg) =>
+        msg.toLowerCase().includes('inference endpoint')
+      );
+      expect(preflightError).toBeDefined();
+      expect(preflightError).toContain('.elser-2-elasticsearch');
+      expect(preflightError).toContain('my-type');
+      expect(preflightError).toContain('proceeding');
+      expect(result).toEqual(SUCCESSFUL_MIGRATION_RESULT);
+    });
+  });
+
+  describe('when two types share the same inference endpoint', () => {
+    it('calls inference.get exactly once for the shared endpoint', async () => {
+      const registry = createRegistry([
+        {
+          name: 'type-a',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        },
+        {
+          name: 'type-b',
+          mappings: { properties: { body: { type: 'text' } } },
+          semanticSearch: { fields: ['body'] },
+        },
+      ]);
+      const options = mockOptions(registry);
+      (options.client as any).inference.get.mockRejectedValue(createResponseError(404));
+
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      await migrator.runMigrations();
+
+      // Both types resolve to the same default ELSER endpoint — only one GET call.
+      expect((options.client as any).inference.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('names both types in the error log when the shared endpoint is missing', async () => {
+      const registry = createRegistry([
+        {
+          name: 'type-a',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        },
+        {
+          name: 'type-b',
+          mappings: { properties: { body: { type: 'text' } } },
+          semanticSearch: { fields: ['body'] },
+        },
+      ]);
+      const options = mockOptions(registry);
+      (options.client as any).inference.get.mockRejectedValue(createResponseError(404));
+
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      await migrator.runMigrations();
+
+      const errorCalls: string[] = (options.logger.error as jest.Mock).mock.calls.map(
+        ([msg]: [string]) => msg
+      );
+      const preflightError = errorCalls.find((msg) =>
+        msg.toLowerCase().includes('inference endpoint')
+      );
+      expect(preflightError).toContain('type-a');
+      expect(preflightError).toContain('type-b');
+    });
+  });
+
+  describe('ZDT migration path', () => {
+    it('also runs the preflight before ZDT migration', async () => {
+      const registry = createRegistry([
+        {
+          name: 'my-type',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        },
+      ]);
+      const options = mockOptions(registry, 'zdt');
+      (options.client as any).inference.get.mockRejectedValue(createResponseError(404));
+
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      const result = await migrator.runMigrations();
+
+      expect((options.client as any).inference.get).toHaveBeenCalledTimes(1);
+      // ZDT migration still completes.
+      expect(result).toEqual(SUCCESSFUL_MIGRATION_RESULT);
+    });
+  });
+
+  describe('when useCumulativeLogger is true (serverless path)', () => {
+    const mockOptionsWithCumulativeLogger = (
+      typeRegistry: SavedObjectTypeRegistry
+    ): KibanaMigratorOptions => ({
+      ...mockOptions(typeRegistry),
+      soMigrationsConfig: {
+        ...mockOptions(typeRegistry).soMigrationsConfig,
+        useCumulativeLogger: true,
+      },
+    });
+
+    it('still emits the preflight degradation error to the underlying logger on migration success', async () => {
+      const registry = createRegistry([
+        {
+          name: 'my-type',
+          mappings: { properties: { title: { type: 'text' } } },
+          semanticSearch: { fields: ['title'] },
+        },
+      ]);
+      const options = mockOptionsWithCumulativeLogger(registry);
+      (options.client as any).inference.get.mockRejectedValue(createResponseError(404));
+
+      const migrator = new KibanaMigrator(options);
+      migrator.prepareMigrations();
+
+      // Migration succeeds (the cumulative logger clears buffered logs on success).
+      const result = await migrator.runMigrations();
+      expect(result).toEqual(SUCCESSFUL_MIGRATION_RESULT);
+
+      // The preflight error must still reach the underlying logger because preflight
+      // is called with this.log, not the cumulative wrapper.
+      const errorCalls: string[] = (options.logger.error as jest.Mock).mock.calls.map(
+        ([msg]: [string]) => msg
+      );
+      const preflightError = errorCalls.find((msg) =>
+        msg.toLowerCase().includes('inference endpoint')
+      );
+      expect(preflightError).toBeDefined();
+      expect(preflightError).toContain('.elser-2-elasticsearch');
+      expect(preflightError?.toLowerCase()).toContain('degraded');
+    });
+  });
+});

--- a/src/core/packages/saved-objects/migration-server-internal/src/zdt/utils/generate_additive_mapping_diff.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/zdt/utils/generate_additive_mapping_diff.test.ts
@@ -260,6 +260,33 @@ describe('generateAdditiveMappingDiff', () => {
     });
   });
 
+  it('includes the shadow semantic_text field for a type that declares semanticSearch', () => {
+    // Verify that the additive diff routes through buildTypesMappings so the
+    // {field}_semantic shadow field is included in the mapping update sent to ES.
+    const semanticType = createType({
+      name: 'semantic',
+      mappings: { properties: { title: { type: 'text' } } },
+      semanticSearch: { fields: ['title'] },
+    });
+    const types = [semanticType];
+    const meta: IndexMappingMeta = {
+      // Index is at 10.0.0 (pre-semanticSearch); type is now at 10.1.0 (bumped).
+      mappingVersions: { semantic: '10.0.0' },
+    };
+
+    const addedMappings = generateAdditiveMappingDiff({
+      types,
+      mapping: mappingFromMeta(meta),
+      deletedTypes,
+    });
+
+    // The mapping update must contain the shadow field, not just the author-written mappings.
+    expect(addedMappings.semantic).toBeDefined();
+    expect((addedMappings.semantic as any).properties?.title_semantic).toMatchObject({
+      type: 'semantic_text',
+    });
+  });
+
   it('combines the changes from the types and from the root fields', () => {
     const { foo, bar } = getTypes();
     const types = [foo, bar];

--- a/src/core/packages/saved-objects/migration-server-internal/src/zdt/utils/generate_additive_mapping_diff.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/zdt/utils/generate_additive_mapping_diff.ts
@@ -20,6 +20,7 @@ import {
 import { initialModelVersion } from '@kbn/core-saved-objects-base-server-internal';
 import { getUpdatedRootFields } from '../../core/compare_mappings';
 import { getBaseMappings } from '../../core/build_active_mappings';
+import { buildTypesMappings } from '../../core';
 
 interface GenerateAdditiveMappingsDiffOpts {
   types: SavedObjectsType[];
@@ -77,7 +78,9 @@ export const generateAdditiveMappingDiff = ({
 
   const addedMappings: SavedObjectsMappingProperties = {};
   changedTypes.forEach((type) => {
-    addedMappings[type] = typeMap[type].mappings;
+    // Route through buildTypesMappings so shadow semantic_text fields synthesized for
+    // types that declare semanticSearch are included in the mapping update sent to ES.
+    addedMappings[type] = buildTypesMappings([typeMap[type]])[type];
   });
 
   const changedRootFields = getUpdatedRootFields(mapping);

--- a/src/core/packages/saved-objects/server/index.ts
+++ b/src/core/packages/saved-objects/server/index.ts
@@ -84,6 +84,7 @@ export {
 } from './src/saved_objects_length_limits';
 export type {
   SavedObjectsType,
+  SavedObjectsTypeSemanticSearchDefinition,
   SavedObjectTypeExcludeFromUpgradeFilterHook,
   SavedObjectTypeVersionGuesser,
 } from './src/saved_objects_type';
@@ -97,6 +98,7 @@ export type {
 } from './src/serialization';
 export type { ISavedObjectTypeRegistry } from './src/type_registry';
 export type { SavedObjectsValidationMap, SavedObjectsValidationSpec } from './src/validation';
+export type { ISavedObjectsEmbeddingExtension } from './src/extensions/embedding';
 export type {
   ISavedObjectsEncryptionExtension,
   EncryptedObjectDescriptor,
@@ -135,6 +137,7 @@ export type {
 export type { ISavedObjectsSpacesExtension } from './src/extensions/spaces';
 export type { SavedObjectsExtensions } from './src/extensions/extensions';
 export {
+  EMBEDDING_EXTENSION_ID,
   ENCRYPTION_EXTENSION_ID,
   SECURITY_EXTENSION_ID,
   SPACES_EXTENSION_ID,

--- a/src/core/packages/saved-objects/server/src/extensions/embedding.ts
+++ b/src/core/packages/saved-objects/server/src/extensions/embedding.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Reserved extension point for the `dense_vector` / pre-computed-embeddings path (ADR-2).
+ *
+ * This interface is defined now so that the slot in `create`/`bulk_create`/`update`/`bulk_update`
+ * next to `optionallyEncryptAttributes` is committed from day one, but it is **not yet invoked by
+ * the repository**. The synchronous `semantic_text` + writer-controlled shadow-field strategy
+ * (Mechanism B) does not require a Kibana-side interception point. This extension becomes
+ * load-bearing only if S4 findings show that pre-computed embeddings must bypass ES inference, or
+ * if a `dense_vector` path is promoted for bulk-heavy types. Do not implement or call this
+ * extension without a deliberate ADR-2 reversal.
+ */
+export interface ISavedObjectsEmbeddingExtension {
+  /**
+   * Returns true if a type has been registered as embeddable (i.e. declares
+   * {@link SavedObjectsType.semanticSearch | semanticSearch}).
+   * @param type - the string name of the object type
+   * @returns boolean, true if the type is embeddable
+   */
+  isEmbeddableType: (type: string) => boolean;
+
+  /**
+   * Given a saved object descriptor and its current attributes, returns attributes augmented with
+   * pre-computed embedding values in the shadow-field convention (`{field}_semantic`).
+   * @param descriptor - an object containing a saved object id and type
+   * @param attributes - T, the current attributes of the saved object
+   * @returns T, attributes with shadow embedding fields populated
+   */
+  embedAttributes: <T>(descriptor: { type: string; id: string }, attributes: T) => Promise<T>;
+
+  /**
+   * Returns true if the type accepts pre-computed embeddings supplied by the caller (e.g. from a
+   * package build pipeline), bypassing ES inference on write.
+   * @param type - the string name of the object type
+   * @returns boolean, true if caller-supplied embeddings are accepted for this type
+   */
+  acceptsPrecomputedEmbeddings: (type: string) => boolean;
+}

--- a/src/core/packages/saved-objects/server/src/extensions/extensions.ts
+++ b/src/core/packages/saved-objects/server/src/extensions/extensions.ts
@@ -7,15 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ISavedObjectsEmbeddingExtension } from './embedding';
 import type { ISavedObjectsEncryptionExtension } from './encryption';
 import type { ISavedObjectsSecurityExtension } from './security';
 import type { ISavedObjectsSpacesExtension } from './spaces';
 
 /**
- * The SavedObjectsExtensions interface contains the intefaces for three
- * extensions to the saved objects repository. These extensions augment
- * the funtionality of the saved objects repository to provide encryption,
- * security, and spaces features.
+ * The SavedObjectsExtensions interface contains the interfaces for extensions to the saved objects
+ * repository. These extensions augment the functionality of the saved objects repository to
+ * provide encryption, security, spaces, and (reserved) embedding features.
  */
 export interface SavedObjectsExtensions {
   /** The encryption extension - handles encrypting and decrypting attributes of saved objects */
@@ -24,8 +24,14 @@ export interface SavedObjectsExtensions {
   securityExtension?: ISavedObjectsSecurityExtension;
   /** The spaces extension - handles retrieving the current space and retrieving available spaces */
   spacesExtension?: ISavedObjectsSpacesExtension;
+  /**
+   * Reserved embedding extension — defined for the pre-computed / `dense_vector` escape hatch
+   * (ADR-2) but not yet invoked by the repository. See {@link ISavedObjectsEmbeddingExtension}.
+   */
+  embeddingExtension?: ISavedObjectsEmbeddingExtension;
 }
 
 export const ENCRYPTION_EXTENSION_ID = 'encryptedSavedObjects' as const;
 export const SECURITY_EXTENSION_ID = 'security' as const;
 export const SPACES_EXTENSION_ID = 'spaces' as const;
+export const EMBEDDING_EXTENSION_ID = 'semanticSearch' as const;

--- a/src/core/packages/saved-objects/server/src/import.ts
+++ b/src/core/packages/saved-objects/server/src/import.ts
@@ -79,6 +79,17 @@ export interface SavedObjectsImportOptions {
    * make their edits to the copy.
    */
   managed?: boolean;
+  /**
+   * When `true`, shadow semantic fields are omitted from the raw documents written by
+   * `bulkCreate` during import, so that Elasticsearch performs no inference during indexing.
+   * Imported objects are immediately findable via `find()`/BM25 and become semantically
+   * searchable only after a background reconciliation cycle.
+   *
+   * Use this for large-scale bulk imports (e.g. 10k prebuilt detection rules) where synchronous
+   * ML inference per write would be prohibitively slow. Only meaningful for types that declare
+   * {@link SavedObjectsType.semanticSearch | semanticSearch}; silently ignored otherwise.
+   */
+  deferEmbeddings?: boolean;
 }
 
 /**
@@ -107,6 +118,16 @@ export interface SavedObjectsResolveImportErrorsOptions {
    * make their edits to the copy.
    */
   managed?: boolean;
+  /**
+   * When `true`, shadow semantic fields are omitted from the raw documents written by `bulkCreate`
+   * during the retry, so that Elasticsearch performs no inference during indexing. Retried objects
+   * are immediately findable via BM25 and become semantically searchable only after a background
+   * reconciliation cycle.
+   *
+   * Only meaningful for types that declare {@link SavedObjectsType.semanticSearch | semanticSearch};
+   * silently ignored otherwise.
+   */
+  deferEmbeddings?: boolean;
 }
 
 export type CreatedObject<T> = SavedObject<T> & { destinationId?: string };

--- a/src/core/packages/saved-objects/server/src/saved_objects_type.ts
+++ b/src/core/packages/saved-objects/server/src/saved_objects_type.ts
@@ -22,6 +22,60 @@ import type {
 import type { SavedObjectUnsanitizedDoc } from './serialization';
 
 /**
+ * Declarative intent for semantic (vector) search on a {@link SavedObjectsType | saved object type}.
+ *
+ * Declare which `text` source attributes should be made semantically searchable. The platform
+ * synthesises a shadow `{field}_semantic` field in the index mappings automatically — authors must
+ * never write `semantic_text` mappings by hand.
+ *
+ * @example
+ * ```ts
+ * savedObjects.registerType({
+ *   name: 'dashboard',
+ *   mappings: {
+ *     properties: {
+ *       title: { type: 'text' },
+ *       description: { type: 'text' },
+ *     },
+ *   },
+ *   semanticSearch: {
+ *     fields: ['title', 'description'],
+ *     // inferenceId is optional; omit it to use the platform default (.elser-2-elasticsearch)
+ *   },
+ * });
+ * ```
+ *
+ * @public
+ */
+export interface SavedObjectsTypeSemanticSearchDefinition {
+  /**
+   * Source attribute names (must exist in {@link SavedObjectsType.mappings | mappings} as `text`
+   * fields) to make semantically searchable.
+   */
+  fields: string[];
+  /**
+   * Optional inference endpoint override. Omit to use the platform default (discouraged to set
+   * explicitly — the platform selects the best available model).
+   */
+  inferenceId?: string;
+  /**
+   * Per-type default embedding timing.
+   *
+   * - `'sync'` (default) — the save call pays synchronous inference latency inside Elasticsearch;
+   *   the object is semantically searchable immediately after the write returns.
+   * - `'deferred'` — the write costs exactly what it costs today (no inference at write time);
+   *   the object is immediately findable via `find()`/BM25 and becomes semantically searchable
+   *   only after a background reconciliation cycle (eventual consistency for semantic search only).
+   *   Use this for bulk-heavy types (e.g. prebuilt detection rules) where synchronous inference
+   *   per write would be prohibitively slow.
+   *
+   * Can be overridden at request scope via `deferEmbeddings` in
+   * {@link SavedObjectsCreateOptions | SavedObjectsCreateOptions}.
+   */
+  embedding?: 'sync' | 'deferred';
+}
+
+/**
  * Definition of a type of savedObject.
  *
  * @public
@@ -253,6 +307,13 @@ export interface SavedObjectsType<Attributes = any> {
    * purpose. This field will be removed once the deprecated SO HTTP API is removed.
    */
   typeVersionGuesser?: SavedObjectTypeVersionGuesser;
+
+  /**
+   * Optional declaration that makes one or more `text` attributes semantically searchable via the
+   * platform's vector-search infrastructure. See {@link SavedObjectsTypeSemanticSearchDefinition}
+   * for details and constraints.
+   */
+  semanticSearch?: SavedObjectsTypeSemanticSearchDefinition;
 }
 
 /**

--- a/src/core/packages/saved-objects/server/src/type_registry.ts
+++ b/src/core/packages/saved-objects/server/src/type_registry.ts
@@ -105,4 +105,18 @@ export interface ISavedObjectTypeRegistry {
    * Returns whether the type supports access control.
    */
   supportsAccessControl(type: string): boolean;
+
+  /**
+   * Returns the resolved semantic-search definition for the given type, with `inferenceId` already
+   * run through the platform resolver and `embedding` defaulted to `'sync'`. Returns `undefined`
+   * if the type is not registered or does not declare
+   * {@link SavedObjectsType.semanticSearch | semanticSearch}.
+   */
+  getSemanticSearchDefinition(typeName: string):
+    | {
+        readonly fields: readonly string[];
+        readonly inferenceId: string;
+        readonly embedding: 'sync' | 'deferred';
+      }
+    | undefined;
 }

--- a/src/core/server/integration_tests/saved_objects/migrations/zdt_2/semantic_search_smoke.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/zdt_2/semantic_search_smoke.test.ts
@@ -1,0 +1,296 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Phase 1 + 2 integration smoke test for the Kibana SO semantic-search POC.
+ *
+ * Covers:
+ *  1. Mapping synthesis (Phase 1 exit criterion): the migrator synthesises
+ *     `{field}_semantic: semantic_text` shadow fields with the correct `inference_id`
+ *     and NO `copy_to` on the source fields.  This assertion is deterministic on any
+ *     bare ES snapshot — ES accepts `semantic_text` mappings without validating the
+ *     inference endpoint at mapping time (S7 spike finding).
+ *
+ *  2. Write path — deferred mode (Phase 2): a create with `deferEmbeddings: true`
+ *     writes NO `*_semantic` keys into the raw ES document.
+ *
+ *  3. Write path — sync mode (Phase 2, env-gated): a create without `deferEmbeddings`
+ *     includes shadow keys in the raw document and ES runs inference.  On a bare test
+ *     ES that lacks the `.elser-2-elasticsearch` inference endpoint the call fails with
+ *     a fast per-item error (not a hang).  If ELSER is unexpectedly available, the
+ *     happy path is verified instead.  The test marks itself env-blocked in either case
+ *     so the deterministic assertion (no hang) is always checked.
+ *
+ *  4. Serializer strip (Phase 1): `rawToSavedObject` strips `*_semantic` keys from
+ *     attributes for opted-in types.  Verified end-to-end by directly indexing a raw
+ *     doc that contains null-valued shadow fields (null skips inference per S7) and
+ *     retrieving it through `repository.find()`, which calls `serializerHelper
+ *     .rawToSavedObject()`.
+ *
+ * Phase 2 fix: `repository.get()` now strips shadow keys via `getSavedObjectFromSource()`
+ * (internal_utils.ts fix, Finding #2).  The unit-level coverage lives in
+ * `semantic_search_write_path.test.ts`.
+ */
+
+import Path from 'path';
+import fs from 'fs/promises';
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { ISavedObjectsRepository } from '@kbn/core-saved-objects-api-server';
+import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
+import type { TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
+import { getKibanaMigratorTestKit, startElasticsearch } from '@kbn/migrator-test-kit';
+import {
+  SavedObjectsSerializer,
+  SavedObjectTypeRegistry,
+  modelVersionToVirtualVersion,
+} from '@kbn/core-saved-objects-base-server-internal';
+import { createType } from '../test_utils';
+import { getBaseMigratorParams, dummyModelVersion } from '../fixtures/zdt_base.fixtures';
+
+const TYPE_NAME = 'ss_smoke_type';
+const INFERENCE_ID = '.elser-2-elasticsearch';
+
+export const logFilePath = Path.join(__dirname, 'semantic_search_smoke.test.log');
+
+/** Type with two text fields opted into semantic search (sync-default). */
+const semanticType = createType({
+  name: TYPE_NAME,
+  mappings: {
+    properties: {
+      title: { type: 'text' },
+      description: { type: 'text' },
+    },
+  },
+  semanticSearch: {
+    fields: ['title', 'description'],
+    // inferenceId not set: exercises default resolver path
+  },
+  modelVersions: {
+    '1': dummyModelVersion,
+  },
+});
+
+describe('SO semantic search — Phase 1+2 integration smoke', () => {
+  let esServer: TestElasticsearchUtils['es'];
+  let client: ElasticsearchClient;
+  let savedObjectsRepository: ISavedObjectsRepository;
+
+  beforeAll(async () => {
+    await fs.unlink(logFilePath).catch(() => {});
+    esServer = await startElasticsearch();
+
+    const kit = await getKibanaMigratorTestKit({
+      ...getBaseMigratorParams(),
+      logFilePath,
+      types: [semanticType],
+    });
+
+    await kit.runMigrations();
+
+    client = kit.client;
+    savedObjectsRepository = kit.savedObjectsRepository;
+  }, 120_000);
+
+  afterAll(async () => {
+    await esServer?.stop();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. Mapping synthesis — Phase 1 exit criterion
+  // ---------------------------------------------------------------------------
+
+  describe('Phase 1 exit criterion: shadow semantic_text mapping synthesis', () => {
+    it('synthesises title_semantic and description_semantic as semantic_text with inference_id', async () => {
+      const response = await client.indices.getMapping({ index: '.kibana_1' });
+      const typeProp = (
+        response['.kibana_1'].mappings.properties as Record<
+          string,
+          { properties?: Record<string, unknown> }
+        >
+      )?.[TYPE_NAME];
+
+      expect(typeProp).toBeDefined();
+      const props = typeProp!.properties ?? {};
+
+      expect(props.title_semantic).toMatchObject({
+        type: 'semantic_text',
+        inference_id: INFERENCE_ID,
+      });
+      expect(props.description_semantic).toMatchObject({
+        type: 'semantic_text',
+        inference_id: INFERENCE_ID,
+      });
+    });
+
+    it('source fields (title, description) have NO copy_to', async () => {
+      const response = await client.indices.getMapping({ index: '.kibana_1' });
+      const typeProp = (
+        response['.kibana_1'].mappings.properties as Record<
+          string,
+          { properties?: Record<string, unknown> }
+        >
+      )?.[TYPE_NAME];
+
+      const props = (typeProp?.properties ?? {}) as Record<string, { copy_to?: unknown }>;
+
+      expect(props.title).not.toHaveProperty('copy_to');
+      expect(props.description).not.toHaveProperty('copy_to');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Write path — deferred mode (deterministic, no inference required)
+  // ---------------------------------------------------------------------------
+
+  describe('Phase 2 write path: deferred mode', () => {
+    it('raw ES document contains NO *_semantic keys when deferEmbeddings:true', async () => {
+      const id = 'deferred-smoke-test-1';
+
+      await savedObjectsRepository.create(
+        TYPE_NAME,
+        { title: 'Deferred hello', description: 'No inference please' },
+        { id, deferEmbeddings: true }
+      );
+
+      // Read the raw document directly via the ES client to inspect _source
+      const rawDoc = await client.get({
+        index: '.kibana',
+        id: `${TYPE_NAME}:${id}`,
+      });
+
+      const rawAttrs = (rawDoc._source as Record<string, unknown>)?.[TYPE_NAME] as
+        | Record<string, unknown>
+        | undefined;
+
+      expect(rawAttrs).toBeDefined();
+
+      const shadowKeys = Object.keys(rawAttrs ?? {}).filter((k) => k.endsWith('_semantic'));
+      expect(shadowKeys).toHaveLength(0);
+
+      // Clean up so subsequent test runs on the same ES are idempotent
+      await savedObjectsRepository.delete(TYPE_NAME, id).catch(() => {});
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Write path — sync mode (env-gated on ELSER availability)
+  // ---------------------------------------------------------------------------
+
+  describe('Phase 2 write path: sync mode', () => {
+    it('sync create either surfaces a proper ES error (no hang) or succeeds with shadow keys in raw doc', async () => {
+      const id = 'sync-smoke-test-1';
+
+      try {
+        const created = await savedObjectsRepository.create(
+          TYPE_NAME,
+          { title: 'Sync hello', description: 'Run inference please' },
+          { id }
+        );
+
+        // If ES returned a result (ELSER available), verify:
+        // a) The returned SavedObject has NO shadow keys (serializer stripped them on create response)
+        // b) The raw ES doc DOES contain shadow keys (Mechanism B populated them)
+
+        const rawAttrs = (created.attributes ?? {}) as Record<string, unknown>;
+        expect(rawAttrs).not.toHaveProperty('title_semantic');
+        expect(rawAttrs).not.toHaveProperty('description_semantic');
+
+        const rawDoc = await client.get({
+          index: '.kibana',
+          id: `${TYPE_NAME}:${id}`,
+        });
+        const docAttrs = (rawDoc._source as Record<string, unknown>)?.[TYPE_NAME] as
+          | Record<string, unknown>
+          | undefined;
+
+        expect(docAttrs).toHaveProperty('title_semantic', 'Sync hello');
+        expect(docAttrs).toHaveProperty('description_semantic', 'Run inference please');
+
+        await savedObjectsRepository.delete(TYPE_NAME, id).catch(() => {});
+      } catch (err: unknown) {
+        // Expected on a bare test ES without the ELSER inference endpoint.
+        // The error must be an ES-originated inference failure — not a write-path bug.
+        // Verify it matches at least one inference/resource error pattern:
+        //   • SavedObjects 503 (isEsUnavailableError) wrapping the ES 404 from the endpoint
+        //   • statusCode 404/503 with an inference-related message
+        //   • message matching /inference|resource_not_found/i
+        // Any other error (e.g. TypeError from a write-path bug) causes an explicit rethrow.
+        expect(err).toBeTruthy();
+        const anyErr = err as Record<string, unknown>;
+        const statusCode = (anyErr.statusCode as number | undefined) ?? 0;
+        const message = String(anyErr.message ?? '');
+        const isInferenceError =
+          SavedObjectsErrorHelpers.isEsUnavailableError(err as Error) ||
+          statusCode === 404 ||
+          statusCode === 503 ||
+          /inference|resource_not_found/i.test(message);
+
+        if (!isInferenceError) {
+          // Not the expected env-blocked error — propagate so Jest reports the real cause.
+          throw err;
+        }
+      }
+    }, 30_000); // explicit per-test timeout guards against hangs
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Serializer strip — Phase 1, read path via find()
+  // ---------------------------------------------------------------------------
+
+  describe('Phase 1 serializer strip: rawToSavedObject strips *_semantic keys on find()', () => {
+    it('repository.find() returns attributes without shadow keys even when raw _source[type] contains them', async () => {
+      // Build a valid raw Kibana SO document using the serializer so that all
+      // required metadata fields (_id format, type, references, etc.) are correct.
+      // We use a local registry so the serializer does NOT strip shadow keys during
+      // savedObjectToRaw() — stripping only happens in rawToSavedObject().
+      const localRegistry = new SavedObjectTypeRegistry();
+      localRegistry.registerType(semanticType);
+      const serializer = new SavedObjectsSerializer(localRegistry);
+
+      const raw = serializer.savedObjectToRaw({
+        type: TYPE_NAME,
+        id: 'strip-test-1',
+        attributes: { title: 'Strip me', description: 'Remove shadow' },
+        references: [],
+        typeMigrationVersion: modelVersionToVirtualVersion(1),
+      });
+
+      // Inject null-valued shadow keys into the raw _source[type].
+      // null values skip inference on ES (S7 spike finding) but ARE stored in
+      // _source, giving us a doc that exercises the strip path.
+      const rawTypeAttrs = raw._source[TYPE_NAME] as Record<string, unknown>;
+      rawTypeAttrs.title_semantic = null;
+      rawTypeAttrs.description_semantic = null;
+
+      // Index directly — bypass the SO write path so shadow keys reach _source
+      await client.index({
+        index: '.kibana',
+        id: raw._id,
+        document: raw._source,
+        refresh: 'true',
+      });
+
+      // Read back via repository.find() — this path calls
+      // serializerHelper.rawToSavedObject() which invokes
+      // stripSemanticAttributes() for opted-in types.
+      const findResponse = await savedObjectsRepository.find({ type: TYPE_NAME });
+      const found = findResponse.saved_objects.find((so) => so.id === 'strip-test-1');
+
+      expect(found).toBeDefined();
+
+      const attrs = (found?.attributes ?? {}) as Record<string, unknown>;
+      expect(attrs).not.toHaveProperty('title_semantic');
+      expect(attrs).not.toHaveProperty('description_semantic');
+      expect(attrs).toMatchObject({ title: 'Strip me', description: 'Remove shadow' });
+
+      // Clean up
+      await savedObjectsRepository.delete(TYPE_NAME, 'strip-test-1').catch(() => {});
+    }, 30_000);
+  });
+});

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/jest.config.js
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/jest.config.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/platform/plugins/private/saved_objects_semantic_reconciler'],
+  coverageDirectory:
+    '<rootDir>/target/kibana-coverage/jest/x-pack/platform/plugins/private/saved_objects_semantic_reconciler',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/**/*.{ts,tsx}',
+  ],
+};

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/jest.integration.config.js
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/jest.integration.config.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_integration',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/platform/plugins/private/saved_objects_semantic_reconciler'],
+};

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/kibana.jsonc
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/kibana.jsonc
@@ -1,0 +1,23 @@
+{
+  "type": "plugin",
+  "id": "@kbn/saved-objects-semantic-reconciler-plugin",
+  "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
+  "description": "Reconciler task that backfills and refreshes ELSER semantic shadow fields for opted-in saved-object types (Phase 2/4 of the SO semantic-search POC).",
+  "plugin": {
+    "id": "savedObjectsSemanticReconciler",
+    "server": true,
+    "browser": false,
+    "configPath": [
+      "xpack",
+      "savedObjectsSemanticReconciler"
+    ],
+    "requiredPlugins": [
+      "taskManager"
+    ],
+    "optionalPlugins": [],
+    "requiredBundles": [],
+    "extraPublicDirs": []
+  }
+}

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/config.ts
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/config.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
+import type { PluginConfigDescriptor } from '@kbn/core/server';
+
+const pluginConfigSchema = schema.object({
+  /** Master switch — when false the plugin does nothing (task not registered or scheduled). */
+  enabled: schema.boolean({ defaultValue: true }),
+
+  /**
+   * How often the reconciler sweep task fires (Task Manager recurring interval).
+   * `requests_per_second` config is a cluster-courtesy knob; at ELSER throughput (~18–33 docs/s
+   * on laptop-class hardware) the actual cap is ELSER, not this throttle.
+   */
+  pollInterval: schema.string({
+    defaultValue: '1m',
+    validate: (v) => {
+      if (!/^\d+[smhd]$/.test(v)) return 'must be a duration string like 30s, 1m, 2h';
+    },
+    maxLength: 20,
+  }),
+
+  /** scroll_size for each UBQ scroll batch. Tune down if ELSER OOMs; tune up for throughput. */
+  batchSize: schema.number({ defaultValue: 100, min: 1, max: 10_000 }),
+
+  /**
+   * max_docs cap per UBQ invocation per type per cycle. Prevents a single oversized backfill
+   * sweep from monopolising ELSER for too long. Docs beyond the cap are picked up next cycle.
+   */
+  maxDocsPerSweep: schema.number({ defaultValue: 10_000, min: 100, max: 1_000_000 }),
+
+  /**
+   * requests_per_second throttle passed to UBQ. Primarily a cluster-courtesy knob — at current
+   * ELSER throughput (~18–33 docs/s) this has no observable limiting effect, but provides
+   * headroom for faster inference hardware.
+   */
+  requestsPerSecond: schema.number({ defaultValue: 50, min: 1, max: 10_000 }),
+});
+
+export type ReconcilerConfig = TypeOf<typeof pluginConfigSchema>;
+
+export const config: PluginConfigDescriptor<ReconcilerConfig> = {
+  schema: pluginConfigSchema,
+};

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/index.ts
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginInitializerContext } from '@kbn/core/server';
+
+export { config } from './config';
+
+export const plugin = async (context: PluginInitializerContext) => {
+  const { SavedObjectsSemanticReconcilerPlugin } = await import('./plugin');
+  return new SavedObjectsSemanticReconcilerPlugin(context);
+};

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/integration_tests/reconciler_sweep.test.ts
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/integration_tests/reconciler_sweep.test.ts
@@ -1,0 +1,495 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Phase 4 reconciler integration test — exercises runReconcilerSweep against a real
+ * (ephemeral) Elasticsearch instance without booting full Kibana or Task Manager.
+ *
+ * PLACEMENT RATIONALE
+ * -------------------
+ * Located in the plugin's own server/integration_tests/ directory because:
+ *   • The test exercises code exported from this plugin package and must import it
+ *     directly.  Putting it in src/core/… would reverse the dependency direction
+ *     (core cannot depend on x-pack plugins).
+ *   • The x-pack Task Manager plugin's integration tests (task_state_validation, etc.)
+ *     boot a full Kibana root, which takes ~90 s and is unnecessary here — the
+ *     reconciler's sweep logic can be exercised with just a real ES client.
+ *   • The core SO zdt_2 harness (getKibanaMigratorTestKit) is adopted for ES
+ *     lifecycle (startElasticsearch / getEsClient) because the smoke test already
+ *     proves it works with semantic_text mappings on the test ES.
+ *
+ * WHAT IS PROVEN ON BARE ES (no ELSER model deployed)
+ * ---------------------------------------------------
+ *   1.  Detection query shape — correct docs selected, wrong-type docs excluded.
+ *   2.  Null-shadow values count as absent in the exists filter (S7a finding).
+ *   3.  The watermark clause independently catches recently-updated docs.
+ *   4.  UBQ submission succeeds (async path; wait_for_completion=false → task ID).
+ *   5.  Inference failures surface in response.failures[], not as an exception.
+ *       On bare ES the inference endpoint exists (default .elser-2-elasticsearch)
+ *       but the model is not deployed, so every doc update that would trigger
+ *       inference fails and lands in failures[].
+ *   6.  The reconciler interprets failures as retryable: logs WARN, does NOT advance
+ *       the watermark, does NOT throw.
+ *   7.  updated_at is NOT changed on the docs the UBQ touched (inference failure
+ *       rolls back the update; additionally, the Painless script never writes
+ *       updated_at, so the field is safe even on a successful inference run).
+ *   8.  A second sweep with the same state is idempotent.
+ *   9.  No-op invariant verified against real ES: zero ES writes when no types opt in.
+ *
+ * ENV-BLOCKED (requires a running ELSER deployment)
+ * -------------------------------------------------
+ *   • Shadow field values are populated and readable in _source after a sweep.
+ *   • Watermark advances after a fully successful, non-truncated sweep.
+ *   • Detection query correctly EXCLUDES docs whose shadow fields are already
+ *     non-null (proving the exists clause excludes embedded docs).
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { startElasticsearch, getEsClient } from '@kbn/migrator-test-kit';
+import { runReconcilerSweep } from '../task/reconciler_task';
+import { emptyState } from '../task/task_state';
+import { buildDetectionQuery } from '../task/ubq_builder';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INDEX = 'spike-p4-reconciler-int-test';
+const TYPE_NAME = 'test_rule';
+const OTHER_TYPE = 'other_type';
+const INFERENCE_ID = '.elser-2-elasticsearch';
+
+/** Epoch — used as the "first sweep ever" watermark to match every doc. */
+const EPOCH_WATERMARK = '1970-01-01T00:00:00.000Z';
+/** "Old" updated_at for backfill docs (predates any realistic watermark). */
+const OLD_DATE = '2020-01-01T00:00:00.000Z';
+/** "Recent" updated_at — after STALE_WATERMARK; caught by the watermark clause. */
+const RECENT_DATE = '2026-07-01T00:00:00.000Z';
+/** A watermark that is between OLD_DATE and RECENT_DATE. */
+const STALE_WATERMARK = '2026-06-01T00:00:00.000Z';
+
+// Stable doc IDs seeded in beforeAll
+const DOC_DEFERRED_A = 'doc-deferred-a'; // test_rule, no shadow keys, OLD_DATE
+const DOC_DEFERRED_B = 'doc-deferred-b'; // test_rule, no shadow keys, OLD_DATE
+const DOC_NULL_SHADOW = 'doc-null-shadow'; // test_rule, null shadows, OLD_DATE
+const DOC_RECENT = 'doc-recent'; // test_rule, no shadow keys, RECENT_DATE
+const DOC_OTHER_TYPE = 'doc-other-type'; // other_type, no shadows (must NOT match)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const makeCfg = () =>
+  ({
+    enabled: true,
+    pollInterval: '1m',
+    batchSize: 100,
+    maxDocsPerSweep: 10_000,
+    requestsPerSecond: 50,
+  } as const);
+
+const makeLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+/**
+ * Builds a minimal mock CoreSetup that routes ES calls through the supplied real client.
+ * Only the subset of coreStart consumed by runReconcilerSweep is implemented.
+ */
+const makeCore = (esClient: ElasticsearchClient) => ({
+  getStartServices: async () =>
+    [
+      {
+        savedObjects: {
+          getTypeRegistry: () => ({
+            getAllTypes: () => [{ name: TYPE_NAME }],
+            getSemanticSearchDefinition: (typeName: string) =>
+              typeName === TYPE_NAME
+                ? {
+                    fields: ['name', 'description'],
+                    inferenceId: INFERENCE_ID,
+                    embedding: 'deferred' as const,
+                  }
+                : undefined,
+          }),
+          getIndexForType: () => INDEX,
+        },
+        elasticsearch: {
+          client: { asInternalUser: esClient },
+        },
+      },
+      {},
+      undefined,
+    ] as const,
+});
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('SO Semantic Reconciler — integration sweep (bare ES)', () => {
+  let esServer: Awaited<ReturnType<typeof startElasticsearch>>;
+  let esClient: ElasticsearchClient;
+
+  // -------------------------------------------------------------------------
+  // Setup: start ES, create test index, seed docs
+  // -------------------------------------------------------------------------
+
+  beforeAll(async () => {
+    esServer = await startElasticsearch();
+    esClient = await getEsClient();
+
+    // Create a spike SO-style index with semantic_text shadow field mappings.
+    //
+    // ES accepts semantic_text mappings without validating the inference endpoint
+    // at mapping time (S7 spike finding; confirmed by Phase 1 smoke test).
+    // Mapping is deliberately restrictive (dynamic: strict) to mirror real SO indices.
+    //
+    // The `as any` cast is required because the TS types for indices.create do not yet
+    // include `semantic_text` as a known field type.  Using `as any` is standard practice
+    // in integration tests (see existing unit tests in this package) and is distinct from
+    // @ts-ignore/@ts-expect-error which are prohibited by project conventions.
+    await esClient.indices.create({
+      index: INDEX,
+      mappings: {
+        dynamic: 'strict',
+        properties: {
+          type: { type: 'keyword' },
+          updated_at: { type: 'date' },
+          [TYPE_NAME]: {
+            properties: {
+              name: { type: 'text' },
+              name_semantic: { type: 'semantic_text', inference_id: INFERENCE_ID },
+              description: { type: 'text' },
+              description_semantic: { type: 'semantic_text', inference_id: INFERENCE_ID },
+            },
+          },
+          [OTHER_TYPE]: {
+            properties: {
+              name: { type: 'text' },
+            },
+          },
+        },
+      },
+    } as any);
+
+    // Seed docs via direct client.index() rather than the SO repository so that:
+    //   (a) no SO write-path hooks fire (keeps updated_at exactly as set)
+    //   (b) null shadow values can be injected without triggering inference
+    //       (null skips inference — S7 spike / Phase 2 smoke test)
+
+    // Doc A — deferred style, no shadow keys, OLD_DATE.  Exists clause catches it.
+    await esClient.index({
+      index: INDEX,
+      id: DOC_DEFERRED_A,
+      refresh: 'false',
+      document: {
+        type: TYPE_NAME,
+        updated_at: OLD_DATE,
+        [TYPE_NAME]: { name: 'Rule A', description: 'Rule A description' },
+      },
+    });
+
+    // Doc B — deferred style, no shadow keys, OLD_DATE.  Same as A; two docs exercise
+    // the "batch" dimension and make sure the detection query does not deduplicate.
+    await esClient.index({
+      index: INDEX,
+      id: DOC_DEFERRED_B,
+      refresh: 'false',
+      document: {
+        type: TYPE_NAME,
+        updated_at: OLD_DATE,
+        [TYPE_NAME]: { name: 'Rule B', description: 'Rule B description' },
+      },
+    });
+
+    // Doc C — null shadow values (emitted by the write path when a declared field is cleared,
+    // per Phase 2 invariant: "cleared declared fields emit null shadow values so stale
+    // embeddings don't survive partial updates").  null counts as absent for the ES exists
+    // filter (S7a spike, confirmed by Phase 2 smoke test).
+    await esClient.index({
+      index: INDEX,
+      id: DOC_NULL_SHADOW,
+      refresh: 'false',
+      document: {
+        type: TYPE_NAME,
+        updated_at: OLD_DATE,
+        [TYPE_NAME]: {
+          name: 'Rule C',
+          description: 'Rule C description',
+          name_semantic: null,
+          description_semantic: null,
+        },
+      },
+    });
+
+    // Doc D — no shadow keys, RECENT_DATE (after STALE_WATERMARK).
+    // With epoch watermark: caught by exists clause (no shadows).
+    // With STALE_WATERMARK: caught by BOTH exists clause AND watermark clause.
+    // Lets us verify that the watermark clause independently fires.
+    await esClient.index({
+      index: INDEX,
+      id: DOC_RECENT,
+      refresh: 'false',
+      document: {
+        type: TYPE_NAME,
+        updated_at: RECENT_DATE,
+        [TYPE_NAME]: { name: 'Rule D recent', description: 'Rule D description' },
+      },
+    });
+
+    // Doc E — wrong type.  Must never match the test_rule detection query.
+    await esClient.index({
+      index: INDEX,
+      id: DOC_OTHER_TYPE,
+      refresh: 'true', // last index; force refresh so all docs are visible
+      document: {
+        type: OTHER_TYPE,
+        updated_at: OLD_DATE,
+        [OTHER_TYPE]: { name: 'Other type doc' },
+      },
+    });
+  }, 120_000);
+
+  // -------------------------------------------------------------------------
+  // Teardown: delete spike index + stop ephemeral ES
+  // -------------------------------------------------------------------------
+
+  afterAll(async () => {
+    try {
+      await esClient.indices.delete({ index: INDEX });
+    } catch {
+      // best effort; if the test failed before creating the index, ignore
+    }
+    await esServer?.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Detection query correctness
+  // -------------------------------------------------------------------------
+
+  describe('detection query', () => {
+    it('matches deferred-style docs (no shadow keys) and excludes wrong-type docs', async () => {
+      const query = buildDetectionQuery(TYPE_NAME, ['name', 'description'], EPOCH_WATERMARK);
+      const resp = await esClient.search({
+        index: INDEX,
+        // Query is Record<string,unknown> from the builder; cast acceptable in test context.
+        query: query as any,
+        size: 100,
+      });
+
+      const ids = (resp.hits.hits as Array<{ _id: string }>).map((h) => h._id);
+
+      expect(ids).toContain(DOC_DEFERRED_A);
+      expect(ids).toContain(DOC_DEFERRED_B);
+      // null shadows count as absent → exists clause catches them
+      expect(ids).toContain(DOC_NULL_SHADOW);
+      // RECENT_DATE doc: caught by exists clause (no shadows)
+      expect(ids).toContain(DOC_RECENT);
+
+      // Wrong-type doc must be excluded (type filter enforces this)
+      expect(ids).not.toContain(DOC_OTHER_TYPE);
+    });
+
+    it('also excludes wrong-type docs when using STALE_WATERMARK', async () => {
+      const query = buildDetectionQuery(TYPE_NAME, ['name', 'description'], STALE_WATERMARK);
+      const resp = await esClient.search({
+        index: INDEX,
+        query: query as any,
+        size: 100,
+      });
+      const ids = (resp.hits.hits as Array<{ _id: string }>).map((h) => h._id);
+
+      // A, B, C: exists clause (null/absent shadows, OLD_DATE < STALE_WATERMARK but exists wins)
+      expect(ids).toContain(DOC_DEFERRED_A);
+      expect(ids).toContain(DOC_DEFERRED_B);
+      expect(ids).toContain(DOC_NULL_SHADOW);
+      // D: both exists clause AND watermark clause (RECENT_DATE > STALE_WATERMARK)
+      expect(ids).toContain(DOC_RECENT);
+      // E: never
+      expect(ids).not.toContain(DOC_OTHER_TYPE);
+    });
+
+    it('watermark clause independently catches doc D (RECENT_DATE > STALE_WATERMARK)', async () => {
+      // Verify that doc D is specifically matched by the watermark clause.
+      // We narrow the query with an ids filter to isolate doc D.
+      const baseQuery = buildDetectionQuery(TYPE_NAME, ['name', 'description'], STALE_WATERMARK);
+      const resp = await esClient.search({
+        index: INDEX,
+        query: {
+          bool: {
+            must: [baseQuery as any, { ids: { values: [DOC_RECENT] } }],
+          },
+        } as any,
+        size: 1,
+      });
+
+      // Doc D matches: it satisfies the watermark clause (RECENT_DATE > STALE_WATERMARK).
+      // Also satisfies the exists clause (no shadows), but the watermark clause is sufficient.
+      const total = resp.hits.total as { value: number };
+      expect(total.value).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. UBQ execution + inference-failure interpretation (R1 failure-mode contract)
+  // -------------------------------------------------------------------------
+
+  describe('runReconcilerSweep against bare ES', () => {
+    let sweepResult: Awaited<ReturnType<typeof runReconcilerSweep>>;
+    let logger: ReturnType<typeof makeLogger>;
+
+    beforeAll(async () => {
+      logger = makeLogger();
+      sweepResult = await runReconcilerSweep({
+        core: makeCore(esClient) as any,
+        logger: logger as any,
+        cfg: makeCfg(),
+        state: emptyState,
+        signal: new AbortController().signal,
+        // Use a short poll interval so the test completes quickly.
+        // The UBQ itself is fast (5 docs, inference fails immediately).
+        pollIntervalMs: 100,
+      });
+    }, 60_000);
+
+    it('does not throw — the task runner always resolves even when inference fails', () => {
+      expect(sweepResult).toBeDefined();
+      expect(sweepResult.state).toHaveProperty('watermarks');
+    });
+
+    it('does NOT advance the watermark when inference failures are reported (retryable)', () => {
+      // On bare ES every doc update that reaches the inference step fails.
+      // The reconciler must hold the watermark so failed docs are retried next cycle.
+      //
+      // ENV-BLOCKED counterpart: watermark advances when inference succeeds (ELSER required).
+      expect(sweepResult.state.watermarks[TYPE_NAME]).toBeUndefined();
+    });
+
+    it('logs at WARN level for inference failures (R1 failure-mode contract)', () => {
+      // The reconciler emits one WARN per type (not per doc) when failures[] is non-empty.
+      // The inference-failure WARN path calls logger.warn with a single string argument
+      // (no trailing error object — contrast with the UBQ-submission-failure path which
+      // does pass { error: err }).
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('inference failure'));
+      // Must never escalate to ERROR (failures are retryable, not fatal)
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('updated_at is unchanged on docs processed by the failed UBQ', async () => {
+      // When inference fails, ES rolls back the document update.  updated_at must stay
+      // at the original seed value on every touched doc.
+      // Additionally (design invariant): the Painless script never writes updated_at,
+      // so even a SUCCESSFUL sweep would not bump it — preventing an infinite reconcile loop.
+
+      const docA = await esClient.get({ index: INDEX, id: DOC_DEFERRED_A });
+      expect((docA._source as Record<string, unknown>).updated_at).toBe(OLD_DATE);
+
+      const docB = await esClient.get({ index: INDEX, id: DOC_DEFERRED_B });
+      expect((docB._source as Record<string, unknown>).updated_at).toBe(OLD_DATE);
+
+      const docC = await esClient.get({ index: INDEX, id: DOC_NULL_SHADOW });
+      expect((docC._source as Record<string, unknown>).updated_at).toBe(OLD_DATE);
+
+      const docD = await esClient.get({ index: INDEX, id: DOC_RECENT });
+      expect((docD._source as Record<string, unknown>).updated_at).toBe(RECENT_DATE);
+    });
+
+    it('wrong-type doc is untouched by the sweep', async () => {
+      // The UBQ query filters by type=test_rule, so other_type doc must be left alone.
+      const docE = await esClient.get({ index: INDEX, id: DOC_OTHER_TYPE });
+      expect((docE._source as Record<string, unknown>).updated_at).toBe(OLD_DATE);
+      expect((docE._source as Record<string, unknown>).type).toBe(OTHER_TYPE);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Second run idempotent
+  // -------------------------------------------------------------------------
+
+  describe('second run is idempotent', () => {
+    it('produces identical behavior on a second sweep with the same empty state', async () => {
+      const logger2 = makeLogger();
+      const result2 = await runReconcilerSweep({
+        core: makeCore(esClient) as any,
+        logger: logger2 as any,
+        cfg: makeCfg(),
+        // Deliberately reuse the same empty state (simulating: first sweep never advanced
+        // watermark because of inference failures)
+        state: emptyState,
+        signal: new AbortController().signal,
+        pollIntervalMs: 100,
+      });
+
+      // Same outcome as the first run
+      expect(result2.state.watermarks[TYPE_NAME]).toBeUndefined();
+      expect(logger2.warn).toHaveBeenCalledWith(expect.stringContaining('inference failure'));
+      expect(logger2.error).not.toHaveBeenCalled();
+
+      // docs must still have their original updated_at (double idempotency check)
+      const docA = await esClient.get({ index: INDEX, id: DOC_DEFERRED_A });
+      expect((docA._source as Record<string, unknown>).updated_at).toBe(OLD_DATE);
+    }, 60_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. No-op invariant: zero ES writes when no types opt in
+  // -------------------------------------------------------------------------
+
+  describe('no-op invariant against real ES', () => {
+    it('makes zero ES writes and returns state unchanged when no types declare semanticSearch', async () => {
+      // Build a core whose registry reports zero opted-in types.
+      const noOpCore = {
+        getStartServices: async () =>
+          [
+            {
+              savedObjects: {
+                getTypeRegistry: () => ({
+                  getAllTypes: () => [],
+                  getSemanticSearchDefinition: () => undefined,
+                }),
+                getIndexForType: () => INDEX,
+              },
+              elasticsearch: {
+                client: { asInternalUser: esClient },
+              },
+            },
+            {},
+            undefined,
+          ] as const,
+      };
+
+      const preWatermark = '2026-05-01T00:00:00.000Z';
+      const initialState = { ...emptyState, watermarks: { [TYPE_NAME]: preWatermark } };
+      const logger3 = makeLogger();
+
+      const result = await runReconcilerSweep({
+        core: noOpCore as any,
+        logger: logger3 as any,
+        cfg: makeCfg(),
+        state: initialState,
+        signal: new AbortController().signal,
+        pollIntervalMs: 0,
+      });
+
+      // State returned unchanged (no types processed)
+      expect(result.state).toEqual(initialState);
+
+      // No warn or error — the no-op path is completely silent
+      expect(logger3.warn).not.toHaveBeenCalled();
+      expect(logger3.error).not.toHaveBeenCalled();
+
+      // The index must not have been modified (verify by checking count unchanged)
+      const countResp = await esClient.count({ index: INDEX });
+      // 5 docs were seeded in beforeAll; no-op sweep must not alter that
+      expect(countResp.count).toBe(5);
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/plugin.ts
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/plugin.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CoreSetup,
+  CoreStart,
+  Plugin,
+  PluginInitializerContext,
+  Logger,
+} from '@kbn/core/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { ReconcilerConfig } from './config';
+import { registerReconcilerTask, ensureReconcilerScheduled } from './task/reconciler_task';
+
+interface SetupDeps {
+  taskManager: TaskManagerSetupContract;
+}
+
+interface StartDeps {
+  taskManager: TaskManagerStartContract;
+}
+
+export class SavedObjectsSemanticReconcilerPlugin
+  implements Plugin<void, void, SetupDeps, StartDeps>
+{
+  private readonly logger: Logger;
+  private readonly cfg: ReconcilerConfig;
+  /**
+   * Stored at setup time and reused in start/task-runner via getStartServices().
+   * This is the standard pattern for accessing CoreStart from a task runner.
+   */
+  private coreSetup!: CoreSetup<StartDeps>;
+
+  constructor(context: PluginInitializerContext<ReconcilerConfig>) {
+    this.logger = context.logger.get();
+    this.cfg = context.config.get();
+  }
+
+  public setup(core: CoreSetup<StartDeps>, plugins: SetupDeps): void {
+    this.coreSetup = core;
+
+    if (!this.cfg.enabled) {
+      this.logger.info('[SavedObjectsSemanticReconciler] Disabled via config — skipping setup.');
+      return;
+    }
+
+    registerReconcilerTask(plugins.taskManager, core, this.logger, this.cfg);
+  }
+
+  public start(_core: CoreStart, plugins: StartDeps): void {
+    if (!this.cfg.enabled) {
+      return;
+    }
+
+    // Bootstrap scheduling asynchronously so Kibana's start lifecycle is not blocked on
+    // ES/Task Manager availability (ensureScheduled is idempotent via ensureScheduled).
+    void ensureReconcilerScheduled(plugins.taskManager, this.coreSetup, this.logger, this.cfg);
+  }
+
+  public stop(): void {
+    this.logger.debug('[SavedObjectsSemanticReconciler] Stopped.');
+  }
+}

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/__tests__/__snapshots__/ubq_builder.test.ts.snap
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/__tests__/__snapshots__/ubq_builder.test.ts.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildUbqBody matches the R1-proven UBQ request shape snapshot 1`] = `
+Object {
+  "query": Object {
+    "bool": Object {
+      "filter": Array [
+        Object {
+          "term": Object {
+            "type": "dashboard",
+          },
+        },
+      ],
+      "minimum_should_match": 1,
+      "should": Array [
+        Object {
+          "bool": Object {
+            "minimum_should_match": 1,
+            "should": Array [
+              Object {
+                "bool": Object {
+                  "filter": Array [
+                    Object {
+                      "exists": Object {
+                        "field": "dashboard.title",
+                      },
+                    },
+                  ],
+                  "must_not": Array [
+                    Object {
+                      "exists": Object {
+                        "field": "dashboard.title_semantic",
+                      },
+                    },
+                  ],
+                },
+              },
+              Object {
+                "bool": Object {
+                  "filter": Array [
+                    Object {
+                      "exists": Object {
+                        "field": "dashboard.description",
+                      },
+                    },
+                  ],
+                  "must_not": Array [
+                    Object {
+                      "exists": Object {
+                        "field": "dashboard.description_semantic",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        Object {
+          "range": Object {
+            "updated_at": Object {
+              "gte": "2026-08-09T00:00:00.000Z",
+            },
+          },
+        },
+      ],
+    },
+  },
+  "script": Object {
+    "lang": "painless",
+    "source": "def _t = ctx._source.get('dashboard'); if (_t == null) { ctx.op = 'noop'; return; } boolean _changed = false; def _v0 = _t.get('title'); if (_v0 != null && _v0 instanceof String && !((String)_v0).isEmpty()) {   if (!_v0.equals(_t.get('title_semantic'))) { _t['title_semantic'] = _v0; _changed = true; } } else {   if (_t.containsKey('title_semantic')) { _t.remove('title_semantic'); _changed = true; } } def _v1 = _t.get('description'); if (_v1 != null && _v1 instanceof String && !((String)_v1).isEmpty()) {   if (!_v1.equals(_t.get('description_semantic'))) { _t['description_semantic'] = _v1; _changed = true; } } else {   if (_t.containsKey('description_semantic')) { _t.remove('description_semantic'); _changed = true; } } if (!_changed) { ctx.op = 'noop'; }",
+  },
+}
+`;

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/__tests__/reconciler_task.test.ts
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/__tests__/reconciler_task.test.ts
@@ -1,0 +1,551 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  TASK_TYPE,
+  TASK_ID,
+  registerReconcilerTask,
+  ensureReconcilerScheduled,
+  runReconcilerSweep,
+} from '../reconciler_task';
+import { emptyState, type ReconcilerTaskState } from '../task_state';
+import type { ReconcilerConfig } from '../../config';
+
+// ---------------------------------------------------------------------------
+// Helpers / mocks
+// ---------------------------------------------------------------------------
+
+const makeCfg = (overrides: Partial<ReconcilerConfig> = {}): ReconcilerConfig => ({
+  enabled: true,
+  pollInterval: '1m',
+  batchSize: 100,
+  maxDocsPerSweep: 10_000,
+  requestsPerSecond: 50,
+  ...overrides,
+});
+
+const makeRegistry = (types: Array<{ name: string; fields: string[] }>) => {
+  const defs = new Map(
+    types.map(({ name, fields }) => [
+      name,
+      { fields, inferenceId: '.elser-2-elasticsearch', embedding: 'deferred' as const },
+    ])
+  );
+  return {
+    getAllTypes: jest.fn(() => types.map(({ name }) => ({ name }))),
+    getSemanticSearchDefinition: jest.fn((typeName: string) => defs.get(typeName)),
+  };
+};
+
+const makeEsClient = (overrides: Record<string, jest.Mock> = {}) => ({
+  updateByQuery: jest.fn().mockResolvedValue({ task: 'node:1234' }),
+  count: jest.fn().mockResolvedValue({ count: 5 }),
+  delete: jest.fn().mockResolvedValue({}),
+  tasks: {
+    get: jest.fn().mockResolvedValue({
+      completed: true,
+      response: { total: 5, updated: 5, version_conflicts: 0, failures: [] },
+    }),
+    cancel: jest.fn().mockResolvedValue({}),
+  },
+  ...overrides,
+});
+
+const makeCoreStart = (
+  registry: ReturnType<typeof makeRegistry>,
+  esClient: ReturnType<typeof makeEsClient>,
+  extraSO: Record<string, jest.Mock> = {}
+) => ({
+  savedObjects: {
+    getTypeRegistry: jest.fn(() => registry),
+    getIndexForType: jest.fn(() => '.kibana'),
+    ...extraSO,
+  },
+  elasticsearch: {
+    client: { asInternalUser: esClient },
+  },
+});
+
+const makeCore = (coreStart: ReturnType<typeof makeCoreStart>) => ({
+  getStartServices: jest.fn().mockResolvedValue([coreStart, {}, undefined]),
+});
+
+const makeAbortSignal = (aborted = false): AbortSignal =>
+  ({
+    aborted,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+    reason: undefined,
+    onabort: null,
+    throwIfAborted: jest.fn(),
+  } as unknown as AbortSignal);
+
+/** Build a complete ReconcilerTaskState with optional watermarks override. */
+const makeState = (watermarks: Record<string, string> = {}): ReconcilerTaskState => ({
+  ...emptyState,
+  watermarks,
+});
+
+// ---------------------------------------------------------------------------
+// Task registration
+// ---------------------------------------------------------------------------
+
+describe('registerReconcilerTask', () => {
+  it('registers a task definition with the correct type key', () => {
+    const taskManager = { registerTaskDefinitions: jest.fn() };
+    const core = makeCore(makeCoreStart(makeRegistry([]), makeEsClient()));
+    registerReconcilerTask(
+      taskManager as any,
+      core as any,
+      { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      makeCfg()
+    );
+    expect(taskManager.registerTaskDefinitions).toHaveBeenCalledTimes(1);
+    const defs = taskManager.registerTaskDefinitions.mock.calls[0][0];
+    expect(defs).toHaveProperty(TASK_TYPE);
+  });
+
+  it('uses 30m timeout on the definition', () => {
+    const taskManager = { registerTaskDefinitions: jest.fn() };
+    const core = makeCore(makeCoreStart(makeRegistry([]), makeEsClient()));
+    registerReconcilerTask(
+      taskManager as any,
+      core as any,
+      {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      } as any,
+      makeCfg()
+    );
+    const def = taskManager.registerTaskDefinitions.mock.calls[0][0][TASK_TYPE];
+    expect(def.timeout).toBe('30m');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scheduling gating
+// ---------------------------------------------------------------------------
+
+describe('ensureReconcilerScheduled', () => {
+  it('does NOT call ensureScheduled when no types opt in', async () => {
+    const taskManager = { ensureScheduled: jest.fn() };
+    const registry = makeRegistry([]);
+    const core = makeCore(makeCoreStart(registry, makeEsClient()));
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    await ensureReconcilerScheduled(taskManager as any, core as any, logger as any, makeCfg());
+    expect(taskManager.ensureScheduled).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('No types declare semanticSearch')
+    );
+  });
+
+  it('calls ensureScheduled with the correct task ID and interval when types opt in', async () => {
+    const taskManager = { ensureScheduled: jest.fn().mockResolvedValue(undefined) };
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, makeEsClient()));
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    await ensureReconcilerScheduled(taskManager as any, core as any, logger as any, makeCfg());
+    expect(taskManager.ensureScheduled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: TASK_ID,
+        taskType: TASK_TYPE,
+        schedule: { interval: '1m' },
+      })
+    );
+  });
+
+  it('uses the configured pollInterval in the schedule', async () => {
+    const taskManager = { ensureScheduled: jest.fn().mockResolvedValue(undefined) };
+    const registry = makeRegistry([{ name: 'rule', fields: ['name'] }]);
+    const core = makeCore(makeCoreStart(registry, makeEsClient()));
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    await ensureReconcilerScheduled(
+      taskManager as any,
+      core as any,
+      logger as any,
+      makeCfg({ pollInterval: '5m' })
+    );
+    expect(taskManager.ensureScheduled).toHaveBeenCalledWith(
+      expect.objectContaining({ schedule: { interval: '5m' } })
+    );
+  });
+
+  it('logs error but does not throw if ensureScheduled rejects', async () => {
+    const taskManager = {
+      ensureScheduled: jest.fn().mockRejectedValue(new Error('TM unavailable')),
+    };
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, makeEsClient()));
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    await expect(
+      ensureReconcilerScheduled(taskManager as any, core as any, logger as any, makeCfg())
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to schedule'),
+      expect.anything()
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-op invariant
+// ---------------------------------------------------------------------------
+
+describe('runReconcilerSweep — no-op invariant', () => {
+  it('returns unchanged state and makes zero ES calls when no types opt in', async () => {
+    const esClient = makeEsClient();
+    const registry = makeRegistry([]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+    const initialState = makeState({ dashboard: '2026-01-01T00:00:00.000Z' });
+
+    const { state } = await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      cfg: makeCfg(),
+      state: initialState,
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    expect(esClient.updateByQuery).not.toHaveBeenCalled();
+    expect(esClient.tasks.get).not.toHaveBeenCalled();
+    expect(state).toEqual(initialState);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Successful sweep
+// ---------------------------------------------------------------------------
+
+describe('runReconcilerSweep — successful sweep', () => {
+  it('submits one UBQ per opted-in type and advances the watermark on full success', async () => {
+    const esClient = makeEsClient();
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title', 'description'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    const { state } = await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      cfg: makeCfg(),
+      state: makeState(),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    expect(esClient.updateByQuery).toHaveBeenCalledTimes(1);
+    expect(esClient.tasks.get).toHaveBeenCalledTimes(1);
+    // Watermark must be set to an ISO date after the run
+    expect(state.watermarks.dashboard).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('submits one UBQ per type for multi-type registrations', async () => {
+    const esClient = makeEsClient();
+    const registry = makeRegistry([
+      { name: 'dashboard', fields: ['title'] },
+      { name: 'lens', fields: ['title', 'description'] },
+    ]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      cfg: makeCfg(),
+      state: makeState(),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    expect(esClient.updateByQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes the correct index, conflicts, scroll_size, max_docs, requests_per_second to UBQ', async () => {
+    const esClient = makeEsClient();
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      cfg: makeCfg({ batchSize: 50, maxDocsPerSweep: 500, requestsPerSecond: 25 }),
+      state: makeState(),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    const [callArgs] = esClient.updateByQuery.mock.calls[0];
+    expect(callArgs.index).toBe('.kibana');
+    expect(callArgs.conflicts).toBe('proceed');
+    expect(callArgs.scroll_size).toBe(50);
+    expect(callArgs.max_docs).toBe(500);
+    expect(callArgs.requests_per_second).toBe(25);
+    expect(callArgs.wait_for_completion).toBe(false);
+  });
+
+  it('uses the stored watermark from state in the detection query', async () => {
+    const esClient = makeEsClient();
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    const storedWatermark = '2026-06-01T12:00:00.000Z';
+    await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      cfg: makeCfg(),
+      state: makeState({ dashboard: storedWatermark }),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    const body = esClient.updateByQuery.mock.calls[0][0];
+    const queryStr = JSON.stringify(body.query);
+    expect(queryStr).toContain(storedWatermark);
+  });
+
+  it('uses epoch watermark for a type not yet in state', async () => {
+    const esClient = makeEsClient();
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      cfg: makeCfg(),
+      state: makeState(),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    const body = esClient.updateByQuery.mock.calls[0][0];
+    const queryStr = JSON.stringify(body.query);
+    expect(queryStr).toContain('1970-01-01T00:00:00.000Z');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response interpretation — version conflicts
+// ---------------------------------------------------------------------------
+
+describe('runReconcilerSweep — version conflicts', () => {
+  it('advances watermark even when version_conflicts > 0 (conflicts are benign)', async () => {
+    const esClient = makeEsClient({
+      updateByQuery: jest.fn().mockResolvedValue({ task: 'node:999' }),
+    });
+    esClient.tasks.get = jest.fn().mockResolvedValue({
+      completed: true,
+      response: { total: 10, updated: 9, version_conflicts: 1, failures: [] },
+    });
+
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    const { state } = await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      cfg: makeCfg(),
+      state: makeState(),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    expect(state.watermarks.dashboard).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response interpretation — inference failures
+// ---------------------------------------------------------------------------
+
+describe('runReconcilerSweep — inference failures', () => {
+  it('does NOT advance watermark when failures[] is non-empty', async () => {
+    const esClient = makeEsClient({
+      updateByQuery: jest.fn().mockResolvedValue({ task: 'node:999' }),
+    });
+    esClient.tasks.get = jest.fn().mockResolvedValue({
+      completed: true,
+      response: {
+        total: 10,
+        updated: 0,
+        version_conflicts: 0,
+        failures: [
+          {
+            id: 'doc-1',
+            cause: { type: 'resource_not_found_exception', reason: 'Inference id not found' },
+            status: 404,
+          },
+        ],
+      },
+    });
+
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+    const { state } = await runReconcilerSweep({
+      core: core as any,
+      logger: logger as any,
+      cfg: makeCfg(),
+      state: makeState(),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    // Watermark must NOT be set
+    expect(state.watermarks.dashboard).toBeUndefined();
+    // Must log at WARN
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('inference failure'));
+  });
+
+  it('does not throw and task succeeds even with inference failures (R1 failure-mode contract)', async () => {
+    const esClient = makeEsClient({
+      updateByQuery: jest.fn().mockResolvedValue({ task: 'node:999' }),
+    });
+    esClient.tasks.get = jest.fn().mockResolvedValue({
+      completed: true,
+      response: {
+        total: 5,
+        updated: 0,
+        failures: Array.from({ length: 5 }, (_, i) => ({
+          id: `doc-${i}`,
+          cause: { type: 'resource_not_found_exception', reason: 'Inference id not found' },
+        })),
+      },
+    });
+
+    const registry = makeRegistry([{ name: 'rule', fields: ['name'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    await expect(
+      runReconcilerSweep({
+        core: core as any,
+        logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+        cfg: makeCfg(),
+        state: makeState(),
+        signal: makeAbortSignal(),
+        pollIntervalMs: 0,
+      })
+    ).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response interpretation — truncation
+// ---------------------------------------------------------------------------
+
+describe('runReconcilerSweep — maxDocsPerSweep truncation', () => {
+  it('does NOT advance watermark when total >= maxDocsPerSweep', async () => {
+    const esClient = makeEsClient({
+      updateByQuery: jest.fn().mockResolvedValue({ task: 'node:999' }),
+    });
+    esClient.tasks.get = jest.fn().mockResolvedValue({
+      completed: true,
+      response: { total: 500, updated: 500, version_conflicts: 0, failures: [] },
+    });
+
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    const { state } = await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      // maxDocsPerSweep=500 → total(500) >= 500 → truncated
+      cfg: makeCfg({ maxDocsPerSweep: 500 }),
+      state: makeState(),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    expect(state.watermarks.dashboard).toBeUndefined();
+  });
+
+  it('advances watermark when total < maxDocsPerSweep', async () => {
+    const esClient = makeEsClient({
+      updateByQuery: jest.fn().mockResolvedValue({ task: 'node:999' }),
+    });
+    esClient.tasks.get = jest.fn().mockResolvedValue({
+      completed: true,
+      response: { total: 42, updated: 42, version_conflicts: 0, failures: [] },
+    });
+
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    const { state } = await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      cfg: makeCfg({ maxDocsPerSweep: 500 }),
+      state: makeState(),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    expect(state.watermarks.dashboard).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Abort signal handling
+// ---------------------------------------------------------------------------
+
+describe('runReconcilerSweep — abort signal', () => {
+  it('skips all types and returns current state immediately if signal is already aborted', async () => {
+    const esClient = makeEsClient();
+    const registry = makeRegistry([{ name: 'dashboard', fields: ['title'] }]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+
+    const { state } = await runReconcilerSweep({
+      core: core as any,
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      cfg: makeCfg(),
+      state: makeState(),
+      signal: makeAbortSignal(true),
+      pollIntervalMs: 0,
+    });
+
+    // No UBQ submitted because signal was aborted before the loop started
+    expect(esClient.updateByQuery).not.toHaveBeenCalled();
+    expect(state.watermarks).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UBQ submission failure (genuine bug / network error)
+// ---------------------------------------------------------------------------
+
+describe('runReconcilerSweep — UBQ submission failure', () => {
+  it('logs and continues to next type when UBQ submission throws', async () => {
+    const esClient = makeEsClient({
+      updateByQuery: jest.fn().mockRejectedValue(new Error('index_not_found_exception')),
+    });
+    const registry = makeRegistry([
+      { name: 'dashboard', fields: ['title'] },
+      { name: 'lens', fields: ['description'] },
+    ]);
+    const core = makeCore(makeCoreStart(registry, esClient));
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+    // Should not throw
+    const { state } = await runReconcilerSweep({
+      core: core as any,
+      logger: logger as any,
+      cfg: makeCfg(),
+      state: makeState(),
+      signal: makeAbortSignal(),
+      pollIntervalMs: 0,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('UBQ submission failed'),
+      expect.anything()
+    );
+    // Neither type's watermark advanced
+    expect(state.watermarks.dashboard).toBeUndefined();
+    expect(state.watermarks.lens).toBeUndefined();
+  });
+});

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/__tests__/ubq_builder.test.ts
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/__tests__/ubq_builder.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildDetectionQuery, buildPainlessScript, buildUbqBody } from '../ubq_builder';
+
+const WATERMARK = '2026-08-09T00:00:00.000Z';
+
+describe('buildDetectionQuery', () => {
+  it('builds the combined detection query for a single field with source-field gate', () => {
+    const query = buildDetectionQuery('dashboard', ['title'], WATERMARK);
+    expect(query).toEqual({
+      bool: {
+        filter: [{ term: { type: 'dashboard' } }],
+        should: [
+          {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    filter: [{ exists: { field: 'dashboard.title' } }],
+                    must_not: [{ exists: { field: 'dashboard.title_semantic' } }],
+                  },
+                },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+          { range: { updated_at: { gte: WATERMARK } } },
+        ],
+        minimum_should_match: 1,
+      },
+    });
+  });
+
+  it('includes a source-gate + must_not exists clause for every declared shadow field', () => {
+    const query = buildDetectionQuery('dashboard', ['title', 'description'], WATERMARK);
+    const outerBool = (query as any).bool;
+    const missingBool = outerBool.should[0].bool;
+    expect(missingBool.should).toHaveLength(2);
+    // Each clause gates on source field existing AND shadow absent.
+    expect(missingBool.should[0]).toEqual({
+      bool: {
+        filter: [{ exists: { field: 'dashboard.title' } }],
+        must_not: [{ exists: { field: 'dashboard.title_semantic' } }],
+      },
+    });
+    expect(missingBool.should[1]).toEqual({
+      bool: {
+        filter: [{ exists: { field: 'dashboard.description' } }],
+        must_not: [{ exists: { field: 'dashboard.description_semantic' } }],
+      },
+    });
+  });
+
+  it('uses the provided watermark in the range clause', () => {
+    const wm = '2025-01-01T00:00:00.000Z';
+    const query = buildDetectionQuery('rule', ['name'], wm);
+    const outerBool = (query as any).bool;
+    expect(outerBool.should[1]).toEqual({ range: { updated_at: { gte: wm } } });
+  });
+
+  it('filters by type in the bool filter', () => {
+    const query = buildDetectionQuery('myType', ['field1'], WATERMARK);
+    expect((query as any).bool.filter).toEqual([{ term: { type: 'myType' } }]);
+  });
+
+  it('qualifies shadow field names as typeName.fieldName_semantic', () => {
+    const query = buildDetectionQuery('lens', ['title', 'description'], WATERMARK);
+    const shadows = (query as any).bool.should[0].bool.should;
+    expect(shadows[0].bool.must_not[0].exists.field).toBe('lens.title_semantic');
+    expect(shadows[1].bool.must_not[0].exists.field).toBe('lens.description_semantic');
+    // Also verify source-field gate uses unqualified-with-type prefix.
+    expect(shadows[0].bool.filter[0].exists.field).toBe('lens.title');
+    expect(shadows[1].bool.filter[0].exists.field).toBe('lens.description');
+  });
+});
+
+describe('buildPainlessScript', () => {
+  it('generates a script for a single field with noop-on-no-change logic', () => {
+    const script = buildPainlessScript('dashboard', ['title']);
+    // Must reference the type namespace
+    expect(script).toContain("ctx._source.get('dashboard')");
+    // Must noop when type map is absent
+    expect(script).toContain("ctx.op = 'noop'");
+    // Must read source field
+    expect(script).toContain("_t.get('title')");
+    // Must check instanceof String (Painless null-safety)
+    expect(script).toContain('instanceof String');
+    // Must set shadow field only when value changed
+    expect(script).toContain("_t['title_semantic']");
+    // Must remove shadow field when source is absent/empty (only if key present)
+    expect(script).toContain("_t.remove('title_semantic')");
+    // Must track whether any field changed and noop if not
+    expect(script).toContain('boolean _changed = false');
+    expect(script).toContain("if (!_changed) { ctx.op = 'noop'; }");
+  });
+
+  it('generates assignments for every declared field', () => {
+    const script = buildPainlessScript('dashboard', ['title', 'description']);
+    expect(script).toContain("_t.get('title')");
+    expect(script).toContain("_t['title_semantic']");
+    expect(script).toContain("_t.get('description')");
+    expect(script).toContain("_t['description_semantic']");
+  });
+
+  it('uses distinct Painless variable names per field to avoid collisions', () => {
+    const script = buildPainlessScript('lens', ['title', 'description', 'summary']);
+    // Variables _v0, _v1, _v2 must all appear
+    expect(script).toContain('def _v0');
+    expect(script).toContain('def _v1');
+    expect(script).toContain('def _v2');
+  });
+
+  it('handles a type with a single field without syntax errors (no trailing semicolons needed)', () => {
+    // Just verify it's a non-empty string with the right structure
+    const script = buildPainlessScript('rule', ['name']);
+    expect(script.length).toBeGreaterThan(0);
+    expect(script).toContain("ctx._source.get('rule')");
+  });
+
+  it('uses bracket notation for a hyphenated type name, keeping the script well-formed', () => {
+    // 'index-pattern' is a real SO type with a hyphen. The builder must use
+    // single-quoted bracket notation (get('index-pattern')) so that the hyphen is
+    // treated as a literal character by Painless rather than a subtraction operator.
+    const script = buildPainlessScript('index-pattern', ['title']);
+    // Type access must use bracket/get notation, not dot notation.
+    expect(script).toContain("ctx._source.get('index-pattern')");
+    // Source field accessed via bracket notation on the type map.
+    expect(script).toContain("_t.get('title')");
+    // Shadow field assignment uses bracket notation.
+    expect(script).toContain("_t['title_semantic']");
+    // Must still include noop logic.
+    expect(script).toContain('boolean _changed = false');
+    expect(script).toContain("if (!_changed) { ctx.op = 'noop'; }");
+    // Must NOT contain dot-notation access for the type (e.g. ctx._source.index-pattern).
+    expect(script).not.toContain('ctx._source.index-pattern');
+  });
+});
+
+describe('buildUbqBody', () => {
+  it('returns both query and script keys', () => {
+    const body = buildUbqBody('dashboard', ['title', 'description'], WATERMARK);
+    expect(body).toHaveProperty('query');
+    expect(body).toHaveProperty('script');
+    expect((body.script as any).lang).toBe('painless');
+    expect(typeof (body.script as any).source).toBe('string');
+  });
+
+  it('matches the R1-proven UBQ request shape snapshot', () => {
+    const body = buildUbqBody('dashboard', ['title', 'description'], WATERMARK);
+    expect(body).toMatchSnapshot();
+  });
+});

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/reconciler_task.ts
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/reconciler_task.ts
@@ -1,0 +1,442 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, Logger } from '@kbn/core/server';
+import type {
+  RunContext,
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import { TaskCost, TaskPriority } from '@kbn/task-manager-plugin/server';
+import type { ReconcilerConfig } from '../config';
+import { stateSchemaByVersion, emptyState, type ReconcilerTaskState } from './task_state';
+import { buildUbqBody } from './ubq_builder';
+
+export const TASK_TYPE = 'savedObjectsSemanticReconciler:sweep';
+export const TASK_ID = 'savedObjectsSemanticReconciler:sweep';
+
+/** Epoch fallback watermark — used on first run before any successful sweep. */
+const EPOCH_WATERMARK = '1970-01-01T00:00:00.000Z';
+
+/**
+ * Milliseconds to wait between ES task-status polls when waiting for an async UBQ to complete.
+ * Long enough to avoid hammering ES but short enough to react promptly on small sweeps.
+ */
+const POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Safety margin subtracted from taskStartTime when computing the new watermark.
+ * Covers ES index refresh latency (up to 1 s default) + cross-node clock skew.
+ * 60 s is conservative; re-embedding a 60-second overlap window per cycle is idempotent
+ * and cheap compared to permanently missing a deferred-mode update.
+ */
+const WATERMARK_SAFETY_MARGIN_MS = 60_000;
+
+/**
+ * Maximum number of cycles to skip when backing off from persistent inference failures.
+ * At N consecutive-failure streaks, the type is skipped for min(2^(N-1), MAX_BACKOFF_CYCLES)
+ * cycles. Caps at ~1 h at 1 m pollInterval.
+ */
+const MAX_BACKOFF_CYCLES = 64;
+
+/**
+ * ES UBQ response shape — the fields we care about after a completed async task.
+ * `failures` is capped at 10 by ES by default; the count reflects that cap.
+ */
+interface UbqResult {
+  total?: number;
+  updated?: number;
+  version_conflicts?: number;
+  failures?: Array<{
+    id?: string;
+    cause?: { type?: string; reason?: string };
+    status?: number;
+  }>;
+}
+
+/** Polls `GET /_tasks/{taskId}` until `completed: true`, passing signal to every call. */
+const pollUntilDone = async (
+  esClient: Awaited<
+    ReturnType<CoreSetup['getStartServices']>
+  >[0]['elasticsearch']['client']['asInternalUser'],
+  esTaskId: string,
+  signal: AbortSignal,
+  pollIntervalMs: number = POLL_INTERVAL_MS
+): Promise<{ result: UbqResult; taskError?: string }> => {
+  while (true) {
+    if (signal.aborted) {
+      // Best-effort cancellation of the running ES task so we don't leave orphaned work.
+      try {
+        await esClient.tasks.cancel({ task_id: esTaskId });
+      } catch {
+        // ignore — task may have already completed
+      }
+      return { result: {} };
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, pollIntervalMs));
+
+    const status = await esClient.tasks.get(
+      { task_id: esTaskId, wait_for_completion: false },
+      { signal }
+    );
+
+    if (status.completed) {
+      // Surface task-level error (Painless compile error, search_phase_execution_exception, etc.)
+      // alongside the per-doc result. status.error is typed as ErrorCause | undefined.
+      const taskError = status.error
+        ? `${status.error.type ?? 'unknown'}: ${status.error.reason ?? 'no reason'}`
+        : undefined;
+
+      // canceled may appear in response body (not in the top-level TypeScript type)
+      const rawResponse = status.response as Record<string, unknown> | undefined;
+      const canceled = rawResponse?.canceled === true;
+      const errorStr = taskError ?? (canceled ? 'task was externally cancelled' : undefined);
+
+      return { result: (status.response ?? {}) as UbqResult, taskError: errorStr };
+    }
+  }
+};
+
+/**
+ * Registers the reconciler task with Task Manager.
+ * Must be called during the plugin setup phase so the definition is available before tasks fire.
+ */
+export const registerReconcilerTask = (
+  taskManager: TaskManagerSetupContract,
+  core: CoreSetup,
+  logger: Logger,
+  cfg: ReconcilerConfig
+): void => {
+  taskManager.registerTaskDefinitions({
+    [TASK_TYPE]: {
+      title: 'Saved Objects Semantic Search Reconciler',
+      description:
+        'Sweeps for saved-object docs that have absent or stale semantic shadow fields and populates them via scripted update_by_query (backfill + deferred-embedding pickup).',
+      timeout: '30m',
+      cost: TaskCost.ExtraLarge,
+      priority: TaskPriority.Low,
+      stateSchemaByVersion,
+      createTaskRunner: ({ taskInstance, signal }: RunContext) => ({
+        run: async (): Promise<{ state: ReconcilerTaskState }> => {
+          const state = (taskInstance.state ?? emptyState) as ReconcilerTaskState;
+          return runReconcilerSweep({ core, logger, cfg, state, signal });
+        },
+      }),
+    },
+  });
+};
+
+/**
+ * Schedules the singleton recurring reconciler task if any registered type opts in to
+ * semantic search. Called from plugin start (idempotent via ensureScheduled).
+ * Also updates the schedule interval on existing tasks when the config changes.
+ */
+export const ensureReconcilerScheduled = async (
+  taskManager: TaskManagerStartContract,
+  core: CoreSetup,
+  logger: Logger,
+  cfg: ReconcilerConfig
+): Promise<void> => {
+  const [coreStart] = await core.getStartServices();
+  const registry = coreStart.savedObjects.getTypeRegistry();
+  const optedInTypes = registry
+    .getAllTypes()
+    .filter((t) => registry.getSemanticSearchDefinition(t.name) !== undefined);
+
+  if (optedInTypes.length === 0) {
+    logger.debug(
+      '[ReconcilerTask] No types declare semanticSearch — reconciler task will not be scheduled.'
+    );
+    return;
+  }
+
+  try {
+    await taskManager.ensureScheduled({
+      id: TASK_ID,
+      taskType: TASK_TYPE,
+      schedule: { interval: cfg.pollInterval },
+      params: {},
+      state: emptyState,
+    });
+    logger.info(
+      `[ReconcilerTask] Scheduled with interval=${cfg.pollInterval} for ${optedInTypes.length} opted-in type(s).`
+    );
+
+    // Update the interval on the existing task document if the config changed since it was
+    // first scheduled — ensureScheduled preserves the existing schedule (idempotent).
+    try {
+      const existing = await taskManager.get(TASK_ID);
+      if (existing?.schedule?.interval !== cfg.pollInterval) {
+        await taskManager.bulkUpdateSchedules([TASK_ID], { interval: cfg.pollInterval });
+        logger.info(
+          `[ReconcilerTask] Updated schedule interval to ${cfg.pollInterval} (was ${existing?.schedule?.interval}).`
+        );
+      }
+    } catch {
+      // Non-fatal: the task will run at its existing interval until the next restart.
+    }
+  } catch (err) {
+    logger.error(`[ReconcilerTask] Failed to schedule: ${err.message}`, { error: err });
+  }
+};
+
+/**
+ * Core sweep logic — runs per task invocation.
+ * Separated from the runner factory so it can be unit-tested without Task Manager plumbing.
+ */
+export const runReconcilerSweep = async ({
+  core,
+  logger,
+  cfg,
+  state,
+  signal,
+  pollIntervalMs = POLL_INTERVAL_MS,
+}: {
+  core: CoreSetup;
+  logger: Logger;
+  cfg: ReconcilerConfig;
+  state: ReconcilerTaskState;
+  signal: AbortSignal;
+  /** Milliseconds between ES task-status polls. Overridable in tests (set to 0 for instant). */
+  pollIntervalMs?: number;
+}): Promise<{ state: ReconcilerTaskState }> => {
+  const [coreStart] = await core.getStartServices();
+  const registry = coreStart.savedObjects.getTypeRegistry();
+
+  // Collect opted-in types at run time — types can register after start.
+  const allOptedInTypes = registry
+    .getAllTypes()
+    .filter((t) => registry.getSemanticSearchDefinition(t.name) !== undefined);
+
+  if (allOptedInTypes.length === 0) {
+    // No-op invariant: zero ES calls when nothing opts in.
+    return { state };
+  }
+
+  const esClient = coreStart.elasticsearch.client.asInternalUser;
+  const taskStartTime = new Date().toISOString();
+
+  // Carry forward all state fields, mutating only what changes this sweep.
+  const updatedWatermarks = { ...state.watermarks };
+  const updatedConsecutiveFailures = { ...state.consecutiveFailures };
+  const updatedLastFailureReason = { ...state.lastFailureReason };
+
+  // Rotation cursor: start from where we left off so tail types are not starved.
+  const cursor = (state.rotationCursor ?? 0) % allOptedInTypes.length;
+  const rotatedTypes = [...allOptedInTypes.slice(cursor), ...allOptedInTypes.slice(0, cursor)];
+  // nextCursor advances past each type we fully process.
+  let nextCursor = cursor;
+
+  for (const soType of rotatedTypes) {
+    if (signal.aborted) break;
+
+    const typeName = soType.name;
+    const def = registry.getSemanticSearchDefinition(typeName)!;
+    const watermark = updatedWatermarks[typeName] ?? EPOCH_WATERMARK;
+
+    // --- Exponential backoff for persistent inference failures ---
+    // consecutiveFailures[typeName] encodes the remaining skip-budget: when > 0, skip this
+    // cycle and decrement. When it reaches 0, retry. On each new failure, set budget to
+    // min(2^streakCount-1, MAX_BACKOFF_CYCLES) where streakCount is stored in lastFailureReason
+    // as a "streak:<count>:<reason>" prefix.
+    const skipBudget = updatedConsecutiveFailures[typeName] ?? 0;
+    if (skipBudget > 0) {
+      logger.debug(
+        `[ReconcilerTask] type="${typeName}" skipping this cycle (backoff; skips remaining: ${skipBudget}).`
+      );
+      updatedConsecutiveFailures[typeName] = skipBudget - 1;
+      nextCursor = (allOptedInTypes.indexOf(soType) + cursor + 1) % allOptedInTypes.length;
+      continue;
+    }
+
+    const targetIndex = coreStart.savedObjects.getIndexForType(typeName);
+
+    logger.debug(
+      `[ReconcilerTask] Sweeping type="${typeName}" index="${targetIndex}" watermark="${watermark}"`
+    );
+
+    // --- Preflight count: skip UBQ submission if nothing matches ---
+    let matchCount = -1; // -1 = unknown (count failed), proceed anyway
+    try {
+      const countResp = await esClient.count(
+        {
+          index: targetIndex,
+          query: buildUbqBody(typeName, def.fields, watermark).query as Record<string, unknown>,
+        },
+        { signal }
+      );
+      matchCount = countResp.count;
+    } catch (err) {
+      logger.debug(
+        `[ReconcilerTask] type="${typeName}" preflight count failed (${err.message}); proceeding with UBQ.`
+      );
+    }
+
+    if (matchCount === 0) {
+      logger.debug(
+        `[ReconcilerTask] type="${typeName}" preflight count=0 — no docs need reconciliation; skipping UBQ.`
+      );
+      // Advance watermark: the sweep is effectively complete for this type.
+      const newWatermark = new Date(
+        Date.parse(taskStartTime) - WATERMARK_SAFETY_MARGIN_MS
+      ).toISOString();
+      updatedWatermarks[typeName] = newWatermark;
+      nextCursor = (allOptedInTypes.indexOf(soType) + cursor + 1) % allOptedInTypes.length;
+      continue;
+    }
+
+    const body = buildUbqBody(typeName, def.fields, watermark);
+
+    let esTaskId: string | undefined;
+    try {
+      const submitResp = await esClient.updateByQuery(
+        {
+          index: targetIndex,
+          conflicts: 'proceed',
+          scroll_size: cfg.batchSize,
+          max_docs: cfg.maxDocsPerSweep,
+          requests_per_second: cfg.requestsPerSecond,
+          wait_for_completion: false,
+          ...body,
+        } as Parameters<typeof esClient.updateByQuery>[0],
+        { signal }
+      );
+      // When wait_for_completion=false, the response contains { task: '<node>:<taskId>' }.
+      esTaskId = 'task' in submitResp ? String(submitResp.task) : undefined;
+    } catch (err) {
+      // A genuine query/mapping error — log and let TM retry/visibility apply.
+      logger.warn(
+        `[ReconcilerTask] type="${typeName}" UBQ submission failed: ${err.message}. Will retry next cycle.`,
+        { error: err }
+      );
+      continue;
+    }
+
+    if (!esTaskId) {
+      logger.warn(`[ReconcilerTask] type="${typeName}" UBQ returned no task ID; skipping.`);
+      continue;
+    }
+
+    let pollResult: { result: UbqResult; taskError?: string };
+    try {
+      pollResult = await pollUntilDone(esClient, esTaskId, signal, pollIntervalMs);
+    } catch (err) {
+      // Polling error (network blip, etc.) — doc retry is implicit next cycle.
+      logger.warn(
+        `[ReconcilerTask] type="${typeName}" UBQ polling failed: ${err.message}. Docs will retry next cycle.`,
+        { error: err }
+      );
+      continue;
+    } finally {
+      // Best-effort delete the .tasks result document to prevent unbounded .tasks index growth.
+      // ES persists task results in .tasks until explicitly deleted; at 1-min poll intervals
+      // these accumulate indefinitely (~1440/day/type).
+      esClient.delete({ index: '.tasks', id: esTaskId }).catch(() => {});
+    }
+
+    if (signal.aborted) break;
+
+    const { result, taskError } = pollResult;
+
+    // Check for task-level error (not per-doc failures) — e.g. Painless compile error,
+    // search_phase_execution_exception, external cancellation.
+    if (taskError) {
+      logger.warn(
+        `[ReconcilerTask] type="${typeName}" UBQ task failed: ${taskError}. Watermark NOT advanced; docs will retry next cycle.`
+      );
+      continue;
+    }
+
+    const versionConflicts = result.version_conflicts ?? 0;
+    const failures = result.failures ?? [];
+    const totalDocs = result.total ?? 0;
+    const updatedDocs = result.updated ?? 0;
+
+    if (versionConflicts > 0) {
+      logger.debug(
+        `[ReconcilerTask] type="${typeName}" ${versionConflicts} version conflict(s) — skipped docs will retry next cycle.`
+      );
+    }
+
+    if (failures.length > 0) {
+      // ES caps failures[] at 10 by default — actual failure count may be higher.
+      const sample = failures[0];
+      const reason = `${sample?.cause?.type ?? 'unknown'}: ${sample?.cause?.reason ?? 'unknown'}`;
+
+      // Compute exponential backoff skip budget.
+      // lastFailureReason encodes "streak:<count>:<reason>" to track the failure streak.
+      const prevEncoded = updatedLastFailureReason[typeName];
+      let streakCount = 1;
+      let prevReason: string | undefined;
+      if (prevEncoded?.startsWith('streak:')) {
+        const colonIdx = prevEncoded.indexOf(':', 'streak:'.length);
+        const countStr = prevEncoded.slice('streak:'.length, colonIdx);
+        prevReason = prevEncoded.slice(colonIdx + 1);
+        if (prevReason === reason) {
+          streakCount = Math.min(parseInt(countStr, 10) + 1, 62);
+        }
+      }
+      const newSkipBudget = Math.min(Math.pow(2, streakCount - 1), MAX_BACKOFF_CYCLES);
+      updatedConsecutiveFailures[typeName] = newSkipBudget;
+      updatedLastFailureReason[typeName] = `streak:${streakCount}:${reason}`;
+
+      // Warn only on the first occurrence of this reason or when the reason changes,
+      // to avoid spamming logs every cycle.
+      if (prevReason === undefined || prevReason !== reason || streakCount === 1) {
+        logger.warn(
+          `[ReconcilerTask] type="${typeName}" ${failures.length} inference failure(s) (ES cap=10; actual count may be higher). ` +
+            `Sample: ${reason}. ` +
+            `Affected docs will retry next cycle via detection filter. ` +
+            `Backing off for ${newSkipBudget} cycle(s).`
+        );
+      } else {
+        logger.debug(
+          `[ReconcilerTask] type="${typeName}" inference failures continuing (streak=${streakCount}); backoff=${newSkipBudget} cycles.`
+        );
+      }
+      // Do NOT advance watermark — failed docs remain matchable, retry next cycle.
+      continue;
+    }
+
+    // Success: reset backoff state.
+    updatedConsecutiveFailures[typeName] = 0;
+    delete updatedLastFailureReason[typeName];
+
+    const truncated = totalDocs >= cfg.maxDocsPerSweep;
+    if (truncated) {
+      logger.debug(
+        `[ReconcilerTask] type="${typeName}" sweep capped at maxDocsPerSweep=${cfg.maxDocsPerSweep} ` +
+          `(total=${totalDocs}, updated=${updatedDocs}). Remaining docs will process next cycle.`
+      );
+      // Do NOT advance watermark so remaining docs stay in the detection window.
+      nextCursor = (allOptedInTypes.indexOf(soType) + cursor + 1) % allOptedInTypes.length;
+      continue;
+    }
+
+    // Advance watermark with a safety margin to cover refresh latency + clock skew.
+    // This ensures deferred-mode docs written just before taskStartTime (and not yet
+    // searchable at UBQ snapshot time) are still picked up next cycle.
+    const newWatermark = new Date(
+      Date.parse(taskStartTime) - WATERMARK_SAFETY_MARGIN_MS
+    ).toISOString();
+    logger.debug(
+      `[ReconcilerTask] type="${typeName}" sweep complete: updated=${updatedDocs}, conflicts=${versionConflicts}. Advancing watermark to ${newWatermark}.`
+    );
+    updatedWatermarks[typeName] = newWatermark;
+    nextCursor = (allOptedInTypes.indexOf(soType) + cursor + 1) % allOptedInTypes.length;
+  }
+
+  return {
+    state: {
+      watermarks: updatedWatermarks,
+      consecutiveFailures: updatedConsecutiveFailures,
+      lastFailureReason: updatedLastFailureReason,
+      rotationCursor: nextCursor,
+    },
+  };
+};

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/task_state.ts
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/task_state.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
+
+/**
+ * WARNING: Do not modify existing versioned schemas. Add a new version instead.
+ * See https://github.com/elastic/kibana/issues/155764.
+ *
+ * watermarks: map of saved-object type name → ISO-8601 date string (last successful sweep
+ * start time for that type). On first run the key is absent; the reconciler treats absence as
+ * the Unix epoch so the full detection query covers all docs.
+ */
+const stateSchemaV1 = schema.object({
+  watermarks: schema.recordOf(schema.string({ maxLength: 100 }), schema.string({ maxLength: 30 })),
+});
+
+/**
+ * V2 adds:
+ * - consecutiveFailures: per-type count of consecutive inference failure sweeps, used to
+ *   apply exponential backoff so a persistently broken inference endpoint does not spam logs
+ *   or waste ES work every minute.
+ * - lastFailureReason: per-type last failure reason string (to detect when the reason changes
+ *   and emit a fresh WARN).
+ * - rotationCursor: index into the sorted opted-in type list to start the next sweep from,
+ *   so that no tail type is permanently starved when the list is long.
+ */
+const stateSchemaV2 = schema.object({
+  watermarks: schema.recordOf(schema.string({ maxLength: 100 }), schema.string({ maxLength: 30 })),
+  consecutiveFailures: schema.recordOf(
+    schema.string({ maxLength: 100 }),
+    schema.number({ min: 0, max: 1_000_000 })
+  ),
+  lastFailureReason: schema.recordOf(
+    schema.string({ maxLength: 100 }),
+    schema.string({ maxLength: 500 })
+  ),
+  rotationCursor: schema.number({ min: 0, max: 100_000 }),
+});
+
+export const stateSchemaByVersion = {
+  1: {
+    up: (state: Record<string, unknown>) => ({
+      watermarks:
+        state.watermarks && typeof state.watermarks === 'object' && !Array.isArray(state.watermarks)
+          ? (state.watermarks as Record<string, string>)
+          : {},
+    }),
+    schema: stateSchemaV1,
+  },
+  2: {
+    up: (state: Record<string, unknown>) => ({
+      watermarks:
+        state.watermarks && typeof state.watermarks === 'object' && !Array.isArray(state.watermarks)
+          ? (state.watermarks as Record<string, string>)
+          : {},
+      consecutiveFailures:
+        state.consecutiveFailures &&
+        typeof state.consecutiveFailures === 'object' &&
+        !Array.isArray(state.consecutiveFailures)
+          ? (state.consecutiveFailures as Record<string, number>)
+          : {},
+      lastFailureReason:
+        state.lastFailureReason &&
+        typeof state.lastFailureReason === 'object' &&
+        !Array.isArray(state.lastFailureReason)
+          ? (state.lastFailureReason as Record<string, string>)
+          : {},
+      rotationCursor:
+        typeof state.rotationCursor === 'number' && state.rotationCursor >= 0
+          ? (state.rotationCursor as number)
+          : 0,
+    }),
+    schema: stateSchemaV2,
+  },
+};
+
+const latestSchema = stateSchemaByVersion[2].schema;
+export type ReconcilerTaskState = TypeOf<typeof latestSchema>;
+
+export const emptyState: ReconcilerTaskState = {
+  watermarks: {},
+  consecutiveFailures: {},
+  lastFailureReason: {},
+  rotationCursor: 0,
+};

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/ubq_builder.ts
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/server/task/ubq_builder.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getSemanticFieldName } from '@kbn/core-saved-objects-base-server-internal';
+
+/**
+ * Fully-qualified shadow field name for a given type + source field.
+ * E.g. "dashboard" + "title" → "dashboard.title_semantic"
+ */
+const qualifiedShadowField = (typeName: string, field: string): string =>
+  `${typeName}.${getSemanticFieldName(field)}`;
+
+/**
+ * Builds the boolean detection query for docs that need reconciliation:
+ *   must match type
+ *   AND (any shadow field absent/null while its source is present  OR  updated_at >= watermark)
+ *
+ * Each shadow-missing clause is paired with a source-field exists gate so that docs with
+ * absent source fields (e.g. a dashboard with no description) drop out of the detection set
+ * permanently rather than matching every sweep.
+ *
+ * A null shadow value counts as "absent" for the exists filter — confirmed by R1 spike.
+ */
+export const buildDetectionQuery = (
+  typeName: string,
+  fields: readonly string[],
+  watermark: string
+): Record<string, unknown> => {
+  // Each clause: source field IS present AND shadow field IS absent/null.
+  // Docs with absent source fields are excluded — no point re-embedding them.
+  const missingShould = fields.map((field) => ({
+    bool: {
+      filter: [{ exists: { field: `${typeName}.${field}` } }],
+      must_not: [{ exists: { field: qualifiedShadowField(typeName, field) } }],
+    },
+  }));
+
+  return {
+    bool: {
+      filter: [{ term: { type: typeName } }],
+      should: [
+        // Clause 1: any shadow field absent or null
+        { bool: { should: missingShould, minimum_should_match: 1 } },
+        // Clause 2: doc touched since last successful sweep (catches stale embeddings)
+        { range: { updated_at: { gte: watermark } } },
+      ],
+      minimum_should_match: 1,
+    },
+  };
+};
+
+/**
+ * Builds the Painless script that copies source text fields into the shadow semantic fields.
+ * The script:
+ *   - Uses ctx._source.get(typeName) for null-safety
+ *   - Handles absent shadow key (adds it)
+ *   - Handles null shadow value (removes then re-adds via overwrite)
+ *   - Handles empty/missing source field (removes shadow key to clean up stale data)
+ *
+ * Variable names are prefixed with `_v` + index to avoid Painless keyword collisions.
+ * Exact approach proven in R1 spike.
+ */
+export const buildPainlessScript = (typeName: string, fields: readonly string[]): string => {
+  const shadowField = (field: string): string => getSemanticFieldName(field);
+
+  const lines: string[] = [];
+  lines.push(`def _t = ctx._source.get('${typeName}');`);
+  lines.push(`if (_t == null) { ctx.op = 'noop'; return; }`);
+  // Track whether any field actually changes so we can noop unchanged docs.
+  lines.push(`boolean _changed = false;`);
+
+  fields.forEach((field, idx) => {
+    const varName = `_v${idx}`;
+    const shadow = shadowField(field);
+    lines.push(`def ${varName} = _t.get('${field}');`);
+    lines.push(
+      `if (${varName} != null && ${varName} instanceof String && !((String)${varName}).isEmpty()) {`
+    );
+    // Source non-empty: shadow should equal source. Only write if different.
+    lines.push(
+      `  if (!${varName}.equals(_t.get('${shadow}'))) { _t['${shadow}'] = ${varName}; _changed = true; }`
+    );
+    lines.push(`} else {`);
+    // Source empty/missing: shadow should be absent. Only remove if present.
+    lines.push(`  if (_t.containsKey('${shadow}')) { _t.remove('${shadow}'); _changed = true; }`);
+    lines.push(`}`);
+  });
+
+  // If no field changed, mark this doc as a noop so ES does not bump _version.
+  lines.push(`if (!_changed) { ctx.op = 'noop'; }`);
+
+  return lines.join(' ');
+};
+
+/**
+ * Builds the complete UBQ request body (query + script) for a single type sweep.
+ */
+export const buildUbqBody = (
+  typeName: string,
+  fields: readonly string[],
+  watermark: string
+): Record<string, unknown> => ({
+  query: buildDetectionQuery(typeName, fields, watermark),
+  script: {
+    lang: 'painless',
+    source: buildPainlessScript(typeName, fields),
+  },
+});

--- a/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/tsconfig.json
+++ b/x-pack/platform/plugins/private/saved_objects_semantic_reconciler/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types"
+  },
+  "include": [
+    "server/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/core",
+    "@kbn/task-manager-plugin",
+    "@kbn/config-schema",
+    "@kbn/core-saved-objects-base-server-internal",
+    "@kbn/core-elasticsearch-server",
+    "@kbn/migrator-test-kit"
+  ],
+  "exclude": [
+    "target/**/*"
+  ]
+}

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -246,6 +246,7 @@ export default function ({ getService }: FtrProviderContext) {
         'report:execute',
         'report:execute-scheduled',
         'reporting_telemetry',
+        'savedObjectsSemanticReconciler:sweep',
         'search:agentless-connectors-manager',
         'security-solution-ea-asset-criticality-ecs-migration',
         'security:endpoint-diagnostics',


### PR DESCRIPTION
> [!NOTE]
> **This is a POC and is not intended to merge.** It exists so the design can be evaluated against working, tested code.

## Summary

A saved object type opts into semantic search with one registration option:

```ts
savedObjects.registerType({
  name: 'dashboard',
  mappings: {
    properties: {
      title: { type: 'text' },
      description: { type: 'text' },
    },
  },
  semanticSearch: {
    fields: ['title', 'description'], // source attributes, must be `text`
    // inferenceId?: optional override. Omit it to use the platform default (ELSER today).
    // embedding?: 'sync' (default) | 'deferred'
  },
});
```

and queries it through `find()`:

```ts
const { saved_objects } = await soClient.find({
  type: 'dashboard',
  semanticSearch: {
    query: 'why do my containers keep dying',
    mode: 'hybrid', // default. 'semantic' is often better for natural-language queries.
  },
});
```

The platform owns everything else: mappings, embedding generation, query DSL, namespace filtering, and backfill. Type authors never see field names like `title_semantic` or inference endpoint IDs. Attributes round-trip unchanged, API consumers never see an embedding, and types that don't opt in hit zero new code.

<details>
<summary>Terminology</summary>

| Term | What it means here |
|---|---|
| **BM25** | Lucene's standard keyword relevance scoring. This is how `find()` ranks text today. |
| **Embedding** | A numeric representation of text that lets you compare meaning rather than matching words. Generated by a model. |
| **ELSER** | Elastic Learned Sparse EncodeR, Elastic's own embedding model. It produces weighted token lists rather than dense vectors, which means it works with normal inverted-index machinery. Runs on ML nodes. |
| **`semantic_text`** | An ES field type that handles the whole embedding lifecycle: you index text, ES chunks it, calls the model, and stores the result. Querying it with a `semantic` query embeds the query text the same way. Kibana never calls the model itself. |
| **Inference endpoint** | ES-side configuration binding a model to deployment settings (allocations, chunking), referenced by ID. `.elser-2-elasticsearch` is preconfigured on modern clusters and deploys the model lazily on first use. |
| **Retriever** | ES's composable replacement for a plain `query` in a search body. A `standard` retriever wraps a query; an `rrf` retriever combines several child retrievers ("leaves"). |
| **RRF** | Reciprocal Rank Fusion. Merges multiple result lists by each document's rank position rather than by score, which is how you combine keyword and semantic results whose scores aren't comparable. |
| **`knn`** | Vector nearest-neighbor search. Not used by this PR's query builder, but relevant because callers can pass it to `search()`, which is what commit 1 fixes. |

</details>

## How it works

The short version: for each declared field, the platform adds a hidden sibling `semantic_text` field to the type's mappings (`title` gets a `title_semantic` next to it). The write path copies the field's text into that sibling, Elasticsearch generates the embedding during indexing, and reads strip the sibling back out. Queries target the sibling fields through ES retrievers.

### Registration and boot

Registration validates the declaration (fields exist and are `text`, the `_semantic` suffix is reserved, hand-written `semantic_text` mappings are rejected). During mapping assembly the platform synthesizes the shadow fields:

```
"title":          { "type": "text" }                       <- untouched, exactly as the author wrote it
"title_semantic": { "type": "semantic_text",
                    "inference_id": ".elser-2-elasticsearch" }
```

Opting in bumps the type's mappings version, so existing `.kibana` indices pick up the new fields through the normal migration path on upgrade. This is a compatible mapping addition: no reindex, and no inference runs during migration (see "Why not `copy_to`" below).

A boot-time preflight checks that the resolved inference endpoints exist. If one is missing it logs an error and semantic search degrades for that type. It never blocks boot or a migration.

### Writes

```mermaid
flowchart LR
    A[attributes] --> B[migrations]
    B --> C[schema validation]
    C --> D{embedding helper}
    D -- "sync" --> E["+ title_semantic: (copy of title)"]
    D -- "deferred" --> F[nothing added]
    E --> G[encryption]
    F --> G
    G --> H[(Elasticsearch)]
    H -- "inference runs inside the indexing call" --> H
```

In sync mode (the default) the repository copies each declared field's text into its shadow key, and ES runs inference inside the indexing call. A dashboard save on a laptop with a warm model measured about 0.5s end to end. The object is semantically searchable the moment the write returns.

In deferred mode nothing is added, so the write costs exactly what it costs today. The background reconciler embeds the document within a cycle (about a minute). Deferred objects are still immediately findable through regular `find()`; only their semantic searchability is eventually consistent. Bulk code paths can also opt out per request with `deferEmbeddings: true` on `create`/`bulkCreate` (threaded through the importer), even for sync-default types.

Partial updates re-send shadow copies for whichever declared fields the update touches. Clearing a field clears its embedding. Caller-supplied `*_semantic` keys are stripped on every write path, so callers cannot inject embedding text.

### Reads

`get`, `find`, `resolve`, and the bulk variants strip `*_semantic` keys from attributes, only for opted-in types. Everything else returns the same object references it does today.

### Queries

`find()` with `semanticSearch` swaps the usual `query` for an ES retriever:

```mermaid
flowchart TD
    subgraph hybrid ["mode: 'hybrid' (default)"]
        R[rrf retriever] --> L1["BM25 leaf<br/>(today's find query)<br/>+ namespace/type filter"]
        R --> L2["semantic leaf<br/>(semantic query on shadow fields)<br/>+ namespace/type filter"]
    end
    subgraph semantic ["mode: 'semantic'"]
        S["standard retriever<br/>semantic query on shadow fields<br/>+ namespace/type filter"]
    end
```

The namespace/type filter is duplicated into every retriever leaf. This is not stylistic: a filter at the top level of the search body does not apply to `knn` or `rrf` branches, and we verified against a multi-space index that an unfiltered leaf returns other spaces' documents with a normal 200 response. A recursive test walks the generated retriever tree and fails if any leaf (or any future unrecognized node type) is missing the filter.

`performFind` validates the new option against RRF's actual behavior on ES 9.x: `searchAfter`/PIT are rejected (ES rejects them with retrievers anyway), and paging is validated up front because ES silently returns short or empty pages past `rank_window_size` rather than erroring.

The option is server-side only. The public `/api/saved_objects/_find` route schema is unchanged; exposing ranking parameters over HTTP is a compatibility commitment to make deliberately, later.

### Background reconciler

A small x-pack plugin registers a Task Manager task that runs every minute and serves two jobs with one mechanism:

* **Backfill**: documents that existed before their type opted in.
* **Deferred pickup**: documents written with deferred embedding.

Each sweep finds documents whose shadow field is missing (or whose `updated_at` moved past the last sweep's watermark) and populates the shadow fields with a scripted, throttled `update_by_query`. ES re-runs inference on the touched fields. The script changes nothing else, and `update_by_query` does not modify `updated_at`, so a sweep can never re-trigger itself. Inference failures are counted, logged, and retried on the next cycle; they never fail the task. When no registered type opts in, the task is a no-op with zero ES calls.

## Why these choices

**Why hidden sibling fields instead of making the attribute itself `semantic_text`?** Attributes stay byte-identical through every read path and every ES version, the serializer core is untouched, and a future model swap becomes "add a new sibling field, re-embed, cut over" with no change to attribute schemas or consumers.

**Why does the write path copy text instead of using `copy_to` in the mapping?** `copy_to` is a mapping directive that tells ES to duplicate a field's value into another field at index time, which would mean zero write-path code in Kibana. That was our starting preference. We measured both approaches against a real ES before writing any Kibana code, and `copy_to` failed three ways:

1. Bulk-installing 10k detection-rule-sized documents through ELSER took 17 minutes versus 1.2 seconds without inference. `copy_to` is unconditional, so bulk installers would have no way out. Writer-controlled population gives them `deferEmbeddings`.
2. With `copy_to`, the migration that adds the fields re-runs inference for every existing document during upgrade, and a single document-level inference failure makes the migrator throw. That puts ML capacity on the boot path, which we consider a hard no.
3. When inference is unavailable, the only way ES lets a write succeed is to omit the `semantic_text` value entirely. Only the writer can choose to omit it.

**Why a single inference-ID resolver?** Every subsystem asks one function which endpoint a type uses. "A better model came along" becomes a config change and a background re-embed instead of a cross-codebase migration. Type authors can override per type, but the default is deliberately the platform's choice.

## Does it actually improve search?

<details>
<summary>Relevance measurements (labeled corpus + live demo)</summary>

**What the baseline is, and what it isn't.** The comparison is against `find()`'s keyword ranking, because that is the ranking saved object consumers get today and the thing this PR changes. `search()` is not a useful comparison point: it passes caller-supplied DSL straight through to ES, so its relevance is whatever query the caller wrote rather than behavior the platform provides. The baseline below reproduces the shape `find()` emits, a `simple_query_string` over per-type-prefixed fields, with one boost choice (`title^2 description`). Someone hand-tuning DSL through `search()` could beat it. Read these numbers as "default keyword search versus semantic," not "the best achievable keyword search versus semantic."

**Corpus.** 150 documents with dashboard and rule style titles and descriptions across 8 topic clusters, 15 queries with hand-labeled relevant sets, split into keyword queries (the search terms appear verbatim), paraphrases (same meaning, different words), and vague queries. All three strategies ran with identical namespace filters.

**Metrics.** MRR is mean reciprocal rank: 1.0 if the first relevant document ranks first, 0.5 if second, and so on, averaged over queries. recall@10 is the fraction of all known-relevant documents that appear in the top 10.

| Strategy | MRR | recall@10 |
|---|---|---|
| Keyword / BM25 (today's `find()`) | 0.637 | 0.462 |
| Hybrid (RRF over both) | 0.699 | |
| Semantic only (ELSER) | **0.810** | **0.695** |

All three tie on keyword queries, which is the expected and reassuring result. Semantic pulls ahead on paraphrases and dominates on vague queries. It also beats hybrid overall, because on vague queries BM25 contributes high-ranking documents that merely share tokens, and RRF fuses that noise into the final list. Hybrid stays the default because it degrades more gracefully at scale and on exact-term searches, but the documentation points natural-language use cases at `mode: 'semantic'`.

Live check with the dashboard type opted in on a dev stack, using queries that share no keywords with their targets:

* "why do my containers keep dying" found **Kubernetes Pod Restart Investigation**
* "someone is trying to break into accounts" found **Failed Login Attempts Overview**
* "how much money did we make this quarter" found **Quarterly Revenue Breakdown**

The reconciler backfilled every pre-existing dashboard (including Kibana-managed ones) within one cycle, without touching `updated_at`.

</details>

## Known limitations

* The mappings-version bump for opted-in types is synthetic (+1 over the type's latest model version). If the author later adds a real model version, documents stamped with the synthetic number would skip that version's transform. A GA implementation needs to pin these versions; the constraint is documented in `version_map.ts`.
* Everything empirical was measured on ES 9.6 snapshot, single node, stateful with ML. Serverless, minimum-supported ES, and 100k-document scale are extrapolated.
* Pre-computed embeddings (embedding prebuilt content at package build time and skipping inference at install) were proven viable and are the right answer for large prebuilt packages, but are not implemented here. The repository has a reserved extension interface as the seam.
* A reindex-style migration round-trips documents through the serializer, which drops shadow values; the reconciler re-embeds afterward.
* In hybrid mode, KQL `filter`/`hasReference` apply to the BM25 leaf only (documented on the option).
* `search()` does not strip shadow fields. It returns raw ES hits, so a caller querying an opted-in type sees `dashboard.title_semantic` (the copied source text) in `_source`, unlike every other read path. The embeddings themselves live in `_inference_fields` rather than `_source`, so nothing large is exposed, but the inconsistency should be resolved before GA: either strip there too or document it as expected for a raw-document API.
