### PR TITLE
[Custom content] Listens to filters, query, approximation and project routing

### DIFF
--- a/x-pack/platform/plugins/shared/custom_content/moon.yml
+++ b/x-pack/platform/plugins/shared/custom_content/moon.yml
@@ -47,6 +47,7 @@ dependsOn:
   - '@kbn/core-http-server'
   - '@kbn/ui-callout'
   - '@kbn/shared-ux-ai-components'
+  - '@kbn/data-views-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/custom_content/public/components/custom_content_component.tsx
+++ b/x-pack/platform/plugins/shared/custom_content/public/components/custom_content_component.tsx
@@ -19,6 +19,7 @@ interface CustomContentComponentProps {
   timeRange: TimeRange | undefined;
   generationVersion: number;
   savedTemplate: string | undefined;
+  isApproximate: boolean;
   onTemplateChange: (template: string) => void;
   onErrorChange?: (error: string | undefined) => void;
 }
@@ -45,6 +46,7 @@ export const CustomContentComponent = ({
   timeRange,
   generationVersion,
   savedTemplate,
+  isApproximate,
   onTemplateChange,
   onErrorChange,
 }: CustomContentComponentProps) => {
@@ -57,6 +59,7 @@ export const CustomContentComponent = ({
     generationVersion,
     savedTemplate,
     colorMode,
+    isApproximate,
     onTemplateChange,
   });
 

--- a/x-pack/platform/plugins/shared/custom_content/public/components/custom_content_component.tsx
+++ b/x-pack/platform/plugins/shared/custom_content/public/components/custom_content_component.tsx
@@ -8,7 +8,7 @@
 import { EuiCallOut, EuiEmptyPrompt, EuiProgress, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import type { TimeRange, ProjectRouting } from '@kbn/es-query';
+import type { AggregateQuery, Filter, Query, TimeRange, ProjectRouting } from '@kbn/es-query';
 import React, { useEffect, useMemo } from 'react';
 import { useCustomContentHtml } from '../hooks/use_custom_content_html';
 
@@ -21,6 +21,8 @@ interface CustomContentComponentProps {
   savedTemplate: string | undefined;
   isApproximate: boolean;
   projectRouting: ProjectRouting | undefined;
+  query: Query | AggregateQuery | undefined;
+  filters: Filter[] | undefined;
   onTemplateChange: (template: string) => void;
   onErrorChange?: (error: string | undefined) => void;
 }
@@ -49,6 +51,8 @@ export const CustomContentComponent = ({
   savedTemplate,
   isApproximate,
   projectRouting,
+  query,
+  filters,
   onTemplateChange,
   onErrorChange,
 }: CustomContentComponentProps) => {
@@ -63,6 +67,8 @@ export const CustomContentComponent = ({
     colorMode,
     isApproximate,
     projectRouting,
+    query,
+    filters,
     onTemplateChange,
   });
 

--- a/x-pack/platform/plugins/shared/custom_content/public/components/custom_content_component.tsx
+++ b/x-pack/platform/plugins/shared/custom_content/public/components/custom_content_component.tsx
@@ -8,7 +8,7 @@
 import { EuiCallOut, EuiEmptyPrompt, EuiProgress, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import type { TimeRange } from '@kbn/es-query';
+import type { TimeRange, ProjectRouting } from '@kbn/es-query';
 import React, { useEffect, useMemo } from 'react';
 import { useCustomContentHtml } from '../hooks/use_custom_content_html';
 
@@ -20,6 +20,7 @@ interface CustomContentComponentProps {
   generationVersion: number;
   savedTemplate: string | undefined;
   isApproximate: boolean;
+  projectRouting: ProjectRouting | undefined;
   onTemplateChange: (template: string) => void;
   onErrorChange?: (error: string | undefined) => void;
 }
@@ -47,6 +48,7 @@ export const CustomContentComponent = ({
   generationVersion,
   savedTemplate,
   isApproximate,
+  projectRouting,
   onTemplateChange,
   onErrorChange,
 }: CustomContentComponentProps) => {
@@ -60,6 +62,7 @@ export const CustomContentComponent = ({
     savedTemplate,
     colorMode,
     isApproximate,
+    projectRouting,
     onTemplateChange,
   });
 

--- a/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
@@ -24,7 +24,7 @@ import {
   fetch$,
 } from '@kbn/presentation-publishing';
 import { i18n } from '@kbn/i18n';
-import type { TimeRange } from '@kbn/es-query';
+import type { TimeRange, ProjectRouting } from '@kbn/es-query';
 import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { BehaviorSubject, distinctUntilChanged, EMPTY, map, merge, skip, switchMap } from 'rxjs';
 import { isRoundCompleteEvent } from '@kbn/agent-builder-common';
@@ -63,6 +63,7 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
     const isFlyoutOpen$ = new BehaviorSubject<boolean>(false);
     const usesEsql$ = new BehaviorSubject<boolean>(Boolean(initialState.esqlQuery));
     const isApproximate$ = new BehaviorSubject<boolean>(false);
+    const projectRouting$ = new BehaviorSubject<ProjectRouting | undefined>(undefined);
 
     const serializeState = (): CustomContentEmbeddableState => ({
       ...titleManager.getLatestState(),
@@ -128,25 +129,31 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
       .pipe(map(Boolean), distinctUntilChanged())
       .subscribe((usesEsql) => usesEsql$.next(usesEsql));
 
-    const approximateSubscription = fetch$(api)
-      .pipe(
-        map(({ isApproximate }) => isApproximate),
-        distinctUntilChanged()
-      )
-      .subscribe((isApproximate) => isApproximate$.next(isApproximate));
+    const fetchSubscription = fetch$(api).subscribe(({ isApproximate, projectRouting }) => {
+      isApproximate$.next(isApproximate);
+      projectRouting$.next(projectRouting);
+    });
 
     return {
       api,
       Component: function CustomContentEmbeddableComponent() {
-        const [prompt, esqlQuery, savedTemplate, isFlyoutOpen, panelTitle, isApproximate] =
-          useBatchedPublishingSubjects(
-            prompt$,
-            esqlQuery$,
-            template$,
-            isFlyoutOpen$,
-            titleManager.api.title$,
-            isApproximate$
-          );
+        const [
+          prompt,
+          esqlQuery,
+          savedTemplate,
+          isFlyoutOpen,
+          panelTitle,
+          isApproximate,
+          projectRouting,
+        ] = useBatchedPublishingSubjects(
+          prompt$,
+          esqlQuery$,
+          template$,
+          isFlyoutOpen$,
+          titleManager.api.title$,
+          isApproximate$,
+          projectRouting$
+        );
         const [generationVersion, setGenerationVersion] = useState(0);
         const [timeRange, setTimeRange] = useState<TimeRange | undefined>(
           apiPublishesTimeRange(parentApi)
@@ -157,7 +164,7 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
         useEffect(() => {
           return () => {
             esqlUsageSubscription.unsubscribe();
-            approximateSubscription.unsubscribe();
+            fetchSubscription.unsubscribe();
           };
         }, []);
 
@@ -239,6 +246,7 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
               generationVersion={generationVersion}
               savedTemplate={savedTemplate}
               isApproximate={isApproximate}
+              projectRouting={projectRouting}
               onTemplateChange={onTemplateChange}
             />
             {isFlyoutOpen && (

--- a/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
@@ -9,7 +9,11 @@ import type {
   DefaultEmbeddableApi,
   EmbeddablePublicDefinition,
 } from '@kbn/embeddable-plugin/public';
-import type { HasTypeDisplayName, HasEditCapabilities } from '@kbn/presentation-publishing';
+import type {
+  HasTypeDisplayName,
+  HasEditCapabilities,
+  PublishesEsqlUsage,
+} from '@kbn/presentation-publishing';
 import {
   initializeTitleManager,
   titleComparators,
@@ -17,11 +21,12 @@ import {
   useBatchedPublishingSubjects,
   apiPublishesReload,
   apiPublishesTimeRange,
+  fetch$,
 } from '@kbn/presentation-publishing';
 import { i18n } from '@kbn/i18n';
 import type { TimeRange } from '@kbn/es-query';
 import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react';
-import { BehaviorSubject, EMPTY, map, merge, skip, switchMap } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, EMPTY, map, merge, skip, switchMap } from 'rxjs';
 import { isRoundCompleteEvent } from '@kbn/agent-builder-common';
 import { ATTACHMENT_REF_ACTOR } from '@kbn/agent-builder-common/attachments';
 import { getLatestVersion } from '@kbn/agent-builder-common/attachments';
@@ -42,7 +47,8 @@ const EditCustomContentFlyout = lazy(() =>
 
 export type CustomContentApi = DefaultEmbeddableApi<CustomContentEmbeddableState> &
   HasTypeDisplayName &
-  HasEditCapabilities;
+  HasEditCapabilities &
+  PublishesEsqlUsage;
 
 export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
   CustomContentEmbeddableState,
@@ -55,6 +61,8 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
     const esqlQuery$ = new BehaviorSubject<string | undefined>(initialState.esqlQuery);
     const template$ = new BehaviorSubject<string | undefined>(initialState.template);
     const isFlyoutOpen$ = new BehaviorSubject<boolean>(false);
+    const usesEsql$ = new BehaviorSubject<boolean>(Boolean(initialState.esqlQuery));
+    const isApproximate$ = new BehaviorSubject<boolean>(false);
 
     const serializeState = (): CustomContentEmbeddableState => ({
       ...titleManager.getLatestState(),
@@ -105,6 +113,7 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
       ...stateApi,
       ...titleManager.api,
       serializeState,
+      usesEsql$,
       getTypeDisplayName: () =>
         i18n.translate('xpack.customContent.embeddable.typeDisplayName', {
           defaultMessage: 'Custom content',
@@ -115,16 +124,28 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
       isEditingEnabled: () => true,
     });
 
+    const esqlUsageSubscription = esqlQuery$
+      .pipe(map(Boolean), distinctUntilChanged())
+      .subscribe((usesEsql) => usesEsql$.next(usesEsql));
+
+    const approximateSubscription = fetch$(api)
+      .pipe(
+        map(({ isApproximate }) => isApproximate),
+        distinctUntilChanged()
+      )
+      .subscribe((isApproximate) => isApproximate$.next(isApproximate));
+
     return {
       api,
       Component: function CustomContentEmbeddableComponent() {
-        const [prompt, esqlQuery, savedTemplate, isFlyoutOpen, panelTitle] =
+        const [prompt, esqlQuery, savedTemplate, isFlyoutOpen, panelTitle, isApproximate] =
           useBatchedPublishingSubjects(
             prompt$,
             esqlQuery$,
             template$,
             isFlyoutOpen$,
-            titleManager.api.title$
+            titleManager.api.title$,
+            isApproximate$
           );
         const [generationVersion, setGenerationVersion] = useState(0);
         const [timeRange, setTimeRange] = useState<TimeRange | undefined>(
@@ -132,6 +153,13 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
             ? parentApi.timeRange$.getValue() ?? undefined
             : undefined
         );
+
+        useEffect(() => {
+          return () => {
+            esqlUsageSubscription.unsubscribe();
+            approximateSubscription.unsubscribe();
+          };
+        }, []);
 
         useEffect(() => {
           if (!apiPublishesReload(parentApi)) return;
@@ -210,6 +238,7 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
               timeRange={timeRange}
               generationVersion={generationVersion}
               savedTemplate={savedTemplate}
+              isApproximate={isApproximate}
               onTemplateChange={onTemplateChange}
             />
             {isFlyoutOpen && (

--- a/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
@@ -12,6 +12,7 @@ import type {
 import type {
   HasTypeDisplayName,
   HasEditCapabilities,
+  PublishesDataViews,
   PublishesEsqlUsage,
 } from '@kbn/presentation-publishing';
 import {
@@ -26,11 +27,24 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { AggregateQuery, Filter, Query, TimeRange, ProjectRouting } from '@kbn/es-query';
 import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react';
-import { BehaviorSubject, distinctUntilChanged, EMPTY, map, merge, skip, switchMap } from 'rxjs';
+import {
+  BehaviorSubject,
+  catchError,
+  distinctUntilChanged,
+  EMPTY,
+  from,
+  map,
+  merge,
+  of,
+  skip,
+  switchMap,
+} from 'rxjs';
 import { isRoundCompleteEvent } from '@kbn/agent-builder-common';
 import { ATTACHMENT_REF_ACTOR } from '@kbn/agent-builder-common/attachments';
 import { getLatestVersion } from '@kbn/agent-builder-common/attachments';
 import { CUSTOM_CONTENT_EMBEDDABLE_TYPE } from '@kbn/custom-content-common';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { getESQLAdHocDataview } from '@kbn/esql-utils';
 import { getServices } from './services';
 import {
   CUSTOM_CONTENT_CONTEXT_ATTACHMENT_TYPE,
@@ -48,6 +62,7 @@ const EditCustomContentFlyout = lazy(() =>
 export type CustomContentApi = DefaultEmbeddableApi<CustomContentEmbeddableState> &
   HasTypeDisplayName &
   HasEditCapabilities &
+  PublishesDataViews &
   PublishesEsqlUsage;
 
 export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
@@ -66,6 +81,7 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
     const projectRouting$ = new BehaviorSubject<ProjectRouting | undefined>(undefined);
     const query$ = new BehaviorSubject<Query | AggregateQuery | undefined>(undefined);
     const filters$ = new BehaviorSubject<Filter[] | undefined>(undefined);
+    const dataViews$ = new BehaviorSubject<DataView[] | undefined>(undefined);
 
     const serializeState = (): CustomContentEmbeddableState => ({
       ...titleManager.getLatestState(),
@@ -117,6 +133,7 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
       ...titleManager.api,
       serializeState,
       usesEsql$,
+      dataViews$,
       getTypeDisplayName: () =>
         i18n.translate('xpack.customContent.embeddable.typeDisplayName', {
           defaultMessage: 'Custom content',
@@ -130,6 +147,20 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
     const esqlUsageSubscription = esqlQuery$
       .pipe(map(Boolean), distinctUntilChanged())
       .subscribe((usesEsql) => usesEsql$.next(usesEsql));
+
+    // Important for unified search support — KQL bar and filter builder suggestions.
+    const dataViewsSubscription = esqlQuery$
+      .pipe(
+        distinctUntilChanged(),
+        switchMap((esqlQuery) => {
+          if (!esqlQuery) return of(undefined);
+          const { core, dataViews } = getServices();
+          return from(
+            getESQLAdHocDataview({ dataViewsService: dataViews, query: esqlQuery, http: core.http })
+          ).pipe(catchError(() => of(undefined)));
+        })
+      )
+      .subscribe((dataView) => dataViews$.next(dataView ? [dataView] : undefined));
 
     const fetchSubscription = fetch$(api).subscribe(
       ({ isApproximate, projectRouting, query, filters }) => {
@@ -174,6 +205,7 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
         useEffect(() => {
           return () => {
             esqlUsageSubscription.unsubscribe();
+            dataViewsSubscription.unsubscribe();
             fetchSubscription.unsubscribe();
           };
         }, []);

--- a/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
@@ -24,7 +24,7 @@ import {
   fetch$,
 } from '@kbn/presentation-publishing';
 import { i18n } from '@kbn/i18n';
-import type { TimeRange, ProjectRouting } from '@kbn/es-query';
+import type { AggregateQuery, Filter, Query, TimeRange, ProjectRouting } from '@kbn/es-query';
 import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { BehaviorSubject, distinctUntilChanged, EMPTY, map, merge, skip, switchMap } from 'rxjs';
 import { isRoundCompleteEvent } from '@kbn/agent-builder-common';
@@ -64,6 +64,8 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
     const usesEsql$ = new BehaviorSubject<boolean>(Boolean(initialState.esqlQuery));
     const isApproximate$ = new BehaviorSubject<boolean>(false);
     const projectRouting$ = new BehaviorSubject<ProjectRouting | undefined>(undefined);
+    const query$ = new BehaviorSubject<Query | AggregateQuery | undefined>(undefined);
+    const filters$ = new BehaviorSubject<Filter[] | undefined>(undefined);
 
     const serializeState = (): CustomContentEmbeddableState => ({
       ...titleManager.getLatestState(),
@@ -129,10 +131,14 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
       .pipe(map(Boolean), distinctUntilChanged())
       .subscribe((usesEsql) => usesEsql$.next(usesEsql));
 
-    const fetchSubscription = fetch$(api).subscribe(({ isApproximate, projectRouting }) => {
-      isApproximate$.next(isApproximate);
-      projectRouting$.next(projectRouting);
-    });
+    const fetchSubscription = fetch$(api).subscribe(
+      ({ isApproximate, projectRouting, query, filters }) => {
+        isApproximate$.next(isApproximate);
+        projectRouting$.next(projectRouting);
+        query$.next(query);
+        filters$.next(filters);
+      }
+    );
 
     return {
       api,
@@ -145,6 +151,8 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
           panelTitle,
           isApproximate,
           projectRouting,
+          query,
+          filters,
         ] = useBatchedPublishingSubjects(
           prompt$,
           esqlQuery$,
@@ -152,7 +160,9 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
           isFlyoutOpen$,
           titleManager.api.title$,
           isApproximate$,
-          projectRouting$
+          projectRouting$,
+          query$,
+          filters$
         );
         const [generationVersion, setGenerationVersion] = useState(0);
         const [timeRange, setTimeRange] = useState<TimeRange | undefined>(
@@ -247,6 +257,8 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
               savedTemplate={savedTemplate}
               isApproximate={isApproximate}
               projectRouting={projectRouting}
+              query={query}
+              filters={filters}
               onTemplateChange={onTemplateChange}
             />
             {isFlyoutOpen && (

--- a/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
@@ -144,33 +144,6 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
       isEditingEnabled: () => true,
     });
 
-    const esqlUsageSubscription = esqlQuery$
-      .pipe(map(Boolean), distinctUntilChanged())
-      .subscribe((usesEsql) => usesEsql$.next(usesEsql));
-
-    // Important for unified search support — KQL bar and filter builder suggestions.
-    const dataViewsSubscription = esqlQuery$
-      .pipe(
-        distinctUntilChanged(),
-        switchMap((esqlQuery) => {
-          if (!esqlQuery) return of(undefined);
-          const { core, dataViews } = getServices();
-          return from(
-            getESQLAdHocDataview({ dataViewsService: dataViews, query: esqlQuery, http: core.http })
-          ).pipe(catchError(() => of(undefined)));
-        })
-      )
-      .subscribe((dataView) => dataViews$.next(dataView ? [dataView] : undefined));
-
-    const fetchSubscription = fetch$(api).subscribe(
-      ({ isApproximate, projectRouting, query, filters }) => {
-        isApproximate$.next(isApproximate);
-        projectRouting$.next(projectRouting);
-        query$.next(query);
-        filters$.next(filters);
-      }
-    );
-
     return {
       api,
       Component: function CustomContentEmbeddableComponent() {
@@ -203,6 +176,35 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
         );
 
         useEffect(() => {
+          const esqlUsageSubscription = esqlQuery$
+            .pipe(map(Boolean), distinctUntilChanged())
+            .subscribe((usesEsql) => usesEsql$.next(usesEsql));
+
+          // Important for unified search support — KQL bar and filter builder suggestions.
+          const dataViewsSubscription = esqlQuery$
+            .pipe(
+              distinctUntilChanged(),
+              switchMap((esqlQueryValue) => {
+                if (!esqlQueryValue) return of(undefined);
+                const { core, dataViews } = getServices();
+                return from(
+                  getESQLAdHocDataview({
+                    dataViewsService: dataViews,
+                    query: esqlQueryValue,
+                    http: core.http,
+                  })
+                ).pipe(catchError(() => of(undefined)));
+              })
+            )
+            .subscribe((dataView) => dataViews$.next(dataView ? [dataView] : undefined));
+
+          const fetchSubscription = fetch$(api).subscribe((ctx) => {
+            isApproximate$.next(ctx.isApproximate);
+            projectRouting$.next(ctx.projectRouting);
+            query$.next(ctx.query);
+            filters$.next(ctx.filters);
+          });
+
           return () => {
             esqlUsageSubscription.unsubscribe();
             dataViewsSubscription.unsubscribe();

--- a/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/custom_content/public/custom_content_embeddable.tsx
@@ -144,6 +144,35 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
       isEditingEnabled: () => true,
     });
 
+    const esqlUsageSubscription = esqlQuery$
+      .pipe(map(Boolean), distinctUntilChanged())
+      .subscribe((usesEsql) => usesEsql$.next(usesEsql));
+
+    // Important for unified search support — KQL bar and filter builder suggestions.
+    const dataViewsSubscription = esqlQuery$
+      .pipe(
+        distinctUntilChanged(),
+        switchMap((esqlQueryValue) => {
+          if (!esqlQueryValue) return of(undefined);
+          const { core, dataViews } = getServices();
+          return from(
+            getESQLAdHocDataview({
+              dataViewsService: dataViews,
+              query: esqlQueryValue,
+              http: core.http,
+            })
+          ).pipe(catchError(() => of(undefined)));
+        })
+      )
+      .subscribe((dataView) => dataViews$.next(dataView ? [dataView] : undefined));
+
+    const fetchSubscription = fetch$(api).subscribe((ctx) => {
+      isApproximate$.next(ctx.isApproximate);
+      projectRouting$.next(ctx.projectRouting);
+      query$.next(ctx.query);
+      filters$.next(ctx.filters);
+    });
+
     return {
       api,
       Component: function CustomContentEmbeddableComponent() {
@@ -176,35 +205,6 @@ export const customContentEmbeddableFactory: EmbeddablePublicDefinition<
         );
 
         useEffect(() => {
-          const esqlUsageSubscription = esqlQuery$
-            .pipe(map(Boolean), distinctUntilChanged())
-            .subscribe((usesEsql) => usesEsql$.next(usesEsql));
-
-          // Important for unified search support — KQL bar and filter builder suggestions.
-          const dataViewsSubscription = esqlQuery$
-            .pipe(
-              distinctUntilChanged(),
-              switchMap((esqlQueryValue) => {
-                if (!esqlQueryValue) return of(undefined);
-                const { core, dataViews } = getServices();
-                return from(
-                  getESQLAdHocDataview({
-                    dataViewsService: dataViews,
-                    query: esqlQueryValue,
-                    http: core.http,
-                  })
-                ).pipe(catchError(() => of(undefined)));
-              })
-            )
-            .subscribe((dataView) => dataViews$.next(dataView ? [dataView] : undefined));
-
-          const fetchSubscription = fetch$(api).subscribe((ctx) => {
-            isApproximate$.next(ctx.isApproximate);
-            projectRouting$.next(ctx.projectRouting);
-            query$.next(ctx.query);
-            filters$.next(ctx.filters);
-          });
-
           return () => {
             esqlUsageSubscription.unsubscribe();
             dataViewsSubscription.unsubscribe();

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
@@ -19,7 +19,7 @@ jest.mock('../utils/fetch_esql_data');
 jest.mock('../utils/fill_template');
 
 import type { HttpStart } from '@kbn/core/public';
-import type { TimeRange } from '@kbn/es-query';
+import type { Filter, Query, TimeRange } from '@kbn/es-query';
 import type { CustomContentTokenEvent } from '../../common/types';
 import { getServices } from '../services';
 import { streamGenerate } from '../utils/stream_generate';
@@ -44,7 +44,10 @@ function makeHttp(events: CustomContentTokenEvent[]) {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  (getServices as jest.Mock).mockReturnValue({ core: { http: mockHttp }, search: mockSearch });
+  (getServices as jest.Mock).mockReturnValue({
+    core: { http: mockHttp, uiSettings: { get: jest.fn().mockReturnValue(false) } },
+    search: mockSearch,
+  });
   (streamGenerate as jest.Mock).mockResolvedValue(undefined);
   mockFetchEsqlData.mockResolvedValue({ columns: [], values: [], all_columns: [] });
   mockFillTemplate.mockResolvedValue('<div>rendered</div>');
@@ -60,6 +63,8 @@ const baseParams: Parameters<typeof useCustomContentHtml>[0] = {
   colorMode: 'LIGHT' as const,
   isApproximate: false,
   projectRouting: undefined,
+  query: undefined,
+  filters: undefined,
   onTemplateChange: jest.fn(),
 };
 
@@ -180,8 +185,12 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        false,
-        undefined
+        expect.objectContaining({
+          isApproximate: false,
+          projectRouting: undefined,
+          query: undefined,
+          filters: undefined,
+        })
       );
       expect(mockFillTemplate).toHaveBeenCalledWith(esqlParams.savedTemplate, [], []);
       expect(result.current.html).toContain('rendered');
@@ -226,8 +235,12 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        false,
-        undefined
+        expect.objectContaining({
+          isApproximate: false,
+          projectRouting: undefined,
+          query: undefined,
+          filters: undefined,
+        })
       );
       expect(mockFillTemplate).toHaveBeenCalledWith(LIQUID_TEMPLATE, [], []);
       expect(result.current.html).toContain('rendered');
@@ -256,8 +269,12 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         timeRange,
         expect.any(AbortSignal),
-        false,
-        undefined
+        expect.objectContaining({
+          isApproximate: false,
+          projectRouting: undefined,
+          query: undefined,
+          filters: undefined,
+        })
       );
     });
 
@@ -368,8 +385,12 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         { from: 'now-7d', to: 'now' },
         expect.any(AbortSignal),
-        false,
-        undefined
+        expect.objectContaining({
+          isApproximate: false,
+          projectRouting: undefined,
+          query: undefined,
+          filters: undefined,
+        })
       );
     });
   });
@@ -420,6 +441,96 @@ describe('useCustomContentHtml', () => {
     });
   });
 
+  describe('ignoreFilterIfFieldNotInIndex — uiSettings passthrough', () => {
+    const esqlParams = {
+      ...baseParams,
+      esqlQuery: 'FROM logs | STATS revenue = SUM(amount)',
+      savedTemplate: '{% for row in rows %}{{ row["revenue"].value }}{% endfor %}',
+      filters: [
+        {
+          meta: { index: 'logs-*', negate: false },
+          query: { match_phrase: { 'host.name': 'prod' } },
+        },
+      ] satisfies Filter[],
+    };
+
+    it('passes ignoreFilterIfFieldNotInIndex=true to fetchEsqlData when the uiSetting is enabled', async () => {
+      (getServices as jest.Mock).mockReturnValue({
+        core: { http: mockHttp, uiSettings: { get: jest.fn().mockReturnValue(true) } },
+        search: mockSearch,
+      });
+
+      const { result } = renderHook(() => useCustomContentHtml(esqlParams));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchEsqlData).toHaveBeenCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        expect.objectContaining({
+          ignoreFilterIfFieldNotInIndex: true,
+          filters: esqlParams.filters,
+        })
+      );
+    });
+  });
+
+  describe('filters — unified search bar filters', () => {
+    const esqlParams = {
+      ...baseParams,
+      esqlQuery: 'FROM logs | STATS revenue = SUM(amount)',
+      savedTemplate: '{% for row in rows %}{{ row["revenue"].value }}{% endfor %}',
+    };
+    const activeFilters = [
+      {
+        meta: { index: 'logs-*', negate: false },
+        query: { match_phrase: { 'host.name': 'prod' } },
+      },
+    ] satisfies Filter[];
+
+    it('passes filters to fetchEsqlData when provided', async () => {
+      const { result } = renderHook(() =>
+        useCustomContentHtml({ ...esqlParams, filters: activeFilters })
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchEsqlData).toHaveBeenCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        expect.objectContaining({ filters: activeFilters })
+      );
+    });
+
+    it('re-fetches when filters change', async () => {
+      const { rerender } = renderHook(
+        ({ filters }: { filters: Filter[] | undefined }) =>
+          useCustomContentHtml({ ...esqlParams, filters }),
+        { initialProps: { filters: undefined as Filter[] | undefined } }
+      );
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(1));
+
+      rerender({ filters: activeFilters });
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(2));
+      expect(mockFetchEsqlData).toHaveBeenLastCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        expect.objectContaining({ filters: activeFilters })
+      );
+    });
+  });
+
   describe('projectRouting — project routing context', () => {
     const esqlParams = {
       ...baseParams,
@@ -441,8 +552,7 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        false,
-        routing
+        expect.objectContaining({ projectRouting: routing })
       );
     });
 
@@ -464,8 +574,7 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        false,
-        routing
+        expect.objectContaining({ projectRouting: routing })
       );
     });
   });
@@ -490,8 +599,7 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        true,
-        undefined
+        expect.objectContaining({ isApproximate: true })
       );
     });
 
@@ -513,8 +621,52 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        true,
-        undefined
+        expect.objectContaining({ isApproximate: true })
+      );
+    });
+  });
+
+  describe('query — KQL search bar', () => {
+    const esqlParams = {
+      ...baseParams,
+      esqlQuery: 'FROM logs | STATS revenue = SUM(amount)',
+      savedTemplate: '{% for row in rows %}{{ row["revenue"].value }}{% endfor %}',
+    };
+    const kqlQuery: Query = { language: 'kuery', query: 'host.name: prod' };
+
+    it('passes query to fetchEsqlData when provided', async () => {
+      const { result } = renderHook(() => useCustomContentHtml({ ...esqlParams, query: kqlQuery }));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchEsqlData).toHaveBeenCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        expect.objectContaining({ query: kqlQuery })
+      );
+    });
+
+    it('re-fetches when query changes', async () => {
+      const { rerender } = renderHook(
+        ({ query }: { query: Query | undefined }) => useCustomContentHtml({ ...esqlParams, query }),
+        { initialProps: { query: undefined as Query | undefined } }
+      );
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(1));
+
+      rerender({ query: kqlQuery });
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(2));
+      expect(mockFetchEsqlData).toHaveBeenLastCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        expect.objectContaining({ query: kqlQuery })
       );
     });
   });

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
@@ -58,6 +58,7 @@ const baseParams: Parameters<typeof useCustomContentHtml>[0] = {
   generationVersion: 0,
   savedTemplate: undefined,
   colorMode: 'LIGHT' as const,
+  isApproximate: false,
   onTemplateChange: jest.fn(),
 };
 
@@ -177,7 +178,8 @@ describe('useCustomContentHtml', () => {
         mockHttp,
         esqlParams.esqlQuery,
         undefined,
-        expect.any(AbortSignal)
+        expect.any(AbortSignal),
+        false
       );
       expect(mockFillTemplate).toHaveBeenCalledWith(esqlParams.savedTemplate, [], []);
       expect(result.current.html).toContain('rendered');
@@ -221,7 +223,8 @@ describe('useCustomContentHtml', () => {
         mockHttp,
         esqlParams.esqlQuery,
         undefined,
-        expect.any(AbortSignal)
+        expect.any(AbortSignal),
+        false
       );
       expect(mockFillTemplate).toHaveBeenCalledWith(LIQUID_TEMPLATE, [], []);
       expect(result.current.html).toContain('rendered');
@@ -249,7 +252,8 @@ describe('useCustomContentHtml', () => {
         mockHttp,
         esqlParams.esqlQuery,
         timeRange,
-        expect.any(AbortSignal)
+        expect.any(AbortSignal),
+        false
       );
     });
 
@@ -359,7 +363,8 @@ describe('useCustomContentHtml', () => {
         mockHttp,
         esqlParams.esqlQuery,
         { from: 'now-7d', to: 'now' },
-        expect.any(AbortSignal)
+        expect.any(AbortSignal),
+        false
       );
     });
   });
@@ -407,6 +412,53 @@ describe('useCustomContentHtml', () => {
 
       rerender({ version: 1 });
       await waitFor(() => expect(streamGenerate).toHaveBeenCalledTimes(2));
+    });
+  });
+
+  describe('isApproximate — approximation switch', () => {
+    const esqlParams = {
+      ...baseParams,
+      esqlQuery: 'FROM logs | STATS revenue = SUM(amount)',
+      savedTemplate: '{% for row in rows %}{{ row["revenue"].value }}{% endfor %}',
+    };
+
+    it('passes isApproximate=true to fetchEsqlData when the switch is on', async () => {
+      const { result } = renderHook(() =>
+        useCustomContentHtml({ ...esqlParams, isApproximate: true })
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchEsqlData).toHaveBeenCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        true
+      );
+    });
+
+    it('re-fetches when isApproximate toggles on an ES|QL panel with a stored template', async () => {
+      const { rerender } = renderHook(
+        ({ isApproximate }: { isApproximate: boolean }) =>
+          useCustomContentHtml({ ...esqlParams, isApproximate }),
+        { initialProps: { isApproximate: false } }
+      );
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(1));
+
+      rerender({ isApproximate: true });
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(2));
+      expect(mockFetchEsqlData).toHaveBeenLastCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        true
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
@@ -59,6 +59,7 @@ const baseParams: Parameters<typeof useCustomContentHtml>[0] = {
   savedTemplate: undefined,
   colorMode: 'LIGHT' as const,
   isApproximate: false,
+  projectRouting: undefined,
   onTemplateChange: jest.fn(),
 };
 
@@ -179,7 +180,8 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        false
+        false,
+        undefined
       );
       expect(mockFillTemplate).toHaveBeenCalledWith(esqlParams.savedTemplate, [], []);
       expect(result.current.html).toContain('rendered');
@@ -224,7 +226,8 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        false
+        false,
+        undefined
       );
       expect(mockFillTemplate).toHaveBeenCalledWith(LIQUID_TEMPLATE, [], []);
       expect(result.current.html).toContain('rendered');
