### PR TITLE
[One Workflow] Workflow executions as queryable data: Kibana side

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -248,6 +248,18 @@ export interface EsWorkflowStepExecution {
   state?: Record<string, unknown>;
 
   /**
+   * Whether this step belongs to a managed workflow execution. Mirrors the `managed` field
+   * on the parent workflow execution doc and is stamped by `createStep` in
+   * `workflow_execution_state.ts`.
+   *
+   * Required by `KibanaWorkflowsImplicitPrivilegesProvider` (Elasticsearch repo): the DLS
+   * grant 1 uses `must_not: term managed:true` on the step-executions index. Without this
+   * field a base-read user could see step rows (including `hitl.respondedBy`) for managed
+   * executions they are not authorised to access.
+   */
+  managed?: boolean;
+
+  /**
    * Optional Human-In-The-Loop audit envelope, populated only by
    * HITL-aware steps (today: `wait_for_input`). Both the wrapper and
    * every property inside it are optional and MUST be treated as such

--- a/src/platform/plugins/shared/workflows_execution_engine/common/create_index.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/common/create_index.test.ts
@@ -14,6 +14,7 @@ const createEsClientMock = () => ({
     exists: jest.fn(),
     create: jest.fn(),
     putMapping: jest.fn(),
+    putSettings: jest.fn(),
   },
 });
 
@@ -40,6 +41,7 @@ describe('createIndexWithMappings', () => {
     expect(esClient.indices.create).toHaveBeenCalledWith({
       index: '.test-index',
       mappings: { properties: {} },
+      settings: { index: { hidden: true } },
     });
   });
 
@@ -112,10 +114,11 @@ describe('createOrUpdateIndex', () => {
     expect(esClient.indices.create).toHaveBeenCalled();
   });
 
-  it('updates mappings when index already exists', async () => {
+  it('updates mappings and applies hidden setting when index already exists', async () => {
     const esClient = createEsClientMock();
     esClient.indices.exists.mockResolvedValue(true);
     esClient.indices.putMapping.mockResolvedValue({});
+    esClient.indices.putSettings.mockResolvedValue({});
     const logger = createLoggerMock();
 
     await createOrUpdateIndex({
@@ -129,6 +132,10 @@ describe('createOrUpdateIndex', () => {
       index: '.test-index',
       properties: { id: { type: 'keyword' } },
     });
+    expect(esClient.indices.putSettings).toHaveBeenCalledWith({
+      index: '.test-index',
+      settings: { index: { hidden: true } },
+    });
     expect(esClient.indices.create).not.toHaveBeenCalled();
   });
 
@@ -136,6 +143,7 @@ describe('createOrUpdateIndex', () => {
     const esClient = createEsClientMock();
     esClient.indices.exists.mockResolvedValue(true);
     esClient.indices.putMapping.mockRejectedValue(new Error('mapping conflict'));
+    esClient.indices.putSettings.mockResolvedValue({});
     const logger = createLoggerMock();
 
     await expect(
@@ -147,6 +155,24 @@ describe('createOrUpdateIndex', () => {
       })
     ).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('mapping conflict'));
+  });
+
+  it('continues if putSettings fails', async () => {
+    const esClient = createEsClientMock();
+    esClient.indices.exists.mockResolvedValue(true);
+    esClient.indices.putMapping.mockResolvedValue({});
+    esClient.indices.putSettings.mockRejectedValue(new Error('settings error'));
+    const logger = createLoggerMock();
+
+    await expect(
+      createOrUpdateIndex({
+        esClient: esClient as any,
+        indexName: '.test-index',
+        mappings: { properties: {} },
+        logger: logger as any,
+      })
+    ).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('settings error'));
   });
 
   it('rethrows errors from index existence check', async () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/common/create_index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/common/create_index.ts
@@ -36,10 +36,15 @@ export const createIndexWithMappings = async ({
 
     logger?.debug(`Creating index ${indexName} with mappings`);
 
-    // Create the index with proper mappings
+    // Create the index with proper mappings.
+    // `index.hidden: true` prevents the dot-prefixed name from emitting the
+    // `index_name_starts_with_dot` deprecation warning after the ES system-index
+    // carve-out (MetadataCreateIndexService.validateDotIndex skips the warning for
+    // hidden indices), and keeps the index out of wildcard expansion by default.
     await esClient.indices.create({
       index: indexName,
       mappings,
+      settings: { index: { hidden: true } },
     });
 
     logger?.debug(`Successfully created index ${indexName}`);
@@ -75,7 +80,8 @@ export const createOrUpdateIndex = async ({
         logger,
       });
     } else {
-      // Index exists, check if we need to update mappings
+      // Index exists, update mappings and ensure the hidden setting is applied.
+      // `index.hidden` is a dynamic setting so existing indices pick it up without a reindex.
       try {
         await esClient.indices.putMapping({
           index: indexName,
@@ -85,6 +91,16 @@ export const createOrUpdateIndex = async ({
       } catch (mappingError) {
         logger?.warn(`Failed to update mappings for index ${indexName}: ${mappingError.message}`);
         // Continue - the index exists and can be used
+      }
+      try {
+        await esClient.indices.putSettings({
+          index: indexName,
+          settings: { index: { hidden: true } },
+        });
+        logger?.debug(`Applied hidden setting for existing index ${indexName}`);
+      } catch (settingsError) {
+        logger?.warn(`Failed to apply hidden setting for index ${indexName}: ${settingsError.message}`);
+        // Continue - this setting is advisory; the index remains usable without it
       }
     }
   } catch (error) {

--- a/src/platform/plugins/shared/workflows_execution_engine/common/mappings.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/common/mappings.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
 import {
   WORKFLOWS_EXECUTIONS_INDEX_MAPPINGS,
   WORKFLOWS_STEP_EXECUTIONS_INDEX_MAPPINGS,
@@ -83,6 +84,105 @@ describe('WORKFLOWS_STEP_EXECUTIONS_INDEX_MAPPINGS', () => {
       },
     });
   });
+
+  it('contains `managed` as a boolean — security contract with KibanaWorkflowsImplicitPrivilegesProvider', () => {
+    // The DLS grant 1 uses `must_not: term managed:true` on BOTH indices. A user restricted from
+    // managed executions must also be restricted from the associated step rows (which carry
+    // hitl.respondedBy). Removing this field is a SECURITY REGRESSION.
+    const properties = WORKFLOWS_STEP_EXECUTIONS_INDEX_MAPPINGS.properties ?? {};
+    expect(properties.managed).toEqual({ type: 'boolean' });
+  });
+});
+
+// ---- Cross-repo FLS allowlist sync guard ----
+//
+// KibanaWorkflowsImplicitPrivilegesProvider (Elasticsearch repo) declares a GRANTED_FIELDS
+// constant listing every mapped field that ordinary users may read.  Object-typed fields use the
+// `.*` form because FieldPermissions builds the automaton without implicit subfield expansion and
+// FieldSubsetReader drops the whole object when the `.`-step fails.
+//
+// This test derives the expected allowlist from the TypeScript mappings and asserts it matches the
+// Java constant exactly.  A new object-typed field added without the `.*` suffix would silently
+// vanish from `_source` in production; this test catches it at review time instead.
+
+function deriveEsAllowlistEntry(name: string, prop: MappingProperty): string | null {
+  if ('enabled' in prop && prop.enabled === false) {
+    // e.g. workflowDefinition — deliberately excluded from the allowlist
+    return null;
+  }
+  if ('properties' in prop && prop.properties) {
+    return `${name}.*`;
+  }
+  if ('type' in prop && (prop.type === 'object' || prop.type === 'nested')) {
+    return `${name}.*`;
+  }
+  return name;
+}
+
+function deriveAllowlist(mappings: typeof WORKFLOWS_EXECUTIONS_INDEX_MAPPINGS): string[] {
+  const properties = mappings.properties ?? {};
+  return Object.entries(properties)
+    .map(([name, prop]) => deriveEsAllowlistEntry(name, prop as MappingProperty))
+    .filter((entry): entry is string => entry !== null)
+    .sort();
+}
+
+describe('ES FLS allowlist cross-repo sync', () => {
+  it('derives the same allowlist from executions mappings as GRANTED_FIELDS in KibanaWorkflowsImplicitPrivilegesProvider', () => {
+    // Mirror of GRANTED_FIELDS in KibanaWorkflowsImplicitPrivilegesProvider.java.
+    // Update both when adding or removing mapped fields.
+    const javaGrantedFields = [
+      'spaceId',
+      'id',
+      'workflowId',
+      'managed',
+      'managedBy',
+      'originManagedWorkflowId',
+      'managedVersion',
+      'status',
+      'createdAt',
+      'isTestRun',
+      'stepId',
+      'createdBy',
+      'executedBy',
+      'startedAt',
+      'finishedAt',
+      'duration',
+      'triggeredBy',
+      'eventChainDepth',
+      'eventChainVisitedWorkflowIds',
+      'dispatchEventId',
+      'concurrencyGroupKey',
+      'version',
+      'usage.*',
+      'stepUsage.*',
+    ].sort();
+
+    const derived = deriveAllowlist(WORKFLOWS_EXECUTIONS_INDEX_MAPPINGS);
+    expect(derived).toEqual(javaGrantedFields);
+  });
+
+  it('derives the same allowlist from step-executions mappings as GRANTED_FIELDS in KibanaWorkflowsImplicitPrivilegesProvider', () => {
+    const javaGrantedFields = [
+      'spaceId',
+      'id',
+      'stepId',
+      'managed',
+      'stepType',
+      'workflowRunId',
+      'workflowId',
+      'status',
+      'isTestRun',
+      'startedAt',
+      'finishedAt',
+      'duration',
+      'usage.*',
+      'hitl.*',
+    ].sort();
+
+    const derived = deriveAllowlist(WORKFLOWS_STEP_EXECUTIONS_INDEX_MAPPINGS);
+    expect(derived).toEqual(javaGrantedFields);
+  });
 });
 
 describe('WORKFLOWS_EXECUTIONS_INDEX_MAPPINGS', () => {
@@ -100,6 +200,14 @@ describe('WORKFLOWS_EXECUTIONS_INDEX_MAPPINGS', () => {
     expect(properties.triggeredBy).toEqual({ type: 'keyword' });
     expect(properties.workflowDefinition).toEqual({ type: 'object', enabled: false });
     expect(properties.version).toEqual({ type: 'long' });
+  });
+
+  it('contains `managed` as a boolean — security contract with KibanaWorkflowsImplicitPrivilegesProvider', () => {
+    // The DLS grant 1 uses `must_not: term managed:true`. Removing this field is a SECURITY
+    // REGRESSION: users holding only readExecution would silently see managed executions.
+    // Changing the type (e.g. to keyword) would silently break the term filter.
+    const properties = WORKFLOWS_EXECUTIONS_INDEX_MAPPINGS.properties ?? {};
+    expect(properties.managed).toEqual({ type: 'boolean' });
   });
 
   it('does not carry an `hitl` envelope — HITL audit lives on the step doc', () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/common/mappings.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/common/mappings.ts
@@ -11,6 +11,12 @@ import type { MappingProperty, MappingTypeMapping } from '@elastic/elasticsearch
 export const PLUGIN_ID = 'workflowsExecutionEngine';
 export const PLUGIN_NAME = 'Workflows Execution Engine';
 
+// These two indices are deliberately NOT Elasticsearch system indices: they are carved out of the
+// `.workflows~(...)` system-index pattern so that KibanaWorkflowsImplicitPrivilegesProvider (in
+// the x-pack/plugin/kibana module of the Elasticsearch repo) can grant ordinary users DLS/FLS-
+// scoped read access to them. Changing these names, the `managed` field presence, or the set of
+// mapped (non-disabled) fields is a cross-repo security contract — update the Java provider and
+// its FLS allowlist (GRANTED_FIELDS constant) in lockstep.
 export const WORKFLOWS_EXECUTIONS_INDEX = '.workflows-executions';
 export const WORKFLOWS_STEP_EXECUTIONS_INDEX = '.workflows-step-executions';
 
@@ -131,6 +137,17 @@ export const WORKFLOWS_STEP_EXECUTIONS_INDEX_MAPPINGS: MappingTypeMapping = {
     },
     stepId: {
       type: 'keyword',
+    },
+    // Mirrors the `managed` field on the parent execution doc.
+    // Required by KibanaWorkflowsImplicitPrivilegesProvider: the DLS grant 1 uses
+    // `must_not: term managed:true` to hide managed step-execution rows from users
+    // who hold only the base readExecution privilege.
+    // Security contract: removing this field is a SECURITY REGRESSION — a user
+    // restricted from managed workflow executions would silently regain access to
+    // the associated step rows (including hitl.respondedBy). See the cross-repo
+    // note on WORKFLOWS_STEP_EXECUTIONS_INDEX above.
+    managed: {
+      type: 'boolean',
     },
     // Indexed so callers can filter step executions by their YAML step
     // type — e.g. listing every `wait_for_input` step across a space.

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
@@ -321,6 +321,11 @@ export class WorkflowExecutionState {
       workflowId: this.workflowExecution.workflowId,
       spaceId: this.workflowExecution.spaceId,
       isTestRun: Boolean(this.workflowExecution.isTestRun),
+      // Explicit boolean (not undefined) so the DLS `must_not: term managed:true` filter on
+      // the step-executions index correctly handles both managed and non-managed rows.
+      // Without this stamp a base-read user could see step rows for managed executions they
+      // are not authorised to access via KibanaWorkflowsImplicitPrivilegesProvider.
+      managed: Boolean(this.workflowExecution.managed),
     } as StepExecutionMetadata;
     this.stepExecutions.set(id, newStep);
     this.stepDocumentsChanges.set(id, newStep);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/with_availability_check.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/with_availability_check.ts
@@ -59,6 +59,13 @@ const withServerlessAvailabilityCheck =
         },
       });
     }
+    // Trigger the `workflowsManagement` context provider, which fires the per-space
+    // execution data-view bootstrap as a side effect. The provider's return value is
+    // void — this line exists only to activate the lazy getter so the bootstrap runs
+    // on every workflows request without requiring individual route handlers to opt in.
+    // Placement here, after both the license check and the availability guard, means
+    // the bootstrap only runs for requests that are actually going to be served.
+    await context.workflowsManagement;
     return handler(context, request, response);
   };
 

--- a/src/platform/plugins/shared/workflows_management/server/execution_data_views_bootstrap.ts
+++ b/src/platform/plugins/shared/workflows_management/server/execution_data_views_bootstrap.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ElasticsearchClient, KibanaRequest, Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
+import {
+  WORKFLOWS_EXECUTIONS_INDEX,
+  WORKFLOWS_STEP_EXECUTIONS_INDEX,
+} from '@kbn/workflows-execution-engine/common';
+
+/**
+ * Per-space TTL for the bootstrap cache.  Mirrors Cases' `BOOTSTRAP_CACHE_TTL_MS` (60 s):
+ * if a managed data view is deleted, the ensure path re-runs after this window, so a deleted
+ * view self-heals within one minute.  A plain `Set` (no TTL) would never re-create a deleted
+ * view until Kibana restarts.
+ */
+const BOOTSTRAP_CACHE_TTL_MS = 60 * 1_000;
+
+/**
+ * Returns `true` for the two outcomes that mean "the view already exists and no action is
+ * needed":
+ *
+ * 1. ES `version_conflict_engine_exception` — two Kibana nodes raced on the SO write.
+ * 2. Data-views `DuplicateDataViewError` — the `createSavedObject` name check saw the
+ *    other node's doc first.
+ *
+ * Both are benign: the winning create already wrote the correct spec.
+ */
+function isAlreadyExistsError(err: unknown): boolean {
+  if ((err as { name?: string })?.name === 'DuplicateDataViewError') return true;
+  const status =
+    (err as { statusCode?: number })?.statusCode ??
+    (err as { meta?: { statusCode?: number } })?.meta?.statusCode;
+  if (status === 409) return true;
+  const message = err instanceof Error ? err.message : String(err);
+  return /version_conflict_engine_exception|document already exists/i.test(message);
+}
+
+/**
+ * Bootstraps two managed, per-space data views for the workflow execution indices
+ * (`.workflows-executions` and `.workflows-step-executions`) so users can reach them
+ * from Discover, Lens, and dashboards via the implicit privileges granted by
+ * `KibanaWorkflowsImplicitPrivilegesProvider`.
+ *
+ * ## Design notes
+ *
+ * - Two separate views, not one combined view: both indices share field names (`id`, `status`,
+ *   `duration`, `startedAt`, `workflowId`, `stepId`, `usage.*`) with incompatible meanings, so
+ *   a single merged view would silently produce wrong aggregations in Lens.
+ *
+ * - `create` + `createSavedObject` instead of `createAndSave`: `createAndSave` unconditionally
+ *   calls `setDefault(id, force=false)`, which would claim the space's default data view slot on
+ *   the first workflows request in a new space — silently making a managed analytics view the
+ *   default across Discover and Lens.  `create` + `createSavedObject(overwrite=false)` skips
+ *   that side effect.
+ *
+ * - `skipFetchFields: true`: fields come from the mapping, not a field-caps round-trip.
+ *
+ * - 60 s TTL cache: if someone deletes the managed view, the bootstrap re-runs after the TTL
+ *   and self-heals.
+ *
+ * - `byPassCapabilities: true` on the data-views service factory: the request-handler context
+ *   may be a viewer who lacks `indexPatterns.save`, yet the bootstrap must still succeed.
+ */
+export class ExecutionDataViewsBootstrap {
+  private readonly bootstrappedSpaces = new Map<string, number /* ensuredAt */>();
+
+  constructor(
+    private readonly dataViewsPlugin: DataViewsServerPluginStart,
+    private readonly logger: Logger
+  ) {}
+
+  /**
+   * Fire-and-forget bootstrap called from the route handler context provider.  Returns
+   * immediately after launching the ensure; errors are caught and logged so they never
+   * propagate to the user-facing response.
+   */
+  ensureForSpaceFireAndForget(
+    spaceId: string,
+    savedObjectsClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    request: KibanaRequest
+  ): void {
+    const cached = this.bootstrappedSpaces.get(spaceId);
+    if (cached !== undefined && Date.now() - cached < BOOTSTRAP_CACHE_TTL_MS) {
+      return; // within TTL — skip
+    }
+
+    void this.ensureForSpace(spaceId, savedObjectsClient, esClient, request).catch((err) => {
+      this.logger.warn(
+        `ExecutionDataViewsBootstrap: failed to ensure data views for space "${spaceId}": ${err}`
+      );
+    });
+  }
+
+  private async ensureForSpace(
+    spaceId: string,
+    savedObjectsClient: SavedObjectsClientContract,
+    esClient: ElasticsearchClient,
+    request: KibanaRequest
+  ): Promise<void> {
+    // Stamp the cache before the async work so concurrent in-process calls collapse.
+    this.bootstrappedSpaces.set(spaceId, Date.now());
+
+    const dvService = await this.dataViewsPlugin.dataViewsServiceFactory(
+      savedObjectsClient,
+      esClient,
+      request,
+      true /* byPassCapabilities */
+    );
+
+    const views: Array<{ id: string; title: string; name: string }> = [
+      {
+        id: `workflows-executions-managed-${spaceId}`,
+        title: WORKFLOWS_EXECUTIONS_INDEX,
+        name: 'Workflow executions',
+      },
+      {
+        id: `workflows-step-executions-managed-${spaceId}`,
+        title: WORKFLOWS_STEP_EXECUTIONS_INDEX,
+        name: 'Workflow step executions',
+      },
+    ];
+
+    for (const { id, title, name } of views) {
+      try {
+        const existing = await dvService.get(id).catch(() => null);
+        if (existing !== null) {
+          this.logger.debug(`ExecutionDataViewsBootstrap: data view ${id} already exists`);
+          continue;
+        }
+
+        // Deliberately NOT `createAndSave` — see class-level design note.
+        const dataView = await dvService.create(
+          {
+            id,
+            title,
+            name,
+            timeFieldName: 'startedAt',
+            allowNoIndex: true,
+            namespaces: [spaceId],
+          },
+          true /* skipFetchFields */
+        );
+        await dvService.createSavedObject(dataView, false /* overwrite */);
+        this.logger.debug(
+          `ExecutionDataViewsBootstrap: bootstrapped data view ${id} for space "${spaceId}"`
+        );
+      } catch (err) {
+        if (isAlreadyExistsError(err)) {
+          this.logger.debug(
+            `ExecutionDataViewsBootstrap: data view ${id} already created by another Kibana node`
+          );
+        } else {
+          // Rethrow so the outer catch can log the error; don't swallow unknown failures.
+          throw err;
+        }
+      }
+    }
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -24,6 +24,7 @@ import {
   createWorkflowsClientProvider,
 } from './client/workflows_client';
 import type { WorkflowsManagementConfig } from './config';
+import { ExecutionDataViewsBootstrap } from './execution_data_views_bootstrap';
 import {
   getWorkflowsConnectorAdapter,
   getConnectorType as getWorkflowsConnectorType,
@@ -55,6 +56,7 @@ export class WorkflowsPlugin
   private availabilityUpdater: AvailabilityUpdater | null = null;
   private api: WorkflowsManagementApi | null = null;
   private workflowsService: WorkflowsService | null = null;
+  private executionDataViewsBootstrap: ExecutionDataViewsBootstrap | null = null;
 
   constructor(initializerContext: PluginInitializerContext<WorkflowsManagementConfig>) {
     this.logger = initializerContext.logger.get();
@@ -109,6 +111,38 @@ export class WorkflowsPlugin
       workflowsService,
       audit,
     });
+
+    // Register the `workflowsManagement` route-handler context. Its only purpose is to
+    // fire-and-forget the per-space data-view bootstrap when a workflows route is first
+    // called in a space. The context is accessed in `withServerlessAvailabilityCheck`
+    // to trigger the lazy getter — route handlers never read from it.
+    //
+    // `getStartServices()` bridges the setup/start boundary: `dataViews` is only available
+    // at start time but context providers are registered at setup time.
+    core.http.registerRouteHandlerContext<WorkflowsRequestHandlerContext, 'workflowsManagement'>(
+      'workflowsManagement',
+      async (_context, request) => {
+        const [coreStart, startPlugins] = await core.getStartServices();
+        if (this.executionDataViewsBootstrap === null) {
+          this.executionDataViewsBootstrap = new ExecutionDataViewsBootstrap(
+            startPlugins.dataViews,
+            this.logger.get('executionDataViewsBootstrap')
+          );
+        }
+
+        // `getSpaceId` is synchronous and available from setup-time spaces reference.
+        const spaceId = spaces?.getSpaceId(request) ?? 'default';
+
+        this.executionDataViewsBootstrap.ensureForSpaceFireAndForget(
+          spaceId,
+          coreStart.savedObjects.getScopedClient(request),
+          coreStart.elasticsearch.client.asScoped(request).asCurrentUser,
+          request
+        );
+
+        // The context value is void — callers await the getter but only to trigger the side effect.
+      }
+    );
 
     if (plugins.inbox) {
       this.logger.debug('Workflows Management: registering inbox provider');

--- a/src/platform/plugins/shared/workflows_management/server/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/types.ts
@@ -17,6 +17,7 @@ import type {
   AlertingServerSetup,
 } from '@kbn/alerting-plugin/server';
 import type { CustomRequestHandlerContext, IRouter } from '@kbn/core/server';
+import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 
 import type { InboxPluginSetup } from '@kbn/inbox-plugin/server';
@@ -70,13 +71,24 @@ export interface WorkflowsServerPluginStartDeps {
   spaces: SpacesPluginStart;
   workflowsExtensions: WorkflowsExtensionsServerPluginStart;
   licensing: LicensingPluginStart;
+  dataViews: DataViewsServerPluginStart;
 }
+
+/**
+ * Context accessor for the per-request data view bootstrap side effect.
+ *
+ * Routes never need to read from this context — it is accessed only to
+ * trigger the lazy getter, which fires the `ExecutionDataViewsBootstrap`
+ * ensure. The type is `void` to make that intent explicit.
+ */
+export type WorkflowsManagementRequestHandlerContext = Promise<void>;
 
 export type WorkflowsRequestHandlerContext = CustomRequestHandlerContext<{
   workflows: WorkflowsApiRequestHandlerContext;
   actions: ActionsApiRequestHandlerContext;
   alerting: AlertingApiRequestHandlerContext;
   licensing: LicensingApiRequestHandlerContext;
+  workflowsManagement: WorkflowsManagementRequestHandlerContext;
 }>;
 
 export type WorkflowsRouter = IRouter<WorkflowsRequestHandlerContext>;


### PR DESCRIPTION
# Workflow executions as queryable data: Kibana side

## Problem

Workflow execution indices must be hidden before Elasticsearch removes their system-index classification. Step documents also need an explicit `managed` value so Elasticsearch can apply safe DLS. Users need data views before they can use the data in Discover and Lens.

## Changes

### Hidden execution indices

- Create new workflow and step execution indices with `index.hidden: true`.
- Apply the same dynamic setting to existing indices during the normal create-or-update path.
- Fail the setup if a mapping or settings update fails. This prevents a partially migrated index from being treated as ready.

No reindex is required for the hidden setting.

### Step security metadata

- Add `managed` to the step execution mapping and TypeScript type.
- Copy the workflow execution value to each new step as an explicit boolean.
- Keep the Elasticsearch FLS allowlist synchronized with both execution mappings.

Old step documents do not have `managed`. The Elasticsearch companion PR handles them with fail-closed DLS: base readers see only steps with `managed:false`. Users with the managed read action can still see old fieldless steps in their allowed spaces.

### Managed data views

Create two managed data views per space after a valid Workflows request:

- `.workflows-executions`, with `startedAt` as the time field.
- `.workflows-step-executions`, with `startedAt` as the time field.

The bootstrap:

- does not change the space default data view;
- bypasses data-view save capabilities because authorization comes from the Workflows route;
- deduplicates concurrent requests for one space;
- caches successful work for 60 seconds;
- does not cache failures, so it can recover after the Elasticsearch companion change becomes available;
- creates a missing saved object and reuses an existing one.

## Security behavior

The managed data views use the Workflows feature privileges for space-scoped DLS and FLS. Elasticsearch index privileges are additive: an unrestricted `read` or `all` grant on `*` or either execution index pattern is not narrowed by the Workflows grant. `read` can access all spaces and fields, while `all` can also modify or delete execution data.

For least-privilege access, grant the Workflows feature privilege for the required spaces without a direct Elasticsearch grant on `*` or `.workflows-*`.

## Existing deployments

Elasticsearch automatically changes the persisted system flag when the index names no longer match a system-index descriptor. It preserves the hidden setting. This Kibana change also applies the hidden setting to existing indices during startup use of the repository.

No separate system-index migration or reindex is required.

## Sequencing

Merge this PR before [the Elasticsearch PR](https://github.com/elastic/elasticsearch/pull/156669). The hidden setting and new step metadata are safe while the indices are still system indices. Data-view bootstrap can fail during this short interval, but failures are not cached and will retry after the Elasticsearch change is present.

## Validation

```bash
node scripts/check --scope branch
```

The branch-scoped check passed for 14 files, 3 TypeScript projects, and 8,754 tests. Focused workflow execution and workflow management suites also passed.