### PR TITLE
Fix-servicenow-connector

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/lib/servicenow/types.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/lib/servicenow/types.ts
@@ -37,7 +37,8 @@ export type { SNProductsConfigValue, SNProductsConfig } from '../../../../common
 export type ServiceNowExecutorResultData =
   | PushToServiceResponse
   | GetCommonFieldsResponse
-  | GetChoicesResponse;
+  | GetChoicesResponse
+  | ServiceNowIncident;
 
 export type ServiceNowEndpoint = 'table' | 'import_set' | 'oauth' | 'jwt' | 'event' | 'other';
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/servicenow_itsm/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/servicenow_itsm/index.test.ts
@@ -101,6 +101,31 @@ describe('ServiceNow', () => {
           (api.closeIncident as jest.Mock).mock.calls[0][0].params.incident.correlationId
         ).toBe('custom_correlation_id');
       });
+
+      test('calls getIncident sub action correctly', async () => {
+        const actionId = 'some-action-id';
+        const incident = { sys_id: 'incident-id', number: 'INC0010001' };
+        (api.getIncident as jest.Mock).mockResolvedValue(incident);
+        const executorOptions = {
+          actionId,
+          config,
+          secrets,
+          params: {
+            subAction: 'getIncident',
+            subActionParams: { externalId: 'incident-id' },
+          },
+          services,
+          logger: mockedLogger,
+        } as unknown as ServiceNowConnectorTypeExecutorOptions<
+          ServiceNowPublicConfigurationType,
+          ExecutorParams
+        >;
+        const result = await connectorType.executor(executorOptions);
+        expect((api.getIncident as jest.Mock).mock.calls[0][0].params.externalId).toBe(
+          'incident-id'
+        );
+        expect(result).toEqual({ status: 'ok', data: incident, actionId });
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/servicenow_itsm/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/servicenow_itsm/index.ts
@@ -30,6 +30,7 @@ import type {
   ExecutorSubActionGetChoicesParams,
   ExecutorSubActionCloseIncidentParams,
   ExecutorSubActionCommonFieldsParams,
+  ExecutorSubActionGetIncidentParams,
   ServiceNowPublicConfigurationType,
 } from '@kbn/connector-schemas/servicenow';
 import {
@@ -187,6 +188,15 @@ async function executor(
     data = await api.getChoices({
       externalService,
       params: getChoicesParams,
+      logger,
+    });
+  }
+
+  if (subAction === 'getIncident') {
+    const getIncidentParams = subActionParams as ExecutorSubActionGetIncidentParams;
+    data = await api.getIncident({
+      externalService,
+      params: getIncidentParams,
       logger,
     });
   }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/servicenow_sir/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/servicenow_sir/index.test.ts
@@ -74,6 +74,31 @@ describe('ServiceNow', () => {
           'work_notes'
         );
       });
+
+      test('calls getIncident sub action correctly', async () => {
+        const actionId = 'some-action-id';
+        const incident = { sys_id: 'incident-id', number: 'SIR0010001' };
+        (api.getIncident as jest.Mock).mockResolvedValue(incident);
+        const executorOptions = {
+          actionId,
+          config,
+          secrets,
+          params: {
+            subAction: 'getIncident',
+            subActionParams: { externalId: 'incident-id' },
+          },
+          services,
+          logger: mockedLogger,
+        } as unknown as ServiceNowConnectorTypeExecutorOptions<
+          ServiceNowPublicConfigurationType,
+          ExecutorParams
+        >;
+        const result = await connectorType.executor(executorOptions);
+        expect((api.getIncident as jest.Mock).mock.calls[0][0].params.externalId).toBe(
+          'incident-id'
+        );
+        expect(result).toEqual({ status: 'ok', data: incident, actionId });
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/servicenow_sir/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/servicenow_sir/index.ts
@@ -28,6 +28,7 @@ import type {
   ServiceNowSecretConfigurationType,
   ExecutorSubActionGetChoicesParams,
   ExecutorSubActionCommonFieldsParams,
+  ExecutorSubActionGetIncidentParams,
   ServiceNowPublicConfigurationType,
 } from '@kbn/connector-schemas/servicenow';
 import {
@@ -178,6 +179,15 @@ async function executor(
     data = await api.getChoices({
       externalService,
       params: getChoicesParams,
+      logger,
+    });
+  }
+
+  if (subAction === 'getIncident') {
+    const getIncidentParams = subActionParams as ExecutorSubActionGetIncidentParams;
+    data = await api.getIncident({
+      externalService,
+      params: getIncidentParams,
       logger,
     });
   }

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_itsm.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_itsm.ts
@@ -677,6 +677,29 @@ export default function serviceNowITSMTest({ getService }: FtrProviderContext) {
               });
           });
         });
