### PR TITLE
[8.19] [Index Management] Fix flaky mapper-size plugin test by moving coverage to unit tests (#283251)

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_create.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_template_wizard/template_create.test.tsx
@@ -388,39 +388,6 @@ describe('<TemplateCreate />', () => {
 
         expect(find('fieldsListItem').length).toBe(1);
       });
-
-      describe('plugin parameters', () => {
-        test('should not render the _size parameter if the mapper size plugin is not installed', async () => {
-          const { exists } = testBed;
-          // Navigate to the advanced configuration
-
-          await act(async () => {
-            testBed.find('advancedOptionsTab').simulate('click');
-          });
-          testBed.component.update();
-
-          expect(exists('mappingsEditor.advancedConfiguration.sizeEnabledToggle')).toBe(false);
-        });
-
-        test('should render the _size parameter if the mapper size plugin is installed', async () => {
-          httpRequestsMockHelpers.setLoadNodesPluginsResponse(['mapper-size']);
-
-          await act(async () => {
-            testBed = await setup(httpSetup);
-          });
-          testBed.component.update();
-          await navigateToMappingsStep();
-
-          await act(async () => {
-            testBed.find('advancedOptionsTab').simulate('click');
-          });
-          testBed.component.update();
-
-          expect(testBed.exists('mappingsEditor.advancedConfiguration.sizeEnabledToggle')).toBe(
-            true
-          );
-        });
-      });
     });
 
     describe('aliases (step 5)', () => {

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/__jest__/client_integration/mappings_editor_plugins.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/__jest__/client_integration/mappings_editor_plugins.test.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act } from 'react-dom/test-utils';
+import { docLinksServiceMock } from '@kbn/core/public/mocks';
+
+import { documentationService } from '../../../../services/documentation';
+import { componentHelpers, MappingsEditorTestBed } from './helpers';
+
+const { setup } = componentHelpers.mappingsEditor;
+
+jest.mock('../../../component_templates/component_templates_context', () => ({
+  useComponentTemplatesContext: jest.fn().mockReturnValue({
+    toasts: {
+      addError: jest.fn(),
+      addSuccess: jest.fn(),
+    },
+  }),
+}));
+
+describe('Mappings editor: mapper-size plugin support (esNodesPlugins prop)', () => {
+  let testBed: MappingsEditorTestBed;
+  const onChangeHandler: jest.Mock = jest.fn();
+
+  const defaultMappings = {
+    properties: {},
+    dynamic_templates: [],
+  };
+
+  const ctx = {
+    config: {
+      enableMappingsSourceFieldSection: true,
+    },
+    core: { application: {}, http: {} },
+    services: {
+      notificationService: { toasts: {} },
+    },
+    docLinks: docLinksServiceMock.createStartContract(),
+    plugins: {
+      ml: { mlApi: {} },
+    },
+  };
+
+  beforeAll(() => {
+    documentationService.setup(docLinksServiceMock.createStartContract());
+    jest.useFakeTimers({ legacyFakeTimers: true });
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const setupWithPlugins = async (esNodesPlugins: string[]) => {
+    await act(async () => {
+      testBed = setup({ value: defaultMappings, onChange: onChangeHandler, esNodesPlugins }, ctx);
+    });
+    testBed.component.update();
+  };
+
+  test('passes installed node plugins to the advanced configuration form', async () => {
+    await setupWithPlugins(['mapper-size']);
+
+    const {
+      actions: { selectTab },
+      exists,
+    } = testBed;
+
+    await selectTab('advanced');
+
+    expect(exists('sizeEnabledToggle')).toBe(true);
+  });
+
+  test("doesn't substitute an installed node plugin when the plugin list is empty", async () => {
+    await setupWithPlugins([]);
+
+    const {
+      actions: { selectTab },
+      exists,
+    } = testBed;
+
+    await selectTab('advanced');
+
+    expect(exists('sizeEnabledToggle')).toBe(false);
+  });
+
+  test('updates the advanced configuration form when node plugins finish loading', async () => {
+    await setupWithPlugins([]);
+
+    const {
+      actions: { selectTab },
+      exists,
+      setProps,
+      component,
+    } = testBed;
+
+    await selectTab('advanced');
+    expect(exists('sizeEnabledToggle')).toBe(false);
+
+    await act(async () => {
+      setProps({
+        value: defaultMappings,
+        onChange: onChangeHandler,
+        esNodesPlugins: ['mapper-size'],
+      });
+    });
+    component.update();
+
+    expect(exists('sizeEnabledToggle')).toBe(true);
+  });
+});

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/configuration_form.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/configuration_form.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { docLinksServiceMock } from '@kbn/core/public/mocks';
+
+import { documentationService } from '../../../../services/documentation';
+import { AppContextProvider, type AppDependencies } from '../../../../app_context';
+import { MappingsEditorProvider } from '../../mappings_editor_context';
+import { ConfigurationForm } from './configuration_form';
+
+jest.mock('@kbn/es-ui-shared-plugin/static/forms/components', () => {
+  const original = jest.requireActual('@kbn/es-ui-shared-plugin/static/forms/components');
+  return {
+    ...original,
+    // JsonEditorField pulls in the shared-ux code editor (Monaco) which requires Canvas/Suspense.
+    // For this suite we only care about configuration options, not editor rendering.
+    JsonEditorField: ({ codeEditorProps }: { codeEditorProps?: Record<string, unknown> }) => (
+      <div
+        data-test-subj={(codeEditorProps?.['data-test-subj'] as string) ?? 'mockJsonEditorField'}
+      />
+    ),
+  };
+});
+
+const appDependencies = {
+  config: {
+    enableMappingsSourceFieldSection: true,
+  },
+  hasAtLeastEnterpriseLicense: false,
+} as unknown as AppDependencies;
+
+const setup = (props: Partial<React.ComponentProps<typeof ConfigurationForm>>) =>
+  render(
+    <I18nProvider>
+      <AppContextProvider value={appDependencies}>
+        <MappingsEditorProvider>
+          <ConfigurationForm esNodesPlugins={[]} {...props} />
+        </MappingsEditorProvider>
+      </AppContextProvider>
+    </I18nProvider>
+  );
+
+describe('ConfigurationForm: _size field (mapper-size plugin)', () => {
+  beforeAll(() => {
+    documentationService.setup(docLinksServiceMock.createStartContract());
+  });
+
+  it('renders the _size parameter when the mapper size plugin is installed', () => {
+    setup({ esNodesPlugins: ['mapper-size'] });
+
+    expect(screen.getByTestId('sizeEnabledToggle')).toBeInTheDocument();
+  });
+
+  it("doesn't render the _size parameter when the mapper size plugin is not installed", () => {
+    setup({ esNodesPlugins: ['unrelated-plugin'] });
+
+    expect(screen.queryByTestId('sizeEnabledToggle')).not.toBeInTheDocument();
+  });
+
+  it('renders the _size parameter when the mappings define _size, even without the plugin', () => {
+    setup({ esNodesPlugins: [], value: { _size: { enabled: false } } });
+
+    expect(screen.getByTestId('sizeEnabledToggle')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/shared/components/wizard_steps/step_mappings_container.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/shared/components/wizard_steps/step_mappings_container.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { docLinksServiceMock, httpServiceMock } from '@kbn/core/public/mocks';
+
+import { API_BASE_PATH } from '../../../../../../common/constants';
+import { AppContextProvider, type AppDependencies } from '../../../../app_context';
+import { httpService } from '../../../../services/http';
+import { MappingsEditor } from '../../../mappings_editor';
+import { documentationService } from '../../../mappings_editor/shared_imports';
+import { StepMappingsContainer } from './step_mappings_container';
+
+jest.mock('../../../../../shared_imports', () => {
+  const actual = jest.requireActual('../../../../../shared_imports');
+  return {
+    ...actual,
+    Forms: {
+      useContent: jest.fn(() => ({
+        defaultValue: {},
+        updateContent: jest.fn(),
+        getSingleContentData: jest.fn(),
+      })),
+      useMultiContentContext: jest.fn(() => ({ getData: jest.fn() })),
+    },
+  };
+});
+
+jest.mock('../../../mappings_editor', () => ({
+  LoadMappingsFromJsonButton: jest.fn(() => null),
+  MappingsEditor: jest.fn(() => null),
+}));
+
+const mockMappingsEditor = jest.mocked(MappingsEditor);
+const docLinks = docLinksServiceMock.createStartContract();
+const appDependencies = { docLinks } as AppDependencies;
+let http = httpServiceMock.createSetupContract();
+
+const renderContainer = () =>
+  render(
+    <I18nProvider>
+      <AppContextProvider value={appDependencies}>
+        <StepMappingsContainer esDocsBase="" />
+      </AppContextProvider>
+    </I18nProvider>
+  );
+
+describe('StepMappingsContainer', () => {
+  beforeAll(() => {
+    documentationService.setup(docLinks);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    http = httpServiceMock.createSetupContract();
+    httpService.setup(http);
+  });
+
+  it('loads node plugins and passes them through StepMappings to MappingsEditor', async () => {
+    http.get.mockResolvedValue(['mapper-size']);
+
+    renderContainer();
+
+    await waitFor(() => {
+      expect(mockMappingsEditor).toHaveBeenLastCalledWith(
+        expect.objectContaining({ esNodesPlugins: ['mapper-size'] }),
+        expect.anything()
+      );
+    });
+    expect(http.get).toHaveBeenCalledWith(`${API_BASE_PATH}/nodes/plugins`, expect.anything());
+  });
+
+  it('passes a resolved empty plugin list through StepMappings to MappingsEditor', async () => {
+    http.get.mockResolvedValue([]);
+
+    renderContainer();
+    const callsWhileLoading = mockMappingsEditor.mock.calls.length;
+
+    await waitFor(() => {
+      expect(mockMappingsEditor.mock.calls.length).toBeGreaterThan(callsWhileLoading);
+    });
+    expect(mockMappingsEditor).toHaveBeenLastCalledWith(
+      expect.objectContaining({ esNodesPlugins: [] }),
+      expect.anything()
+    );
+  });
+
+  it('falls back to an empty plugin list while plugins are loading', () => {
+    http.get.mockReturnValue(new Promise(() => {}));
+
+    renderContainer();
+
+    expect(mockMappingsEditor.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ esNodesPlugins: [] })
+    );
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Index Management] Fix flaky mapper-size plugin test by moving coverage to unit tests (#283251)](https://github.com/elastic/kibana/pull/283251)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-08-12T22:11:35Z","message":"[Index Management] Fix flaky mapper-size plugin test by moving coverage to unit tests (#283251)\n\nCloses #254224\n\n## Summary\n\n- Removes the two flaky wizard-level mapper-size tests from\n`template_create.test.tsx`.\n- Moves coverage to focused tests for `ConfigurationForm` gating, the\nreal `GET /api/index_management/nodes/plugins` request and propagation\nthrough `StepMappings`, and `MappingsEditor` updates after plugin\nloading.\n- Leaves production behavior unchanged.\n\n## Rationale\n\n- The wizard tests synchronously queried UI gated by an async plugin\nrequest inside a full template-wizard render, causing intermittent CI\ntimeouts.\n- Replacing that heavy setup with focused unit tests retains coverage of\nthe gating and plugin-propagation seams while making the tests faster\nand deterministic.\n\n## Test Plan\n\nThe original timeout scenario is no longer applicable because the heavy\nwizard integration setup was replaced with focused unit tests using a\nsmaller, faster setup.\n\n- `node scripts/jest .../configuration_form.test.tsx\n.../mappings_editor.test.tsx .../step_mappings_container.test.tsx` —\n34/34 pass\n- `node scripts/jest .../index_template_wizard/template_create.test.tsx`\n— 26/26 pass\n- `node scripts/eslint` on the 4 changed test files — clean\n- `node scripts/type_check --project\nx-pack/platform/plugins/shared/index_management/tsconfig.json` — 2\npre-existing errors in\n`alerting_v2/server/lib/rules_client/rules_client.ts`, none in changed\nfiles\n- Mutation verification — 15/15 deliberate production breaks failed the\nintended tests\n\nAssisted with Codex using GPT-5\n\nCo-authored-by: Codex <noreply@openai.com>","sha":"8935d6d8d8d11883d4c2507f43bcfdb463491276","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Index Management","failed-test","Team:Kibana Management","release_note:skip","backport:all-open","v9.6.0","v9.4.6","v9.5.2"],"title":"[Index Management] Fix flaky mapper-size plugin test by moving coverage to unit tests","number":283251,"url":"https://github.com/elastic/kibana/pull/283251","mergeCommit":{"message":"[Index Management] Fix flaky mapper-size plugin test by moving coverage to unit tests (#283251)\n\nCloses #254224\n\n## Summary\n\n- Removes the two flaky wizard-level mapper-size tests from\n`template_create.test.tsx`.\n- Moves coverage to focused tests for `ConfigurationForm` gating, the\nreal `GET /api/index_management/nodes/plugins` request and propagation\nthrough `StepMappings`, and `MappingsEditor` updates after plugin\nloading.\n- Leaves production behavior unchanged.\n\n## Rationale\n\n- The wizard tests synchronously queried UI gated by an async plugin\nrequest inside a full template-wizard render, causing intermittent CI\ntimeouts.\n- Replacing that heavy setup with focused unit tests retains coverage of\nthe gating and plugin-propagation seams while making the tests faster\nand deterministic.\n\n## Test Plan\n\nThe original timeout scenario is no longer applicable because the heavy\nwizard integration setup was replaced with focused unit tests using a\nsmaller, faster setup.\n\n- `node scripts/jest .../configuration_form.test.tsx\n.../mappings_editor.test.tsx .../step_mappings_container.test.tsx` —\n34/34 pass\n- `node scripts/jest .../index_template_wizard/template_create.test.tsx`\n— 26/26 pass\n- `node scripts/eslint` on the 4 changed test files — clean\n- `node scripts/type_check --project\nx-pack/platform/plugins/shared/index_management/tsconfig.json` — 2\npre-existing errors in\n`alerting_v2/server/lib/rules_client/rules_client.ts`, none in changed\nfiles\n- Mutation verification — 15/15 deliberate production breaks failed the\nintended tests\n\nAssisted with Codex using GPT-5\n\nCo-authored-by: Codex <noreply@openai.com>","sha":"8935d6d8d8d11883d4c2507f43bcfdb463491276"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283251","number":283251,"mergeCommit":{"message":"[Index Management] Fix flaky mapper-size plugin test by moving coverage to unit tests (#283251)\n\nCloses #254224\n\n## Summary\n\n- Removes the two flaky wizard-level mapper-size tests from\n`template_create.test.tsx`.\n- Moves coverage to focused tests for `ConfigurationForm` gating, the\nreal `GET /api/index_management/nodes/plugins` request and propagation\nthrough `StepMappings`, and `MappingsEditor` updates after plugin\nloading.\n- Leaves production behavior unchanged.\n\n## Rationale\n\n- The wizard tests synchronously queried UI gated by an async plugin\nrequest inside a full template-wizard render, causing intermittent CI\ntimeouts.\n- Replacing that heavy setup with focused unit tests retains coverage of\nthe gating and plugin-propagation seams while making the tests faster\nand deterministic.\n\n## Test Plan\n\nThe original timeout scenario is no longer applicable because the heavy\nwizard integration setup was replaced with focused unit tests using a\nsmaller, faster setup.\n\n- `node scripts/jest .../configuration_form.test.tsx\n.../mappings_editor.test.tsx .../step_mappings_container.test.tsx` —\n34/34 pass\n- `node scripts/jest .../index_template_wizard/template_create.test.tsx`\n— 26/26 pass\n- `node scripts/eslint` on the 4 changed test files — clean\n- `node scripts/type_check --project\nx-pack/platform/plugins/shared/index_management/tsconfig.json` — 2\npre-existing errors in\n`alerting_v2/server/lib/rules_client/rules_client.ts`, none in changed\nfiles\n- Mutation verification — 15/15 deliberate production breaks failed the\nintended tests\n\nAssisted with Codex using GPT-5\n\nCo-authored-by: Codex <noreply@openai.com>","sha":"8935d6d8d8d11883d4c2507f43bcfdb463491276"}},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/284796","number":284796,"state":"MERGED","mergeCommit":{"sha":"7a8f45f7cea31b66f9f4555ee8105d5e81d922f4","message":"[9.4] [Index Management] Fix flaky mapper-size plugin test by moving coverage to unit tests (#283251) (#284796)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Index Management] Fix flaky mapper-size plugin test by moving\ncoverage to unit tests\n(#283251)](https://github.com/elastic/kibana/pull/283251)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/284785","number":284785,"state":"MERGED","mergeCommit":{"sha":"9486133869f1869c6375374f295de601ccb2f5d3","message":"[9.5] [Index Management] Fix flaky mapper-size plugin test by moving coverage to unit tests (#283251) (#284785)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Index Management] Fix flaky mapper-size plugin test by moving\ncoverage to unit tests\n(#283251)](https://github.com/elastic/kibana/pull/283251)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Codex <noreply@openai.com>"}}]}] BACKPORT-->