### PR TITLE
[9.5] fix(apm): remove redundant version label from annotation popup (#273578)

### DIFF
--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -13432,7 +13432,6 @@
     "xpack.apm.appName": "APM",
     "xpack.apm.betaBadgeDescription": "Dieses Feature befindet sich derzeit in der Beta-Phase. Falls Sie auf Fehler stoßen oder Feedback haben, öffnen Sie bitte ein Ticket oder besuchen Sie unser Diskussionsforum.",
     "xpack.apm.betaBadgeLabel": "Beta",
-    "xpack.apm.chart.annotation.version": "Version",
     "xpack.apm.chart.comparison.defaultPreviousPeriodLabel": "Vorheriger Zeitraum",
     "xpack.apm.chart.cpuSeries.processAverageLabel": "Prozessdurchschnitt",
     "xpack.apm.chart.cpuSeries.processMaxLabel": "Prozess Max.",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -13413,7 +13413,6 @@
     "xpack.apm.appName": "APM",
     "xpack.apm.betaBadgeDescription": "Cette fonctionnalité est actuellement en version bêta. Si vous rencontrez des bugs ou si vous souhaitez apporter des commentaires, ouvrez un ticket de problème ou visitez notre forum de discussion.",
     "xpack.apm.betaBadgeLabel": "Bêta",
-    "xpack.apm.chart.annotation.version": "Version",
     "xpack.apm.chart.comparison.defaultPreviousPeriodLabel": "Période précédente",
     "xpack.apm.chart.cpuSeries.processAverageLabel": "Moyenne de processus",
     "xpack.apm.chart.cpuSeries.processMaxLabel": "Max de processus",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -13471,7 +13471,6 @@
     "xpack.apm.appName": "APM",
     "xpack.apm.betaBadgeDescription": "現在、この機能はベータです。不具合を見つけた場合やご意見がある場合、サポートに問い合わせるか、またはディスカッションフォーラムにご報告ください。",
     "xpack.apm.betaBadgeLabel": "ベータ",
-    "xpack.apm.chart.annotation.version": "バージョン",
     "xpack.apm.chart.comparison.defaultPreviousPeriodLabel": "前の期間",
     "xpack.apm.chart.cpuSeries.processAverageLabel": "プロセス平均",
     "xpack.apm.chart.cpuSeries.processMaxLabel": "プロセス最大",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -13474,7 +13474,6 @@
     "xpack.apm.appName": "APM",
     "xpack.apm.betaBadgeDescription": "此功能当前为公测版。如果遇到任何错误或有任何反馈，请报告问题或访问我们的论坛。",
     "xpack.apm.betaBadgeLabel": "公测版",
-    "xpack.apm.chart.annotation.version": "版本",
     "xpack.apm.chart.comparison.defaultPreviousPeriodLabel": "上一时段",
     "xpack.apm.chart.cpuSeries.processAverageLabel": "进程平均值",
     "xpack.apm.chart.cpuSeries.processMaxLabel": "进程最大值",

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/breakdown_chart/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/breakdown_chart/index.tsx
@@ -136,9 +136,7 @@ export function BreakdownChart({
             dataValues={annotations.map((annotation) => ({
               dataValue: annotation['@timestamp'],
               header: asAbsoluteDateTime(annotation['@timestamp']),
-              details: `${i18n.translate('xpack.apm.chart.annotation.version', {
-                defaultMessage: 'Version',
-              })} ${annotation.text}`,
+              details: annotation.text,
             }))}
             style={{
               line: { strokeWidth: 1, stroke: annotationColor, opacity: 1 },

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/timeseries_chart_with_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/timeseries_chart_with_context.tsx
@@ -9,7 +9,6 @@ import type { LegendItemListener, YDomainRange } from '@elastic/charts';
 import { AnnotationDomainType, LineAnnotation, Position } from '@elastic/charts';
 import React from 'react';
 import { EuiIcon, useEuiTheme } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import { asAbsoluteDateTime } from '../../../../common/utils/formatters';
 import { useAnnotationsContext } from '../../../context/annotations/use_annotations_context';
 import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
@@ -78,9 +77,7 @@ export function TimeseriesChartWithContext({
       dataValues={annotations.map((annotation) => ({
         dataValue: annotation['@timestamp'],
         header: asAbsoluteDateTime(annotation['@timestamp']),
-        details: `${i18n.translate('xpack.apm.chart.annotation.version', {
-          defaultMessage: 'Version',
-        })} ${annotation.text}`,
+        details: annotation.text,
       }))}
       style={{
         line: { strokeWidth: 1, stroke: annotationColor, opacity: 1 },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
- fix(apm): remove redundant version label from annotation popup (#273578)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

## Summary

The annotation popup on APM charts was prefixing the annotation text with a hardcoded `Version: ` label, which was confusing when annotations used custom text unrelated to service versions. This change drops the prefix so the annotation's own text is shown directly in the popup, and removes the now-unused `xpack.apm.chart.annotation.version` translation string from the locale files.

Closes #66138