### PR TITLE
[Cases] Apply v2 template connector, settings, and assignees in system action

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/cases/expand_template_defaults.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/expand_template_defaults.test.ts
@@ -357,7 +357,7 @@ describe('expand_template_defaults', () => {
 
       // The caller's .none connector is kept and the debug log makes the drop diagnosable.
       expect(expanded.connector).toEqual(baseRequest.connector);
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('Dropping template connector default "deleted-connector"')
       );
     });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/expand_template_defaults.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/expand_template_defaults.ts
@@ -21,6 +21,7 @@ import {
 import { parseTemplate } from '../../routes/api/templates/parse_template';
 import type { TemplatesService } from '../../services/templates';
 import type { FieldDefinitionsService } from '../../services/field_definitions';
+import { resolveTemplateConnector } from './resolve_template_connector';
 
 /**
  * A template resolved and prepared for expansion into a create-case request.
@@ -105,35 +106,6 @@ export const resolveTemplateForCreate = async ({
 };
 
 /**
- * Resolves the template's default connector `name` from its `id` (the YAML stores connectors
- * without a name). Returns undefined when the template has no connector or the id no longer
- * resolves — the case then keeps the caller's connector, mirroring the create form's fallback.
- */
-const resolveTemplateConnector = async (
-  parsed: ParsedTemplate,
-  actionsClient: PublicMethodsOf<ActionsClient>,
-  logger: Logger
-): Promise<CasePostRequest['connector'] | undefined> => {
-  const templateConnector = parsed.definition.connector;
-  if (!templateConnector || templateConnector.type === ConnectorTypes.none) {
-    return undefined;
-  }
-
-  try {
-    const action = await actionsClient.get({ id: templateConnector.id });
-    return { ...templateConnector, name: action.name } as CasePostRequest['connector'];
-  } catch (error) {
-    // The connector default is dropped and the case keeps the caller's connector (the UI does the
-    // same). A genuinely-missing / unauthorized connector is expected here, but so is a transient
-    // ES/auth error — log so a real infra failure silently changing the created case is diagnosable.
-    logger.debug(
-      `Dropping template connector default "${templateConnector.id}"; could not resolve it: ${error}`
-    );
-    return undefined;
-  }
-};
-
-/**
  * Applies a resolved template's case defaults and `extended_fields` defaults onto a create-case
  * request. **Caller-wins**: any value explicitly present in the request survives; template
  * defaults only fill what the caller left unset.
@@ -210,7 +182,7 @@ export const applyTemplateDefaultsToCreateRequest = async <T extends CasePostReq
   // spares callers with their own connector an actions-client round-trip and a spurious debug log.
   if (query.connector.type === ConnectorTypes.none) {
     const templateConnector = await resolveTemplateConnector(
-      resolved.parsed,
+      resolved.parsed.definition.connector,
       actionsClient,
       logger
     );

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/resolve_template_connector.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/resolve_template_connector.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { actionsClientMock } from '@kbn/actions-plugin/server/actions_client/actions_client.mock';
+import { ConnectorTypes } from '../../../common/types/domain';
+import { resolveTemplateConnector } from './resolve_template_connector';
+
+describe('resolveTemplateConnector', () => {
+  const actionsClient = actionsClientMock.create();
+  const logger = loggingSystemMock.createLogger();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    actionsClient.get.mockRejectedValue(new Error('not found'));
+  });
+
+  it('returns undefined when the template has no connector', async () => {
+    await expect(
+      resolveTemplateConnector(undefined, actionsClient, logger)
+    ).resolves.toBeUndefined();
+    expect(actionsClient.get).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for a .none connector without calling Actions', async () => {
+    await expect(
+      resolveTemplateConnector(
+        { id: 'none', type: ConnectorTypes.none, fields: null },
+        actionsClient,
+        logger
+      )
+    ).resolves.toBeUndefined();
+    expect(actionsClient.get).not.toHaveBeenCalled();
+  });
+
+  it('resolves the connector name from Actions', async () => {
+    actionsClient.get.mockResolvedValue({ name: 'My Jira' } as Awaited<
+      ReturnType<typeof actionsClient.get>
+    >);
+
+    await expect(
+      resolveTemplateConnector(
+        { id: 'jira-1', type: ConnectorTypes.jira, fields: null },
+        actionsClient,
+        logger
+      )
+    ).resolves.toEqual({
+      id: 'jira-1',
+      type: ConnectorTypes.jira,
+      fields: null,
+      name: 'My Jira',
+    });
+    expect(actionsClient.get).toHaveBeenCalledWith({ id: 'jira-1' });
+  });
+
+  it('returns undefined and logs when Actions cannot resolve the id', async () => {
+    await expect(
+      resolveTemplateConnector(
+        { id: 'deleted-connector', type: ConnectorTypes.jira, fields: null },
+        actionsClient,
+        logger
+      )
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Dropping template connector default "deleted-connector"')
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/resolve_template_connector.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/resolve_template_connector.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import { ConnectorTypes } from '../../../common/types/domain';
+import type { CasePostRequest } from '../../../common/types/api';
+import type { CaseConnectorWithoutName } from '../../../common/types/domain_zod/connector/v1';
+
+/**
+ * Resolves a template connector's display `name` from its `id` (YAML stores connectors without a
+ * name). Returns undefined when there is no connector, the connector is `.none`, or the id no
+ * longer resolves — callers then keep their existing connector (typically `.none`).
+ */
+export const resolveTemplateConnector = async (
+  templateConnector: CaseConnectorWithoutName | undefined,
+  actionsClient: PublicMethodsOf<ActionsClient>,
+  logger: Logger
+): Promise<CasePostRequest['connector'] | undefined> => {
+  if (!templateConnector || templateConnector.type === ConnectorTypes.none) {
+    return undefined;
+  }
+
+  try {
+    const action = await actionsClient.get({ id: templateConnector.id });
+    return { ...templateConnector, name: action.name } as CasePostRequest['connector'];
+  } catch (error) {
+    // The connector default is dropped. A genuinely-missing / unauthorized connector is expected
+    // here, but so is a transient ES/auth error — log at warn so a real infra/authz failure
+    // silently changing the created case is diagnosable (system-action runs under the rule
+    // request context; Actions get can 403 even when Cases create succeeds).
+    logger.warn(
+      `Dropping template connector default "${templateConnector.id}"; could not resolve it: ${error}`
+    );
+    return undefined;
+  }
+};

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector.test.ts
@@ -76,6 +76,7 @@ describe('CasesConnector', () => {
     getUiSettingsClient,
     isCasesAttachmentsEnabled: false,
     isTemplatesEnabled: false,
+    isAtLeastPlatinum: jest.fn().mockResolvedValue(true),
   };
   const connectorParams = {
     configurationUtilities: actionsConfigMock.create(),
@@ -135,6 +136,7 @@ describe('CasesConnector', () => {
       spaceId: 'default',
       isCasesAttachmentsEnabled: false,
       isTemplatesEnabled: false,
+      isAtLeastPlatinum: casesParams.isAtLeastPlatinum,
     });
   });
 
@@ -161,6 +163,33 @@ describe('CasesConnector', () => {
 
     expect(CasesConnectorExecutorMock).toBeCalledWith(
       expect.objectContaining({ isTemplatesEnabled: true })
+    );
+  });
+
+  it('threads isAtLeastPlatinum through to the CasesConnectorExecutor', async () => {
+    const isAtLeastPlatinum = jest.fn().mockResolvedValue(false);
+    const connectorWithLicenseCheck = new CasesConnector({
+      casesParams: { ...casesParams, isAtLeastPlatinum },
+      connectorParams,
+    });
+
+    await connectorWithLicenseCheck.run({
+      alerts: [{ _id: 'alert-id-0', _index: 'alert-index-0' }],
+      groupedAlerts,
+      groupingBy,
+      owner,
+      rule,
+      timeWindow,
+      internallyManagedAlerts,
+      reopenClosedCases,
+      maximumCasesToOpen,
+      templateId,
+      templateVersion,
+      autoPushCase,
+    });
+
+    expect(CasesConnectorExecutorMock).toBeCalledWith(
+      expect.objectContaining({ isAtLeastPlatinum })
     );
   });
 

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector.test.ts
@@ -70,6 +70,7 @@ describe('CasesConnector', () => {
 
   const casesParams = {
     getCasesClient,
+    getActionsClient: jest.fn().mockResolvedValue({}),
     getSpaceId,
     getUnsecuredSavedObjectsClient,
     getUiSettingsClient,
@@ -128,6 +129,7 @@ describe('CasesConnector', () => {
     expect(CasesConnectorExecutorMock).toBeCalledWith({
       logger,
       casesClient: { foo: 'bar' },
+      actionsClient: {},
       casesOracleService: expect.any(CasesOracleService),
       casesService: expect.any(CasesService),
       spaceId: 'default',

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector.ts
@@ -47,6 +47,7 @@ interface CasesConnectorParams {
     getUiSettingsClient: (request: KibanaRequest) => Promise<IUiSettingsClient>;
     isCasesAttachmentsEnabled: boolean;
     isTemplatesEnabled: boolean;
+    isAtLeastPlatinum: () => Promise<boolean>;
   };
 }
 
@@ -142,6 +143,7 @@ export class CasesConnector extends SubActionConnector<
         spaceId,
         isCasesAttachmentsEnabled: this.casesParams.isCasesAttachmentsEnabled,
         isTemplatesEnabled: this.casesParams.isTemplatesEnabled,
+        isAtLeastPlatinum: this.casesParams.isAtLeastPlatinum,
       });
 
       this.logDebugCurrentState(

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector.ts
@@ -6,10 +6,11 @@
  */
 
 import Boom from '@hapi/boom';
-import type { ServiceParams } from '@kbn/actions-plugin/server';
+import type { ServiceParams, ActionsClient } from '@kbn/actions-plugin/server';
 import { SubActionConnector } from '@kbn/actions-plugin/server';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { IUiSettingsClient, SavedObjectsClientContract } from '@kbn/core/server';
+import type { PublicMethodsOf } from '@kbn/utility-types';
 import { fullJitterBackoffFactory } from '@kbn/response-ops-retry-service';
 import type { CasesConnectorConfig, CasesConnectorRunParams, CasesConnectorSecrets } from './types';
 import { ZCasesConnectorRunParamsSchema } from './schema';
@@ -37,6 +38,7 @@ interface CasesConnectorParams {
   connectorParams: ServiceParams<CasesConnectorConfig, CasesConnectorSecrets>;
   casesParams: {
     getCasesClient: (request: KibanaRequest) => Promise<CasesClient>;
+    getActionsClient: (request: KibanaRequest) => Promise<PublicMethodsOf<ActionsClient>>;
     getSpaceId: (request?: KibanaRequest) => string;
     getUnsecuredSavedObjectsClient: (
       request: KibanaRequest,
@@ -118,6 +120,7 @@ export class CasesConnector extends SubActionConnector<
       const uiSettingsClient = await this.casesParams.getUiSettingsClient(kibanaRequest);
       const validatedParams = await this.getValidatedRunParams(params, uiSettingsClient);
       const casesClient = await this.casesParams.getCasesClient(kibanaRequest);
+      const actionsClient = await this.casesParams.getActionsClient(kibanaRequest);
       const savedObjectsClient = await this.casesParams.getUnsecuredSavedObjectsClient(
         kibanaRequest,
         [...getSavedObjectsTypes(), CASE_RULES_SAVED_OBJECT]
@@ -135,6 +138,7 @@ export class CasesConnector extends SubActionConnector<
         casesOracleService,
         casesService: this.casesService,
         casesClient,
+        actionsClient,
         spaceId,
         isCasesAttachmentsEnabled: this.casesParams.isCasesAttachmentsEnabled,
         isTemplatesEnabled: this.casesParams.isTemplatesEnabled,

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
@@ -17,6 +17,8 @@ import {
   MAX_TAGS_PER_CASE,
   MAX_TITLE_LENGTH,
   MAX_SUFFIX_LENGTH,
+  SECURITY_SOLUTION_OWNER,
+  OBSERVABILITY_OWNER,
 } from '../../../common/constants';
 import { CasesOracleService } from './cases_oracle_service';
 import { CasesService } from './cases_service';
@@ -1366,6 +1368,86 @@ fields: []
             expect(actionsClient.get).toHaveBeenCalledWith({ id: 'jira-1' });
           });
 
+          it('skips template assignees without a Platinum license so case creation still succeeds', async () => {
+            const v2TemplateWithAssignees = {
+              ...v2TemplateSO,
+              attributes: {
+                ...v2TemplateSO.attributes,
+                definition: `
+name: "V2 Template"
+assignees:
+  - uid: assignee-uid-1
+fields: []
+`,
+              },
+            };
+            casesClientMock.templates.getTemplate = jest
+              .fn()
+              .mockResolvedValue(v2TemplateWithAssignees);
+
+            const connectorExecutorWithoutPlatinum = new CasesConnectorExecutor({
+              logger: mockLogger,
+              casesOracleService: new CasesOracleServiceMock(),
+              casesService: new CasesServiceMock(),
+              casesClient: casesClientMock,
+              actionsClient,
+              spaceId: 'default',
+              isTemplatesEnabled: true,
+              isAtLeastPlatinum: async () => false,
+            });
+
+            casesClientMock.cases.bulkGet.mockResolvedValue({
+              cases: [],
+              errors: [
+                { caseId: 'mock-id-1', error: 'Not found', message: 'Not found', status: 404 },
+              ],
+            });
+
+            await connectorExecutorWithoutPlatinum.execute({
+              ...params,
+              templateId: 'tmpl-v2-id',
+              templateVersion: '1',
+            });
+
+            const createdCase = casesClientMock.cases.bulkCreate.mock.calls[0][0].cases[0];
+            expect(createdCase.assignees).toBeUndefined();
+          });
+
+          it('drops empty-uid template assignees', async () => {
+            const v2TemplateWithEmptyUid = {
+              ...v2TemplateSO,
+              attributes: {
+                ...v2TemplateSO.attributes,
+                definition: `
+name: "V2 Template"
+assignees:
+  - uid: assignee-uid-1
+  - uid: ""
+fields: []
+`,
+              },
+            };
+            casesClientMock.templates.getTemplate = jest
+              .fn()
+              .mockResolvedValue(v2TemplateWithEmptyUid);
+
+            casesClientMock.cases.bulkGet.mockResolvedValue({
+              cases: [],
+              errors: [
+                { caseId: 'mock-id-1', error: 'Not found', message: 'Not found', status: 404 },
+              ],
+            });
+
+            await connectorExecutor.execute({
+              ...params,
+              templateId: 'tmpl-v2-id',
+              templateVersion: '1',
+            });
+
+            const createdCase = casesClientMock.cases.bulkCreate.mock.calls[0][0].cases[0];
+            expect(createdCase.assignees).toEqual([{ uid: 'assignee-uid-1' }]);
+          });
+
           it('merges partial template settings over defaults so syncAlerts is always set', async () => {
             const v2TemplateWithPartialSettings = {
               ...v2TemplateSO,
@@ -2015,6 +2097,47 @@ fields: []
 
               expect(createdCase.template).toBeUndefined();
               expect(createdCase[CASE_EXTENDED_FIELDS]).toBeUndefined();
+            });
+          });
+        });
+
+        describe('Owner default settings', () => {
+          const mockCaseNotFound = () => {
+            casesClientMock.cases.bulkGet.mockResolvedValue({
+              cases: [],
+              errors: [
+                { caseId: 'mock-id-1', error: 'Not found', message: 'Not found', status: 404 },
+              ],
+            });
+          };
+
+          it('turns syncAlerts and extractObservables on for Security when no template is selected', async () => {
+            mockCaseNotFound();
+
+            await connectorExecutor.execute({
+              ...params,
+              owner: SECURITY_SOLUTION_OWNER,
+              templateId: null,
+            });
+
+            expect(casesClientMock.cases.bulkCreate.mock.calls[0][0].cases[0].settings).toEqual({
+              syncAlerts: true,
+              extractObservables: true,
+            });
+          });
+
+          it('keeps syncAlerts and extractObservables off for Observability when no template is selected', async () => {
+            mockCaseNotFound();
+
+            await connectorExecutor.execute({
+              ...params,
+              owner: OBSERVABILITY_OWNER,
+              templateId: null,
+            });
+
+            expect(casesClientMock.cases.bulkCreate.mock.calls[0][0].cases[0].settings).toEqual({
+              syncAlerts: false,
+              extractObservables: false,
             });
           });
         });

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
@@ -46,6 +46,7 @@ import {
 } from './test_helpers';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import type { Logger } from '@kbn/core/server';
+import { actionsClientMock } from '@kbn/actions-plugin/server/actions_client/actions_client.mock';
 import type { CasesConnectorRunParams } from './types';
 import { INITIAL_ORACLE_RECORD_COUNTER } from './constants';
 import { CaseSeverity, ConnectorTypes, CustomFieldTypes } from '../../../common/types/domain';
@@ -68,6 +69,7 @@ describe('CasesConnectorExecutor', () => {
   const getCasesClient = jest.fn();
   const casesClientMock = createCasesClientMock();
   const mockLogger = loggingSystemMock.create().get() as jest.Mocked<Logger>;
+  const actionsClient = actionsClientMock.create();
 
   let connectorExecutor: CasesConnectorExecutor;
   let oracleIdCounter = 0;
@@ -133,12 +135,14 @@ describe('CasesConnectorExecutor', () => {
     });
 
     getCasesClient.mockReturnValue(casesClientMock);
+    actionsClient.get.mockRejectedValue(new Error('not found'));
 
     connectorExecutor = new CasesConnectorExecutor({
       logger: mockLogger,
       casesOracleService: new CasesOracleServiceMock(),
       casesService: new CasesServiceMock(),
       casesClient: casesClientMock,
+      actionsClient,
       spaceId: 'default',
       isTemplatesEnabled: true,
     });
@@ -1286,7 +1290,194 @@ fields: []
             expect(createdCase.severity).toBe('medium');
             expect(createdCase.category).toBe('Phishing');
             expect(createdCase.connector.type).toBe('.none');
+            expect(createdCase.settings).toEqual({
+              syncAlerts: false,
+              extractObservables: false,
+            });
+            expect(createdCase.assignees).toBeUndefined();
             expect(createdCase.customFields).toEqual([]);
+          });
+
+          it('applies the template connector, settings, and assignees from the v2 definition', async () => {
+            const v2TemplateWithConnectorSettingsAssignees = {
+              ...v2TemplateSO,
+              attributes: {
+                ...v2TemplateSO.attributes,
+                definition: `
+name: "V2 Template"
+description: "Created from v2 template"
+tags:
+  - v2-tag
+severity: medium
+category: "Phishing"
+connector:
+  type: .jira
+  id: jira-1
+  fields:
+    issueType: "10001"
+    priority: "High"
+    parent: null
+settings:
+  syncAlerts: true
+  extractObservables: true
+assignees:
+  - uid: assignee-uid-1
+fields: []
+`,
+              },
+            };
+            casesClientMock.templates.getTemplate = jest
+              .fn()
+              .mockResolvedValue(v2TemplateWithConnectorSettingsAssignees);
+            actionsClient.get.mockResolvedValue({ name: 'My Jira' } as Awaited<
+              ReturnType<typeof actionsClient.get>
+            >);
+
+            casesClientMock.cases.bulkGet.mockResolvedValue({
+              cases: [],
+              errors: [
+                { caseId: 'mock-id-1', error: 'Not found', message: 'Not found', status: 404 },
+              ],
+            });
+
+            await connectorExecutor.execute({
+              ...params,
+              templateId: 'tmpl-v2-id',
+              templateVersion: '1',
+            });
+
+            const createdCase = casesClientMock.cases.bulkCreate.mock.calls[0][0].cases[0];
+
+            expect(createdCase.connector).toEqual({
+              id: 'jira-1',
+              type: '.jira',
+              name: 'My Jira',
+              fields: {
+                issueType: '10001',
+                priority: 'High',
+                parent: null,
+              },
+            });
+            expect(createdCase.settings).toEqual({
+              syncAlerts: true,
+              extractObservables: true,
+            });
+            expect(createdCase.assignees).toEqual([{ uid: 'assignee-uid-1' }]);
+            expect(actionsClient.get).toHaveBeenCalledWith({ id: 'jira-1' });
+          });
+
+          it('falls back to .none when the template connector cannot be resolved', async () => {
+            const v2TemplateWithDeletedConnector = {
+              ...v2TemplateSO,
+              attributes: {
+                ...v2TemplateSO.attributes,
+                definition: `
+name: "V2 Template"
+connector:
+  type: .jira
+  id: deleted-connector
+  fields: null
+fields: []
+`,
+              },
+            };
+            casesClientMock.templates.getTemplate = jest
+              .fn()
+              .mockResolvedValue(v2TemplateWithDeletedConnector);
+            // actionsClient.get rejects by default (see beforeEach).
+
+            casesClientMock.cases.bulkGet.mockResolvedValue({
+              cases: [],
+              errors: [
+                { caseId: 'mock-id-1', error: 'Not found', message: 'Not found', status: 404 },
+              ],
+            });
+
+            await connectorExecutor.execute({
+              ...params,
+              templateId: 'tmpl-v2-id',
+              templateVersion: '1',
+            });
+
+            const createdCase = casesClientMock.cases.bulkCreate.mock.calls[0][0].cases[0];
+            expect(createdCase.connector).toEqual({
+              id: 'none',
+              name: 'none',
+              type: ConnectorTypes.none,
+              fields: null,
+            });
+            expect(mockLogger.warn).toHaveBeenCalledWith(
+              expect.stringContaining('Dropping template connector default "deleted-connector"')
+            );
+          });
+
+          it('applies connector, settings, and assignees when bridging a legacy template key to v2', async () => {
+            const migratedV2Template = {
+              templateId: 'migrated-v2-id',
+              name: 'Migrated Template',
+              owner: params.owner,
+              legacyKey: 'legacy-template-key',
+              templateVersion: 2,
+              definition: `
+name: "Migrated Template"
+connector:
+  type: .jira
+  id: jira-legacy-1
+  fields:
+    issueType: "10001"
+    priority: null
+    parent: null
+settings:
+  syncAlerts: true
+  extractObservables: false
+assignees:
+  - uid: legacy-assignee
+fields: []
+`,
+              deletedAt: null,
+              isEnabled: true,
+              isLatest: true,
+            };
+            casesClientMock.templates.getAllTemplates.mockResolvedValue({
+              templates: [migratedV2Template],
+              page: 1,
+              perPage: 10000,
+              total: 1,
+            });
+            actionsClient.get.mockResolvedValue({ name: 'Legacy Jira' } as Awaited<
+              ReturnType<typeof actionsClient.get>
+            >);
+
+            casesClientMock.cases.bulkGet.mockResolvedValue({
+              cases: [],
+              errors: [
+                { caseId: 'mock-id-1', error: 'Not found', message: 'Not found', status: 404 },
+              ],
+            });
+
+            await connectorExecutor.execute({
+              ...params,
+              templateId: 'legacy-template-key',
+              templateVersion: null,
+            });
+
+            const createdCase = casesClientMock.cases.bulkCreate.mock.calls[0][0].cases[0];
+            expect(createdCase.connector).toEqual({
+              id: 'jira-legacy-1',
+              type: '.jira',
+              name: 'Legacy Jira',
+              fields: {
+                issueType: '10001',
+                priority: null,
+                parent: null,
+              },
+            });
+            expect(createdCase.settings).toEqual({
+              syncAlerts: true,
+              extractObservables: false,
+            });
+            expect(createdCase.assignees).toEqual([{ uid: 'legacy-assignee' }]);
+            expect(createdCase.template).toEqual({ id: 'migrated-v2-id', version: 2 });
           });
 
           it('does not use the v2 template name as the title, letting the Oracle-generated title win', async () => {
@@ -1355,6 +1546,7 @@ fields: []
               casesOracleService: new CasesOracleServiceMock(),
               casesService: new CasesServiceMock(),
               casesClient: casesClientMock,
+              actionsClient,
               spaceId: 'default',
               isTemplatesEnabled: false,
             });
@@ -1392,6 +1584,7 @@ fields: []
               casesOracleService: new CasesOracleServiceMock(),
               casesService: new CasesServiceMock(),
               casesClient: casesClientMock,
+              actionsClient,
               spaceId: 'default',
               isTemplatesEnabled: false,
             });
@@ -2570,6 +2763,7 @@ fields: []
         casesOracleService: new CasesOracleServiceMock(),
         casesService: new CasesServiceMock(),
         casesClient: casesClientMock,
+        actionsClient,
         spaceId: 'default',
       });
     });
