### PR TITLE
[9.4] [Entity Analytics] Fix yellow cluster health on single-node ES by adding auto_expand_replicas to EA index settings (#284625)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.test.ts
@@ -136,6 +136,7 @@ describe('AssetCriticalityDataClient', () => {
             },
           },
           settings: {
+            auto_expand_replicas: '0-1',
             default_pipeline: 'entity_analytics_create_eventIngest_from_timestamp-pipeline-default',
           },
         },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
@@ -101,6 +101,7 @@ export class AssetCriticalityDataClient {
           },
         },
         settings: {
+          auto_expand_replicas: '0-1',
           default_pipeline: getIngestPipelineName(this.options.namespace),
         },
       },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/indices/lead_index_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/indices/lead_index_service.test.ts
@@ -44,7 +44,7 @@ describe('LeadIndexService', () => {
       expect(indexNames).toContain(scheduledIndex);
 
       const [{ options }] = mockCreateOrUpdateIndex.mock.calls[0];
-      expect(options.settings).toEqual({ hidden: true });
+      expect(options.settings).toEqual({ auto_expand_replicas: '0-1', hidden: true });
       expect(options.mappings.properties).toHaveProperty('id');
       expect(options.mappings.properties).toHaveProperty('observations');
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/indices/lead_index_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/lead_generation/indices/lead_index_service.ts
@@ -40,7 +40,7 @@ export const createLeadIndexService = ({ esClient, logger, spaceId }: LeadIndexS
         options: {
           index: name,
           mappings,
-          settings: { hidden: true },
+          settings: { hidden: true, auto_expand_replicas: '0-1' },
         },
       });
     }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/engine/elasticsearch/indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/engine/elasticsearch/indices.ts