+
+        describe('getIncident', () => {
+          it('should fail when externalId is not provided', async () => {
+            await supertest
+              .post(`/api/actions/connector/${simulatedActionId}/_execute`)
+              .set('kbn-xsrf', 'foo')
+              .send({
+                params: {
+                  subAction: 'getIncident',
+                  subActionParams: {},
+                },
+              })
+              .then((resp: any) => {
+                expect(resp.body).to.eql({
+                  connector_id: simulatedActionId,
+                  status: 'error',
+                  retry: false,
+                  errorSource: TaskErrorSource.USER,
+                  message: `error validating action params: ✖ Invalid input: expected string, received undefined\n  → at subActionParams.externalId`,
+                });
+              });
+          });
+        });
       });
 
       describe('Execution', () => {
@@ -717,8 +740,8 @@ export default function serviceNowITSMTest({ getService }: FtrProviderContext) {
                 id: simulatedActionId,
                 provider: 'actions',
                 actions: new Map([
-                  ['execute-start', { equal: 11 }],
-                  ['execute', { equal: 11 }],
+                  ['execute-start', { equal: 12 }],
+                  ['execute', { equal: 12 }],
                 ]),
               });
             });
@@ -895,6 +918,50 @@ export default function serviceNowITSMTest({ getService }: FtrProviderContext) {
             });
 
             const executeEvent = events[5];
+            expect(executeEvent?.kibana?.action?.execution?.usage?.request_body_bytes).to.be(0);
+          });
+        });
+
+        describe('getIncident', () => {
+          it('should get the incident', async () => {
+            const { body: result } = await supertest
+              .post(`/api/actions/connector/${simulatedActionId}/_execute`)
+              .set('kbn-xsrf', 'foo')
+              .send({
+                params: {
+                  subAction: 'getIncident',
+                  subActionParams: { externalId: '123' },
+                },
+              })
+              .expect(200);
+
+            expect(proxyHaveBeenCalled).to.equal(true);
+            expect(result).to.eql({
+              status: 'ok',
+              connector_id: simulatedActionId,
+              data: {
+                sys_id: '123',
+                number: 'INC01',
+                sys_created_on: '2020-03-10 12:24:20',
+                sys_updated_on: '2020-03-10 12:24:20',
+              },
+            });
+
+            const events: IValidatedEvent[] = await retry.try(async () => {
+              return await getEventLog({
+                getService,
+                spaceId: 'default',
+                type: 'action',
+                id: simulatedActionId,
+                provider: 'actions',
+                actions: new Map([
+                  ['execute-start', { gte: 4 }],
+                  ['execute', { gte: 4 }],
+                ]),
+              });
+            });
+
+            const executeEvent = events[7];
             expect(executeEvent?.kibana?.action?.execution?.usage?.request_body_bytes).to.be(0);
           });
         });

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_sir.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_sir.ts
@@ -690,6 +690,29 @@ export default function serviceNowSIRTest({ getService }: FtrProviderContext) {
               });
           });
         });
+
+        describe('getIncident', () => {
+          it('should fail when externalId is not provided', async () => {
+            await supertest
+              .post(`/api/actions/connector/${simulatedActionId}/_execute`)
+              .set('kbn-xsrf', 'foo')
+              .send({
+                params: {
+                  subAction: 'getIncident',
+                  subActionParams: {},
+                },
+              })
+              .then((resp: any) => {
+                expect(resp.body).to.eql({
+                  connector_id: simulatedActionId,
+                  status: 'error',
+                  retry: false,
+                  errorSource: TaskErrorSource.USER,
+                  message: `error validating action params: ✖ Invalid input: expected string, received undefined\n  → at subActionParams.externalId`,
+                });
+              });
+          });
+        });
       });
 
       describe('Execution', () => {
@@ -730,8 +753,8 @@ export default function serviceNowSIRTest({ getService }: FtrProviderContext) {
                 id: simulatedActionId,
                 provider: 'actions',
                 actions: new Map([
-                  ['execute-start', { equal: 11 }],
-                  ['execute', { equal: 11 }],
+                  ['execute-start', { equal: 12 }],
+                  ['execute', { equal: 12 }],
                 ]),
               });
             });
@@ -865,6 +888,50 @@ export default function serviceNowSIRTest({ getService }: FtrProviderContext) {
             });
 
             const executeEvent = events[3];