@@ -253,7 +256,8 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         timeRange,
         expect.any(AbortSignal),
-        false
+        false,
+        undefined
       );
     });
 
@@ -364,7 +368,8 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         { from: 'now-7d', to: 'now' },
         expect.any(AbortSignal),
-        false
+        false,
+        undefined
       );
     });
   });
@@ -415,6 +420,56 @@ describe('useCustomContentHtml', () => {
     });
   });
 
+  describe('projectRouting — project routing context', () => {
+    const esqlParams = {
+      ...baseParams,
+      esqlQuery: 'FROM logs | STATS revenue = SUM(amount)',
+      savedTemplate: '{% for row in rows %}{{ row["revenue"].value }}{% endfor %}',
+    };
+    const routing = 'my-project';
+
+    it('passes projectRouting to fetchEsqlData when provided', async () => {
+      const { result } = renderHook(() =>
+        useCustomContentHtml({ ...esqlParams, projectRouting: routing })
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchEsqlData).toHaveBeenCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        false,
+        routing
+      );
+    });
+
+    it('re-fetches when projectRouting changes', async () => {
+      const { rerender } = renderHook(
+        ({ projectRouting }: { projectRouting: string | undefined }) =>
+          useCustomContentHtml({ ...esqlParams, projectRouting }),
+        { initialProps: { projectRouting: undefined as string | undefined } }
+      );
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(1));
+
+      rerender({ projectRouting: routing });
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(2));
+      expect(mockFetchEsqlData).toHaveBeenLastCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        false,
+        routing
+      );
+    });
+  });
+
   describe('isApproximate — approximation switch', () => {
     const esqlParams = {
       ...baseParams,
@@ -435,7 +490,8 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        true
+        true,
+        undefined
       );
     });
 
