### PR TITLE
[Fleet] Fix custom ILM policy removal on disabling integration policy namespace index templates

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/apply_ilm_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/apply_ilm_policy.test.ts
@@ -44,7 +44,8 @@ describe('applyIlmPolicyChange', () => {
       'my-policy',
       buildPackageInfo(),
       notifications as any,
-      'Nginx'
+      'Nginx',
+      true
     );
     expect(mockSendUpdatePackage).not.toHaveBeenCalled();
   });
@@ -58,7 +59,8 @@ describe('applyIlmPolicyChange', () => {
       'my-policy',
       buildPackageInfo('my-policy'),
       notifications as any,
-      'Nginx'
+      'Nginx',
+      true
     );
     expect(mockSendUpdatePackage).not.toHaveBeenCalled();
   });
@@ -72,7 +74,8 @@ describe('applyIlmPolicyChange', () => {
       'new-policy',
       buildPackageInfo('old-policy'),
       notifications as any,
-      'Nginx'
+      'Nginx',
+      true
     );
     expect(mockSendUpdatePackage).toHaveBeenCalledWith('nginx', '1.0.0', {
       namespace_customization_settings: { production: { ilm_policy: 'new-policy' } },
@@ -80,7 +83,7 @@ describe('applyIlmPolicyChange', () => {
     expect(notifications.toasts.addSuccess).toHaveBeenCalled();
   });
 
-  it('sends an empty settings object to clear the policy', async () => {
+  it('sends an empty settings object to clear the policy when namespace customization remains enabled', async () => {
     const notifications = buildNotifications();
     await applyIlmPolicyChange(
       'nginx',
@@ -89,11 +92,27 @@ describe('applyIlmPolicyChange', () => {
       undefined,
       buildPackageInfo('old-policy'),
       notifications as any,
-      'Nginx'
+      'Nginx',
+      true
     );
     expect(mockSendUpdatePackage).toHaveBeenCalledWith('nginx', '1.0.0', {
       namespace_customization_settings: { production: {} },
     });
+  });
+
+  it('is a no-op when namespace customization is disabled (server handles ILM cleanup on opt-out)', async () => {
+    const notifications = buildNotifications();
+    await applyIlmPolicyChange(
+      'nginx',
+      '1.0.0',
+      'production',
+      undefined,
+      buildPackageInfo('old-policy'),
+      notifications as any,
+      'Nginx',
+      false
+    );
+    expect(mockSendUpdatePackage).not.toHaveBeenCalled();
   });
 
   it('shows an error toast when sendUpdatePackage fails', async () => {
@@ -106,7 +125,8 @@ describe('applyIlmPolicyChange', () => {
       'new-policy',
       buildPackageInfo(),
       notifications as any,
-      'Nginx'
+      'Nginx',
+      true
     );
     expect(notifications.toasts.addError).toHaveBeenCalled();
     expect(notifications.toasts.addSuccess).not.toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/apply_ilm_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/apply_ilm_policy.ts
@@ -18,10 +18,18 @@ export async function applyIlmPolicyChange(
   ilmPolicy: string | undefined,
   packageInfo: PackageInfo,
   notifications: NotificationsStart,
-  packageTitle: string
+  packageTitle: string,
+  namespaceCustomizationEnabled: boolean
 ): Promise<void> {
   const trimmed = namespace?.trim();
   if (!trimmed) {
+    return;
+  }
+
+  // When namespace customization is being disabled, the server automatically clears the ILM
+  // policy for opted-out namespaces as part of the opt-out call. Sending a separate ILM
+  // settings request would fail because the namespace is no longer in the opt-in list.
+  if (!namespaceCustomizationEnabled) {
     return;
   }
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -358,7 +358,8 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
         selectedIlmPolicy,
         packageInfo,
         notifications,
-        packageInfo.title ?? packageInfo.name
+        packageInfo.title ?? packageInfo.name,
+        wasEnabled
       );
     })();
   }, [savedPackagePolicy, packageInfo, installedNamespaceCustomizationEnabledFor, notifications]);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -401,7 +401,8 @@ export const EditPackagePolicyForm = memo<{
           ilmPolicyRef.current,
           packageInfo,
           notifications,
-          packageInfo.title ?? packageInfo.name
+          packageInfo.title ?? packageInfo.name,
+          namespaceCustomizationEnabledRef.current
         );
       }
       setIsEdited(false);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/280422

This PR fixes a bug where disabling namespace index templates for a package policy with a custom ILM policy assigned caused an error "Could not update ILM policy for [integration]" / "Cannot set ILM policy for namespace(s) not opted in for namespace customization: [namespace]"

Origin of the bug:
1. `applyNamespaceCustomizationChange` removes the namespace from the opt-in list, the server automatically clears the ILM policy as a side-effect.
2. `applyIlmPolicyChange` is then called with `ilmPolicy=undefined` (UI reset the picker). The no-op check doesn't catch it because `existingIlmPolicy` is not `undefined`.
3. The server rejects `namespace_customization_settings: {"test": {}}` because "test" is no longer opted in.

This fix adds a `namespaceCustomizationEnabled: boolean` parameter to `applyIlmPolicyChange` and returns early when it's `false`. The two callers (edit page and create page) pass their respective enabled state.

### Testing

1. Create a package policy with a namespace, namespace index templates enabled, and assign it a custom ILM policy. Save.
2. Edit the package policy and disable namespace index templates: check that the dropdown to select a custom ILM policy resets to None.
3. Save: there should be no errors and the policy should have been saved with disabled namespace index templates and no custom ILM policy assigned.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low: the new guard only skips the `applyIlmPolicyChange` call when `namespaceCustomizationEnabled` is `false`. In that state, the server was already rejecting the call.

## Release note

Fixes a bug where disabling namespace index templates for a package policy with a custom ILM policy assigned caused an error "Could not update ILM policy for [integration]".

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->