### PR TITLE
[Discover][Metrics Exp] Add consistent tooltip to sort direction buttons

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector.tsx
@@ -27,7 +27,7 @@ export const SortSelector = ({ sort, onChange, fullWidth = false }: SortSelector
   const [, direction] = sort;
 
   return (
-    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
       <EuiFlexItem grow={fullWidth}>
         <ToolbarSelector
           data-test-subj="metricsExperienceSortSelector"

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
@@ -46,7 +46,7 @@ const directionOptions = [
     'data-test-subj': 'metricsExperienceSortDirectionAsc',
     label: ascendingLabel,
     toolTipContent: ascendingLabel,
-    title: undefined, // Prevent default html tooltip from being shown
+    title: '', // Prevent the native html tooltip from being shown
     ...getEbtProps({
       action: EBT_CLICK_ACTIONS.SET_SORT_DIRECTION,
       element: CHARTS_TOOLBAR_EBT_ELEMENT,
@@ -59,7 +59,7 @@ const directionOptions = [
     'data-test-subj': 'metricsExperienceSortDirectionDesc',
     label: descendingLabel,
     toolTipContent: descendingLabel,
-    title: undefined, // Prevent default html tooltip from being shown
+    title: '', // Prevent the native html tooltip from being shown
     ...getEbtProps({
       action: EBT_CLICK_ACTIONS.SET_SORT_DIRECTION,
       element: CHARTS_TOOLBAR_EBT_ELEMENT,

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
@@ -46,6 +46,7 @@ const directionOptions = [
     'data-test-subj': 'metricsExperienceSortDirectionAsc',
     label: ascendingLabel,
     toolTipContent: ascendingLabel,
+    title: '',
     ...getEbtProps({
       action: EBT_CLICK_ACTIONS.SET_SORT_DIRECTION,
       element: CHARTS_TOOLBAR_EBT_ELEMENT,
@@ -58,6 +59,7 @@ const directionOptions = [
     'data-test-subj': 'metricsExperienceSortDirectionDesc',
     label: descendingLabel,
     toolTipContent: descendingLabel,
+    title: '',
     ...getEbtProps({
       action: EBT_CLICK_ACTIONS.SET_SORT_DIRECTION,
       element: CHARTS_TOOLBAR_EBT_ELEMENT,

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
@@ -46,7 +46,7 @@ const directionOptions = [
     'data-test-subj': 'metricsExperienceSortDirectionAsc',
     label: ascendingLabel,
     toolTipContent: ascendingLabel,
-    title: '',
+    title: undefined, // Prevent default html tooltip from being shown
     ...getEbtProps({
       action: EBT_CLICK_ACTIONS.SET_SORT_DIRECTION,
       element: CHARTS_TOOLBAR_EBT_ELEMENT,
@@ -59,7 +59,7 @@ const directionOptions = [
     'data-test-subj': 'metricsExperienceSortDirectionDesc',
     label: descendingLabel,
     toolTipContent: descendingLabel,
-    title: '',
+    title: undefined, // Prevent default html tooltip from being shown
     ...getEbtProps({
       action: EBT_CLICK_ACTIONS.SET_SORT_DIRECTION,
       element: CHARTS_TOOLBAR_EBT_ELEMENT,

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
@@ -32,11 +32,11 @@ const directionLegend = i18n.translate('metricsExperience.sortSelector.direction
 });
 
 const ascendingLabel = i18n.translate('metricsExperience.sortSelector.ascending', {
-  defaultMessage: 'Ascending',
+  defaultMessage: 'Sort ascending',
 });
 
 const descendingLabel = i18n.translate('metricsExperience.sortSelector.descending', {
-  defaultMessage: 'Descending',
+  defaultMessage: 'Sort descending',
 });
 
 const directionOptions = [

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/toolbar/sort_selector_helpers.tsx
@@ -31,14 +31,21 @@ const directionLegend = i18n.translate('metricsExperience.sortSelector.direction
   defaultMessage: 'Sort direction',
 });
 
+const ascendingLabel = i18n.translate('metricsExperience.sortSelector.ascending', {
+  defaultMessage: 'Ascending',
+});
+
+const descendingLabel = i18n.translate('metricsExperience.sortSelector.descending', {
+  defaultMessage: 'Descending',
+});
+
 const directionOptions = [
   {
     id: METRICS_SORT_DIRECTION.asc,
     iconType: 'sortAscending',
     'data-test-subj': 'metricsExperienceSortDirectionAsc',
-    label: i18n.translate('metricsExperience.sortSelector.ascending', {
-      defaultMessage: 'Ascending',
-    }),
+    label: ascendingLabel,
+    toolTipContent: ascendingLabel,
     ...getEbtProps({
       action: EBT_CLICK_ACTIONS.SET_SORT_DIRECTION,
       element: CHARTS_TOOLBAR_EBT_ELEMENT,
@@ -49,9 +56,8 @@ const directionOptions = [
     id: METRICS_SORT_DIRECTION.desc,
     iconType: 'sortDescending',
     'data-test-subj': 'metricsExperienceSortDirectionDesc',
-    label: i18n.translate('metricsExperience.sortSelector.descending', {
-      defaultMessage: 'Descending',
-    }),
+    label: descendingLabel,
+    toolTipContent: descendingLabel,
     ...getEbtProps({
       action: EBT_CLICK_ACTIONS.SET_SORT_DIRECTION,
       element: CHARTS_TOOLBAR_EBT_ELEMENT,


### PR DESCRIPTION
Related #279279

## Summary

The sort direction buttons in the metrics experience toolbar now show the same custom tooltip as the other toolbar buttons, so the toolbar behaves consistently on hover.

Follow-up to a comment raised in [#282141](https://github.com/elastic/kibana/pull/282141#pullrequestreview-4924266562).

Before:
<img width="1728" height="607" alt="image" src="https://github.com/user-attachments/assets/ec08b919-89ea-44d8-8910-5d079116c0c2" />


After:
<img width="1724" height="662" alt="image" src="https://github.com/user-attachments/assets/119b402f-2599-4183-a20d-b4b8612112a7" />