+            expect(executeEvent?.kibana?.action?.execution?.usage?.request_body_bytes).to.be(0);
+          });
+        });
+
+        describe('getIncident', () => {
+          it('should get the incident', async () => {
+            const { body: result } = await supertest
+              .post(`/api/actions/connector/${simulatedActionId}/_execute`)
+              .set('kbn-xsrf', 'foo')
+              .send({
+                params: {
+                  subAction: 'getIncident',
+                  subActionParams: { externalId: '123' },
+                },
+              })
+              .expect(200);
+
+            expect(proxyHaveBeenCalled).to.equal(true);
+            expect(result).to.eql({
+              status: 'ok',
+              connector_id: simulatedActionId,
+              data: {
+                sys_id: '123',
+                number: 'INC01',
+                sys_created_on: '2020-03-10 12:24:20',
+                sys_updated_on: '2020-03-10 12:24:20',
+              },
+            });
+
+            const events: IValidatedEvent[] = await retry.try(async () => {
+              return await getEventLog({
+                getService,
+                spaceId: 'default',
+                type: 'action',
+                id: simulatedActionId,
+                provider: 'actions',
+                actions: new Map([
+                  ['execute-start', { gte: 3 }],
+                  ['execute', { gte: 3 }],
+                ]),
+              });
+            });
+
+            const executeEvent = events[5];
             expect(executeEvent?.kibana?.action?.execution?.usage?.request_body_bytes).to.be(0);
           });
         });


### PR DESCRIPTION
## Summary

Both the ServiceNow ITSM and ServiceNow SecOps connectors declare `getIncident` in `supportedSubActions`, and the handler already exists as `getIncidentHandler` in `lib/servicenow/api.ts`, but neither executor had an `if (subAction === 'getIncident')` branch. The call fell straight through to the final return and came back as:

```json
{"status":"ok","data":{}}
```

A successful empty response rather than an error. `throwIfSubActionIsNotSupported` let it past precisely because the connector declared support, so the one guard that exists for this class of mistake was defeated by the declaration itself.

The Jira connector implements this correctly, and that is what the fix is modelled on.

Closes #277829

### Changes

- `servicenow_itsm/index.ts`: added the `getIncident` branch, placed to match the order in `supportedSubActions`
- `servicenow_sir/index.ts`: same
- `lib/servicenow/types.ts`: added `ServiceNowIncident` to the `ServiceNowExecutorResultData` union. `api.getIncident` returns `Promise<ServiceNowIncident>` and the union did not include it, so the assignment would not typecheck
- unit tests in `servicenow_itsm/index.test.ts` and `servicenow_sir/index.test.ts`

Two small differences from the Jira implementation, both driven by the ServiceNow types:

- `logger` is passed, because `GetIncidentApiHandlerArgs` extends `ExternalServiceApiHandlerArgs`, which requires it. Jira's handler args do not.
- no `if (res != null)` guard. Jira's `getIncident` returns `Promise<ExternalServiceParams | undefined>`, so the guard is doing real type work there. ServiceNow's returns `Promise<ServiceNowIncident>`. The `data ?? {}` at the return produces the same output either way, and the sibling branches in the same file (`getFields`, `getChoices`, `closeIncident`) all assign directly.

`pushToService` and `closeIncident` were never affected. They call `externalService.getIncident` directly inside `service.ts`, bypassing subaction dispatch, so the Cases push flow behaved correctly throughout.

### Testing

```
node scripts/jest --config x-pack/platform/plugins/shared/stack_connectors/jest.config.js \
  server/connector_types/servicenow_itsm/index.test.ts \
  server/connector_types/servicenow_sir/index.test.ts
```

Both new tests fail when the two `index.ts` changes are reverted, so they guard the regression rather than passing either way.

Verified end to end against a stub returning the table API shape from `x-pack/platform/test/alerting_api_integration/common/plugins/actions_simulators/server/servicenow_simulation.ts`:

```
POST /api/actions/connector/<id>/_execute
{"params":{"subAction":"getIncident","subActionParams":{"externalId":"itsm-sys-id-123"}}}
```

Before: `{"status":"ok","data":{}}`

After: `{"status":"ok","data":{"sys_id":"itsm-sys-id-123","number":"INC0010001","sys_created_on":"2026-08-13 09:00:00","sys_updated_on":"2026-08-13 09:30:00","short_description":"Simulated ITSM incident"}}`

Same result for `.servicenow-sir`. `type_check` on the plugin exits 0 and `eslint` on the changed paths reports no errors.

## Release Notes

Fixed the `getIncident` subaction on the ServiceNow ITSM and ServiceNow SecOps connectors, which returned an empty result instead of the incident record.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md) (n/a, no user-facing text)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials (n/a, the subaction was already declared as supported)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker) (n/a, no config keys changed)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations. (see risks, the response body for this one subaction changes from `{}` to the incident record)
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed (the added tests are deterministic with a mocked `api`, happy to run it if a reviewer wants)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- The `_execute` response for `subAction: getIncident` on `.servicenow` and `.servicenow-sir` changes from `{}` to the incident record. Severity low. The old response carried no data at all, so nothing could have been reading fields off it, but it is a visible change on a public API and worth a reviewer's judgement on whether it needs a `release_note:breaking` label.
- Blast radius is limited to subaction dispatch. The handler, the HTTP request and the response parsing already existed and are exercised today by the create, update and close paths, none of which are touched here.
- ITOM was checked for the same gap and does not have it. `supportedSubActionsITOM` is `['addEvent', 'getChoices']` and both are wired up.