@@ -457,7 +513,8 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        true
+        true,
+        undefined
       );
     });
   });

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
@@ -678,4 +678,176 @@ describe('useCustomContentHtml', () => {
       );
     });
   });
+
+  // Tests for the echo-skip guard bug: after LLM generation sets selfWrittenRef,
+  // changes to unified-search inputs must still trigger a re-fetch and not be swallowed by
+  // the guard.
+  describe('echo-skip guard does not block unified-search changes after LLM generation', () => {
+    const LIQUID_TEMPLATE =
+      '<html><body>{% for row in rows %}<p>{{ row.value }}</p>{% endfor %}</body></html>';
+    const esqlParams = {
+      ...baseParams,
+      esqlQuery: 'FROM logs | STATS revenue = SUM(amount)',
+      savedTemplate: undefined,
+    };
+
+    // Simulate LLM generation: returns LIQUID_TEMPLATE via streamGenerate, then the hook writes
+    // it back via onTemplateChange. The test then re-renders with savedTemplate = LIQUID_TEMPLATE
+    // (as a parent component would), puts the guard in the active state, and changes the search
+    // input — verifying the guard does not suppress the resulting re-fetch.
+    async function runGenerationPhase(
+      onTemplateChange: jest.Mock,
+      rerenderFn: (p: { savedTemplate: string | undefined }) => void
+    ) {
+      (streamGenerate as jest.Mock).mockImplementation(
+        makeHttp([{ type: 'token', token: LIQUID_TEMPLATE }])
+      );
+
+      await waitFor(() => expect(onTemplateChange).toHaveBeenCalledWith(LIQUID_TEMPLATE));
+
+      // Parent receives the written-back template and re-renders — guard is now armed.
+      rerenderFn({ savedTemplate: LIQUID_TEMPLATE });
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(1));
+      mockFetchEsqlData.mockClear();
+    }
+
+    it('re-fetches when filters change after LLM generation', async () => {
+      const onTemplateChange = jest.fn();
+      const activeFilters: Filter[] = [
+        { meta: { index: 'logs-*', negate: false }, query: { match_phrase: { env: 'prod' } } },
+      ] satisfies Filter[];
+
+      const { rerender } = renderHook(
+        ({
+          savedTemplate,
+          filters,
+        }: {
+          savedTemplate: string | undefined;
+          filters: Filter[] | undefined;
+        }) => useCustomContentHtml({ ...esqlParams, savedTemplate, filters, onTemplateChange }),
+        {
+          initialProps: {
+            savedTemplate: undefined as string | undefined,
+            filters: undefined as Filter[] | undefined,
+          },
+        }
+      );
+
+      await runGenerationPhase(onTemplateChange, (p) => rerender({ ...p, filters: undefined }));
+
+      rerender({ savedTemplate: LIQUID_TEMPLATE, filters: activeFilters });
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(1));
+      expect(mockFetchEsqlData).toHaveBeenCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        expect.objectContaining({ filters: activeFilters })
+      );
+    });
+
+    it('re-fetches when query changes after LLM generation', async () => {
+      const onTemplateChange = jest.fn();
+      const kqlQuery: Query = { language: 'kuery', query: 'host.name: web-01' };
+
+      const { rerender } = renderHook(
+        ({
+          savedTemplate,
+          query,
+        }: {
+          savedTemplate: string | undefined;
+          query: Query | undefined;
+        }) => useCustomContentHtml({ ...esqlParams, savedTemplate, query, onTemplateChange }),
+        {
+          initialProps: {
+            savedTemplate: undefined as string | undefined,
+            query: undefined as Query | undefined,
+          },
+        }
+      );
+
+      await runGenerationPhase(onTemplateChange, (p) => rerender({ ...p, query: undefined }));
+
+      rerender({ savedTemplate: LIQUID_TEMPLATE, query: kqlQuery });
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(1));
+      expect(mockFetchEsqlData).toHaveBeenCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        expect.objectContaining({ query: kqlQuery })
+      );
+    });
+
+    it('re-fetches when isApproximate toggles after LLM generation', async () => {
+      const onTemplateChange = jest.fn();
+
+      const { rerender } = renderHook(
+        ({
+          savedTemplate,
+          isApproximate,
+        }: {
+          savedTemplate: string | undefined;
+          isApproximate: boolean;
+        }) =>
+          useCustomContentHtml({ ...esqlParams, savedTemplate, isApproximate, onTemplateChange }),
+        { initialProps: { savedTemplate: undefined as string | undefined, isApproximate: false } }
+      );
+
+      await runGenerationPhase(onTemplateChange, (p) => rerender({ ...p, isApproximate: false }));
+
+      rerender({ savedTemplate: LIQUID_TEMPLATE, isApproximate: true });
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(1));
+      expect(mockFetchEsqlData).toHaveBeenCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        expect.objectContaining({ isApproximate: true })
+      );
+    });
+
+    it('re-fetches when projectRouting changes after LLM generation', async () => {
+      const onTemplateChange = jest.fn();
+
+      const { rerender } = renderHook(
+        ({
+          savedTemplate,
+          projectRouting,
+        }: {
+          savedTemplate: string | undefined;
+          projectRouting: string | undefined;
+        }) =>
+          useCustomContentHtml({ ...esqlParams, savedTemplate, projectRouting, onTemplateChange }),
+        {
+          initialProps: {
+            savedTemplate: undefined as string | undefined,
+            projectRouting: undefined as string | undefined,
+          },
+        }
+      );
+
+      await runGenerationPhase(onTemplateChange, (p) =>
+        rerender({ ...p, projectRouting: undefined })
+      );
+
+      rerender({ savedTemplate: LIQUID_TEMPLATE, projectRouting: 'p-abc123' });
+
+      await waitFor(() => expect(mockFetchEsqlData).toHaveBeenCalledTimes(1));
+      expect(mockFetchEsqlData).toHaveBeenCalledWith(
+        mockSearch,
+        mockHttp,
+        esqlParams.esqlQuery,
+        undefined,
+        expect.any(AbortSignal),
+        expect.objectContaining({ projectRouting: 'p-abc123' })
+      );
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.test.ts
@@ -17,15 +17,21 @@ jest.mock('../services');
 jest.mock('../utils/stream_generate');
 jest.mock('../utils/fetch_esql_data');
 jest.mock('../utils/fill_template');
+jest.mock('@kbn/data-plugin/public', () => ({
+  getEsQueryConfig: jest.fn(),
+}));
 
 import type { HttpStart } from '@kbn/core/public';
-import type { Filter, Query, TimeRange } from '@kbn/es-query';
+import type { EsQueryConfig, Filter, Query, TimeRange } from '@kbn/es-query';
 import type { CustomContentTokenEvent } from '../../common/types';
+import { getEsQueryConfig } from '@kbn/data-plugin/public';
 import { getServices } from '../services';
 import { streamGenerate } from '../utils/stream_generate';
 import { fetchEsqlData } from '../utils/fetch_esql_data';
 import { fillTemplate } from '../utils/fill_template';
 import { useCustomContentHtml } from './use_custom_content_html';
+
+const mockGetEsQueryConfig = getEsQueryConfig as jest.MockedFunction<typeof getEsQueryConfig>;
 
 const mockFetchEsqlData = fetchEsqlData as jest.MockedFunction<typeof fetchEsqlData>;
 const mockFillTemplate = fillTemplate as jest.MockedFunction<typeof fillTemplate>;
@@ -42,12 +48,20 @@ function makeHttp(events: CustomContentTokenEvent[]) {
   };
 }
 
+const defaultEsQueryConfig: EsQueryConfig = {
+  allowLeadingWildcards: false,
+  queryStringOptions: {},
+  ignoreFilterIfFieldNotInIndex: false,
+  dateFormatTZ: 'Browser',
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
   (getServices as jest.Mock).mockReturnValue({
-    core: { http: mockHttp, uiSettings: { get: jest.fn().mockReturnValue(false) } },
+    core: { http: mockHttp, uiSettings: {} },
     search: mockSearch,
   });
+  mockGetEsQueryConfig.mockReturnValue(defaultEsQueryConfig);
   (streamGenerate as jest.Mock).mockResolvedValue(undefined);
   mockFetchEsqlData.mockResolvedValue({ columns: [], values: [], all_columns: [] });
   mockFillTemplate.mockResolvedValue('<div>rendered</div>');
@@ -441,24 +455,21 @@ describe('useCustomContentHtml', () => {
     });
   });
 
