### PR TITLE
[Chrome Next] Add item description

### DIFF
--- a/src/platform/kbn-ui/app-menu/app_menu.stories.tsx
+++ b/src/platform/kbn-ui/app-menu/app_menu.stories.tsx
@@ -641,3 +641,86 @@ export const SelectedItems: Story = {
     config: selectedItemsConfig,
   },
 };
+
+const itemDescriptionsConfig: AppMenuConfig = {
+  items: [
+    {
+      id: 'add',
+      order: 1,
+      label: 'add',
+      testId: 'addButton',
+      iconType: 'plus',
+      popoverWidth: 280,
+      items: [
+        {
+          run: () => action('visualization-clicked'),
+          id: 'visualization',
+          order: 1,
+          label: 'Visualization',
+          iconType: 'lensApp',
+          testId: 'visualizationButton',
+          description: 'Create a chart or metric',
+        },
+        {
+          run: () => action('from-library-clicked'),
+          id: 'fromLibrary',
+          order: 2,
+          label: 'From library',
+          iconType: 'folderOpen',
+          testId: 'fromLibraryButton',
+          description: 'Add an existing visualization, map, or saved search from the library.',
+        },
+        {
+          run: () => action('controls-clicked'),
+          id: 'controls',
+          order: 3,
+          label: 'Controls',
+          iconType: 'controls',
+          testId: 'controlsButton',
+          description: 'Requires edit privileges',
+          disableButton: true,
+        },
+      ],
+    },
+  ],
+  primaryActionItem: {
+    id: 'create',
+    label: 'Create',
+    testId: 'createPopoverButton',
+    iconType: 'plus',
+    popoverWidth: 280,
+    items: [
+      {
+        run: () => action('create-dashboard-clicked'),
+        id: 'createDashboard',
+        order: 1,
+        label: 'Dashboard',
+        iconType: 'productDashboard',
+        testId: 'createDashboardButton',
+        description: 'Start from a blank canvas',
+      },
+      {
+        run: () => action('create-visualization-clicked'),
+        id: 'createVisualization',
+        order: 2,
+        label: 'Visualization',
+        iconType: 'chartBarVertical',
+        testId: 'createVisualizationButton',
+        description: 'Create a chart or metric from your data',
+      },
+    ],
+  },
+};
+
+/**
+ * `description` renders subdued supporting text below the item label inside popover menus
+ * (sub-items, overflow/static items, and `primaryActionItem.items`). It is ignored for
+ * inline top-level buttons and for the primary action button itself. Descriptions truncate
+ * to a single line.
+ */
+export const ItemDescriptions: Story = {
+  name: 'Item descriptions',
+  args: {
+    config: itemDescriptionsConfig,
+  },
+};

