### PR TITLE
[One workflows] Do not require `read` to execute a workflow

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -67184,7 +67184,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a single step from a workflow definition in test mode.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a single step from a workflow definition in test mode.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-step-test
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -67297,7 +67297,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a workflow in test mode without requiring it to be saved or enabled. Provide either a workflow ID to test a saved workflow, a YAML definition to test an unsaved draft, or both to test a modified version of an existing workflow.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a workflow in test mode without requiring it to be saved or enabled. Provide either a workflow ID to test a saved workflow, a YAML definition to test an unsaved draft, or both to test a modified version of an existing workflow.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-test
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -67891,7 +67891,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a workflow by its ID with the provided inputs. The workflow must be enabled and have a valid definition. Returns an execution ID that can be used to monitor progress.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a workflow by its ID with the provided inputs. The workflow must be enabled and have a valid definition. Returns an execution ID that can be used to monitor progress.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-workflow-id-run
       parameters:
         - description: A required header to protect against CSRF attacks

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -75210,7 +75210,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a single step from a workflow definition in test mode.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a single step from a workflow definition in test mode.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-step-test
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -75323,7 +75323,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a workflow in test mode without requiring it to be saved or enabled. Provide either a workflow ID to test a saved workflow, a YAML definition to test an unsaved draft, or both to test a modified version of an existing workflow.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a workflow in test mode without requiring it to be saved or enabled. Provide either a workflow ID to test a saved workflow, a YAML definition to test an unsaved draft, or both to test a modified version of an existing workflow.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-test
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -75917,7 +75917,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a workflow by its ID with the provided inputs. The workflow must be enabled and have a valid definition. Returns an execution ID that can be used to monitor progress.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a workflow by its ID with the provided inputs. The workflow must be enabled and have a valid definition. Returns an execution ID that can be used to monitor progress.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-workflow-id-run
       parameters:
         - description: A required header to protect against CSRF attacks

--- a/src/platform/packages/shared/kbn-workflows/common/privileges.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/privileges.ts
@@ -25,6 +25,44 @@ export enum WorkflowsManagementApiActions {
   'cancelExecution' = `${WORKFLOWS_MANAGEMENT_FEATURE_ID}:cancelExecution`,
 }
 
