### PR TITLE
[Agent Builder] Image upload: shared types and Files plugin wiring

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -178,6 +178,11 @@ export interface AttachmentUIDefinition<TAttachment extends UnknownAttachment = 
    */
   getIcon?: () => IconType;
   /**
+   * Returns a URL (or data URL) to use as a thumbnail image in the attachment pill.
+   * When provided, renders an <img> instead of an EuiIcon in the pill icon slot.
+   */
+  getPillThumbnail?: (attachment: TAttachment) => string | undefined;
+  /**
    * Returns header metadata (icon, subtitle, badges) for the attachment header
    * (inline / canvas). Omitted fields fall back to their defaults (no icon, no
    * subtitle, no badges).

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
@@ -17,6 +17,7 @@ export enum AttachmentType {
   text = 'text',
   esql = 'esql',
   connector = 'connector',
+  image = 'image',
 }
 
 interface AttachmentDataMap {
@@ -24,6 +25,7 @@ interface AttachmentDataMap {
   [AttachmentType.text]: TextAttachmentData;
   [AttachmentType.screenContext]: ScreenContextAttachmentData;
   [AttachmentType.connector]: ConnectorAttachmentData;
+  [AttachmentType.image]: ImageAttachmentData;
 }
 
 export const esqlAttachmentDataSchema = z.object({
@@ -124,3 +126,29 @@ export interface ConnectorAttachmentData {
 }
 
 export type AttachmentDataOf<Type extends AttachmentType> = AttachmentDataMap[Type];
+
+export const SUPPORTED_IMAGE_MIME_TYPES = ['image/png', 'image/jpeg'] as const;
+export type SupportedImageMimeType = (typeof SUPPORTED_IMAGE_MIME_TYPES)[number];
+
+export const AGENT_BUILDER_IMAGE_FILE_KIND = 'agentBuilderImages';
+
+export const imageAttachmentDataSchema = z.object({
+  file_id: z.string().optional(),
+  name: z.string(),
+  mime_type: z.string(),
+  content: z.string().optional(),
+});
+
+/**
+ * Data for an image attachment.
+ */
+export interface ImageAttachmentData {
+  /** files plugin file id */
+  file_id?: string;
+  /** original filename */
+  name: string;
+  /** mime type of the image */
+  mime_type: string;
+  /** base64 payload for API consumers; server uploads to files plugin and strips this before persistence */
+  content?: string;
+}

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
@@ -27,13 +27,18 @@ export {
   esqlAttachmentDataSchema,
   screenContextAttachmentDataSchema,
   connectorAttachmentDataSchema,
+  imageAttachmentDataSchema,
   CONNECTOR_TAG_PREFIX,
+  SUPPORTED_IMAGE_MIME_TYPES,
+  AGENT_BUILDER_IMAGE_FILE_KIND,
   type TextAttachmentData,
   type ScreenContextAttachmentData,
   type TimeRange,
   screenContextTimeRangeSchema,
   type EsqlAttachmentData,
   type ConnectorAttachmentData,
+  type ImageAttachmentData,
+  type SupportedImageMimeType,
 } from './attachment_types';
 
 export type {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/tool_result.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/tool_result.ts
@@ -18,6 +18,7 @@ export enum ToolResultType {
   other = 'other',
   error = 'error',
   fileReference = 'file_reference',
+  image = 'image',
 }
 
 interface ToolResultTypeDataMap {
@@ -30,6 +31,7 @@ interface ToolResultTypeDataMap {
   [ToolResultType.error]: ErrorResultData;
   [ToolResultType.fileReference]: FileReferenceResultData;
   [ToolResultType.other]: OtherResultData;
+  [ToolResultType.image]: ImageResultData;
 }
 
 export type ToolResultDataOf<Type extends ToolResultType> = ToolResultTypeDataMap[Type];
@@ -206,4 +208,19 @@ export const isFileReferenceResult = (result: ToolResult): result is FileReferen
 
 export const isVisualizationResult = (result: ToolResult): result is VisualizationResult => {
   return result.type === ToolResultType.visualization;
+};
+
+// image
+
+export interface ImageResultData {
+  attachment_id: string;
+  mime_type: string;
+  name?: string;
+  description: string;
+}
+
+export type ImageResult = ToolResultMixin<ToolResultType.image>;
+
+export const isImageResult = (result: ToolResult): result is ImageResult => {
+  return result.type === ToolResultType.image;
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -267,6 +267,7 @@ export const AGENT_BUILDER_BUILTIN_ATTACHMENTS = [
   'connector',
   'connector_setup',
   'skill',
+  'image',
 
   // Platform – Visualizations
   'visualization',

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/index.ts
@@ -9,6 +9,7 @@ export type {
   AttachmentTypeDefinition,
   AttachmentRepresentation,
   TextAttachmentRepresentation,
+  ImageAttachmentRepresentation,
   AttachmentValidationResult,
   AgentFormattedAttachment,
   AttachmentFormatContext,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/type_definition.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/type_definition.ts
@@ -122,11 +122,18 @@ export interface TextAttachmentRepresentation {
 }
 
 /**
- * Representation of an attachment when exposed to the LLM.
- *
- * Only plain text (inlined into the message) is supported for now.
+ * Image representation of an attachment when exposed to the LLM.
  */
-export type AttachmentRepresentation = TextAttachmentRepresentation;
+export interface ImageAttachmentRepresentation {
+  type: 'image';
+  mimeType: string;
+  getBase64: () => MaybePromise<string>;
+}
+
+/**
+ * Representation of an attachment when exposed to the LLM.
+ */
+export type AttachmentRepresentation = TextAttachmentRepresentation | ImageAttachmentRepresentation;
 
 /**
  * Structure containing all methods which will be used to present the attachment to the agent.

--- a/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
@@ -36,7 +36,8 @@
       "unifiedSearch",
       "esUiShared",
       "workflowsExtensions",
-      "searchInferenceEndpoints"
+      "searchInferenceEndpoints",
+      "files"
     ],
     "requiredBundles": [
       "kibanaReact",

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -13,7 +13,11 @@ import {
   type AppUpdater,
 } from '@kbn/core/public';
 import type { Logger } from '@kbn/logging';
-import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
+import {
+  AGENT_BUILDER_IMAGE_FILE_KIND,
+  SUPPORTED_IMAGE_MIME_TYPES,
+  type AttachmentInput,
+} from '@kbn/agent-builder-common/attachments';
 import { BehaviorSubject, distinctUntilChanged, type Subscription } from 'rxjs';
 import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
 import React from 'react';
@@ -112,6 +116,13 @@ export class AgentBuilderPlugin
     this.setupServices = { navigationService, usageCollection: deps.usageCollection };
     this.isEarsEnabled = deps.actions.isEarsEnabled;
     this.isEarsExperimentalEnabled = deps.actions.isEarsExperimentalEnabled;
+
+    const MAX_IMAGE_BYTES = 2 * 1024 * 1024;
+    deps.files.registerFileKind({
+      id: AGENT_BUILDER_IMAGE_FILE_KIND,
+      allowedMimeTypes: [...SUPPORTED_IMAGE_MIME_TYPES],
+      maxSizeBytes: MAX_IMAGE_BYTES,
+    });
 
     registerApp({
       core,

--- a/x-pack/platform/plugins/shared/agent_builder/public/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/types.ts
@@ -30,6 +30,10 @@ import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import type { EvalsPublicStart } from '@kbn/evals-plugin/public';
 import type { CPSPluginStart } from '@kbn/cps/public';
+import type {
+  FilesSetup as FilesPublicSetup,
+  FilesStart as FilesPublicStart,
+} from '@kbn/files-plugin/public';
 
 export type {
   AgentBuilderPluginSetup,
@@ -47,6 +51,7 @@ export interface ConfigSchema {}
 
 export interface AgentBuilderSetupDependencies {
   actions: ActionsPublicPluginSetup;
+  files: FilesPublicSetup;
   lens: LensPublicSetup;
   dataViews: DataViewsPublicPluginSetup;
   licenseManagement?: LicenseManagementUIPluginSetup;
@@ -59,6 +64,7 @@ export interface AgentBuilderSetupDependencies {
 
 export interface AgentBuilderStartDependencies {
   aiAssistantManagementSelection: AIAssistantManagementSelectionPluginPublicStart;
+  files: FilesPublicStart;
   evals?: EvalsPublicStart;
   inference: InferencePublicStart;
   lens: LensPublicStart;

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -9,6 +9,10 @@ import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kb
 import type { Logger } from '@kbn/logging';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type { HomeServerPluginSetup } from '@kbn/home-plugin/server';
+import {
+  AGENT_BUILDER_IMAGE_FILE_KIND,
+  SUPPORTED_IMAGE_MIME_TYPES,
+} from '@kbn/agent-builder-common/attachments';
 import type { AgentBuilderConfig } from './config';
 import { registerTracingExporter } from './tracing/register_tracing';
 import { ServiceManager } from './services';
@@ -37,6 +41,8 @@ import { createSmlTools } from './services/tools/builtin/sml';
 import { createConnectorTools } from './services/tools/builtin/connectors';
 import { createAdminPrivilegeSwitcher } from './capabilities/admin_privilege_switcher';
 import { registerInferenceFeatures } from './inference_features';
+
+const MAX_IMAGE_BYTES = 2 * 1024 * 1024;
 
 export class AgentBuilderPlugin
   implements
@@ -67,6 +73,20 @@ export class AgentBuilderPlugin
     setupDeps: AgentBuilderSetupDependencies
   ): AgentBuilderPluginSetup {
     this.home = setupDeps.home;
+
+    setupDeps.files.registerFileKind({
+      id: AGENT_BUILDER_IMAGE_FILE_KIND,
+      allowedMimeTypes: [...SUPPORTED_IMAGE_MIME_TYPES],
+      maxSizeBytes: MAX_IMAGE_BYTES,
+      http: {
+        create: { requiredPrivileges: ['agentBuilder'] },
+        download: { requiredPrivileges: ['agentBuilder'] },
+        getById: { requiredPrivileges: ['agentBuilder'] },
+        list: { requiredPrivileges: ['agentBuilder'] },
+        delete: { requiredPrivileges: ['agentBuilder'] },
+      },
+    });
+
     // Create usage counter for telemetry (if usageCollection is available)
     if (setupDeps.usageCollection) {
       this.usageCounter = createAgentBuilderUsageCounter(setupDeps.usageCollection);

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -32,6 +32,7 @@ import type {
   AgentBuilderSmlPluginSetup,
   AgentBuilderSmlPluginStart,
 } from '@kbn/agent-builder-sml-plugin/server';
+import type { FilesSetup, FilesStart } from '@kbn/files-plugin/server';
 
 export type {
   AgentBuilderPluginSetup,
@@ -66,6 +67,7 @@ export interface AgentBuilderSetupDependencies {
   home: HomeServerPluginSetup;
   searchInferenceEndpoints: SearchInferenceEndpointsPluginSetup;
   agentBuilderSml: AgentBuilderSmlPluginSetup;
+  files: FilesSetup;
 }
 
 export interface AgentBuilderStartDependencies {
@@ -79,4 +81,5 @@ export interface AgentBuilderStartDependencies {
   security?: SecurityPluginStart;
   searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
   agentBuilderSml: AgentBuilderSmlPluginStart;
+  files: FilesStart;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
@@ -143,5 +143,7 @@
     "@kbn/embeddable-plugin",
     "@kbn/storybook",
     "@kbn/context-engine-plugin",
+    "@kbn/files-plugin",
+    "@kbn/shared-ux-file-types",
   ]
 }

--- a/x-pack/platform/plugins/shared/agent_builder_platform/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/kibana.jsonc
@@ -13,6 +13,7 @@
       "actions",
       "agentBuilder",
       "agentBuilderSml",
+      "files",
       "share",
       "triggersActionsUi"
     ],

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/types.ts
@@ -16,11 +16,13 @@ import type {
 } from '@kbn/actions-plugin/server';
 import type { LlmTasksPluginStart } from '@kbn/llm-tasks-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { FilesSetup, FilesStart } from '@kbn/files-plugin/server';
 
 export interface PluginSetupDependencies {
   agentBuilder: AgentBuilderPluginSetup;
   agentBuilderSml: AgentBuilderSmlPluginSetup;
   actions: ActionsPluginSetup;
+  files: FilesSetup;
 }
 
 export interface PluginStartDependencies {
@@ -29,6 +31,7 @@ export interface PluginStartDependencies {
   actions: ActionsPluginStart;
   llmTasks?: LlmTasksPluginStart;
   spaces?: SpacesPluginStart;
+  files: FilesStart;
 }
 
 export interface AgentBuilderPlatformTracingFeaturesStart {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
@@ -36,5 +36,6 @@
     "@kbn/logging-mocks",
     "@kbn/triggers-actions-ui-plugin",
     "@kbn/agent-builder-plugin",
+    "@kbn/files-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

Foundation for the image upload feature. Adds the shared types and wires the Files plugin into both Agent Builder plugins. No runtime consumers yet — the server-side attachment pipeline and UI land in follow-up PRs on the same integration branch.

## What's in

- `AttachmentType.image` + `ImageAttachmentData` (+ schema, `AGENT_BUILDER_IMAGE_FILE_KIND`, `SUPPORTED_IMAGE_MIME_TYPES`)
- `ToolResultType.image` marker + `ImageResultData` + `isImageResult` guard
- `ImageAttachmentRepresentation` widens `AttachmentRepresentation` union
- `getPillThumbnail` on `AttachmentUIDefinition`
- `'image'` in `AGENT_BUILDER_BUILTIN_ATTACHMENTS`
- Files plugin dependency in `agent_builder` (server + browser) and `agent_builder_platform` (server)
- `agentBuilderImages` `FileKind` registered on both server and browser sides of `agent_builder`

## What's out (follow-ups)

- Server-side attachment pipeline (`createImageAttachmentType`, `attachment_read` image marker, lazy `getBase64` from Files plugin)
- UI (paste handler, thumbnail pills, upload progress, storybook)
- LLM vision delivery (`injectImageMessages` in prompt builder)

## Acceptance criteria

- [x] `AttachmentType.image` and `ImageAttachmentData` types are defined and exported
- [x] `ToolResultType.image` marker exists
- [x] `getPillThumbnail` contract is defined
- [x] Files plugin is wired into both plugins

## Test plan

- [ ] `node scripts/type_check --project x-pack/platform/plugins/shared/agent_builder/tsconfig.json`
- [ ] `node scripts/type_check --project x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json`
- [ ] `node scripts/check --scope branch`
- [ ] Kibana boots with the new `agentBuilderImages` `FileKind` registered (no runtime errors on startup)

Closes elastic/kibana#284686