--- a/src/platform/kbn-ui/app-menu/src/components/app_menu_item_label.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu_item_label.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiText,
+  EuiTextTruncate,
+  type IconType,
+} from '@elastic/eui';
+import { AppMenuBadge } from './app_menu_badge';
+
+interface AppMenuItemLabelProps {
+  label: string;
+  description: string;
+  isDisabled?: boolean;
+  isLoading?: boolean;
+  testId?: string;
+  labelBadgeText?: string;
+  iconType?: IconType;
+}
+
+export const AppMenuItemLabel = ({
+  label,
+  description,
+  isDisabled,
+  isLoading,
+  testId,
+  labelBadgeText,
+  iconType,
+}: AppMenuItemLabelProps) => {
+  const icon = isLoading ? (
+    <EuiLoadingSpinner size="m" data-test-subj={testId ? `${testId}-loading` : undefined} />
+  ) : iconType ? (
+    <EuiIcon type={iconType} size="m" color="inherit" aria-hidden={true} />
+  ) : undefined;
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="xs" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+          {icon && <EuiFlexItem grow={false}>{icon}</EuiFlexItem>}
+          <EuiFlexItem grow={false}>{label}</EuiFlexItem>
+          {labelBadgeText && (
+            <EuiFlexItem grow={false}>
+              <AppMenuBadge
+                text={labelBadgeText}
+                data-test-subj={testId ? `${testId}-badge` : undefined}
+              />
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText
+          size="xs"
+          color={isDisabled ? undefined : 'subdued'}
+          component="span"
+          data-test-subj={testId ? `${testId}-description` : undefined}
+        >
+          <EuiTextTruncate text={description} />
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/src/platform/kbn-ui/app-menu/src/components/app_menu_popover.test.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu_popover.test.tsx
@@ -102,4 +102,53 @@ describe('AppMenuPopover', () => {
       expect(contextMenu).toHaveStyle({ width: '300px' });
     });
   });
+
+  it('should render item descriptions when provided', async () => {
+    render(
+      <AppMenuPopover
+        {...defaultProps}
+        isOpen={true}
+        items={[
+          {
+            id: 'item1',
+            label: 'Item 1',
+            run: jest.fn(),
+            order: 1,
+            testId: 'described-item',
+            description: 'Supporting text',
+          },
+        ]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+      expect(screen.getByTestId('described-item-description')).toBeInTheDocument();
+    });
+  });
+
+  it('should render item descriptions on disabled items', async () => {
+    render(
+      <AppMenuPopover
+        {...defaultProps}
+        isOpen={true}
+        items={[
+          {
+            id: 'item1',
+            label: 'Item 1',
+            run: jest.fn(),
+            order: 1,
+            testId: 'disabled-described-item',
+            description: 'Unavailable right now',
+            disableButton: true,
+          },
+        ]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+      expect(screen.getByTestId('disabled-described-item-description')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/platform/kbn-ui/app-menu/src/types.ts
+++ b/src/platform/kbn-ui/app-menu/src/types.ts
@@ -114,6 +114,12 @@ interface AppMenuItemBase {
    */
   label: string;
   /**
+   * Optional supporting text rendered below the label. Only shown when the item is rendered
+   * inside a popover menu (sub-items, static items, and items moved to the "More" menu);
+   * ignored for inline top-level buttons and for the primary action button.
+   */
+  description?: string;
+  /**
    * The icon type for the item.
    */
   iconType: IconType;

--- a/src/platform/kbn-ui/app-menu/src/utils.test.tsx
+++ b/src/platform/kbn-ui/app-menu/src/utils.test.tsx
@@ -544,6 +544,84 @@ describe('utils', () => {
 
       expect(result.css).toBeUndefined();
     });
+
+    it('should keep a plain string name when description is not provided', () => {
+      const result = mapAppMenuItemToPanelItem(baseItem);
+
+      expect(result.name).toBe('Test item');
+    });
+
+    it('should omit the panel icon when a description is provided', () => {
+      const result = mapAppMenuItemToPanelItem({
+        ...baseItem,
+        iconType: 'gear',
+        description: 'Supporting text',
+      });
+
+      expect(result.icon).toBeUndefined();
+    });
+
+    it('should render a spinner next to the label when a described item is loading', () => {
+      const { name, icon } = mapAppMenuItemToPanelItem({
+        ...baseItem,
+        testId: 'loading-item',
+        iconType: 'gear',
+        description: 'Supporting text',
+        isLoading: true,
+      });
+
+      expect(icon).toBeUndefined();
+      expect(isValidElement(name)).toBe(true);
+
+      if (!isValidElement(name)) {
+        throw new Error('Expected name to be a React element');
+      }
+
+      const { getByTestId } = render(name as ReactElement);
+      expect(getByTestId('loading-item-loading')).toBeInTheDocument();
+    });
+
+    it('should render the description below the label when provided', () => {
+      const item = {
+        ...baseItem,
+        testId: 'described-item',
+        iconType: 'gear' as const,
+        description: 'Supporting text',
+      };
+      const { name } = mapAppMenuItemToPanelItem(item);
+
+      expect(isValidElement(name)).toBe(true);
+
+      if (!isValidElement(name)) {
+        throw new Error('Expected name to be a React element');
+      }
+
+      const { getByText, getByTestId, container } = render(name as ReactElement);
+      expect(getByText('Test item')).toBeInTheDocument();
+      expect(getByTestId('described-item-description')).toBeInTheDocument();
+      expect(container.querySelector('[data-euiicon-type="gear"]')).toBeInTheDocument();
+    });
+
+    it('should render the description with a label badge when both are provided', () => {
+      const item = {
+        ...baseItem,
+        testId: 'badged-item',
+        labelBadgeText: 'New',
+        description: 'Supporting text',
+      };
+      const { name } = mapAppMenuItemToPanelItem(item);
+
+      expect(isValidElement(name)).toBe(true);
+
+      if (!isValidElement(name)) {
+        throw new Error('Expected name to be a React element');
+      }
+
+      const { getByText, getByTestId } = render(name as ReactElement);
+      expect(getByText('Test item')).toBeInTheDocument();
+      expect(getByTestId('badged-item-badge')).toHaveTextContent('New');
+      expect(getByTestId('badged-item-description')).toBeInTheDocument();
+    });
   });
 
   describe('getPopoverActionItems', () => {
@@ -906,6 +984,42 @@ describe('utils', () => {
       const switchIndex = panelItems.findIndex((i) => i.key === 'switch-test-switch');
       expect(actionIndex).toBeLessThan(switchIndex);
       expect(switchIndex).toBe(panelItems.length - 1);
+    });
+
+    it('should keep a plain string name for items without a description', () => {
+      const items: AppMenuPopoverItem[] = [{ id: '1', label: 'Item 1', run: jest.fn(), order: 1 }];
+
+      const panels = getPopoverPanels({ items });
+      const panelItems = panels[0].items as Array<{ name?: unknown }>;
+
+      expect(panelItems[0].name).toBe('Item 1');
+    });
+
+    it('should include the description in the rendered item name', () => {
+      const items: AppMenuPopoverItem[] = [
+        {
+          id: '1',
+          label: 'Item 1',
+          run: jest.fn(),
+          order: 1,
+          testId: 'item-with-description',
+          description: 'Supporting text',
+        },
+      ];
+
+      const panels = getPopoverPanels({ items });
+      const panelItems = panels[0].items as Array<{ name?: unknown }>;
+      const { name } = panelItems[0];
+
+      expect(isValidElement(name)).toBe(true);
+
+      if (!isValidElement(name)) {
+        throw new Error('Expected name to be a React element');
+      }
+
+      const { getByText, getByTestId } = render(name as ReactElement);
+      expect(getByText('Item 1')).toBeInTheDocument();
+      expect(getByTestId('item-with-description-description')).toBeInTheDocument();
     });
   });
 

--- a/src/platform/kbn-ui/app-menu/src/utils.tsx
+++ b/src/platform/kbn-ui/app-menu/src/utils.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type MouseEvent, type ReactNode } from 'react';
+import React, { type MouseEvent } from 'react';
 import { css } from '@emotion/react';
 import { isArray, isFunction, upperFirst } from 'lodash';
 import {
@@ -23,6 +23,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { AppMenuBadge } from './components/app_menu_badge';
+import { AppMenuItemLabel } from './components/app_menu_item_label';
 import { AppMenuPopoverActionButtons } from './components/app_menu_popover_action_buttons';
 import type {
   AppMenuConfig,
@@ -273,10 +274,11 @@ export const mapAppMenuItemToPanelItem = (
       : { onClick: hasClickHandler ? handleClick : undefined };
 
   const itemTestSubj = item.testId ?? getAppMenuItemTestSubj(item.id);
+  const itemDisabled = isDisabled(item?.disableButton) || loading;
 
   const showAsSelected = Boolean(item.isSelected);
 
-  const itemName: ReactNode = item.labelBadgeText ? (
+  const labelNode = item.labelBadgeText ? (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
       <EuiFlexItem grow={false}>{upperFirst(item.label)}</EuiFlexItem>
       <EuiFlexItem grow={false}>
@@ -287,10 +289,24 @@ export const mapAppMenuItemToPanelItem = (
     upperFirst(item.label)
   );
 
+  const itemLabel = item.description ? (
+    <AppMenuItemLabel
+      label={upperFirst(item.label)}
+      description={item.description}
+      labelBadgeText={item.labelBadgeText}
+      iconType={item.iconType}
+      isDisabled={itemDisabled}
+      isLoading={loading}
+      testId={itemTestSubj}
+    />
+  ) : (
+    labelNode
+  );
+
   return {
     key: item.id,
-    name: itemName,
-    icon: loading ? (
+    name: itemLabel,
+    icon: item.description ? undefined : loading ? (
       <EuiLoadingSpinner size="m" data-test-subj={`${itemTestSubj}-loading`} />
     ) : (
       item?.iconType
@@ -298,7 +314,7 @@ export const mapAppMenuItemToPanelItem = (
     ...linkProps,
     href: item?.href,
     target: item?.href ? item?.target : undefined,
-    disabled: isDisabled(item?.disableButton) || loading,
+    disabled: itemDisabled,
     'data-test-subj': itemTestSubj,
     ...getAppMenuEbtDomProps(item.ebt),
     toolTipContent: content,


### PR DESCRIPTION
## Summary

This PR adds `description` property to app menu items. Description allows for adding one-line descriptions to app menu items rendered inside a popover. 

<img width="419" height="313" alt="Screenshot 2026-08-13 at 21 52 34" src="https://github.com/user-attachments/assets/9f9d3ce0-9e7e-47d7-9ebe-c148794913cd" />

Closes: https://github.com/elastic/kibana/issues/276708