-  describe('ignoreFilterIfFieldNotInIndex — uiSettings passthrough', () => {
+  describe('esQueryConfig — uiSettings passthrough via getEsQueryConfig', () => {
     const esqlParams = {
       ...baseParams,
       esqlQuery: 'FROM logs | STATS revenue = SUM(amount)',
       savedTemplate: '{% for row in rows %}{{ row["revenue"].value }}{% endfor %}',
-      filters: [
-        {
-          meta: { index: 'logs-*', negate: false },
-          query: { match_phrase: { 'host.name': 'prod' } },
-        },
-      ] satisfies Filter[],
     };
 
-    it('passes ignoreFilterIfFieldNotInIndex=true to fetchEsqlData when the uiSetting is enabled', async () => {
-      (getServices as jest.Mock).mockReturnValue({
-        core: { http: mockHttp, uiSettings: { get: jest.fn().mockReturnValue(true) } },
-        search: mockSearch,
-      });
+    it('forwards the full esQueryConfig from getEsQueryConfig to fetchEsqlData', async () => {
+      const customConfig: EsQueryConfig = {
+        allowLeadingWildcards: true,
+        queryStringOptions: { analyze_wildcard: true },
+        ignoreFilterIfFieldNotInIndex: true,
+        dateFormatTZ: 'Europe/Athens',
+      };
+      mockGetEsQueryConfig.mockReturnValue(customConfig);
 
       const { result } = renderHook(() => useCustomContentHtml(esqlParams));
 
@@ -470,10 +481,7 @@ describe('useCustomContentHtml', () => {
         esqlParams.esqlQuery,
         undefined,
         expect.any(AbortSignal),
-        expect.objectContaining({
-          ignoreFilterIfFieldNotInIndex: true,
-          filters: esqlParams.filters,
-        })
+        expect.objectContaining({ esQueryConfig: customConfig })
       );
     });
   });

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
@@ -38,6 +38,7 @@ export interface UseCustomContentHtmlParams {
   generationVersion: number;
   savedTemplate: string | undefined;
   colorMode: EuiThemeColorModeStandard;
+  isApproximate: boolean;
   onTemplateChange: (template: string) => void;
 }
 
@@ -56,6 +57,7 @@ export function useCustomContentHtml({
   generationVersion,
   savedTemplate,
   colorMode,
+  isApproximate,
   onTemplateChange,
 }: UseCustomContentHtmlParams): UseCustomContentHtmlResult {
   const [html, setHtml] = useState('');
@@ -120,7 +122,7 @@ export function useCustomContentHtml({
     if (template && esqlQuery) {
       setIsLoading(true);
       setError(undefined);
-      fetchEsqlData(search, core.http, esqlQuery, timeRange, controller.signal)
+      fetchEsqlData(search, core.http, esqlQuery, timeRange, controller.signal, isApproximate)
         .then((response) => fillTemplate(template, response.columns, response.values ?? []))
         .then((rawHtml) => {
           if (controller.signal.aborted) return;
@@ -192,7 +194,8 @@ export function useCustomContentHtml({
             core.http,
             esqlQuery,
             timeRange,
-            controller.signal
+            controller.signal,
+            isApproximate
           );
         } catch (err) {
           if (controller.signal.aborted || (err instanceof Error && err.name === 'AbortError'))
@@ -270,7 +273,7 @@ export function useCustomContentHtml({
     return () => {
       controller.abort();
     };
-  }, [embeddableId, prompt, esqlQuery, timeRange, generationVersion, savedTemplate]);
+  }, [embeddableId, prompt, esqlQuery, timeRange, generationVersion, savedTemplate, isApproximate]);
 
   return { html, isLoading, error, isAiUnavailable };
 }

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
@@ -8,7 +8,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { EuiThemeColorModeStandard } from '@elastic/eui';
-import type { TimeRange } from '@kbn/es-query';
+import type { TimeRange, ProjectRouting } from '@kbn/es-query';
 import { getServices } from '../services';
 import { streamGenerate } from '../utils/stream_generate';
 import { fetchEsqlData } from '../utils/fetch_esql_data';
@@ -39,6 +39,7 @@ export interface UseCustomContentHtmlParams {
   savedTemplate: string | undefined;
   colorMode: EuiThemeColorModeStandard;
   isApproximate: boolean;
+  projectRouting: ProjectRouting | undefined;
   onTemplateChange: (template: string) => void;
 }
 
@@ -58,6 +59,7 @@ export function useCustomContentHtml({
   savedTemplate,
   colorMode,
   isApproximate,
+  projectRouting,
   onTemplateChange,
 }: UseCustomContentHtmlParams): UseCustomContentHtmlResult {
   const [html, setHtml] = useState('');
@@ -122,7 +124,15 @@ export function useCustomContentHtml({
     if (template && esqlQuery) {
       setIsLoading(true);
       setError(undefined);
-      fetchEsqlData(search, core.http, esqlQuery, timeRange, controller.signal, isApproximate)
+      fetchEsqlData(
+        search,
+        core.http,
+        esqlQuery,
+        timeRange,
+        controller.signal,
+        isApproximate,
+        projectRouting
+      )
         .then((response) => fillTemplate(template, response.columns, response.values ?? []))
         .then((rawHtml) => {
           if (controller.signal.aborted) return;
@@ -195,7 +205,8 @@ export function useCustomContentHtml({
             esqlQuery,
             timeRange,
             controller.signal,
-            isApproximate
+            isApproximate,
+            projectRouting
           );
         } catch (err) {
           if (controller.signal.aborted || (err instanceof Error && err.name === 'AbortError'))
@@ -273,7 +284,16 @@ export function useCustomContentHtml({
     return () => {
       controller.abort();
     };
-  }, [embeddableId, prompt, esqlQuery, timeRange, generationVersion, savedTemplate, isApproximate]);
+  }, [
+    embeddableId,
+    prompt,
+    esqlQuery,
+    timeRange,
+    generationVersion,
+    savedTemplate,
+    isApproximate,
+    projectRouting,
+  ]);
 
   return { html, isLoading, error, isAiUnavailable };
 }

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
@@ -8,7 +8,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { EuiThemeColorModeStandard } from '@elastic/eui';
-import type { TimeRange, ProjectRouting } from '@kbn/es-query';
+import type { AggregateQuery, Filter, Query, TimeRange, ProjectRouting } from '@kbn/es-query';
 import { getServices } from '../services';
 import { streamGenerate } from '../utils/stream_generate';
 import { fetchEsqlData } from '../utils/fetch_esql_data';
@@ -40,6 +40,8 @@ export interface UseCustomContentHtmlParams {
   colorMode: EuiThemeColorModeStandard;
   isApproximate: boolean;
   projectRouting: ProjectRouting | undefined;
+  query: Query | AggregateQuery | undefined;
+  filters: Filter[] | undefined;
   onTemplateChange: (template: string) => void;
 }
 
@@ -60,6 +62,8 @@ export function useCustomContentHtml({
   colorMode,
   isApproximate,
   projectRouting,
+  query,
+  filters,
   onTemplateChange,
 }: UseCustomContentHtmlParams): UseCustomContentHtmlResult {
   const [html, setHtml] = useState('');
@@ -119,20 +123,21 @@ export function useCustomContentHtml({
     let acc = '';
 
     const { core, search } = getServices();
+    const fetchOptions = {
+      isApproximate,
+      projectRouting,
+      query,
+      filters,
+      ignoreFilterIfFieldNotInIndex: core.uiSettings.get<boolean>(
+        'courier:ignoreFilterIfFieldNotInIndex'
+      ),
+    };
 
     // Fast path — ES|QL panel with stored template: fetch data client-side and render, no LLM.
     if (template && esqlQuery) {
       setIsLoading(true);
       setError(undefined);
-      fetchEsqlData(
-        search,
-        core.http,
-        esqlQuery,
-        timeRange,
-        controller.signal,
-        isApproximate,
-        projectRouting
-      )
+      fetchEsqlData(search, core.http, esqlQuery, timeRange, controller.signal, fetchOptions)
         .then((response) => fillTemplate(template, response.columns, response.values ?? []))
         .then((rawHtml) => {
           if (controller.signal.aborted) return;
@@ -205,8 +210,7 @@ export function useCustomContentHtml({
             esqlQuery,
             timeRange,
             controller.signal,
-            isApproximate,
-            projectRouting
+            fetchOptions
           );
         } catch (err) {
           if (controller.signal.aborted || (err instanceof Error && err.name === 'AbortError'))
@@ -293,6 +297,8 @@ export function useCustomContentHtml({
     savedTemplate,
     isApproximate,
     projectRouting,
+    query,
+    filters,
   ]);
 
   return { html, isLoading, error, isAiUnavailable };

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
@@ -76,11 +76,15 @@ export function useCustomContentHtml({
   // wrote so we can skip the echo re-run without also skipping intentional version bumps.
   const selfWrittenRef = useRef<string | undefined>(undefined);
 
-  // Track the last-rendered timeRange and generationVersion so that timepicker changes and
-  // explicit refresh clicks still trigger a re-fetch even when savedTemplate hasn't changed
-  // (which would otherwise trip the echo-skip guard below).
+  // Track the last-rendered fetch inputs so that any change in unified search context
+  // (timeRange, filters, query, isApproximate, projectRouting, generationVersion) still
+  // triggers a re-fetch even when savedTemplate hasn't changed.
   const lastRenderedTimeRangeRef = useRef<TimeRange | undefined>(undefined);
   const lastRenderedGenerationVersionRef = useRef(generationVersion);
+  const lastRenderedIsApproximateRef = useRef(isApproximate);
+  const lastRenderedProjectRoutingRef = useRef<ProjectRouting | undefined>(projectRouting);
+  const lastRenderedQueryRef = useRef<Query | AggregateQuery | undefined>(query);
+  const lastRenderedFiltersRef = useRef<Filter[] | undefined>(filters);
 
   const colorModeRef = useRef(colorMode);
   useEffect(() => {
@@ -101,11 +105,27 @@ export function useCustomContentHtml({
     const generationVersionSame = generationVersion === lastRenderedGenerationVersionRef.current;
     lastRenderedGenerationVersionRef.current = generationVersion;
 
+    const isApproximateSame = isApproximate === lastRenderedIsApproximateRef.current;
+    lastRenderedIsApproximateRef.current = isApproximate;
+
+    const projectRoutingSame = projectRouting === lastRenderedProjectRoutingRef.current;
+    lastRenderedProjectRoutingRef.current = projectRouting;
+
+    const querySame = JSON.stringify(query) === JSON.stringify(lastRenderedQueryRef.current);
+    lastRenderedQueryRef.current = query;
+
+    const filtersSame = JSON.stringify(filters) === JSON.stringify(lastRenderedFiltersRef.current);
+    lastRenderedFiltersRef.current = filters;
+
     if (
       savedTemplate !== undefined &&
       savedTemplate === selfWrittenRef.current &&
       timeRangeSame &&
-      generationVersionSame
+      generationVersionSame &&
+      isApproximateSame &&
+      projectRoutingSame &&
+      querySame &&
+      filtersSame
     ) {
       return;
     }

--- a/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/hooks/use_custom_content_html.ts
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { EuiThemeColorModeStandard } from '@elastic/eui';
 import type { AggregateQuery, Filter, Query, TimeRange, ProjectRouting } from '@kbn/es-query';
+import { getEsQueryConfig } from '@kbn/data-plugin/public';
 import { getServices } from '../services';
 import { streamGenerate } from '../utils/stream_generate';
 import { fetchEsqlData } from '../utils/fetch_esql_data';
@@ -128,9 +129,7 @@ export function useCustomContentHtml({
       projectRouting,
       query,
       filters,
-      ignoreFilterIfFieldNotInIndex: core.uiSettings.get<boolean>(
-        'courier:ignoreFilterIfFieldNotInIndex'
-      ),
+      esQueryConfig: getEsQueryConfig(core.uiSettings),
     };
 
     // Fast path — ES|QL panel with stored template: fetch data client-side and render, no LLM.

--- a/x-pack/platform/plugins/shared/custom_content/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/plugin.ts
@@ -37,7 +37,7 @@ export class CustomContentPlugin implements Plugin<void, void, SetupDeps, StartD
   start(core: CoreStart, { data, agentBuilder }: StartDeps) {
     // Temporary kill-switch — remove once the feature is approved to ship.
     if (!core.featureFlags.getBooleanValue(CUSTOM_CONTENT_ENABLED_FLAG_KEY, false)) return;
-    setServices(core, data.search.search, agentBuilder);
+    setServices(core, data.search.search, data.dataViews, agentBuilder);
 
     if (agentBuilder) {
       agentBuilder.attachments.addAttachmentType(

--- a/x-pack/platform/plugins/shared/custom_content/public/services.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/services.ts
@@ -8,10 +8,12 @@
 import type { CoreStart } from '@kbn/core/public';
 import type { ISearchGeneric } from '@kbn/search-types';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-browser';
+import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 
 interface Services {
   core: CoreStart;
   search: ISearchGeneric;
+  dataViews: DataViewsPublicPluginStart;
   agentBuilder: AgentBuilderPluginStart | undefined;
 }
 
@@ -20,9 +22,10 @@ let services: Services | undefined;
 export const setServices = (
   core: CoreStart,
   search: ISearchGeneric,
+  dataViews: DataViewsPublicPluginStart,
   agentBuilder: AgentBuilderPluginStart | undefined
 ) => {
-  services = { core, search, agentBuilder };
+  services = { core, search, dataViews, agentBuilder };
 };
 
 export const getServices = (): Services => {

--- a/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.test.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.test.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+jest.mock('@kbn/datemath', () => ({
+  __esModule: true,
+  default: {
+    parse: jest.fn((val: string, opts?: { roundUp?: boolean }) => ({
+      toISOString: () => (opts?.roundUp ? '2024-01-08T00:00:00.000Z' : '2024-01-01T00:00:00.000Z'),
+    })),
+  },
+}));
+
+jest.mock('@kbn/es-query', () => ({
+  buildEsQuery: jest.fn(),
+}));
+
+jest.mock('@kbn/esql-utils', () => ({
+  getESQLResults: jest.fn(),
+  getESQLTimeField: jest.fn(),
+}));
+
+import type { HttpStart } from '@kbn/core/public';
+import type { Filter, Query } from '@kbn/es-query';
+import { buildEsQuery } from '@kbn/es-query';
+import { getESQLResults, getESQLTimeField } from '@kbn/esql-utils';
+import { fetchEsqlData } from './fetch_esql_data';
+
+const mockBuildEsQuery = buildEsQuery as jest.MockedFunction<typeof buildEsQuery>;
+const mockGetESQLResults = getESQLResults as jest.MockedFunction<typeof getESQLResults>;
+const mockGetESQLTimeField = getESQLTimeField as jest.MockedFunction<typeof getESQLTimeField>;
+
+const mockHttp = {} as HttpStart;
+const mockSearch = jest.fn();
+const mockSignal = new AbortController().signal;
+const esqlQuery = 'FROM logs | STATS count = COUNT(*)';
+const mockResponse = { columns: [], values: [], all_columns: [] };
+
+const emptyBoolQuery = {
+  bool: { filter: [], must: [], must_not: [], should: [] },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockBuildEsQuery.mockReturnValue(emptyBoolQuery as ReturnType<typeof buildEsQuery>);
+  mockGetESQLResults.mockResolvedValue({
+    response: mockResponse,
+    params: { query: esqlQuery },
+  } as Awaited<ReturnType<typeof getESQLResults>>);
+  mockGetESQLTimeField.mockResolvedValue(undefined);
+});
+
+describe('fetchEsqlData', () => {
+  describe('no constraints', () => {
+    it('passes filter: undefined to getESQLResults when no filters, query, or time range', async () => {
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
+
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: undefined })
+      );
+    });
+
+    it('returns the response from getESQLResults', async () => {
+      const result = await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
+      expect(result).toBe(mockResponse);
+    });
+  });
+
+  describe('buildEsQuery args', () => {
+    it('calls buildEsQuery with empty arrays when query and filters are undefined', async () => {
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
+
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], [], expect.any(Object));
+    });
+
+    it('passes query array to buildEsQuery when query is provided', async () => {
+      const kqlQuery: Query = { language: 'kuery', query: 'host.name: "web-01"' };
+
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal, {
+        query: kqlQuery,
+      });
+
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, kqlQuery, [], expect.any(Object));
+    });
+
+    it('passes filters array to buildEsQuery when filters are provided', async () => {
+      const filters: Filter[] = [
+        {
+          meta: { index: 'logs-*', alias: null, disabled: false, negate: false },
+          query: { match_phrase: { 'host.name': 'web-01' } },
+        } satisfies Filter,
+      ];
+
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal, { filters });
+
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], filters, expect.any(Object));
+    });
+
+    it('defaults ignoreFilterIfFieldNotInIndex to true when not provided', async () => {
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
+
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], [], {
+        ignoreFilterIfFieldNotInIndex: true,
+      });
+    });
+
+    it('forwards ignoreFilterIfFieldNotInIndex: false from options', async () => {
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal, {
+        ignoreFilterIfFieldNotInIndex: false,
+      });
+
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], [], {
+        ignoreFilterIfFieldNotInIndex: false,
+      });
+    });
+  });
+
+  describe('time range', () => {
+    const timeRange = { from: 'now-7d', to: 'now' };
+
+    it('skips the time filter when getESQLTimeField returns undefined', async () => {
+      mockGetESQLTimeField.mockResolvedValue(undefined);
+
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, timeRange, mockSignal);
+
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: undefined })
+      );
+    });
+
+    it('merges the time range filter into esBoolQuery.bool.filter', async () => {
+      mockGetESQLTimeField.mockResolvedValue('@timestamp');
+      const existingFilter = { match_phrase: { 'host.name': 'web-01' } };
+      mockBuildEsQuery.mockReturnValue({
+        bool: { filter: [existingFilter], must: [], must_not: [], should: [] },
+      } as ReturnType<typeof buildEsQuery>);
+
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, timeRange, mockSignal);
+
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: {
+            bool: {
+              filter: [existingFilter, { range: { '@timestamp': expect.any(Object) } }],
+              must: [],
+              must_not: [],
+              should: [],
+            },
+          },
+        })
+      );
+    });
+
+    it('produces a bool filter from time range alone when esBoolQuery has no other constraints', async () => {
+      mockGetESQLTimeField.mockResolvedValue('@timestamp');
+
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, timeRange, mockSignal);
+
+      const call = mockGetESQLResults.mock.calls[0][0];
+      const filter = call.filter as { bool: { filter: unknown[] } };
+      expect(filter).toBeDefined();
+      expect(filter.bool.filter).toHaveLength(1);
+      expect(filter.bool.filter[0]).toMatchObject({
+        range: { '@timestamp': { format: 'strict_date_optional_time' } },
+      });
+    });
+
+    it('silently skips the time filter when getESQLTimeField throws', async () => {
+      mockGetESQLTimeField.mockRejectedValue(new Error('field caps unavailable'));
+
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, timeRange, mockSignal);
+
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: undefined })
+      );
+    });
+  });
+
+  describe('hasConstraints — filter produced only when needed', () => {
+    it('sets filter when must_not is non-empty even if filter array is empty', async () => {
+      mockBuildEsQuery.mockReturnValue({
+        bool: { filter: [], must: [], must_not: [{ term: { status: 'error' } }], should: [] },
+      } as ReturnType<typeof buildEsQuery>);
+
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
+
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: expect.objectContaining({ bool: expect.any(Object) }) })
+      );
+    });
+
+    it('sets filter when should is non-empty', async () => {
+      mockBuildEsQuery.mockReturnValue({
+        bool: { filter: [], must: [], must_not: [], should: [{ term: { env: 'prod' } }] },
+      } as ReturnType<typeof buildEsQuery>);
+
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
+
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: expect.objectContaining({ bool: expect.any(Object) }) })
+      );
+    });
+  });
+
+  describe('approximation and projectRouting passthrough', () => {
+    it('omits approximation from getESQLResults when not provided', async () => {
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
+
+      const call = mockGetESQLResults.mock.calls[0][0];
+      expect(call).not.toHaveProperty('approximation');
+    });
+
+    it('forwards isApproximate: true to getESQLResults as approximation', async () => {
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal, {
+        isApproximate: true,
+      });
+
+      expect(mockGetESQLResults).toHaveBeenCalledWith(
+        expect.objectContaining({ approximation: true })
+      );
+    });
+
+    it('forwards projectRouting when provided', async () => {
+      const projectRouting = 'p-abc123' as import('@kbn/es-query').ProjectRouting;
+
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal, {
+        projectRouting,
+      });
+
+      expect(mockGetESQLResults).toHaveBeenCalledWith(expect.objectContaining({ projectRouting }));
+    });
+
+    it('omits projectRouting from getESQLResults when not provided', async () => {
+      await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
+
+      const call = mockGetESQLResults.mock.calls[0][0];
+      expect(call).not.toHaveProperty('projectRouting');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.test.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.test.ts
@@ -73,7 +73,7 @@ describe('fetchEsqlData', () => {
     it('calls buildEsQuery with empty arrays when query and filters are undefined', async () => {
       await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
 
-      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], [], expect.any(Object));
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], [], undefined);
     });
 
     it('passes query array to buildEsQuery when query is provided', async () => {
@@ -83,7 +83,7 @@ describe('fetchEsqlData', () => {
         query: kqlQuery,
       });
 
-      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, kqlQuery, [], expect.any(Object));
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, kqlQuery, [], undefined);
     });
 
     it('passes filters array to buildEsQuery when filters are provided', async () => {
@@ -96,25 +96,28 @@ describe('fetchEsqlData', () => {
 
       await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal, { filters });
 
-      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], filters, expect.any(Object));
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], filters, undefined);
     });
 