+/**
+ * The API actions required to perform each Workflows Management operation, and the single source of
+ * truth for every consumer: the Workflows Management HTTP routes, and the plugins that perform the
+ * same operations through the server-side API (Agent Builder) and check the privileges themselves.
+ *
+ * All the actions listed for an operation are required (AND).
+ *
+ * Only the actions the operation itself requires are listed. Reads performed as an implementation
+ * detail of an operation (e.g. loading a workflow document before executing it) do not expose data
+ * to the caller, so they do not require the `read` action.
+ *
+ * The managed variants are supersets: reading a managed workflow requires the base `read` action on
+ * top of the managed one.
+ */
+export const WorkflowsManagementOperationPrivileges = {
+  create: [WorkflowsManagementApiActions.create],
+  clone: [WorkflowsManagementApiActions.create, WorkflowsManagementApiActions.read],
+  bulkCreate: [WorkflowsManagementApiActions.create, WorkflowsManagementApiActions.update],
+  read: [WorkflowsManagementApiActions.read],
+  readManaged: [WorkflowsManagementApiActions.read, WorkflowsManagementApiActions.readManaged],
+  update: [WorkflowsManagementApiActions.update],
+  updateManaged: [
+    WorkflowsManagementApiActions.update,
+    WorkflowsManagementApiActions.updateManaged,
+  ],
+  delete: [WorkflowsManagementApiActions.delete],
+  execute: [WorkflowsManagementApiActions.execute],
+  // Resuming acts on an execution that is already running, so it rides on `execute` until the
+  // resume-specific privilege model is defined.
+  resumeExecution: [WorkflowsManagementApiActions.execute],
+  readExecution: [WorkflowsManagementApiActions.readExecution],
+  readManagedExecution: [
+    WorkflowsManagementApiActions.readExecution,
+    WorkflowsManagementApiActions.readManagedExecution,
+  ],
+  cancelExecution: [WorkflowsManagementApiActions.cancelExecution],
+} as const satisfies Record<string, readonly WorkflowsManagementApiActions[]>;
+
 // The UI actions (aka capabilities) added by feature privileges, to be checked in the UI components.
 // UI actions are scoped by feature ID ("workflowsManagement"), so no need to add any prefix.
 // example: application.capabilities.workflowsManagement.createWorkflow

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/tests/route_privilege_consistency.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/tests/route_privilege_consistency.test.ts
@@ -145,6 +145,11 @@ const INTERNAL_READ_EXCEPTIONS: Record<string, string[]> = {
   'POST:/api/workflows': [WORKFLOWS_INDEX],
   // Existence check before cancelAllActiveWorkflowExecutions (see WorkflowsManagementApi.cancelAllActiveWorkflowExecutions)
   'POST:/api/workflows/workflow/{workflowId}/executions/cancel': [WORKFLOWS_INDEX],
+  // Executing a persisted workflow loads its document to build the execution
+  // model. The definition is never returned to the caller (only an execution
+  // id), so running a workflow does not require the `read` privilege.
+  'POST:/api/workflows/workflow/{id}/run': [WORKFLOWS_INDEX],
+  'POST:/api/workflows/test': [WORKFLOWS_INDEX],
   // Resume resolves the waiting `waitForInput` step (by run id) before claiming
   // it — an internal lookup intrinsic to the resume action, not data exposed to
   // the caller. See WorkflowsManagementApi.resumeWorkflowExecution →

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/route_security.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/route_security.ts
@@ -8,7 +8,10 @@
  */
 
 import type { RouteSecurity } from '@kbn/core-http-server';
-import { WorkflowsManagementApiActions } from '@kbn/workflows';
+import {
+  WorkflowsManagementApiActions,
+  WorkflowsManagementOperationPrivileges,
+} from '@kbn/workflows';
 import { ManagedWorkflowExecutionReadForbiddenError } from '../../managed_workflow_execution_read_error';
 import { ManagedWorkflowReadForbiddenError } from '../../managed_workflow_read_error';
 import type { GetWorkflowsParams } from '../../workflows_management_api';
@@ -24,17 +27,22 @@ interface ManagedResource {
 /**
  * Security configuration objects ready to be used in route definitions.
  *
+ * The privileges each operation requires are defined in
+ * `WorkflowsManagementOperationPrivileges` (`@kbn/workflows`), shared with the other plugins that
+ * perform the same operations through the server-side API. These objects only add the
+ * route-specific composition on top (`anyRequired` / `extendedPrivileges`).
+ *
  * Privilege model:
  * - Routes that return workflow data to the caller require `read`.
  * - Routes that return execution data require `readExecution`.
- * - Mutating routes (update / delete) perform internal reads as part of the
- *   write operation (merge, space-scoping). These reads are implementation
- *   details and do NOT require the `read` privilege.
+ * - Routes that mutate or execute perform internal reads as part of the operation
+ *   (merge, space-scoping, loading the definition to run it). These reads are
+ *   implementation details and do NOT require the `read` privilege.
  * - `get_workflows` and `get_stats` use `extendedPrivileges` for optional
  *   execution/managed privileges checked via `authzResult` without gating access.
  */
 export const WORKFLOW_READ_SECURITY: RouteSecurity = {
-  authz: { requiredPrivileges: [WorkflowsManagementApiActions.read] },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.read] },
 };
 /**
  * Allows either base read or managed read through platform authz so handlers can
@@ -42,14 +50,7 @@ export const WORKFLOW_READ_SECURITY: RouteSecurity = {
  */
 export const WORKFLOW_READ_WITH_MANAGED_SECURITY: RouteSecurity = {
   authz: {
-    requiredPrivileges: [
-      {
-        anyRequired: [
-          WorkflowsManagementApiActions.read,
-          WorkflowsManagementApiActions.readManaged,
-        ],
-      },
-    ],
+    requiredPrivileges: [{ anyRequired: [...WorkflowsManagementOperationPrivileges.readManaged] }],
   },
 };
 /**
@@ -59,7 +60,7 @@ export const WORKFLOW_READ_WITH_MANAGED_SECURITY: RouteSecurity = {
  */
 export const WORKFLOW_READ_WITH_EXECUTION_EXTENDED_SECURITY: RouteSecurity = {
   authz: {
-    requiredPrivileges: [WorkflowsManagementApiActions.read],
+    requiredPrivileges: [...WorkflowsManagementOperationPrivileges.read],
     extendedPrivileges: [
       WorkflowsManagementApiActions.readManaged,
       WorkflowsManagementApiActions.readExecution,
@@ -68,42 +69,28 @@ export const WORKFLOW_READ_WITH_EXECUTION_EXTENDED_SECURITY: RouteSecurity = {
   },
 };
 export const WORKFLOW_CREATE_SECURITY: RouteSecurity = {
-  authz: { requiredPrivileges: [WorkflowsManagementApiActions.create] },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.create] },
 };
 export const WORKFLOW_CLONE_SECURITY: RouteSecurity = {
-  authz: {
-    requiredPrivileges: [WorkflowsManagementApiActions.create, WorkflowsManagementApiActions.read],
-  },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.clone] },
 };
 export const WORKFLOW_BULK_CREATE_SECURITY: RouteSecurity = {
-  authz: {
-    requiredPrivileges: [
-      WorkflowsManagementApiActions.create,
-      WorkflowsManagementApiActions.update,
-    ],
-  },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.bulkCreate] },
 };
 export const WORKFLOW_UPDATE_SECURITY: RouteSecurity = {
-  authz: { requiredPrivileges: [WorkflowsManagementApiActions.update] },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.update] },
 };
 export const WORKFLOW_MANAGED_UPDATE_SECURITY: RouteSecurity = {
-  authz: {
-    requiredPrivileges: [
-      WorkflowsManagementApiActions.update,
-      WorkflowsManagementApiActions.updateManaged,
-    ],
-  },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.updateManaged] },
 };
 export const WORKFLOW_DELETE_SECURITY: RouteSecurity = {
-  authz: { requiredPrivileges: [WorkflowsManagementApiActions.delete] },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.delete] },
 };
 export const WORKFLOW_EXECUTE_SECURITY: RouteSecurity = {
-  authz: {
-    requiredPrivileges: [WorkflowsManagementApiActions.execute, WorkflowsManagementApiActions.read],
-  },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.execute] },
 };
 export const WORKFLOW_EXECUTION_READ_SECURITY: RouteSecurity = {
-  authz: { requiredPrivileges: [WorkflowsManagementApiActions.readExecution] },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.readExecution] },
 };
 /**
  * Allows either base execution read or managed execution read through platform
@@ -113,20 +100,15 @@ export const WORKFLOW_EXECUTION_READ_SECURITY: RouteSecurity = {
 export const WORKFLOW_EXECUTION_READ_WITH_MANAGED_SECURITY: RouteSecurity = {
   authz: {
     requiredPrivileges: [
-      {
-        anyRequired: [
-          WorkflowsManagementApiActions.readExecution,
-          WorkflowsManagementApiActions.readManagedExecution,
-        ],
-      },
+      { anyRequired: [...WorkflowsManagementOperationPrivileges.readManagedExecution] },
     ],
   },
 };
 export const WORKFLOW_EXECUTION_CANCEL_SECURITY: RouteSecurity = {
-  authz: { requiredPrivileges: [WorkflowsManagementApiActions.cancelExecution] },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.cancelExecution] },
 };
 export const WORKFLOW_EXECUTION_RESUME_SECURITY: RouteSecurity = {
-  authz: { requiredPrivileges: [WorkflowsManagementApiActions.execute] },
+  authz: { requiredPrivileges: [...WorkflowsManagementOperationPrivileges.resumeExecution] },
 };
 
 const hasPrivilege = (request: AuthzRequest, action: WorkflowsManagementApiActions): boolean =>

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.test.ts
@@ -62,16 +62,13 @@ describe('workflow privilege checks', () => {
   });
 
   describe('hasWorkflowExecutePrivilege', () => {
-    it('requires both execute and read', async () => {
+    it('requires execute only, so a workflow can be run without reading its definition', async () => {
       const { security, atSpace } = createSecurityMock(true);
 
       await expect(hasWorkflowExecutePrivilege({ security, request, spaceId })).resolves.toBe(true);
 
       expect(atSpace).toHaveBeenCalledWith(spaceId, {
-        kibana: [
-          `api:${WorkflowsManagementApiActions.execute}`,
-          `api:${WorkflowsManagementApiActions.read}`,
-        ],
+        kibana: [`api:${WorkflowsManagementApiActions.execute}`],
       });
     });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.ts
@@ -7,7 +7,7 @@
 
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
-import { WorkflowsManagementApiActions } from '@kbn/workflows';
+import { WorkflowsManagementOperationPrivileges } from '@kbn/workflows';
 
 export interface CheckWorkflowPrivilegeParams {
   security: SecurityPluginStart | undefined;
@@ -28,7 +28,7 @@ const hasAllApiPrivileges = async ({
   spaceId,
   actions,
 }: CheckWorkflowPrivilegeParams & {
-  actions: string[];
+  actions: readonly string[];
 }): Promise<boolean> => {
   if (!security) {
     return true;
@@ -43,22 +43,18 @@ const hasAllApiPrivileges = async ({
 };
 
 /**
- * Verifies the caller holds the `workflowsManagement:read` privilege before a
- * workflow is referenced (e.g. wrapped in a tool or listed) through Agent Builder.
+ * Verifies the caller holds the privileges required to read a workflow before it
+ * is referenced (e.g. wrapped in a tool or listed) through Agent Builder.
  */
 export const hasWorkflowReadPrivilege = (params: CheckWorkflowPrivilegeParams): Promise<boolean> =>
