### PR TITLE
[9.5] Prevent nagivating away from roles management with unsaved changes (#283525)

### DIFF
--- a/x-pack/platform/plugins/shared/security/moon.yml
+++ b/x-pack/platform/plugins/shared/security/moon.yml
@@ -113,6 +113,7 @@ dependsOn:
   - '@kbn/agent-builder-browser'
   - '@kbn/core-user-profile-common'
   - '@kbn/core-chrome-browser-components'
+  - '@kbn/unsaved-changes-prompt'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/edit_role_page.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/edit_role_page.test.tsx
@@ -6,10 +6,12 @@
  */
 
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import React from 'react';
 
 import type { BuildFlavor } from '@kbn/config';
 import type { Capabilities } from '@kbn/core/public';
+import { CoreScopedHistory } from '@kbn/core/public';
 import { coreMock, scopedHistoryMock } from '@kbn/core/public/mocks';
 import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
 import { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
@@ -215,7 +217,7 @@ function getProps({
   } as any);
 
   const { fatalErrors } = coreMock.createSetup();
-  const { http, docLinks, notifications, rendering } = coreMock.createStart();
+  const { http, docLinks, notifications, overlays, rendering } = coreMock.createStart();
   http.get.mockImplementation(async (path: any) => {
     if (path === '/api/spaces/space') {
       if (!spacesEnabled) {
@@ -251,6 +253,8 @@ function getProps({
     fatalErrors,
     uiCapabilities: buildUICapabilities(canManageSpaces),
     history: scopedHistoryMock.create(),
+    overlays,
+    navigateToUrl: jest.fn(),
     spacesApiUi,
     buildFlavor,
     userProfile: userProfileMock,
@@ -1057,6 +1061,163 @@ describe('<EditRolePage />', () => {
       ).not.toBeInTheDocument();
       expect(props.notifications.toasts.addDanger).toBeCalledTimes(0);
       expectSaveFormButtons();
+    });
+  });
+
+  describe('unsaved changes', () => {
+    const role: Role = {
+      name: 'my custom role',
+      description: 'a role',
+      metadata: {},
+      elasticsearch: { cluster: ['all'], indices: [], run_as: ['*'] },
+      kibana: [{ spaces: ['*'], base: ['all'], feature: {} }],
+    };
+
+    // A real ScopedHistory, rather than `scopedHistoryMock`: the prompt works by installing a
+    // `history.block` handler, which the mock does not implement.
+    const renderEditRolePage = async ({ existingRole = true } = {}) => {
+      const history = new CoreScopedHistory(
+        createMemoryHistory({
+          initialEntries: [existingRole ? '/mock/edit/my_role' : '/mock/edit'],
+        }),
+        '/mock'
+      );
+      const props = {
+        ...getProps({ action: 'edit', role: existingRole ? role : undefined }),
+        history,
+      };
+      props.overlays.openConfirm.mockResolvedValue(false);
+
+      render(
+        <I18nProvider>
+          <KibanaContextProvider services={coreStart}>
+            <EditRolePage {...props} />
+          </KibanaContextProvider>
+        </I18nProvider>
+      );
+
+      await waitForRender();
+
+      return {
+        history,
+        openConfirm: props.overlays.openConfirm,
+        navigateToUrl: props.navigateToUrl,
+        rolesAPIClient: props.rolesAPIClient,
+      };
+    };
+
+    const editDescription = (value: string) =>
+      fireEvent.change(screen.getByTestId('roleFormDescriptionInput'), { target: { value } });
+
+    it('does not prompt when leaving an untouched role', async () => {
+      const { history, openConfirm } = await renderEditRolePage();
+
+      history.push('/');
+
+      expect(openConfirm).not.toHaveBeenCalled();
+      expect(history.location.pathname).toBe('/');
+    });
+
+    it('does not prompt when leaving an untouched create form', async () => {
+      // the create form pre-populates an empty index privilege, which is not a user change
+      const { history, openConfirm } = await renderEditRolePage({ existingRole: false });
+
+      history.push('/');
+
+      expect(openConfirm).not.toHaveBeenCalled();
+      expect(history.location.pathname).toBe('/');
+    });
+
+    it('prompts when leaving a create form with unsaved changes', async () => {
+      const { history, openConfirm } = await renderEditRolePage({ existingRole: false });
+
+      fireEvent.change(screen.getByTestId('roleFormNameInput'), {
+        target: { value: 'my_new_role' },
+      });
+      history.push('/');
+
+      await waitFor(() => {
+        expect(openConfirm).toHaveBeenCalled();
+      });
+      expect(history.location.pathname).toBe('/edit');
+    });
+
+    it('prompts when leaving a role with unsaved changes', async () => {
+      const { history, openConfirm } = await renderEditRolePage();
+
+      editDescription('a different role');
+      history.push('/');
+
+      await waitFor(() => {
+        expect(openConfirm).toHaveBeenCalled();
+      });
+      // navigation stays blocked until the user confirms
+      expect(history.location.pathname).toBe('/edit/my_role');
+    });
+
+    it('does not prompt when the change has been reverted', async () => {
+      const { history, openConfirm } = await renderEditRolePage();
+
+      editDescription('a different role');
+      editDescription('a role');
+      history.push('/');
+
+      expect(openConfirm).not.toHaveBeenCalled();
+      expect(history.location.pathname).toBe('/');
+    });
+
+    it('does not prompt after the role has been saved', async () => {
+      const { history, openConfirm } = await renderEditRolePage();
+
+      editDescription('a different role');
+      fireEvent.click(screen.getByTestId('roleFormSaveButton'));
+
+      await waitFor(() => {
+        expect(history.location.pathname).toBe('/');
+      });
+      expect(openConfirm).not.toHaveBeenCalled();
+    });
+
+    it('prompts again when saving the role failed', async () => {
+      const { history, openConfirm, rolesAPIClient } = await renderEditRolePage();
+      rolesAPIClient.saveRole.mockRejectedValue(new Error('could not save'));
+
+      editDescription('a different role');
+      fireEvent.click(screen.getByTestId('roleFormSaveButton'));
+      await waitForRender();
+
+      // the role was never saved, so those changes are still worth warning about
+      history.push('/');
+
+      await waitFor(() => {
+        expect(openConfirm).toHaveBeenCalled();
+      });
+      expect(history.location.pathname).toBe('/edit/my_role');
+    });
+
+    it('does not prompt when the form is cancelled', async () => {
+      const { history, openConfirm } = await renderEditRolePage();
+
+      editDescription('a different role');
+      fireEvent.click(screen.getByTestId('roleFormCancelButton'));
+
+      await waitFor(() => {
+        expect(history.location.pathname).toBe('/');
+      });
+      expect(openConfirm).not.toHaveBeenCalled();
+    });
+
+    it('navigates away when the user confirms the prompt', async () => {
+      const { history, openConfirm, navigateToUrl } = await renderEditRolePage();
+      openConfirm.mockResolvedValue(true);
+
+      editDescription('a different role');
+      history.push('/');
+
+      // on confirm the prompt unblocks and navigates itself, to the base-path-prepended target
+      await waitFor(() => {
+        expect(navigateToUrl).toHaveBeenCalledWith('/mock/', expect.anything());
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/edit_role_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/edit_role_page.tsx
@@ -22,17 +22,19 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import type { ChangeEvent, FocusEvent, FunctionComponent, HTMLProps } from 'react';
-import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { AsyncState } from 'react-use/lib/useAsync';
 import useAsync from 'react-use/lib/useAsync';
 
 import type { BuildFlavor } from '@kbn/config';
 import type {
+  ApplicationStart,
   Capabilities,
   DocLinksStart,
   FatalErrorsSetup,
   HttpStart,
   NotificationsStart,
+  OverlayStart,
   ScopedHistory,
 } from '@kbn/core/public';
 import type { IHttpFetchError } from '@kbn/core-http-browser';
@@ -49,9 +51,11 @@ import { REMOTE_CLUSTERS_PATH } from '@kbn/remote-clusters-plugin/public';
 import { KibanaPrivileges } from '@kbn/security-role-management-model';
 import { API_VERSIONS as SPACES_API_VERSIONS } from '@kbn/spaces-plugin/common';
 import type { Space, SpacesApiUi } from '@kbn/spaces-plugin/public';
+import { useUnsavedChangesPrompt } from '@kbn/unsaved-changes-prompt';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 
 import { DeleteRoleButton } from './delete_role_button';
+import { hasRoleChanged } from './has_role_changed';
 import { ElasticsearchPrivileges, KibanaPrivilegesRegion } from './privileges';
 import { ReservedRoleBadge } from './reserved_role_badge';
 import type { RoleValidationResult } from './validate_role';
@@ -95,6 +99,8 @@ export interface Props extends StartServices {
   notifications: NotificationsStart;
   fatalErrors: FatalErrorsSetup;
   history: ScopedHistory;
+  overlays: OverlayStart;
+  navigateToUrl: ApplicationStart['navigateToUrl'];
   spacesApiUi?: SpacesApiUi;
   buildFlavor: BuildFlavor;
   cloudOrgUrl?: string;
@@ -208,6 +214,9 @@ function useRole(
   roleName?: string
 ) {
   const [role, setRole] = useState<Role | null>(null);
+  // A pristine copy of the role as it was loaded, used to detect unsaved changes. It has to be a
+  // deep copy: the privilege forms edit their own copy of the role in place.
+  const [initialRole, setInitialRole] = useState<Role | null>(null);
 
   useEffect(() => {
     const rolePromise = roleName
@@ -251,7 +260,10 @@ function useRole(
           fetchedRole.elasticsearch.indices.push(emptyOption);
         }
 
-        setRole(action === 'clone' ? prepareRoleClone(fetchedRole) : copyRole(fetchedRole));
+        const loadedRole =
+          action === 'clone' ? prepareRoleClone(fetchedRole) : copyRole(fetchedRole);
+        setInitialRole(copyRole(loadedRole));
+        setRole(loadedRole);
       })
       .catch((err: IHttpFetchError) => {
         if (err.response?.status === 404) {
@@ -268,7 +280,7 @@ function useRole(
       });
   }, [roleName, action, fatalErrors, rolesAPIClient, notifications, license, backToRoleList]);
 
-  return [role, setRole] as [Role | null, typeof setRole];
+  return { role, setRole, initialRole };
 }
 
 function useSpaces(http: HttpStart, fatalErrors: FatalErrorsSetup) {
@@ -335,6 +347,8 @@ export const EditRolePage: FunctionComponent<Props> = ({
   uiCapabilities,
   notifications,
   history,
+  overlays,
+  navigateToUrl,
   spacesApiUi,
   buildFlavor,
   cloudOrgUrl,
@@ -349,7 +363,8 @@ export const EditRolePage: FunctionComponent<Props> = ({
     // so this error edge case is an acceptable tradeoff.
     throw new Error('The dataViews plugin is required for this page, but it is not available');
   }
-  const backToRoleList = useCallback(() => history.push('/'), [history]);
+  const [isLeaving, setIsLeaving] = useState(false);
+  const backToRoleList = useCallback(() => setIsLeaving(true), []);
   const hasReadOnlyPrivileges = !useCapabilities('roles').save;
 
   // We should keep the same mutable instance of Validator for every re-render since we'll
@@ -365,7 +380,7 @@ export const EditRolePage: FunctionComponent<Props> = ({
   const features = useFeatures(getFeatures, fatalErrors);
   const featureCheckState = useFeatureCheck(http, buildFlavor);
   const remoteClustersState = useRemoteClusters(http);
-  const [role, setRole] = useRole(
+  const { role, setRole, initialRole } = useRole(
     rolesAPIClient,
     fatalErrors,
     notifications,
@@ -382,6 +397,37 @@ export const EditRolePage: FunctionComponent<Props> = ({
       backToRoleList();
     }
   }, [hasReadOnlyPrivileges, isEditingExistingRole]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const hasUnsavedChanges = useMemo(
+    () => Boolean(role && initialRole && !isLeaving && hasRoleChanged(initialRole, role)),
+    [role, initialRole, isLeaving]
+  );
+
+  useUnsavedChangesPrompt({
+    hasUnsavedChanges,
+    http,
+    openConfirm: overlays.openConfirm,
+    navigateToUrl,
+    history,
+    titleText: i18n.translate('xpack.security.management.editRole.unsavedChangesPromptTitle', {
+      defaultMessage: 'Leave without saving?',
+    }),
+    messageText: i18n.translate('xpack.security.management.editRole.unsavedChangesPromptMessage', {
+      defaultMessage: "Unsaved changes won't be applied to the role and will be lost.",
+    }),
+    cancelButtonText: i18n.translate('xpack.security.management.editRole.keepEditingButton', {
+      defaultMessage: 'Keep editing',
+    }),
+    confirmButtonText: i18n.translate('xpack.security.management.editRole.leavePageButton', {
+      defaultMessage: 'Leave',
+    }),
+  });
+
+  useEffect(() => {
+    if (isLeaving) {
+      history.push('/');
+    }
+  }, [isLeaving, history]);
 
   if (
     !role ||

--- a/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/has_role_changed.test.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/has_role_changed.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { hasRoleChanged } from './has_role_changed';
+import type { Role } from '../../../../common';
+
+const role: Role = {
+  name: 'my_role',
+  description: 'a role',
+  elasticsearch: {
+    cluster: ['manage', 'monitor'],
+    indices: [{ names: ['foo*', 'bar*'], privileges: ['read', 'view_index_metadata'] }],
+    run_as: ['user_a', 'user_b'],
+  },
+  kibana: [{ base: [], feature: { discover: ['all'] }, spaces: ['default', 'marketing'] }],
+};
+
+const clone = (value: Role): Role => JSON.parse(JSON.stringify(value));
+
+describe('hasRoleChanged', () => {
+  it('reports no changes for an untouched role', () => {
+    expect(hasRoleChanged(role, clone(role))).toBe(false);
+  });
+
+  it('reports changes to the role itself', () => {
+    expect(hasRoleChanged(role, { ...clone(role), description: 'a different role' })).toBe(true);
+  });
+
+  it('reports changes to elasticsearch privileges', () => {
+    const updated = clone(role);
+    updated.elasticsearch.cluster = ['manage'];
+    expect(hasRoleChanged(role, updated)).toBe(true);
+  });
+
+  it('reports changes to kibana privileges', () => {
+    const updated = clone(role);
+    updated.kibana[0].feature.discover = ['read'];
+    expect(hasRoleChanged(role, updated)).toBe(true);
+  });
+
+  it('reports no changes when a privilege list comes back in a different order', () => {
+    // the form appends to these lists, so removing a privilege and adding it back reorders it
+    const reordered = clone(role);
+    reordered.elasticsearch.cluster = ['monitor', 'manage'];
+    reordered.elasticsearch.indices[0].privileges = ['view_index_metadata', 'read'];
+    reordered.elasticsearch.run_as = ['user_b', 'user_a'];
+    reordered.kibana[0].spaces = ['marketing', 'default'];
+
+    expect(hasRoleChanged(role, reordered)).toBe(false);
+  });
+
+  it('reports no changes when the form fills in blank values', () => {
+    const withBlanks = clone(role);
+    withBlanks.elasticsearch.indices[0].query = '';
+    withBlanks.elasticsearch.indices[0].field_security = { grant: [], except: [] };
+    withBlanks.kibana[0].base = [];
+
+    expect(hasRoleChanged(role, withBlanks)).toBe(false);
+  });
+
+  it('reports no changes when an already empty field is cleared', () => {
+    // clearing the description leaves `undefined` where the role had `''`
+    expect(
+      hasRoleChanged(
+        { ...clone(role), description: '' },
+        { ...clone(role), description: undefined }
+      )
+    ).toBe(false);
+  });
+
+  it('reports changes when a populated field is cleared', () => {
+    expect(hasRoleChanged(role, { ...clone(role), description: undefined })).toBe(true);
+  });
+
+  it('reports changes when a blank value is given a value', () => {
+    const updated = clone(role);
+    updated.elasticsearch.indices[0].query = '{"match_all":{}}';
+    expect(hasRoleChanged(role, updated)).toBe(true);
+  });
+
+  it('reports changes when a privilege is added or removed', () => {
+    const added = clone(role);
+    added.elasticsearch.indices[0].names.push('baz*');
+    expect(hasRoleChanged(role, added)).toBe(true);
+
+    const removed = clone(role);
+    removed.kibana = [];
+    expect(hasRoleChanged(role, removed)).toBe(true);
+  });
+});

--- a/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/has_role_changed.ts
+++ b/x-pack/platform/plugins/shared/security/public/management/roles/edit_role/has_role_changed.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isEqual, mapValues, omitBy } from 'lodash';
+
+import type { Role } from '../../../../common';
+
+const isBlank = (value: unknown) =>
+  value == null ||
+  value === '' ||
+  (Array.isArray(value) && value.length === 0) ||
+  (typeof value === 'object' && !Array.isArray(value) && Object.keys(value!).length === 0);
+
+/**
+ * Puts a role into a shape that can be compared for equality:
+ *
+ * - Privilege lists are sets, but the form appends to them as the user makes selections, so the
+ *   same set of privileges can come back in a different order (e.g. after removing a cluster
+ *   privilege and adding it back). String arrays are therefore sorted.
+ * - The form fills in blank values as the user interacts with it — clearing the description leaves
+ *   `undefined` where the role had `''`, an untouched index privilege has empty `names` and
+ *   `privileges` — none of which are changes. Blank values are therefore dropped.
+ */
+const normalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    const items = value.map(normalize);
+    return items.every((item) => typeof item === 'string')
+      ? [...(items as string[])].sort()
+      : items;
+  }
+
+  if (value && typeof value === 'object') {
+    return omitBy(mapValues(value as Record<string, unknown>, normalize), isBlank);
+  }
+
+  return value;
+};
+
+/**
+ * Determines whether the user has made any changes to the role they are editing, ignoring the
+ * values that the form fills in on their behalf.
+ */
+export const hasRoleChanged = (initialRole: Role, role: Role): boolean =>
+  !isEqual(normalize(initialRole), normalize(role));

--- a/x-pack/platform/plugins/shared/security/public/management/roles/roles_management_app.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/roles/roles_management_app.tsx
@@ -105,6 +105,7 @@ export const rolesManagementApp = Object.freeze({
                 uiCapabilities={application.capabilities}
                 dataViews={dataViews}
                 history={history}
+                navigateToUrl={application.navigateToUrl}
                 spacesApiUi={spacesApiUi}
                 buildFlavor={buildFlavor}
                 cloudOrgUrl={cloud?.organizationUrl}

--- a/x-pack/platform/plugins/shared/security/tsconfig.json
+++ b/x-pack/platform/plugins/shared/security/tsconfig.json
@@ -115,6 +115,7 @@
     "@kbn/agent-builder-browser",
     "@kbn/core-user-profile-common",
     "@kbn/core-chrome-browser-components",
+    "@kbn/unsaved-changes-prompt",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Prevent nagivating away from roles management with unsaved changes (#283525)](https://github.com/elastic/kibana/pull/283525)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2026-08-13T12:09:53Z","message":"Prevent nagivating away from roles management with unsaved changes (#283525)\n\n## Summary\n\nA small fix to prevent losing unsaved changes on the role management\nscreen.\nWhen creating or updating a role, the user will be prompted about\nunsaved changes if they attempt to navigate away.\n\n<img width=\"2104\" height=\"1246\" alt=\"Larry Gregory 2026-08-07 at 11 35\n28@2x\"\nsrc=\"https://github.com/user-attachments/assets/d07939eb-2c30-475a-a584-65a10d5e1ef3\"\n/>\n\n\nResolves https://github.com/elastic/kibana/issues/106576","sha":"5981299009bd60abbee982eecac2ffddc3fa0289","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Security","Feature:Users/Roles/API Keys","backport:version","v9.6.0","v9.4.5","v9.5.2"],"title":"Prevent nagivating away from roles management with unsaved changes","number":283525,"url":"https://github.com/elastic/kibana/pull/283525","mergeCommit":{"message":"Prevent nagivating away from roles management with unsaved changes (#283525)\n\n## Summary\n\nA small fix to prevent losing unsaved changes on the role management\nscreen.\nWhen creating or updating a role, the user will be prompted about\nunsaved changes if they attempt to navigate away.\n\n<img width=\"2104\" height=\"1246\" alt=\"Larry Gregory 2026-08-07 at 11 35\n28@2x\"\nsrc=\"https://github.com/user-attachments/assets/d07939eb-2c30-475a-a584-65a10d5e1ef3\"\n/>\n\n\nResolves https://github.com/elastic/kibana/issues/106576","sha":"5981299009bd60abbee982eecac2ffddc3fa0289"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283525","number":283525,"mergeCommit":{"message":"Prevent nagivating away from roles management with unsaved changes (#283525)\n\n## Summary\n\nA small fix to prevent losing unsaved changes on the role management\nscreen.\nWhen creating or updating a role, the user will be prompted about\nunsaved changes if they attempt to navigate away.\n\n<img width=\"2104\" height=\"1246\" alt=\"Larry Gregory 2026-08-07 at 11 35\n28@2x\"\nsrc=\"https://github.com/user-attachments/assets/d07939eb-2c30-475a-a584-65a10d5e1ef3\"\n/>\n\n\nResolves https://github.com/elastic/kibana/issues/106576","sha":"5981299009bd60abbee982eecac2ffddc3fa0289"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->