-    it('defaults ignoreFilterIfFieldNotInIndex to true when not provided', async () => {
+    it('passes undefined esQueryConfig to buildEsQuery when not provided', async () => {
       await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal);
 
-      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], [], {
-        ignoreFilterIfFieldNotInIndex: true,
-      });
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], [], undefined);
     });
 
-    it('forwards ignoreFilterIfFieldNotInIndex: false from options', async () => {
+    it('forwards esQueryConfig from options to buildEsQuery', async () => {
+      const esQueryConfig = {
+        allowLeadingWildcards: true,
+        queryStringOptions: { analyze_wildcard: true },
+        ignoreFilterIfFieldNotInIndex: true,
+        dateFormatTZ: 'Europe/Athens',
+      };
+
       await fetchEsqlData(mockSearch, mockHttp, esqlQuery, undefined, mockSignal, {
-        ignoreFilterIfFieldNotInIndex: false,
+        esQueryConfig,
       });
 
-      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], [], {
-        ignoreFilterIfFieldNotInIndex: false,
-      });
+      expect(mockBuildEsQuery).toHaveBeenCalledWith(undefined, [], [], esQueryConfig);
     });
   });
 

--- a/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.ts
@@ -7,7 +7,7 @@
 
 import dateMath from '@kbn/datemath';
 import type { HttpStart } from '@kbn/core/public';
