### PR TITLE
[Cases] Fix Activity History type-filter badges for expanded extended_fields rows

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.test.ts
@@ -361,6 +361,7 @@ describe('User actions APIs', () => {
         total_hidden_comment_updates: 0,
         total_other_actions: 5,
         total_other_action_deletions: 0,
+        total_visible_other_actions: 5,
       };
 
       it('has expected attributes in request', () => {
@@ -392,6 +393,7 @@ describe('User actions APIs', () => {
         total_hidden_comment_updates: 0,
         total_other_actions: 40,
         total_other_action_deletions: 0,
+        total_visible_other_actions: 40,
       };
 
       it('has expected attributes in request', () => {

--- a/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api/user_action/v1.ts
@@ -38,6 +38,12 @@ export const CaseUserActionStatsRt = rt.strict({
   total_hidden_comment_updates: rt.number,
   total_other_actions: rt.number,
   total_other_action_deletions: rt.number,
+  /**
+   * Document `total_other_actions` plus extra Activity rows from multi-field
+   * extended_fields expansions. Use for History badges (and to derive All);
+   * keep `total_other_actions` for pagination.
+   */
+  total_visible_other_actions: rt.number,
 });
 
 export type CaseUserActionStatsResponse = rt.TypeOf<typeof CaseUserActionStatsRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/api_zod/user_action/v1.ts
@@ -42,6 +42,8 @@ export const CaseUserActionStatsSchema = z.object({
   total_hidden_comment_updates: z.number(),
   total_other_actions: z.number(),
   total_other_action_deletions: z.number(),
+  /** Visible History rows (document other-actions + extended_fields expansion extras). */
+  total_visible_other_actions: z.number(),
 });
 
 export const UserActionFindRequestSchema = paginationSchema({

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.test.tsx
@@ -115,6 +115,7 @@ const userActionsStats = {
   totalHiddenCommentUpdates: 0,
   totalOtherActions: 11,
   totalOtherActionDeletions: 0,
+  totalVisibleOtherActions: 11,
 };
 
 const caseProps = {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/activity/case_view_activity.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/activity/case_view_activity.test.tsx
@@ -105,6 +105,7 @@ const userActionsStats = {
   totalHiddenCommentUpdates: 0,
   totalOtherActions: 11,
   totalOtherActionDeletions: 0,
+  totalVisibleOtherActions: 11,
 };
 
 const caseProps = {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/user_actions_filter_bar/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/user_actions_filter_bar/index.test.tsx
@@ -29,6 +29,7 @@ const userActionsStats: CaseUserActionsStats = {
   totalHiddenCommentUpdates: 0,
   totalOtherActions: 11,
   totalOtherActionDeletions: 0,
+  totalVisibleOtherActions: 11,
 };
 
 const defaultParams: UserActivityParams = {

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/user_actions_filter_bar/type_filter.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/case_view/components/user_actions_filter_bar/type_filter.tsx
@@ -12,6 +12,7 @@ import { css } from '@emotion/react';
 
 import type { CaseUserActionsStats } from '../../../../../containers/types';
 import * as activityBarI18n from '../../../../user_actions_activity_bar/translations';
+import { getUserActivityTypeFilterCounts } from '../../../../user_actions_activity_bar/get_type_filter_counts';
 import { TYPE } from '../../../../case_view/components/translations';
 import type { UserActivityFilter } from '../../../../user_actions_activity_bar/types';
 
@@ -38,21 +39,11 @@ export const TypeFilter = React.memo<TypeFilterProps>(
     const togglePopover = useCallback(() => setIsPopoverOpen((prevValue) => !prevValue), []);
     const closePopover = useCallback(() => setIsPopoverOpen(false), []);
 
-    const allCount =
-      userActionsStats && userActionsStats.total > 0
-        ? userActionsStats.total -
-          userActionsStats.totalCommentDeletions -
-          userActionsStats.totalHiddenCommentUpdates
-        : 0;
-    const commentsCount = Math.max(
-      (userActionsStats?.totalCommentCreations ?? 0) -
-        (userActionsStats?.totalCommentDeletions ?? 0),
-      0
-    );
-    const historyCount =
-      userActionsStats && userActionsStats.totalOtherActions > 0
-        ? userActionsStats.totalOtherActions
-        : 0;
+    const {
+      all: allCount,
+      comments: commentsCount,
+      history: historyCount,
+    } = useMemo(() => getUserActivityTypeFilterCounts(userActionsStats), [userActionsStats]);
 
     const options = useMemo<TypeOption[]>(
       () => [

--- a/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_redesign/user_actions/index.test.tsx
@@ -50,6 +50,7 @@ const userActionsStats: CaseUserActionsStats = {
   totalHiddenCommentUpdates: 0,
   totalOtherActions: 3,
   totalOtherActionDeletions: 0,
+  totalVisibleOtherActions: 3,
 };
 
 const userActivityQueryParams: UserActivityParams = {

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/index.test.tsx
@@ -43,6 +43,7 @@ const userActionsStats: CaseUserActionsStats = {
   totalHiddenCommentUpdates: 0,
   totalOtherActions: 16,
   totalOtherActionDeletions: 0,
+  totalVisibleOtherActions: 16,
 };
 
 const userActivityQueryParams: UserActivityParams = {

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/use_last_page.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/use_last_page.test.tsx
@@ -27,6 +27,7 @@ const userActionsStats: CaseUserActionsStats = {
   totalHiddenCommentUpdates: 0,
   totalOtherActions: 3,
   totalOtherActionDeletions: 0,
+  totalVisibleOtherActions: 3,
 };
 
 jest.mock('../../common/lib/kibana');
@@ -61,6 +62,7 @@ describe('useLastPage', () => {
           totalCommentCreations: 10,
           totalOtherActions: 0,
           totalOtherActionDeletions: 0,
+          totalVisibleOtherActions: 0,
         },
         userActivityQueryParams,
       })
@@ -83,6 +85,7 @@ describe('useLastPage', () => {
           totalCommentCreations: 10,
           totalOtherActions: 21,
           totalOtherActionDeletions: 0,
+          totalVisibleOtherActions: 21,
         },
         userActivityQueryParams,
       })
@@ -105,6 +108,7 @@ describe('useLastPage', () => {
           totalCommentCreations: 11,
           totalOtherActions: 21,
           totalOtherActionDeletions: 0,
+          totalVisibleOtherActions: 21,
         },
         userActivityQueryParams: {
           ...userActivityQueryParams,
@@ -130,6 +134,7 @@ describe('useLastPage', () => {
           totalCommentCreations: 10,
           totalOtherActions: 21,
           totalOtherActionDeletions: 0,
+          totalVisibleOtherActions: 21,
         },
         userActivityQueryParams: {
           ...userActivityQueryParams,
@@ -155,6 +160,7 @@ describe('useLastPage', () => {
           totalCommentCreations: 10,
           totalOtherActions: 21,
           totalOtherActionDeletions: 0,
+          totalVisibleOtherActions: 21,
         },
         userActivityQueryParams: {
           ...userActivityQueryParams,
@@ -180,6 +186,7 @@ describe('useLastPage', () => {
           totalCommentCreations: 10,
           totalOtherActions: 21,
           totalOtherActionDeletions: 0,
+          totalVisibleOtherActions: 21,
         },
         userActivityQueryParams: {
           ...userActivityQueryParams,
@@ -205,6 +212,7 @@ describe('useLastPage', () => {
           totalCommentCreations: 10,
           totalOtherActions: 21,
           totalOtherActionDeletions: 0,
+          totalVisibleOtherActions: 21,
         },
         userActivityQueryParams: {
           ...userActivityQueryParams,

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/filter_activity.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/filter_activity.test.tsx
@@ -26,6 +26,7 @@ describe('FilterActivity ', () => {
     totalHiddenCommentUpdates: 0,
     totalOtherActions: 9,
     totalOtherActionDeletions: 0,
+    totalVisibleOtherActions: 9,
   };
 
   const userActionsStatsWithDeletions: CaseUserActionsStats = {
@@ -37,6 +38,7 @@ describe('FilterActivity ', () => {
     totalHiddenCommentUpdates: 1,
     totalOtherActions: 9,
     totalOtherActionDeletions: 4,
+    totalVisibleOtherActions: 9,
   };
 
   it('renders filters correctly', () => {
@@ -121,7 +123,7 @@ describe('FilterActivity ', () => {
       )
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText(`${userActionsStats.totalOtherActions} available filters`)
+      screen.getByLabelText(`${userActionsStats.totalVisibleOtherActions} available filters`)
     ).toBeInTheDocument();
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/filter_activity.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/filter_activity.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { EuiFilterGroup, EuiFilterButton } from '@elastic/eui';
 
 import type { CaseUserActionsStats } from '../../containers/types';
 import * as i18n from './translations';
 import type { UserActivityFilter } from './types';
+import { getUserActivityTypeFilterCounts } from './get_type_filter_counts';
 
 interface FilterActivityProps {
   isLoading?: boolean;
@@ -30,6 +31,12 @@ export const FilterActivity = React.memo<FilterActivityProps>(
       [onFilterChange, type]
     );
 
+    const {
+      all: allCount,
+      comments: commentsCount,
+      history: historyCount,
+    } = useMemo(() => getUserActivityTypeFilterCounts(userActionsStats), [userActionsStats]);
+
     return (
       <EuiFilterGroup data-test-subj="user-actions-filter-activity-group">
         <EuiFilterButton
@@ -39,13 +46,7 @@ export const FilterActivity = React.memo<FilterActivityProps>(
           isToggle
           isSelected={type === 'all'}
           hasActiveFilters={type === 'all'}
-          numFilters={
-            userActionsStats && userActionsStats.total > 0
-              ? userActionsStats.total -
-                userActionsStats.totalCommentDeletions -
-                userActionsStats.totalHiddenCommentUpdates
-              : 0
-          }
+          numFilters={allCount}
           isLoading={isLoading}
           isDisabled={isLoading}
           data-test-subj="user-actions-filter-activity-button-all"
@@ -59,10 +60,7 @@ export const FilterActivity = React.memo<FilterActivityProps>(
           isToggle
           isSelected={type === 'user'}
           hasActiveFilters={type === 'user'}
-          numFilters={
-            (userActionsStats?.totalCommentCreations ?? 0) -
-            (userActionsStats?.totalCommentDeletions ?? 0)
-          }
+          numFilters={commentsCount}
           isLoading={isLoading}
           isDisabled={isLoading}
           onClick={() => handleFilterChange('user')}
@@ -74,11 +72,7 @@ export const FilterActivity = React.memo<FilterActivityProps>(
           isToggle
           isSelected={type === 'action'}
           hasActiveFilters={type === 'action'}
-          numFilters={
-            userActionsStats && userActionsStats.totalOtherActions > 0
-              ? userActionsStats.totalOtherActions
-              : 0
-          }
+          numFilters={historyCount}
           onClick={() => handleFilterChange('action')}
           isLoading={isLoading}
           isDisabled={isLoading}

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/get_type_filter_counts.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/get_type_filter_counts.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CaseUserActionsStats } from '../../containers/types';
+import { getUserActivityTypeFilterCounts } from './get_type_filter_counts';
+
+const baseStats: CaseUserActionsStats = {
+  total: 20,
+  totalDeletions: 0,
+  totalComments: 10,
+  totalCommentCreations: 10,
+  totalCommentDeletions: 0,
+  totalHiddenCommentUpdates: 0,
+  totalOtherActions: 10,
+  totalOtherActionDeletions: 0,
+  totalVisibleOtherActions: 10,
+};
+
+describe('getUserActivityTypeFilterCounts', () => {
+  it('returns zeros when stats are missing', () => {
+    expect(getUserActivityTypeFilterCounts()).toEqual({ all: 0, comments: 0, history: 0 });
+  });
+
+  it('uses document totals when there is no extended_fields expansion', () => {
+    expect(getUserActivityTypeFilterCounts(baseStats)).toEqual({
+      all: 20,
+      comments: 10,
+      history: 10,
+    });
+  });
+
+  it('inflates History and All when visible other-actions exceed document other-actions', () => {
+    expect(
+      getUserActivityTypeFilterCounts({
+        ...baseStats,
+        totalVisibleOtherActions: 17,
+      })
+    ).toEqual({
+      all: 27,
+      comments: 10,
+      history: 17,
+    });
+  });
+
+  it('applies comment deletion and hidden-update adjustments to All', () => {
+    expect(
+      getUserActivityTypeFilterCounts({
+        ...baseStats,
+        totalCommentDeletions: 2,
+        totalCommentCreations: 10,
+        totalHiddenCommentUpdates: 1,
+        totalVisibleOtherActions: 12,
+      })
+    ).toEqual({
+      all: 19, // 20 - 2 - 1 - 10 + 12
+      comments: 8,
+      history: 12,
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/get_type_filter_counts.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions_activity_bar/get_type_filter_counts.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CaseUserActionsStats } from '../../containers/types';
+
+export interface UserActivityTypeFilterCounts {
+  all: number;
+  comments: number;
+  history: number;
+}
+
+/**
+ * Badge counts for the Activity Type filter (All / Comments / History).
+ * History/All use visible-row totals so multi-field extended_fields expansions
+ * match the timeline; Comments stay document-based. Pagination must keep using
+ * document totals (`total` / `totalOtherActions`), not these values.
+ */
+export const getUserActivityTypeFilterCounts = (
+  userActionsStats?: CaseUserActionsStats
+): UserActivityTypeFilterCounts => {
+  if (!userActionsStats) {
+    return { all: 0, comments: 0, history: 0 };
+  }
+
+  const history = Math.max(userActionsStats.totalVisibleOtherActions, 0);
+  const comments = Math.max(
+    userActionsStats.totalCommentCreations - userActionsStats.totalCommentDeletions,
+    0
+  );
+
+  if (userActionsStats.total <= 0) {
+    return { all: 0, comments, history };
+  }
+
+  // Replace the document History portion of All with the visible History total.
+  const documentAll =
+    userActionsStats.total -
+    userActionsStats.totalCommentDeletions -
+    userActionsStats.totalHiddenCommentUpdates;
+  const all = Math.max(
+    documentAll - userActionsStats.totalOtherActions + userActionsStats.totalVisibleOtherActions,
+    0
+  );
+
+  return { all, comments, history };
+};

--- a/x-pack/platform/plugins/shared/cases/public/containers/api.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/api.test.tsx
@@ -721,6 +721,7 @@ describe('Cases API', () => {
       total_hidden_comment_updates: 0,
       total_other_actions: 10,
       total_other_action_deletions: 0,
+      total_visible_other_actions: 10,
     };
 
     beforeEach(() => {

--- a/x-pack/platform/plugins/shared/cases/public/containers/mock.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/mock.ts
@@ -992,6 +992,7 @@ export const getCaseUserActionsStatsResponse: CaseUserActionsStats = {
   totalHiddenCommentUpdates: 0,
   totalOtherActions: 10,
   totalOtherActionDeletions: 0,
+  totalVisibleOtherActions: 10,
 };
 
 // components tests

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_get_case_user_actions_stats.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_get_case_user_actions_stats.test.tsx
@@ -46,6 +46,7 @@ describe('useGetCaseUserActionsStats', () => {
           totalHiddenCommentUpdates: 0,
           totalOtherActions: 10,
           totalOtherActionDeletions: 0,
+          totalVisibleOtherActions: 10,
         },
         isError: false,
         isLoading: false,

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/extended_fields_activity_rows.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/extended_fields_activity_rows.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getExtendedFieldsActivityRowCount } from './extended_fields_activity_rows';
+
+describe('getExtendedFieldsActivityRowCount', () => {
+  it('returns 1 for null, undefined, or non-object payloads', () => {
+    expect(getExtendedFieldsActivityRowCount(null)).toBe(1);
+    expect(getExtendedFieldsActivityRowCount(undefined)).toBe(1);
+    expect(getExtendedFieldsActivityRowCount([] as unknown as Record<string, unknown>)).toBe(1);
+  });
+
+  it('returns 1 for an empty object (fallback history row)', () => {
+    expect(getExtendedFieldsActivityRowCount({})).toBe(1);
+  });
+
+  it('returns the number of field keys for multi-field updates', () => {
+    expect(
+      getExtendedFieldsActivityRowCount({
+        risk_score_as_keyword: 'high',
+        label_as_keyword: 'a',
+        my_field_as_keyword: 'b',
+      })
+    ).toBe(3);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/extended_fields_activity_rows.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/extended_fields_activity_rows.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * How many Activity timeline rows a single extended_fields user action renders as.
+ * Matches the public builder in `public/components/user_actions/extended_fields.tsx`:
+ * one row per field key, or a single fallback row when empty.
+ */
+export const getExtendedFieldsActivityRowCount = (
+  extendedFields: Record<string, unknown> | null | undefined
+): number => {
+  if (
+    extendedFields == null ||
+    typeof extendedFields !== 'object' ||
+    Array.isArray(extendedFields)
+  ) {
+    return 1;
+  }
+
+  const keyCount = Object.keys(extendedFields).length;
+  return keyCount > 0 ? keyCount : 1;
+};

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.test.ts
@@ -21,6 +21,7 @@ import type { UserActionEvent } from './types';
 import {
   CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_COMMENT_SAVED_OBJECT,
+  CASE_USER_ACTION_SAVED_OBJECT,
   SECURITY_SOLUTION_OWNER,
 } from '../../../common/constants';
 import { V2_NOOP_ACTIVITY_WRITER } from '../../cases_analytics_v2';
@@ -202,6 +203,16 @@ describe('CaseUserActionService', () => {
         },
       } as unknown as SavedObjectsFindResponse;
 
+      let findAllSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        findAllSpy = jest.spyOn(service.finder, 'findAll').mockResolvedValue([]);
+      });
+
+      afterEach(() => {
+        findAllSpy.mockRestore();
+      });
+
       it('counts both legacy `user` and unified `comment` types as comments', async () => {
         unsecuredSavedObjectsClient.find.mockResolvedValue(mockStatsResponse);
 
@@ -216,6 +227,7 @@ describe('CaseUserActionService', () => {
           total_hidden_comment_updates: 6,
           total_other_actions: 10,
           total_other_action_deletions: 1,
+          total_visible_other_actions: 10,
         });
       });
 
@@ -250,6 +262,109 @@ describe('CaseUserActionService', () => {
             }),
           })
         );
+      });
+
+      it('adds extended_fields expansion extras to visible totals', async () => {
+        findAllSpy.mockResolvedValue([
+          {
+            id: 'ua-multi',
+            type: CASE_USER_ACTION_SAVED_OBJECT,
+            attributes: {
+              payload: {
+                extended_fields: {
+                  a_as_keyword: '1',
+                  b_as_keyword: '2',
+                  c_as_keyword: '3',
+                },
+              },
+            },
+            references: [],
+          },
+          {
+            id: 'ua-single',
+            type: CASE_USER_ACTION_SAVED_OBJECT,
+            attributes: {
+              payload: {
+                extended_fields: {
+                  label_as_keyword: 'on',
+                },
+              },
+            },
+            references: [],
+          },
+        ] as never);
+
+        unsecuredSavedObjectsClient.find.mockResolvedValue(mockStatsResponse);
+
+        const stats = await service.getCaseUserActionStats({ caseId: '123' });
+
+        // 3 rows from multi-field + 1 from single-field = 4 visible rows from 2 docs → +2 extras
+        expect(stats.total_other_actions).toBe(10);
+        expect(stats.total_visible_other_actions).toBe(12);
+        expect(stats.total).toBe(20);
+        expect(findAllSpy).toHaveBeenCalledWith({
+          caseId: '123',
+          types: [UserActionTypes.extended_fields],
+          decode: false,
+        });
+      });
+
+      it('treats empty extended_fields payloads as a single visible row', async () => {
+        findAllSpy.mockResolvedValue([
+          {
+            id: 'ua-empty',
+            type: CASE_USER_ACTION_SAVED_OBJECT,
+            attributes: {
+              payload: {
+                extended_fields: {},
+              },
+            },
+            references: [],
+          },
+        ] as never);
+
+        unsecuredSavedObjectsClient.find.mockResolvedValue(mockStatsResponse);
+
+        const stats = await service.getCaseUserActionStats({ caseId: '123' });
+
+        expect(stats.total_visible_other_actions).toBe(stats.total_other_actions);
+      });
+
+      it('counts every extended_fields document without a sample size cap', async () => {
+        const manyDocs = Array.from({ length: 101 }, (_, i) => ({
+          id: `ua-${i}`,
+          type: CASE_USER_ACTION_SAVED_OBJECT,
+          attributes: {
+            payload: {
+              extended_fields: {
+                a_as_keyword: '1',
+                b_as_keyword: '2',
+              },
+            },
+          },
+          references: [],
+        }));
+        findAllSpy.mockResolvedValue(manyDocs as never);
+
+        unsecuredSavedObjectsClient.find.mockResolvedValue(mockStatsResponse);
+
+        const stats = await service.getCaseUserActionStats({ caseId: '123' });
+
+        // Each of 101 docs expands to 2 rows → +101 extras on top of document other_actions
+        expect(stats.total_visible_other_actions).toBe(10 + 101);
+        expect(findAllSpy.mock.calls[0][0]).not.toHaveProperty('limit');
+      });
+
+      it('does not request extended_fields via top_hits in stats aggregations', async () => {
+        unsecuredSavedObjectsClient.find.mockResolvedValue(mockStatsResponse);
+
+        await service.getCaseUserActionStats({ caseId: '123' });
+
+        const findCall = unsecuredSavedObjectsClient.find.mock.calls[0][0] as {
+          aggs?: Record<string, unknown>;
+        };
+        expect(findCall.aggs).not.toHaveProperty('extendedFieldsActivity');
+        expect(JSON.stringify(findCall.aggs)).not.toContain('top_hits');
       });
     });
 

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
@@ -50,6 +50,7 @@ import type {
 import { UserActionTransformedAttributesRt } from '../../common/types/user_actions';
 import { CaseUserActionDeprecatedResponseRt } from '../../../common/types/api';
 import { isCommentAttachmentType } from '../../../common/utils/attachments';
+import { getExtendedFieldsActivityRowCount } from './extended_fields_activity_rows';
 
 export class CaseUserActionService {
   private readonly _creator: UserActionPersister;
@@ -720,6 +721,7 @@ export class CaseUserActionService {
       total_hidden_comment_updates: 0,
       total_other_actions: 0,
       total_other_action_deletions: 0,
+      total_visible_other_actions: 0,
     };
 
     response.aggregations?.totals.buckets.forEach(({ key, doc_count: docCount }) => {
@@ -763,6 +765,33 @@ export class CaseUserActionService {
 
     result.total_other_actions = result.total - result.total_comments;
     result.total_other_action_deletions = result.total_deletions - result.total_comment_deletions;
+
+    /**
+     * Extended-fields history intentionally renders one Activity row per field from a single
+     * stored user action. Document totals stay SO-based for pagination; visible totals add the
+     * extra rows so Type filter badges match the timeline.
+     *
+     * `payload.extended_fields` is unmapped (dynamic:false), so we page every extended_fields
+     * user action for the case via findAll (no limit) and count rows from each payload.
+     */
+    const extendedFieldsUserActions = await this.finder.findAll({
+      caseId,
+      types: [UserActionTypes.extended_fields],
+      decode: false,
+    });
+    let visibleExtendedFieldsRows = 0;
+    for (const userAction of extendedFieldsUserActions) {
+      const payload = userAction.attributes.payload as
+        | { extended_fields?: Record<string, unknown> | null }
+        | undefined;
+      visibleExtendedFieldsRows += getExtendedFieldsActivityRowCount(payload?.extended_fields);
+    }
+    const extendedFieldsExtras = Math.max(
+      0,
+      visibleExtendedFieldsRows - extendedFieldsUserActions.length
+    );
+
+    result.total_visible_other_actions = result.total_other_actions + extendedFieldsExtras;
 
     return result;
   }


### PR DESCRIPTION
## What & Why

Activity Type filter History/All badges counted saved-object documents, so multi-field `extended_fields` updates (one SO → many timeline rows) undercounted the badges. This adds `total_visible_other_actions` (exact over all `extended_fields` actions) and uses it for badges while pagination stays document-based.

## How to Test

1. Create/configure a case with several custom/template fields; apply a template or bulk-update multiple fields so Activity shows one History row per field from a single update.
2. Open Activity → Type: confirm History (and All with no comments) matches the expanded History row count, not the lower document count.
3. Add a comment; confirm All = Comments + History.
4. On a simple case without multi-field expansions, confirm All/History still match 1:1 document totals.
5. Optional: case with >100 multi-field `extended_fields` docs — History badge must stay exact (no undercount / top_hits errors).

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)