-  hasAllApiPrivileges({ ...params, actions: [WorkflowsManagementApiActions.read] });
+  hasAllApiPrivileges({ ...params, actions: WorkflowsManagementOperationPrivileges.read });
 
 /**
- * Verifies the caller holds the `workflowsManagement:execute` and
- * `workflowsManagement:read` privileges before a workflow is executed through
- * Agent Builder. Mirrors the privileges required by the direct Workflows
- * `.../run` HTTP route.
+ * Verifies the caller holds the privileges required to execute a workflow through
+ * Agent Builder. Executing does not require reading the definition: the workflow
+ * document is loaded to run it, but is never exposed to the caller.
  */
 export const hasWorkflowExecutePrivilege = (
   params: CheckWorkflowPrivilegeParams
 ): Promise<boolean> =>
-  hasAllApiPrivileges({
-    ...params,
-    actions: [WorkflowsManagementApiActions.execute, WorkflowsManagementApiActions.read],
-  });
+  hasAllApiPrivileges({ ...params, actions: WorkflowsManagementOperationPrivileges.execute });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_types/workflow/tool_type.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_types/workflow/tool_type.ts
@@ -55,7 +55,7 @@ export const getWorkflowToolType = ({
               return {
                 results: [
                   errorResult(
-                    `Unauthorized to execute workflow '${workflowId}'. The 'workflowsManagement' execute and read privileges are required.`
+                    `Unauthorized to execute workflow '${workflowId}'. The 'workflowsManagement' execute privilege is required.`
                   ),
                 ],
               };

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/sml_types/workflow.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/sml_types/workflow.ts
@@ -9,7 +9,7 @@ import type { SmlTypeDefinition } from '@kbn/agent-builder-sml-plugin/server';
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 import { WORKFLOW_SML_TYPE, WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
-import { WORKFLOW_INDEX_NAME, WorkflowsManagementApiActions } from '@kbn/workflows';
+import { WORKFLOW_INDEX_NAME, WorkflowsManagementOperationPrivileges } from '@kbn/workflows';
 import type { WorkflowProperties } from '@kbn/workflows-management-plugin/server/storage/workflow_storage';
 
 type WorkflowsManagementApi = WorkflowsServerPluginSetup['management'];
@@ -120,7 +120,11 @@ export const createWorkflowSmlType = (api: WorkflowsManagementApi): SmlTypeDefin
    * Kibana saved objects.
    */
   getPermissions: () => ({
-    kibana: { privileges: [{ name: `api:${WorkflowsManagementApiActions.read}` }] },
+    kibana: {
+      privileges: WorkflowsManagementOperationPrivileges.read.map((action) => ({
+        name: `api:${action}`,
+      })),
+    },
   }),
 
   toAttachment: async (item, context) => {

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/tools/execute_workflow.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/tools/execute_workflow.ts
@@ -139,7 +139,7 @@ If set to false, or if the workflow does not complete within the timeout, the to
           return {
             results: [
               errorResult(
-                `Unauthorized to execute workflow '${resolvedWorkflowId}'. The 'workflowsManagement' execute and read privileges are required.`
+                `Unauthorized to execute workflow '${resolvedWorkflowId}'. The 'workflowsManagement' execute privilege is required.`
               ),
             ],
           };

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/tools/utils/check_execution_read_privilege.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/tools/utils/check_execution_read_privilege.ts
@@ -7,12 +7,11 @@
 
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
-import { WorkflowsManagementApiActions } from '@kbn/workflows';
+import { WorkflowsManagementOperationPrivileges } from '@kbn/workflows';
 
 /**
- * Verifies the caller holds the `workflowsManagement:readExecution` Kibana
- * privilege before workflow execution data is returned through an Agent Builder
- * tool.
+ * Verifies the caller holds the privileges required to read workflow execution
+ * data before it is returned through an Agent Builder tool.
  *
  * Returns `true` when access is allowed. When the security plugin is disabled
  * there is no privilege model to enforce, so access is allowed.
@@ -31,12 +30,12 @@ export const hasWorkflowExecutionReadPrivilege = async ({
     return true;
   }
 
-  const requiredPrivilege = security.authz.actions.api.get(
-    WorkflowsManagementApiActions.readExecution
+  const requiredPrivileges = WorkflowsManagementOperationPrivileges.readExecution.map((action) =>
+    security.authz.actions.api.get(action)
   );
   const { hasAllRequested } = await security.authz
     .checkPrivilegesWithRequest(request)
-    .atSpace(spaceId, { kibana: [requiredPrivilege] });
+    .atSpace(spaceId, { kibana: requiredPrivileges });
 
   return hasAllRequested;
 };


### PR DESCRIPTION
## Summary

Executing a workflow no longer requires the `workflowsManagement:read` privilege, and the privileges required by each Workflows Management operation now live in one shared place.

Running a workflow loads its document to build the execution model, but the definition never reaches the caller — the run API returns an execution id. Requiring `read` was an implementation detail leaking into the RBAC model, and it blocked a legitimate authorization model: letting users execute approved workflows (typically as Agent Builder / MCP tools) without being able to read definitions that may contain sensitive implementation or configuration details.

This is the same rule the route security config already documented and the privilege/ES-operation guard test already enforced for mutating routes ("internal reads performed as part of the operation do not require `read`"), and the same rule `WORKFLOW_EXECUTION_RESUME_SECURITY` already followed. Execute was the exception.

### What changed

- **New `WorkflowsManagementOperationPrivileges` in `@kbn/workflows`** maps each operation to the API actions it requires. It is the single source of truth for both the Workflows Management HTTP routes and the plugins that perform the same operations through the server-side API and check privileges themselves.
  - It exports plain readonly action arrays, not `RouteSecurity` objects: `@kbn/workflows/common` is imported by browser code, so it must stay free of server-only types, and consumers need to compose the actions with their own (route `anyRequired` / `extendedPrivileges`, Agent Builder's `checkPrivileges` calls).
- **`workflows_management`**: every `*_SECURITY` constant in `route_security.ts` is now built from the map. Only `WORKFLOW_EXECUTE_SECURITY` changes behaviour (`execute` + `read` → `execute`), affecting `POST /api/workflows/workflow/{id}/run`, `POST /api/workflows/test` and `POST /api/workflows/step/test`.
- **Agent Builder**: `hasWorkflowReadPrivilege`, `hasWorkflowExecutePrivilege`, `hasWorkflowExecutionReadPrivilege` and the workflow SML type permissions all read from the map, so the two sides can no longer drift. The "execute and read privileges are required" error messages were updated.

`resumeExecution` is mapped to `execute`, which is what the resume route already required — resume acts on an execution that is already running and needs its own privilege model, so it is deliberately left unchanged here.

No feature privilege definitions changed, so no role or `features.ts` migration is involved: this only relaxes what the execute routes demand.

## Testing

- `route_privilege_consistency.test.ts`: the run and test routes are now declared internal-read exceptions (they read `WORKFLOWS_INDEX` without exposing it). I verified both entries are load-bearing — removing them fails the suite — and that `POST /api/workflows/step/test` needs none, since it executes caller-supplied YAML and never touches the index.
- `check_privileges.test.ts` asserts execute-only.
- Ran Jest for `workflows_management/server/api`, `kbn-workflows`, `agent-builder-tools-base`, `agent_builder_workflows/server` and the Agent Builder workflow tool type; all pass. ESLint and type checks pass on the touched projects.

## Follow-up

Attack Discovery pairs `execute` with `read` in its own constants (`WORKFLOW_EXECUTION_REQUIRED_API_PRIVILEGES` and the discoveries routes) for the same reason — it loads the workflow only to run it. That is owned by @elastic/security-threat-hunting, so adopting the shared map there will be proposed in a separate issue once this merges.

## References

Reported in [this thread](https://elastic.slack.com/archives/C08U04SUN49/p1786526494970749?thread_ts=1786458584.765169&cid=C08U04SUN49) after a customer hit it upgrading to 9.5 (privileges enforced on workflow tools by #277389). They expose workflows to users exclusively as MCP tools and need execute-without-read.

Closes elastic/security-team#18853

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->