-import type { TimeRange } from '@kbn/es-query';
+import type { TimeRange, ProjectRouting } from '@kbn/es-query';
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import type { ISearchGeneric } from '@kbn/search-types';
 import { getESQLResults, getESQLTimeField } from '@kbn/esql-utils';
@@ -20,7 +20,8 @@ export async function fetchEsqlData(
   esqlQuery: string,
   timeRange: TimeRange | undefined,
   signal: AbortSignal,
-  isApproximate?: boolean
+  isApproximate?: boolean,
+  projectRouting?: ProjectRouting
 ): Promise<EsqlDataResult> {
   let filter: unknown;
 
@@ -51,6 +52,7 @@ export async function fetchEsqlData(
     filter,
     timeRange,
     ...(isApproximate !== undefined ? { approximation: isApproximate } : {}),
+    ...(projectRouting !== undefined ? { projectRouting } : {}),
   });
 
   return response;

--- a/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.ts
@@ -19,7 +19,8 @@ export async function fetchEsqlData(
   http: HttpStart,
   esqlQuery: string,
   timeRange: TimeRange | undefined,
-  signal: AbortSignal
+  signal: AbortSignal,
+  isApproximate?: boolean
 ): Promise<EsqlDataResult> {
   let filter: unknown;
 
@@ -49,6 +50,7 @@ export async function fetchEsqlData(
     signal,
     filter,
     timeRange,
+    ...(isApproximate !== undefined ? { approximation: isApproximate } : {}),
   });
 
   return response;