@@ -4074,6 +4268,7 @@ fields: []
             casesOracleService: new CasesOracleServiceMock(),
             casesService: new CasesServiceMock(),
             casesClient: casesClientMock,
+            actionsClient,
             spaceId: 'default',
             isCasesAttachmentsEnabled: true,
           });

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.test.ts
@@ -1366,6 +1366,43 @@ fields: []
             expect(actionsClient.get).toHaveBeenCalledWith({ id: 'jira-1' });
           });
 
+          it('merges partial template settings over defaults so syncAlerts is always set', async () => {
+            const v2TemplateWithPartialSettings = {
+              ...v2TemplateSO,
+              attributes: {
+                ...v2TemplateSO.attributes,
+                definition: `
+name: "V2 Template"
+settings:
+  extractObservables: true
+fields: []
+`,
+              },
+            };
+            casesClientMock.templates.getTemplate = jest
+              .fn()
+              .mockResolvedValue(v2TemplateWithPartialSettings);
+
+            casesClientMock.cases.bulkGet.mockResolvedValue({
+              cases: [],
+              errors: [
+                { caseId: 'mock-id-1', error: 'Not found', message: 'Not found', status: 404 },
+              ],
+            });
+
+            await connectorExecutor.execute({
+              ...params,
+              templateId: 'tmpl-v2-id',
+              templateVersion: '1',
+            });
+
+            const createdCase = casesClientMock.cases.bulkCreate.mock.calls[0][0].cases[0];
+            expect(createdCase.settings).toEqual({
+              syncAlerts: false,
+              extractObservables: true,
+            });
+          });
+
           it('falls back to .none when the template connector cannot be resolved', async () => {
             const v2TemplateWithDeletedConnector = {
               ...v2TemplateSO,
@@ -1437,6 +1474,7 @@ fields: []
               deletedAt: null,
               isEnabled: true,
               isLatest: true,
+              fieldSearchMatches: false,
             };
             casesClientMock.templates.getAllTemplates.mockResolvedValue({
               templates: [migratedV2Template],

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
@@ -849,7 +849,8 @@ export class CasesConnectorExecutor {
       tags: this.getCaseTags(params, flattenGrouping, v2Template.tags),
       title: title ?? this.getCasesTitle(params, flattenGrouping, oracleRecord.counter),
       connector: resolvedConnector ?? { ...NONE_CASE_CONNECTOR },
-      settings: v2Template.settings ?? { ...DEFAULT_CASE_SETTINGS },
+      // Template settings keys are individually optional; merge so syncAlerts is always set for CaseSettingsRt.
+      settings: { ...DEFAULT_CASE_SETTINGS, ...v2Template.settings },
       ...(v2Template.assignees ? { assignees: v2Template.assignees } : {}),
       owner: params.owner,
       customFields: builtCustomFields,

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
@@ -26,6 +26,7 @@ import {
   MAX_TITLE_LENGTH,
   MAX_RULE_NAME_LENGTH,
   MAX_SUFFIX_LENGTH,
+  SECURITY_SOLUTION_OWNER,
 } from '../../../common/constants';
 import { COMMENT_ATTACHMENT_TYPE } from '../../../common/constants/attachments';
 import { hasOwnerUnifiedPrefix, toUnifiedAttachmentType } from '../../../common/utils/attachments';
@@ -74,6 +75,7 @@ interface CasesConnectorExecutorParams {
   spaceId: string;
   isCasesAttachmentsEnabled?: boolean;
   isTemplatesEnabled?: boolean;
+  isAtLeastPlatinum?: () => Promise<boolean>;
 }
 
 type GroupedAlertsWithOracleKey = CasesGroupedAlerts & { oracleKey: string };
@@ -88,10 +90,26 @@ const NONE_CASE_CONNECTOR = {
   fields: null,
 } as const;
 
-const DEFAULT_CASE_SETTINGS = {
-  syncAlerts: false,
-  extractObservables: false,
-} as const;
+const getDefaultCaseSettings = (owner: string) => ({
+  syncAlerts: owner === SECURITY_SOLUTION_OWNER,
+  extractObservables: owner === SECURITY_SOLUTION_OWNER,
+});
+
+const getAssigneesFromTemplate = (
+  assignees: Array<{ uid: string }> | undefined,
+  hasPlatinumLicenseOrGreater: boolean
+): { assignees: Array<{ uid: string }> } | Record<string, never> => {
+  if (!hasPlatinumLicenseOrGreater || assignees === undefined) {
+    return {};
+  }
+
+  const templateAssignees = assignees.filter(({ uid }) => uid.length > 0);
+  if (templateAssignees.length === 0) {
+    return {};
+  }
+
+  return { assignees: templateAssignees };
+};
 
 export class CasesConnectorExecutor {
   private readonly logger: Logger;
@@ -102,6 +120,7 @@ export class CasesConnectorExecutor {
   private readonly spaceId: string;
   private readonly isCasesAttachmentsEnabled: boolean;
   private readonly isTemplatesEnabled: boolean;
+  private readonly isAtLeastPlatinum: () => Promise<boolean>;
 
   constructor({
     logger,
@@ -112,6 +131,7 @@ export class CasesConnectorExecutor {
     spaceId,
     isCasesAttachmentsEnabled = false,
     isTemplatesEnabled = false,
+    isAtLeastPlatinum = async () => true,
   }: CasesConnectorExecutorParams) {
     this.logger = logger;
     this.casesOracleService = casesOracleService;
@@ -121,6 +141,7 @@ export class CasesConnectorExecutor {
     this.spaceId = spaceId;
     this.isCasesAttachmentsEnabled = isCasesAttachmentsEnabled;
     this.isTemplatesEnabled = isTemplatesEnabled;
+    this.isAtLeastPlatinum = isAtLeastPlatinum;
   }
 
   public async execute(params: CasesConnectorRunParams) {
@@ -775,6 +796,7 @@ export class CasesConnectorExecutor {
 
     const { v2Template, extendedFields, templateRef, resolvedConnector } =
       await this.resolveV2TemplateWithFields(params, templatesConfigurationMap.get(params.owner));
+    const hasPlatinumLicenseOrGreater = await this.isAtLeastPlatinum();
 
     for (const error of nonFoundErrors) {
       if (groupedAlertsWithCaseId.has(error.caseId)) {
@@ -789,7 +811,8 @@ export class CasesConnectorExecutor {
             v2Template ?? undefined,
             extendedFields,
             templateRef,
-            resolvedConnector
+            resolvedConnector,
+            hasPlatinumLicenseOrGreater
           )
         );
       }
@@ -836,7 +859,8 @@ export class CasesConnectorExecutor {
     customFieldsConfigurations?: CustomFieldsConfiguration,
     extendedFields?: Record<string, string>,
     templateRef?: { id: string; version: number },
-    resolvedConnector?: BulkCreateCasesRequest['cases'][number]['connector']
+    resolvedConnector?: BulkCreateCasesRequest['cases'][number]['connector'],
+    hasPlatinumLicenseOrGreater = true
   ): Omit<BulkCreateCasesRequest['cases'][number], 'id'> & { id: string } {
     const { grouping, caseId, oracleRecord, title } = groupingData;
     const flattenGrouping = getFlattenedObject(grouping);
@@ -849,9 +873,9 @@ export class CasesConnectorExecutor {
       tags: this.getCaseTags(params, flattenGrouping, v2Template.tags),
       title: title ?? this.getCasesTitle(params, flattenGrouping, oracleRecord.counter),
       connector: resolvedConnector ?? { ...NONE_CASE_CONNECTOR },
-      // Template settings keys are individually optional; merge so syncAlerts is always set for CaseSettingsRt.
-      settings: { ...DEFAULT_CASE_SETTINGS, ...v2Template.settings },
-      ...(v2Template.assignees ? { assignees: v2Template.assignees } : {}),
+      // Template settings keys are individually optional; merge over owner defaults so syncAlerts is always set.
+      settings: { ...getDefaultCaseSettings(params.owner), ...v2Template.settings },
+      ...getAssigneesFromTemplate(v2Template.assignees, hasPlatinumLicenseOrGreater),
       owner: params.owner,
       customFields: builtCustomFields,
     };
@@ -886,7 +910,8 @@ export class CasesConnectorExecutor {
     v2Template?: ParsedTemplateDefinition,
     extendedFields?: Record<string, string>,
     templateRef?: { id: string; version: number },
-    resolvedConnector?: BulkCreateCasesRequest['cases'][number]['connector']
+    resolvedConnector?: BulkCreateCasesRequest['cases'][number]['connector'],
+    hasPlatinumLicenseOrGreater = true
   ): Omit<BulkCreateCasesRequest['cases'][number], 'id'> & { id: string } {
     const { grouping, caseId, oracleRecord, title } = groupingData;
     const flattenGrouping = getFlattenedObject(grouping);
@@ -899,7 +924,8 @@ export class CasesConnectorExecutor {
         customFieldsConfigurations,
         extendedFields,
         templateRef,
-        resolvedConnector
+        resolvedConnector,
+        hasPlatinumLicenseOrGreater
       );
     }
 
@@ -934,13 +960,8 @@ export class CasesConnectorExecutor {
         caseFieldsFromTemplate?.title ??
         this.getCasesTitle(params, flattenGrouping, oracleRecord.counter),
       connector: caseFieldsFromTemplate?.connector ?? { ...NONE_CASE_CONNECTOR },
-      /**
-       * TODO: Turn on for Security solution
-       */
-      settings: caseFieldsFromTemplate?.settings ?? { ...DEFAULT_CASE_SETTINGS },
-      ...(caseFieldsFromTemplate?.assignees
-        ? { assignees: caseFieldsFromTemplate?.assignees }
-        : {}),
+      settings: caseFieldsFromTemplate?.settings ?? getDefaultCaseSettings(params.owner),
+      ...getAssigneesFromTemplate(caseFieldsFromTemplate?.assignees, hasPlatinumLicenseOrGreater),
       ...(caseFieldsFromTemplate?.severity ? { severity: caseFieldsFromTemplate?.severity } : {}),
       ...(caseFieldsFromTemplate?.category ? { category: caseFieldsFromTemplate?.category } : null),
       owner: params.owner,
@@ -1205,6 +1226,7 @@ export class CasesConnectorExecutor {
       params,
       templatesConfigurationMapForReopened.get(params.owner)
     );
+    const hasPlatinumLicenseOrGreater = await this.isAtLeastPlatinum();
 
     const bulkCreateReq = Array.from(groupedAlertsWithCaseId.values()).map((record) =>
       this.getCreateCaseRequest(
@@ -1215,7 +1237,8 @@ export class CasesConnectorExecutor {
         v2TemplateForReopened ?? undefined,
         extendedFieldsForReopened,
         templateRefForReopened,
-        resolvedConnectorForReopened
+        resolvedConnectorForReopened,
+        hasPlatinumLicenseOrGreater
       )
     );
 

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/cases_connector_executor.ts
@@ -11,6 +11,8 @@ import dateMath from '@kbn/datemath';
 import { CaseStatuses } from '@kbn/cases-components';
 import type { SavedObjectError } from '@kbn/core-saved-objects-common';
 import type { Logger } from '@kbn/core/server';
+import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
 import { getFlattenedObject, stableStringify } from '@kbn/std';
 import type {
   CustomFieldsConfiguration,
@@ -61,12 +63,14 @@ import {
   resolveV2TemplateForLegacyKey,
 } from './v2_template_utils';
 import type { ParsedTemplateDefinition } from './v2_template_utils';
+import { resolveTemplateConnector } from '../../client/cases/resolve_template_connector';
 
 interface CasesConnectorExecutorParams {
   logger: Logger;
   casesOracleService: CasesOracleService;
   casesService: CasesService;
   casesClient: CasesClient;
+  actionsClient: PublicMethodsOf<ActionsClient>;
   spaceId: string;
   isCasesAttachmentsEnabled?: boolean;
   isTemplatesEnabled?: boolean;
@@ -77,11 +81,24 @@ type GroupedAlertsWithOracleRecords = GroupedAlertsWithOracleKey & { oracleRecor
 type GroupedAlertsWithCaseId = GroupedAlertsWithOracleRecords & { caseId: string };
 type GroupedAlertsWithCases = GroupedAlertsWithCaseId & { theCase: Case };
 
+const NONE_CASE_CONNECTOR = {
+  id: 'none',
+  name: 'none',
+  type: ConnectorTypes.none,
+  fields: null,
+} as const;
+
+const DEFAULT_CASE_SETTINGS = {
+  syncAlerts: false,
+  extractObservables: false,
+} as const;
+
 export class CasesConnectorExecutor {
   private readonly logger: Logger;
   private readonly casesOracleService: CasesOracleService;
   private readonly casesService: CasesService;
   private readonly casesClient: CasesClient;
+  private readonly actionsClient: PublicMethodsOf<ActionsClient>;
   private readonly spaceId: string;
   private readonly isCasesAttachmentsEnabled: boolean;
   private readonly isTemplatesEnabled: boolean;
@@ -91,6 +108,7 @@ export class CasesConnectorExecutor {
     casesOracleService,
     casesService,
     casesClient,
+    actionsClient,
     spaceId,
     isCasesAttachmentsEnabled = false,
     isTemplatesEnabled = false,
@@ -99,6 +117,7 @@ export class CasesConnectorExecutor {
     this.casesOracleService = casesOracleService;
     this.casesService = casesService;
     this.casesClient = casesClient;
+    this.actionsClient = actionsClient;
     this.spaceId = spaceId;
     this.isCasesAttachmentsEnabled = isCasesAttachmentsEnabled;
     this.isTemplatesEnabled = isTemplatesEnabled;
@@ -754,10 +773,8 @@ export class CasesConnectorExecutor {
     const { customFieldsConfigurationMap, templatesConfigurationMap } =
       await this.getCustomFieldsAndTemplatesConfiguration();
 
-    const { v2Template, extendedFields, templateRef } = await this.resolveV2TemplateWithFields(
-      params,
-      templatesConfigurationMap.get(params.owner)
-    );
+    const { v2Template, extendedFields, templateRef, resolvedConnector } =
+      await this.resolveV2TemplateWithFields(params, templatesConfigurationMap.get(params.owner));
 
     for (const error of nonFoundErrors) {
       if (groupedAlertsWithCaseId.has(error.caseId)) {
@@ -771,7 +788,8 @@ export class CasesConnectorExecutor {
             templatesConfigurationMap.get(params.owner),
             v2Template ?? undefined,
             extendedFields,
-            templateRef
+            templateRef,
+            resolvedConnector
           )
         );
       }
@@ -817,7 +835,8 @@ export class CasesConnectorExecutor {
     v2Template: ParsedTemplateDefinition,
     customFieldsConfigurations?: CustomFieldsConfiguration,
     extendedFields?: Record<string, string>,
-    templateRef?: { id: string; version: number }
+    templateRef?: { id: string; version: number },
+    resolvedConnector?: BulkCreateCasesRequest['cases'][number]['connector']
   ): Omit<BulkCreateCasesRequest['cases'][number], 'id'> & { id: string } {
     const { grouping, caseId, oracleRecord, title } = groupingData;
     const flattenGrouping = getFlattenedObject(grouping);
@@ -829,16 +848,9 @@ export class CasesConnectorExecutor {
       description: v2Template.description ?? this.getCaseDescription(params, flattenGrouping),
       tags: this.getCaseTags(params, flattenGrouping, v2Template.tags),
       title: title ?? this.getCasesTitle(params, flattenGrouping, oracleRecord.counter),
-      connector: {
-        id: 'none',
-        name: 'none',
-        type: ConnectorTypes.none,
-        fields: null,
-      },
-      settings: {
-        syncAlerts: false,
-        extractObservables: false,
-      },
+      connector: resolvedConnector ?? { ...NONE_CASE_CONNECTOR },
+      settings: v2Template.settings ?? { ...DEFAULT_CASE_SETTINGS },
+      ...(v2Template.assignees ? { assignees: v2Template.assignees } : {}),
       owner: params.owner,
       customFields: builtCustomFields,
     };
@@ -872,7 +884,8 @@ export class CasesConnectorExecutor {
     templatesConfigurations?: TemplatesConfiguration,
     v2Template?: ParsedTemplateDefinition,
     extendedFields?: Record<string, string>,
-    templateRef?: { id: string; version: number }
+    templateRef?: { id: string; version: number },
+    resolvedConnector?: BulkCreateCasesRequest['cases'][number]['connector']
   ): Omit<BulkCreateCasesRequest['cases'][number], 'id'> & { id: string } {
     const { grouping, caseId, oracleRecord, title } = groupingData;
     const flattenGrouping = getFlattenedObject(grouping);
@@ -884,7 +897,8 @@ export class CasesConnectorExecutor {
         v2Template,
         customFieldsConfigurations,
         extendedFields,
-        templateRef
+        templateRef,
+        resolvedConnector
       );
     }
 
@@ -918,19 +932,11 @@ export class CasesConnectorExecutor {
         title ??
         caseFieldsFromTemplate?.title ??
         this.getCasesTitle(params, flattenGrouping, oracleRecord.counter),
-      connector: caseFieldsFromTemplate?.connector ?? {
-        id: 'none',
-        name: 'none',
-        type: ConnectorTypes.none,
-        fields: null,
-      },
+      connector: caseFieldsFromTemplate?.connector ?? { ...NONE_CASE_CONNECTOR },
       /**
        * TODO: Turn on for Security solution
        */
-      settings: caseFieldsFromTemplate?.settings ?? {
-        syncAlerts: false,
-        extractObservables: false,
-      },
+      settings: caseFieldsFromTemplate?.settings ?? { ...DEFAULT_CASE_SETTINGS },
       ...(caseFieldsFromTemplate?.assignees
         ? { assignees: caseFieldsFromTemplate?.assignees }
         : {}),
@@ -1193,6 +1199,7 @@ export class CasesConnectorExecutor {
       v2Template: v2TemplateForReopened,
       extendedFields: extendedFieldsForReopened,
       templateRef: templateRefForReopened,
+      resolvedConnector: resolvedConnectorForReopened,
     } = await this.resolveV2TemplateWithFields(
       params,
       templatesConfigurationMapForReopened.get(params.owner)
@@ -1206,7 +1213,8 @@ export class CasesConnectorExecutor {
         templatesConfigurationMapForReopened.get(params.owner),
         v2TemplateForReopened ?? undefined,
         extendedFieldsForReopened,
-        templateRefForReopened
+        templateRefForReopened,
+        resolvedConnectorForReopened
       )
     );
 
@@ -1417,9 +1425,15 @@ export class CasesConnectorExecutor {
     v2Template: ParsedTemplateDefinition | null;
     extendedFields: Record<string, string> | undefined;
     templateRef: { id: string; version: number } | undefined;
+    resolvedConnector: BulkCreateCasesRequest['cases'][number]['connector'] | undefined;
   }> {
     if (!this.isTemplatesEnabled || !params.templateId) {
-      return { v2Template: null, extendedFields: undefined, templateRef: undefined };
+      return {
+        v2Template: null,
+        extendedFields: undefined,
+        templateRef: undefined,
+        resolvedConnector: undefined,
+      };
     }
 
     // A rule authored in the v2 UI stores the v2 templateId and its version — resolve it directly.
@@ -1433,19 +1447,24 @@ export class CasesConnectorExecutor {
       );
 
       if (!v2Template) {
-        return { v2Template: null, extendedFields: undefined, templateRef: undefined };
+        return {
+          v2Template: null,
+          extendedFields: undefined,
+          templateRef: undefined,
+          resolvedConnector: undefined,
+        };
       }
 
-      const extendedFields = await buildExtendedFieldsFromTemplate(
-        this.casesClient,
-        v2Template,
-        params.owner
-      );
+      const [extendedFields, resolvedConnector] = await Promise.all([
+        buildExtendedFieldsFromTemplate(this.casesClient, v2Template, params.owner),
+        resolveTemplateConnector(v2Template.connector, this.actionsClient, this.logger),
+      ]);
 
       return {
         v2Template,
         extendedFields,
         templateRef: { id: params.templateId, version: Number(params.templateVersion) },
+        resolvedConnector,
       };
     }
 
@@ -1467,19 +1486,24 @@ export class CasesConnectorExecutor {
     );
 
     if (!resolved) {
-      return { v2Template: null, extendedFields: undefined, templateRef: undefined };
+      return {
+        v2Template: null,
+        extendedFields: undefined,
+        templateRef: undefined,
+        resolvedConnector: undefined,
+      };
     }
 
-    const extendedFields = await buildExtendedFieldsFromTemplate(
-      this.casesClient,
-      resolved.definition,
-      params.owner
-    );
+    const [extendedFields, resolvedConnector] = await Promise.all([
+      buildExtendedFieldsFromTemplate(this.casesClient, resolved.definition, params.owner),
+      resolveTemplateConnector(resolved.definition.connector, this.actionsClient, this.logger),
+    ]);
 
     return {
       v2Template: resolved.definition,
       extendedFields,
       templateRef: { id: resolved.templateId, version: resolved.templateVersion },
+      resolvedConnector,
     };
   }
 

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.test.ts
@@ -42,6 +42,7 @@ describe('getCasesConnectorType', () => {
       getSpaceId: jest.fn(),
       isCasesAttachmentsEnabled: false,
       isTemplatesEnabled: false,
+      isAtLeastPlatinum: jest.fn().mockResolvedValue(true),
     });
   });
 
@@ -65,6 +66,7 @@ describe('getCasesConnectorType', () => {
       getSpaceId: jest.fn(),
       isCasesAttachmentsEnabled: false,
       isTemplatesEnabled: true,
+      isAtLeastPlatinum: jest.fn().mockResolvedValue(true),
     });
 
     // @ts-expect-error: only the subset of params used by getService is provided

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.test.ts
@@ -36,6 +36,7 @@ describe('getCasesConnectorType', () => {
 
     caseConnectorType = getCasesConnectorType({
       getCasesClient: jest.fn(),
+      getActionsClient: jest.fn(),
       getUnsecuredSavedObjectsClient: jest.fn(),
       getUiSettingsClient: jest.fn(),
       getSpaceId: jest.fn(),
@@ -58,6 +59,7 @@ describe('getCasesConnectorType', () => {
   it('threads isTemplatesEnabled: true through to the CasesConnector when enabled', () => {
     const caseConnectorTypeWithTemplatesEnabled = getCasesConnectorType({
       getCasesClient: jest.fn(),
+      getActionsClient: jest.fn(),
       getUnsecuredSavedObjectsClient: jest.fn(),
       getUiSettingsClient: jest.fn(),
       getSpaceId: jest.fn(),

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.ts
@@ -10,10 +10,12 @@ import {
   UptimeConnectorFeatureId,
   SecurityConnectorFeatureId,
 } from '@kbn/actions-plugin/common';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { SubActionConnectorType } from '@kbn/actions-plugin/server/sub_action_framework/types';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { IUiSettingsClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type { ConnectorAdapter } from '@kbn/alerting-plugin/server';
+import type { PublicMethodsOf } from '@kbn/utility-types';
 import { ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID } from '@kbn/elastic-assistant-common';
 import type { ServerlessProjectType } from '../../../common/constants/types';
 import { CasesConnector } from './cases_connector';
@@ -43,6 +45,7 @@ import { ATTACK_DISCOVERY_MAX_OPEN_CASES, groupAttackDiscoveryAlerts } from './a
 
 interface GetCasesConnectorTypeArgs {
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>;
+  getActionsClient: (request: KibanaRequest) => Promise<PublicMethodsOf<ActionsClient>>;
   getUnsecuredSavedObjectsClient: (
     request: KibanaRequest,
     savedObjectTypes: string[]
@@ -56,6 +59,7 @@ interface GetCasesConnectorTypeArgs {
 
 export const getCasesConnectorType = ({
   getCasesClient,
+  getActionsClient,
   getSpaceId,
   getUnsecuredSavedObjectsClient,
   getUiSettingsClient,
@@ -72,6 +76,7 @@ export const getCasesConnectorType = ({
     new CasesConnector({
       casesParams: {
         getCasesClient,
+        getActionsClient,
         getSpaceId,
         getUnsecuredSavedObjectsClient,
         getUiSettingsClient,

--- a/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/cases/index.ts
@@ -55,6 +55,7 @@ interface GetCasesConnectorTypeArgs {
   serverlessProjectType?: string;
   isCasesAttachmentsEnabled: boolean;
   isTemplatesEnabled: boolean;
+  isAtLeastPlatinum: () => Promise<boolean>;
 }
 
 export const getCasesConnectorType = ({
@@ -66,6 +67,7 @@ export const getCasesConnectorType = ({
   serverlessProjectType,
   isCasesAttachmentsEnabled,
   isTemplatesEnabled,
+  isAtLeastPlatinum,
 }: GetCasesConnectorTypeArgs): SubActionConnectorType<
   CasesConnectorConfig,
   CasesConnectorSecrets
@@ -82,6 +84,7 @@ export const getCasesConnectorType = ({
         getUiSettingsClient,
         isCasesAttachmentsEnabled,
         isTemplatesEnabled,
+        isAtLeastPlatinum,
       },
       connectorParams: params,
     }),

--- a/x-pack/platform/plugins/shared/cases/server/connectors/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/index.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import type { PluginSetupContract as ActionsPluginSetupContract } from '@kbn/actions-plugin/server';
+import type {
+  PluginSetupContract as ActionsPluginSetupContract,
+  ActionsClient,
+} from '@kbn/actions-plugin/server';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type {
   CoreSetup,
@@ -15,6 +18,7 @@ import type {
 } from '@kbn/core/server';
 import { SECURITY_EXTENSION_ID } from '@kbn/core/server';
 import type { AlertingServerSetup } from '@kbn/alerting-plugin/server';
+import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { ServerlessProjectType } from '../../common/constants/types';
 import type { CasesClient } from '../client';
 import { getCasesConnectorAdapter, getCasesConnectorType } from './cases';
@@ -28,6 +32,7 @@ export function registerConnectorTypes({
   core,
   logger,
   getCasesClient,
+  getActionsClient,
   getSpaceId,
   serverlessProjectType,
   isCasesAttachmentsEnabled,
@@ -38,6 +43,7 @@ export function registerConnectorTypes({
   core: CoreSetup;
   logger: Logger;
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>;
+  getActionsClient: (request: KibanaRequest) => Promise<PublicMethodsOf<ActionsClient>>;
   getSpaceId: (request?: KibanaRequest) => string;
   serverlessProjectType?: ServerlessProjectType;
   isCasesAttachmentsEnabled: boolean;
@@ -76,6 +82,7 @@ export function registerConnectorTypes({
   actions.registerSubActionConnectorType(
     getCasesConnectorType({
       getCasesClient,
+      getActionsClient,
       getSpaceId,
       getUnsecuredSavedObjectsClient,
       getUiSettingsClient,

--- a/x-pack/platform/plugins/shared/cases/server/connectors/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/connectors/index.ts
@@ -18,9 +18,11 @@ import type {
 } from '@kbn/core/server';
 import { SECURITY_EXTENSION_ID } from '@kbn/core/server';
 import type { AlertingServerSetup } from '@kbn/alerting-plugin/server';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { ServerlessProjectType } from '../../common/constants/types';
 import type { CasesClient } from '../client';
+import { LicensingService } from '../services/licensing';
 import { getCasesConnectorAdapter, getCasesConnectorType } from './cases';
 
 export type * from './types';
@@ -79,6 +81,15 @@ export function registerConnectorTypes({
     return coreStart.uiSettings.asScopedToClient(savedObjectsClient);
   };
 
+  const isAtLeastPlatinum = async (): Promise<boolean> => {
+    const [, pluginsStart] = await core.getStartServices();
+    const { licensing } = pluginsStart as { licensing: LicensingPluginStart };
+    return new LicensingService(
+      licensing.license$,
+      licensing.featureUsage.notifyUsage
+    ).isAtLeastPlatinum();
+  };
+
   actions.registerSubActionConnectorType(
     getCasesConnectorType({
       getCasesClient,
@@ -89,6 +100,7 @@ export function registerConnectorTypes({
       serverlessProjectType,
       isCasesAttachmentsEnabled,
       isTemplatesEnabled,
+      isAtLeastPlatinum,
     })
   );
 

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -251,6 +251,11 @@ export class CasePlugin
       };
     };
 
+    const getActionsClient = async (request: KibanaRequest) => {
+      const [, pluginsStart] = await core.getStartServices();
+      return pluginsStart.actions.getActionsClientWithRequest(request);
+    };
+
     const getSpaceId = (request?: KibanaRequest) => {
       if (!request) {
         return DEFAULT_SPACE_ID;
@@ -269,6 +274,7 @@ export class CasePlugin
       core,
       logger: this.logger,
       getCasesClient: getCasesClient('connector'),
+      getActionsClient,
       getSpaceId,
       serverlessProjectType,
       isCasesAttachmentsEnabled: this.caseConfig.attachments?.enabled === true,


### PR DESCRIPTION
## Summary

- When an alert rule auto-creates a case from a **templates v2** case template, the new case now inherits the template’s external connector (name resolved via Actions), case settings (`syncAlerts` / `extractObservables`), and assignees — matching the v1 system-action path and manual create-from-template behavior.
- Extracts a shared `resolveTemplateConnector` helper so create-from-template and the Cases system action use the same soft-fail resolution (missing/unauthorized connector → keep `.none` and log; do not fail case creation).
- Resolves the connector once per executor run (including the legacy v1→v2 template-key bridge). Auto-push UI on the v2 rule action form remains out of scope.

Addresses [SDH security-team #1781](https://github.com/elastic/sdh-security-team/issues/1781).

## Test plan

- [ ] Unit: `resolve_template_connector`, `expand_template_defaults`, and `cases_connector_executor` (connector apply/fallback, settings, assignees, legacy-key bridge)
- [ ] Manual: enable templates v2; create a case template with an external connector, sync/observables settings, and assignees; attach that template to an Observability/Security rule Cases system action; fire the rule so a **new** case is created
- [ ] Confirm the created case has the template connector (not `.none`), expected settings, and assignees
- [ ] Confirm a template with a deleted/unresolvable connector still creates the case with `.none` and does not fail the rule

## Release note

Fixes Cases system action so cases created from v2 templates inherit the template’s external connector, sync/observables settings, and assignees.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->