### PR TITLE
[Entity Analytics] Add expand action to entity attachment in case activity timeline

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/show_entity_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/show_entity_button.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ShowEntityButton } from './show_entity_button';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import { createFlyoutApiMock } from '../../../../flyout_v2/use_flyout_api.mock';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
+
+const props = {
+  id: 'action-id',
+  entityId: 'entity-euid-1',
+  entityName: 'alice',
+  entityType: 'user',
+};
+
+const mockOpenFlyout = jest.fn();
+
+jest.mock('@kbn/expandable-flyout', () => ({
+  useExpandableFlyoutApi: () => ({ openFlyout: mockOpenFlyout }),
+}));
+
+jest.mock('../../../../flyout_v2/use_flyout_api');
+jest.mock('../../../../common/hooks/use_is_new_flyout_enabled');
+
+describe('ShowEntityButton', () => {
+  let flyoutApi: ReturnType<typeof createFlyoutApiMock>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    flyoutApi = createFlyoutApiMock();
+    jest.mocked(useFlyoutApi).mockReturnValue(flyoutApi);
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(false);
+  });
+
+  it('renders the show entity button', () => {
+    render(<ShowEntityButton {...props} />);
+    expect(screen.getByTestId('comment-action-show-entity-action-id')).toBeInTheDocument();
+  });
+
+  it('opens the new entity flyout when the new flyout is enabled', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    render(<ShowEntityButton {...props} />);
+    fireEvent.click(screen.getByTestId('comment-action-show-entity-action-id'));
+
+    expect(flyoutApi.openEntityFlyout).toHaveBeenCalledWith({
+      engineType: 'user',
+      entityId: 'entity-euid-1',
+      entityName: 'alice',
+      scopeId: 'timeline-case',
+      origin: FLYOUT_ORIGIN.CASE_ATTACHMENT,
+    });
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+  });
+
+  it('opens the legacy expandable flyout for a user when the new flyout is disabled', () => {
+    render(<ShowEntityButton {...props} />);
+    fireEvent.click(screen.getByTestId('comment-action-show-entity-action-id'));
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: 'user-panel',
+        params: { userName: 'alice', entityId: 'entity-euid-1', scopeId: 'timeline-case' },
+      },
+    });
+    expect(flyoutApi.openEntityFlyout).not.toHaveBeenCalled();
+  });
+
+  it('opens the legacy expandable flyout for a host when the new flyout is disabled', () => {
+    render(<ShowEntityButton {...props} entityType="host" entityName="my-host" />);
+    fireEvent.click(screen.getByTestId('comment-action-show-entity-action-id'));
+
+    expect(mockOpenFlyout).toHaveBeenCalledWith({
+      right: {
+        id: 'host-panel',
+        params: { hostName: 'my-host', entityId: 'entity-euid-1', scopeId: 'timeline-case' },
+      },
+    });
+  });
+
+  it('does not open the legacy flyout for a generic entity (no legacy panel exists)', () => {
+    render(<ShowEntityButton {...props} entityType="generic" />);
+    fireEvent.click(screen.getByTestId('comment-action-show-entity-action-id'));
+
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+    expect(flyoutApi.openEntityFlyout).not.toHaveBeenCalled();
+  });
+
+  it('opens the new entity flyout for a generic entity when the new flyout is enabled', () => {
+    jest.mocked(useIsNewFlyoutEnabled).mockReturnValue(true);
+
+    render(<ShowEntityButton {...props} entityType="generic" />);
+    fireEvent.click(screen.getByTestId('comment-action-show-entity-action-id'));
+
+    expect(flyoutApi.openEntityFlyout).toHaveBeenCalledWith(
+      expect.objectContaining({ engineType: 'generic' })
+    );
+    expect(mockOpenFlyout).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/show_entity_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/components/show_entity_button.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { i18n } from '@kbn/i18n';
+import { TimelineId } from '../../../../../common/types/timeline';
+import { FLYOUT_ORIGIN } from '../../../../common/lib/telemetry';
+import { useIsNewFlyoutEnabled } from '../../../../common/hooks/use_is_new_flyout_enabled';
+import { useFlyoutApi } from '../../../../flyout_v2/use_flyout_api';
+import {
+  EntityPanelKeyByType,
+  EntityPanelParamByType,
+} from '../../../../flyout/entity_details/shared/constants';
+import type { EntityType } from '../../../../../common/entity_analytics/types';
+
+const SHOW_ENTITY_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.entityAnalytics.cases.showEntityDetails',
+  { defaultMessage: 'Show entity details' }
+);
+
+export interface ShowEntityButtonProps {
+  id: string;
+  entityId: string;
+  entityName: string;
+  entityType: string;
+}
+
+export const ShowEntityButton = ({
+  id,
+  entityId,
+  entityName,
+  entityType,
+}: ShowEntityButtonProps) => {
+  const enableNewFlyout = useIsNewFlyoutEnabled();
+  const { openEntityFlyout } = useFlyoutApi();
+  const { openFlyout } = useExpandableFlyoutApi();
+
+  const onClick = useCallback(() => {
+    if (enableNewFlyout) {
+      openEntityFlyout({
+        engineType: entityType,
+        entityId,
+        entityName,
+        scopeId: TimelineId.casePage,
+        origin: FLYOUT_ORIGIN.CASE_ATTACHMENT,
+      });
+    } else {
+      // Legacy expandable flyout path. No telemetry here — the new-flyout path reports
+      // telemetry internally via openEntityFlyout, and the legacy path is being deprecated.
+      const panelKey = EntityPanelKeyByType[entityType as EntityType];
+      const paramName = EntityPanelParamByType[entityType as EntityType];
+      if (panelKey && paramName) {
+        openFlyout({
+          right: {
+            id: panelKey,
+            params: { [paramName]: entityName, entityId, scopeId: TimelineId.casePage },
+          },
+        });
+      }
+    }
+  }, [enableNewFlyout, entityId, entityName, entityType, openEntityFlyout, openFlyout]);
+
+  return (
+    <EuiToolTip position="top" content={<p>{SHOW_ENTITY_TOOLTIP}</p>}>
+      <EuiButtonIcon
+        aria-label={SHOW_ENTITY_TOOLTIP}
+        data-test-subj={`comment-action-show-entity-${id}`}
+        onClick={onClick}
+        iconType="chevronSingleRight"
+        id={`${id}-show-entity`}
+      />
+    </EuiToolTip>
+  );
+};
+
+ShowEntityButton.displayName = 'ShowEntityButton';

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.test.tsx
@@ -9,7 +9,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { UnifiedReferenceAttachmentViewProps } from '@kbn/cases-plugin/public/client/attachment_framework/types';
-import { SECURITY_ENTITY_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common';
+import { AttachmentActionType, SECURITY_ENTITY_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common';
 import type { EntityAttachmentPayload } from '../../../../common/cases/attachments/entity';
 import { EntityAttachmentPayloadSchema } from '../../../../common/cases/attachments/entity';
 import { getEntityAttachment } from '.';
@@ -67,6 +67,28 @@ describe('Entity attachment', () => {
 
     it('falls back to the globe icon when the entity type is missing', () => {
       expect(getIconType(undefined)).toBe('globe');
+    });
+  });
+
+  describe('getActions', () => {
+    it('returns a primary custom action when metadata is present', () => {
+      const attachment = getEntityAttachment();
+      const actions = attachment.getAttachmentViewObject(baseProps).getActions?.(baseProps);
+      expect(actions).toHaveLength(1);
+      expect(actions?.[0]).toMatchObject({
+        type: AttachmentActionType.CUSTOM,
+        isPrimary: true,
+        render: expect.any(Function),
+      });
+    });
+
+    it('returns no actions when metadata is missing', () => {
+      const attachment = getEntityAttachment();
+      const propsWithoutMetadata = { ...baseProps, metadata: undefined } as unknown as Props;
+      const actions = attachment
+        .getAttachmentViewObject(propsWithoutMetadata)
+        .getActions?.(propsWithoutMetadata);
+      expect(actions).toHaveLength(0);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
@@ -10,13 +10,14 @@ import type {
   CommonAttachmentTabViewProps,
 } from '@kbn/cases-plugin/public';
 import { defineAttachment } from '@kbn/cases-plugin/public';
-import { SECURITY_ENTITY_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common';
+import { AttachmentActionType, SECURITY_ENTITY_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common';
 import React, { Suspense, type ComponentType } from 'react';
-import { EuiAvatar } from '@elastic/eui';
+import { EuiAvatar, EuiLoadingSpinner } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import type { EntityType } from '../../../../common/entity_analytics/types';
 import { EntityIconByType } from '../../../entity_analytics/components/entity_store/entity_icon_by_type';
+import type { UnifiedReferenceAttachmentViewProps } from '@kbn/cases-plugin/public';
 import type { EntityAttachmentMetadata } from '../../../../common/cases/attachments/entity';
 import { EntityAttachmentPayloadSchema } from '../../../../common/cases/attachments/entity';
 import { ENTITY_STORE_INDEX_PATTERN } from '../../../../common/entity_analytics/entity_store/constants';
@@ -32,12 +33,18 @@ export interface EntityToAttach {
 
 const EntityAttachmentChildrenLazy = React.lazy(() => import('./components/attachment_children'));
 const EntityTabContentLazy = React.lazy(() => import('./components/entity_tab_content'));
+const ShowEntityButton = React.lazy(async () => {
+  const { ShowEntityButton: Component } = await import('./components/show_entity_button');
+  return { default: Component };
+});
 
 const EntityTabContentWrapper: ComponentType<CommonAttachmentTabViewProps> = (props) => (
   <Suspense fallback={null}>
     <EntityTabContentLazy {...props} />
   </Suspense>
 );
+
+type EntityAttachmentViewProps = UnifiedReferenceAttachmentViewProps<EntityAttachmentMetadata>;
 
 const DISPLAY_NAME = i18n.translate('xpack.securitySolution.entityAnalytics.cases.displayName', {
   defaultMessage: 'Entities',
@@ -62,6 +69,26 @@ export const getEntityAttachment = () =>
         ),
         timelineAvatar: <EuiAvatar name="entity" color="subdued" iconType={iconType} />,
         children: EntityAttachmentChildrenLazy,
+        getActions: (actionProps: EntityAttachmentViewProps) => {
+          const { metadata } = actionProps;
+          if (!metadata) return [];
+          return [
+            {
+              type: AttachmentActionType.CUSTOM as const,
+              isPrimary: true,
+              render: () => (
+                <Suspense fallback={<EuiLoadingSpinner size="m" />}>
+                  <ShowEntityButton
+                    id={actionProps.savedObjectId}
+                    entityId={actionProps.attachmentId}
+                    entityName={metadata.entityName ?? ''}
+                    entityType={metadata.entityType ?? ''}
+                  />
+                </Suspense>
+              ),
+            },
+          ];
+        },
       };
     },
     getAttachmentTabViewObject: () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
@@ -80,7 +80,11 @@ export const getEntityAttachment = () =>
                 <Suspense fallback={<EuiLoadingSpinner size="m" />}>
                   <ShowEntityButton
                     id={actionProps.savedObjectId}
-                    entityId={Array.isArray(actionProps.attachmentId) ? actionProps.attachmentId[0] : actionProps.attachmentId}
+                    entityId={
+                      Array.isArray(actionProps.attachmentId)
+                        ? actionProps.attachmentId[0]
+                        : actionProps.attachmentId
+                    }
                     entityName={metadata.entityName ?? ''}
                     entityType={metadata.entityType ?? ''}
                   />

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
@@ -80,7 +80,7 @@ export const getEntityAttachment = () =>
                 <Suspense fallback={<EuiLoadingSpinner size="m" />}>
                   <ShowEntityButton
                     id={actionProps.savedObjectId}
-                    entityId={actionProps.attachmentId}
+                    entityId={Array.isArray(actionProps.attachmentId) ? actionProps.attachmentId[0] : actionProps.attachmentId}
                     entityName={metadata.entityName ?? ''}
                     entityType={metadata.entityType ?? ''}
                   />

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/attachments/entity/index.tsx
@@ -8,6 +8,7 @@
 import type {
   CaseAttachmentsWithoutOwner,
   CommonAttachmentTabViewProps,
+  UnifiedReferenceAttachmentViewProps,
 } from '@kbn/cases-plugin/public';
 import { defineAttachment } from '@kbn/cases-plugin/public';
 import { AttachmentActionType, SECURITY_ENTITY_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common';
@@ -17,7 +18,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import type { EntityType } from '../../../../common/entity_analytics/types';
 import { EntityIconByType } from '../../../entity_analytics/components/entity_store/entity_icon_by_type';
-import type { UnifiedReferenceAttachmentViewProps } from '@kbn/cases-plugin/public';
 import type { EntityAttachmentMetadata } from '../../../../common/cases/attachments/entity';
 import { EntityAttachmentPayloadSchema } from '../../../../common/cases/attachments/entity';
 import { ENTITY_STORE_INDEX_PATTERN } from '../../../../common/entity_analytics/entity_store/constants';


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/security-team/issues/18818

Adds the `>` expand action to entity attachments in the Cases activity timeline, consistent with alert and observable attachment types.

The button opens the entity flyout. Both the new flyout path (`useFlyoutApi`) and the legacy expandable flyout path are supported, with a graceful no-op for unknown entity types on the legacy path.

## Demo
 

https://github.com/user-attachments/assets/dd2ea3c6-0763-4f12-b07b-e17301303f86



## Testing

- Attach an entity to a case → activity timeline → `>` button appears → entity flyout opens with correct entity
- Regression: Attachments tab flyout still works; other attachment types in the timeline unchanged



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->