--- a/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.ts
@@ -7,12 +7,21 @@
 
 import dateMath from '@kbn/datemath';
 import type { HttpStart } from '@kbn/core/public';
-import type { TimeRange, ProjectRouting } from '@kbn/es-query';
+import type { AggregateQuery, Filter, Query, TimeRange, ProjectRouting } from '@kbn/es-query';
+import { buildEsQuery } from '@kbn/es-query';
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import type { ISearchGeneric } from '@kbn/search-types';
 import { getESQLResults, getESQLTimeField } from '@kbn/esql-utils';
 
 export type EsqlDataResult = ESQLSearchResponse;
+
+export interface FetchEsqlOptions {
+  isApproximate?: boolean;
+  projectRouting?: ProjectRouting;
+  query?: Query | AggregateQuery;
+  filters?: Filter[];
+  ignoreFilterIfFieldNotInIndex?: boolean;
+}
 
 export async function fetchEsqlData(
   search: ISearchGeneric,
@@ -20,11 +29,12 @@ export async function fetchEsqlData(
   esqlQuery: string,
   timeRange: TimeRange | undefined,
   signal: AbortSignal,
-  isApproximate?: boolean,
-  projectRouting?: ProjectRouting
+  options?: FetchEsqlOptions
 ): Promise<EsqlDataResult> {
-  let filter: unknown;
+  const { isApproximate, projectRouting, query, filters, ignoreFilterIfFieldNotInIndex } =
+    options ?? {};
 
+  let timeRangeFilter: { range: Record<string, unknown> } | undefined;
   if (timeRange) {
     let timeField: string | undefined;
     try {
@@ -36,14 +46,28 @@ export async function fetchEsqlData(
       const gte = dateMath.parse(timeRange.from)?.toISOString();
       const lt = dateMath.parse(timeRange.to, { roundUp: true })?.toISOString();
       if (gte && lt) {
-        filter = {
-          range: {
-            [timeField]: { gte, lt, format: 'strict_date_optional_time' },
-          },
+        timeRangeFilter = {
+          range: { [timeField]: { gte, lt, format: 'strict_date_optional_time' } },
         };
       }
     }
   }
+
+  const esBoolQuery = buildEsQuery(undefined, query ?? [], filters ?? [], {
+    ignoreFilterIfFieldNotInIndex: ignoreFilterIfFieldNotInIndex ?? true,
+  });
+
+  const allFilters = timeRangeFilter
+    ? [...esBoolQuery.bool.filter, timeRangeFilter]
+    : esBoolQuery.bool.filter;
+
+  const hasConstraints =
+    allFilters.length > 0 ||
+    esBoolQuery.bool.must_not.length > 0 ||
+    esBoolQuery.bool.should.length > 0 ||
+    esBoolQuery.bool.must.length > 0;
+
+  const filter = hasConstraints ? { bool: { ...esBoolQuery.bool, filter: allFilters } } : undefined;
 
   const { response } = await getESQLResults({
     esqlQuery,

--- a/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.ts
+++ b/x-pack/platform/plugins/shared/custom_content/public/utils/fetch_esql_data.ts
@@ -7,7 +7,14 @@
 
 import dateMath from '@kbn/datemath';
 import type { HttpStart } from '@kbn/core/public';
-import type { AggregateQuery, Filter, Query, TimeRange, ProjectRouting } from '@kbn/es-query';
+import type {
+  AggregateQuery,
+  EsQueryConfig,
+  Filter,
+  Query,
+  TimeRange,
+  ProjectRouting,
+} from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
 import type { ESQLSearchResponse } from '@kbn/es-types';
 import type { ISearchGeneric } from '@kbn/search-types';
@@ -20,7 +27,7 @@ export interface FetchEsqlOptions {
   projectRouting?: ProjectRouting;
   query?: Query | AggregateQuery;
   filters?: Filter[];
-  ignoreFilterIfFieldNotInIndex?: boolean;
+  esQueryConfig?: EsQueryConfig;
 }
 
 export async function fetchEsqlData(
@@ -31,8 +38,7 @@ export async function fetchEsqlData(
   signal: AbortSignal,
   options?: FetchEsqlOptions
 ): Promise<EsqlDataResult> {
-  const { isApproximate, projectRouting, query, filters, ignoreFilterIfFieldNotInIndex } =
-    options ?? {};
+  const { isApproximate, projectRouting, query, filters, esQueryConfig } = options ?? {};
 
   let timeRangeFilter: { range: Record<string, unknown> } | undefined;
   if (timeRange) {
@@ -53,9 +59,7 @@ export async function fetchEsqlData(
     }
   }
 
-  const esBoolQuery = buildEsQuery(undefined, query ?? [], filters ?? [], {
-    ignoreFilterIfFieldNotInIndex: ignoreFilterIfFieldNotInIndex ?? true,
-  });
+  const esBoolQuery = buildEsQuery(undefined, query ?? [], filters ?? [], esQueryConfig);
 
   const allFilters = timeRangeFilter
     ? [...esBoolQuery.bool.filter, timeRangeFilter]

--- a/x-pack/platform/plugins/shared/custom_content/tsconfig.json
+++ b/x-pack/platform/plugins/shared/custom_content/tsconfig.json
@@ -34,7 +34,8 @@
     "@kbn/code-editor-mock",
     "@kbn/core-http-server",
     "@kbn/ui-callout",
-    "@kbn/shared-ux-ai-components"
+    "@kbn/shared-ux-ai-components",
+    "@kbn/data-views-plugin"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/279161
Closes https://github.com/elastic/kibana/issues/280416

This PR adds support for:

- DSL filters created by filter builder and controls
- KQL query
- Approximation
- Project routing

This of course applies for dynamic custom content panels (that are using an ES|QL query)


### How to test

Enable it with:
```
dashboard.customContent.enabled: true
```

Play with the unified search elements and check if your custom panel is filtered correctly. The panel needs to have an ES|QL query.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



