### PR TITLE
[Cases] Clean up stale skip references (security-team#18174)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/cases_webhook/webhook_connectors.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/cases_webhook/webhook_connectors.test.tsx
@@ -379,8 +379,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
       expect(await screen.findByTestId('horizontalStep1-danger')).toBeInTheDocument();
     });
 
-    // Flaky - https://github.com/elastic/kibana/issues/205708
-    it.skip('Step 2 is properly validated', async () => {
+    it('Step 2 is properly validated', async () => {
       const incompleteActionConnector = {
         ...actionConnector,
         config: {

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/delete_sub_privilege.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/delete_sub_privilege.ts
@@ -290,11 +290,7 @@ export default ({ getService }: FtrProviderContext): void => {
             expectedHttpCode: 403,
           });
         });
-        // TODO: Enable this test when read path is implemented
-        // https://github.com/elastic/security-team/issues/16051
-        // comment id is not returned when creating an unified comment with createComment
-        // because find does not include the attachment SO
-        it.skip(`should create a comment but not delete a comment`, async () => {
+        it(`should create a comment but not delete a comment`, async () => {
           const caseInfo = await createCase(
             supertestWithoutAuth,
             getPostCaseRequest({ owner: 'securitySolutionFixture' }),


### PR DESCRIPTION
## Summary
First PR in a series cleaning up security-team#18174 (34 skipped/flaky test markers across 23 files in Cases-owned code). This one is pure tracking hygiene — no new fixes, just clearing out stale references and confirming one already-fixed test is safe to re-enable.

## Motivation
Two skip markers in Cases-owned test files pointed at issues that no longer reflect reality: one referenced a closed issue while a sibling skip on the same block already covers it under a still-open issue, and one referenced a closed security-team issue whose underlying blocker turns out to already be fixed in code.

## Changes
- Removed a dead `it.skip` + stale comment in `webhook_connectors.test.tsx` referencing closed elastic/kibana#205708. The test sits inside a parent `describe.skip('Step Validation', ...)` block already governed by a separate, still-open issue (#237095) — the inner skip was redundant dead weight pointing at the wrong (closed) issue. Removing it changes no behavior; the test still doesn't run because the parent block still skips it.
- Unskipped `should create a comment but not delete a comment` in `delete_sub_privilege.ts`. It had been skipped since security-team#16051 (closed) with a comment saying the comment ID wasn't returned because `find()` didn't include the attachment SO. That's since been fixed by the dual-write system work (#253861) — `AttachmentService.find()` now queries both `CASE_COMMENT_SAVED_OBJECT` and `CASE_ATTACHMENT_SAVED_OBJECT`, so the comment ID resolves correctly.

## Risk & Migration
**Score: 0** — test-only changes, one is a no-op comment/skip cleanup, the other re-enables a test that passed locally against current main.

## Testing
**Manual:** N/A (test-only change)
**Automated:**
- [x] Verified locally: `node scripts/jest .../webhook_connectors.test.tsx` — passes, "Step 2" still correctly skipped via parent block.
- [x] Verified locally: FTR run of `delete_sub_privilege.ts` against `config_trial.ts` — 12 passing, including the newly-unskipped test.