@@ -25,6 +25,7 @@ export const createPrivmonIndexService = (dataClient: PrivilegeMonitoringDataCli
         mappings: generateUserIndexMappings(),
         settings: {
           hidden: true,
+          auto_expand_replicas: '0-1',
           mode: 'lookup',
           default_pipeline: PRIVMON_EVENT_INGEST_PIPELINE_ID,
         },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
@@ -113,7 +113,7 @@ export class WatchlistConfigClient {
       options: {
         index: getIndexForWatchlist(this.deps.namespace),
         mappings: generateWatchlistEntityIndexMappings(),
-        settings: { hidden: true },
+        settings: { hidden: true, auto_expand_replicas: '0-1' },
       },
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Analytics] Fix yellow cluster health on single-node ES by adding auto_expand_replicas to EA index settings (#284625)](https://github.com/elastic/kibana/pull/284625)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Chen Ashuri","email":"chen.ashuri@elastic.co"},"sourceCommit":{"committedDate":"2026-08-12T15:32:37Z","message":"[Entity Analytics] Fix yellow cluster health on single-node ES by adding auto_expand_replicas to EA index settings (#284625)\n\n## Summary\n\nFixes #276861\n\nFour Entity Analytics indices were created with the Elasticsearch\ndefault of `number_of_replicas: 1`. On single-node clusters (ECK, dev\nenvironments, small self-managed setups), the replica shard can never be\nallocated because a node cannot hold both a primary and a replica for\nthe same shard. This left the cluster health permanently **yellow**.\n\nThe fix adds `auto_expand_replicas: '0-1'` to the index settings for all\nfour affected indices:\n\n| Index creator | File |\n|---|---|\n| Watchlists | `watchlists/management/watchlist_config.ts` |\n| Privilege monitoring |\n`privilege_monitoring/engine/elasticsearch/indices.ts` |\n| Lead generation | `lead_generation/indices/lead_index_service.ts` |\n| Asset criticality |\n`asset_criticality/asset_criticality_data_client.ts` |\n\n## What changed\n\n**Before:** each index was created with only `{ hidden: true }` (or\nsimilar minimal) settings, inheriting ES's default of 1 replica.\n\n**After:** each index is created with `auto_expand_replicas: '0-1'`,\nwhich instructs Elasticsearch to use 0 replicas when only one data node\nis available and scale up to 1 replica when a second node joins. This is\na standard dynamic setting - no downtime or reindex required.\n\n## Backward compatibility\n\nThis change is fully backward compatible and self-healing for existing\ndeployments:\n\n- `auto_expand_replicas` is a **dynamic** Elasticsearch index setting -\nit can be applied to a live index without closing it or reindexing data.\n- The `createOrUpdateIndex` utility already calls\n`esClient.indices.putSettings()` on existing indices whenever settings\nare provided. This means the fix will be automatically applied to\npre-existing yellow indices on the **next Kibana restart**, recovering\ncluster health without any manual intervention.\n- No data schema changes, no API changes, no feature behaviour changes.\n\n## Additional note\n\nThis is the same fix applied to `#261933` (`.workflows-events`) and\n`#263048` (`.kibana_streams`). The security solution's own\n`@kbn/index-adapter` package (`resource_installer_utils.ts`) hard-codes\n`auto_expand_replicas: '0-1'` for all index templates it manages - this\nPR aligns the four indices that bypass that adapter.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"a932c0d81d25f747ac17bcda93c89d64fb7f91dd","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Entity Analytics","backport:version","v9.6.0","v9.5.1","v9.4.6"],"title":"[Entity Analytics] Fix yellow cluster health on single-node ES by adding auto_expand_replicas to EA index settings","number":284625,"url":"https://github.com/elastic/kibana/pull/284625","mergeCommit":{"message":"[Entity Analytics] Fix yellow cluster health on single-node ES by adding auto_expand_replicas to EA index settings (#284625)\n\n## Summary\n\nFixes #276861\n\nFour Entity Analytics indices were created with the Elasticsearch\ndefault of `number_of_replicas: 1`. On single-node clusters (ECK, dev\nenvironments, small self-managed setups), the replica shard can never be\nallocated because a node cannot hold both a primary and a replica for\nthe same shard. This left the cluster health permanently **yellow**.\n\nThe fix adds `auto_expand_replicas: '0-1'` to the index settings for all\nfour affected indices:\n\n| Index creator | File |\n|---|---|\n| Watchlists | `watchlists/management/watchlist_config.ts` |\n| Privilege monitoring |\n`privilege_monitoring/engine/elasticsearch/indices.ts` |\n| Lead generation | `lead_generation/indices/lead_index_service.ts` |\n| Asset criticality |\n`asset_criticality/asset_criticality_data_client.ts` |\n\n## What changed\n\n**Before:** each index was created with only `{ hidden: true }` (or\nsimilar minimal) settings, inheriting ES's default of 1 replica.\n\n**After:** each index is created with `auto_expand_replicas: '0-1'`,\nwhich instructs Elasticsearch to use 0 replicas when only one data node\nis available and scale up to 1 replica when a second node joins. This is\na standard dynamic setting - no downtime or reindex required.\n\n## Backward compatibility\n\nThis change is fully backward compatible and self-healing for existing\ndeployments:\n\n- `auto_expand_replicas` is a **dynamic** Elasticsearch index setting -\nit can be applied to a live index without closing it or reindexing data.\n- The `createOrUpdateIndex` utility already calls\n`esClient.indices.putSettings()` on existing indices whenever settings\nare provided. This means the fix will be automatically applied to\npre-existing yellow indices on the **next Kibana restart**, recovering\ncluster health without any manual intervention.\n- No data schema changes, no API changes, no feature behaviour changes.\n\n## Additional note\n\nThis is the same fix applied to `#261933` (`.workflows-events`) and\n`#263048` (`.kibana_streams`). The security solution's own\n`@kbn/index-adapter` package (`resource_installer_utils.ts`) hard-codes\n`auto_expand_replicas: '0-1'` for all index templates it manages - this\nPR aligns the four indices that bypass that adapter.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"a932c0d81d25f747ac17bcda93c89d64fb7f91dd"}},"sourceBranch":"main","suggestedTargetBranches":["9.5","9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284625","number":284625,"mergeCommit":{"message":"[Entity Analytics] Fix yellow cluster health on single-node ES by adding auto_expand_replicas to EA index settings (#284625)\n\n## Summary\n\nFixes #276861\n\nFour Entity Analytics indices were created with the Elasticsearch\ndefault of `number_of_replicas: 1`. On single-node clusters (ECK, dev\nenvironments, small self-managed setups), the replica shard can never be\nallocated because a node cannot hold both a primary and a replica for\nthe same shard. This left the cluster health permanently **yellow**.\n\nThe fix adds `auto_expand_replicas: '0-1'` to the index settings for all\nfour affected indices:\n\n| Index creator | File |\n|---|---|\n| Watchlists | `watchlists/management/watchlist_config.ts` |\n| Privilege monitoring |\n`privilege_monitoring/engine/elasticsearch/indices.ts` |\n| Lead generation | `lead_generation/indices/lead_index_service.ts` |\n| Asset criticality |\n`asset_criticality/asset_criticality_data_client.ts` |\n\n## What changed\n\n**Before:** each index was created with only `{ hidden: true }` (or\nsimilar minimal) settings, inheriting ES's default of 1 replica.\n\n**After:** each index is created with `auto_expand_replicas: '0-1'`,\nwhich instructs Elasticsearch to use 0 replicas when only one data node\nis available and scale up to 1 replica when a second node joins. This is\na standard dynamic setting - no downtime or reindex required.\n\n## Backward compatibility\n\nThis change is fully backward compatible and self-healing for existing\ndeployments:\n\n- `auto_expand_replicas` is a **dynamic** Elasticsearch index setting -\nit can be applied to a live index without closing it or reindexing data.\n- The `createOrUpdateIndex` utility already calls\n`esClient.indices.putSettings()` on existing indices whenever settings\nare provided. This means the fix will be automatically applied to\npre-existing yellow indices on the **next Kibana restart**, recovering\ncluster health without any manual intervention.\n- No data schema changes, no API changes, no feature behaviour changes.\n\n## Additional note\n\nThis is the same fix applied to `#261933` (`.workflows-events`) and\n`#263048` (`.kibana_streams`). The security solution's own\n`@kbn/index-adapter` package (`resource_installer_utils.ts`) hard-codes\n`auto_expand_replicas: '0-1'` for all index templates it manages - this\nPR aligns the four indices that bypass that adapter.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"a932c0d81d25f747ac17bcda93c89d64fb7f91dd"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->