### PR TITLE
Infer default MCP annotations for user-created tool types

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.test.ts
@@ -7,10 +7,15 @@
 
 import { z } from '@kbn/zod/v4';
 import { ToolType } from '@kbn/agent-builder-common';
-import type { BuiltinToolDefinition } from '@kbn/agent-builder-server/tools';
+import type {
+  BuiltinToolDefinition,
+  StaticEsqlTool,
+  StaticIndexSearchTool,
+  StaticWorkflowTool,
+} from '@kbn/agent-builder-server/tools';
 import { convertTool } from './converter';
 import { ToolAvailabilityCache } from './availability_cache';
-import type { BuiltinToolTypeDefinition } from '../tool_types/definitions';
+import type { BuiltinToolTypeDefinition, ToolTypeDefinition } from '../tool_types/definitions';
 
 const makeBuiltinRegistration = (
   overrides: Partial<BuiltinToolDefinition> = {}
@@ -30,6 +35,49 @@ const builtinDefinition: BuiltinToolTypeDefinition = {
 };
 
 const baseContext = { spaceId: 'default', request: {} as any };
+
+const makeStaticEsqlTool = (overrides: Partial<StaticEsqlTool> = {}): StaticEsqlTool => ({
+  id: 'my_esql_tool',
+  type: ToolType.esql,
+  description: 'A custom ESQL tool',
+  tags: [],
+  configuration: { query: 'FROM logs | LIMIT 10', params: {} },
+  ...overrides,
+});
+
+const makeStaticIndexSearchTool = (
+  overrides: Partial<StaticIndexSearchTool> = {}
+): StaticIndexSearchTool => ({
+  id: 'my_index_search_tool',
+  type: ToolType.index_search,
+  description: 'A custom index search tool',
+  tags: [],
+  configuration: { index: 'logs-*' },
+  ...overrides,
+});
+
+const makeStaticWorkflowTool = (
+  overrides: Partial<StaticWorkflowTool> = {}
+): StaticWorkflowTool => ({
+  id: 'my_workflow_tool',
+  type: ToolType.workflow,
+  description: 'A custom workflow tool',
+  tags: [],
+  configuration: { workflowId: 'wf-1' },
+  ...overrides,
+});
+
+const nonBuiltinDefinition: ToolTypeDefinition = {
+  toolType: ToolType.esql,
+  getDynamicProps: jest.fn().mockResolvedValue({
+    getSchema: () => z.object({}),
+    getHandler: () => jest.fn(),
+  }),
+  createSchema: {} as any,
+  updateSchema: {} as any,
+  validateForCreate: jest.fn() as any,
+  validateForUpdate: jest.fn() as any,
+};
 
 describe('convertTool (builtin)', () => {
   it('defaults experimental to false when not set', () => {
@@ -63,5 +111,98 @@ describe('convertTool (builtin)', () => {
       cache: new ToolAvailabilityCache(),
     });
     expect(result.experimental).toBe(false);
+  });
+
+  it('propagates annotations from the builtin tool definition', () => {
+    const annotations = {
+      title: 'Test Tool',
+      readOnlyHint: true as const,
+      destructiveHint: false as const,
+      idempotentHint: true as const,
+      openWorldHint: false as const,
+    };
+    const tool = makeBuiltinRegistration({ annotations });
+    const result = convertTool({
+      tool,
+      definition: builtinDefinition,
+      context: baseContext,
+      cache: new ToolAvailabilityCache(),
+    });
+    expect(result.annotations).toEqual(annotations);
+  });
+
+  it('leaves annotations undefined when not set on builtin tool', () => {
+    const tool = makeBuiltinRegistration();
+    const result = convertTool({
+      tool,
+      definition: builtinDefinition,
+      context: baseContext,
+      cache: new ToolAvailabilityCache(),
+    });
+    expect(result.annotations).toBeUndefined();
+  });
+});
+
+describe('convertTool (static/non-builtin) — default annotations', () => {
+  it('assigns read-only annotations for ESQL tools', () => {
+    const tool = makeStaticEsqlTool();
+    const result = convertTool({
+      tool,
+      definition: { ...nonBuiltinDefinition, toolType: ToolType.esql },
+      context: baseContext,
+      cache: new ToolAvailabilityCache(),
+    });
+    expect(result.annotations).toEqual({
+      title: 'my_esql_tool',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  });
+
+  it('assigns read-only annotations for index search tools', () => {
+    const tool = makeStaticIndexSearchTool();
+    const result = convertTool({
+      tool,
+      definition: { ...nonBuiltinDefinition, toolType: ToolType.index_search },
+      context: baseContext,
+      cache: new ToolAvailabilityCache(),
+    });
+    expect(result.annotations).toEqual({
+      title: 'my_index_search_tool',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  });
+
+  it('assigns destructive annotations for workflow tools', () => {
+    const tool = makeStaticWorkflowTool();
+    const result = convertTool({
+      tool,
+      definition: { ...nonBuiltinDefinition, toolType: ToolType.workflow },
+      context: baseContext,
+      cache: new ToolAvailabilityCache(),
+    });
+    expect(result.annotations).toEqual({
+      title: 'my_workflow_tool',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+  });
+
+  it('uses tool.id as the title', () => {
+    const tool = makeStaticEsqlTool({ id: 'custom.query.v2' });
+    const result = convertTool({
+      tool,
+      definition: { ...nonBuiltinDefinition, toolType: ToolType.esql },
+      context: baseContext,
+      cache: new ToolAvailabilityCache(),
+    });
+    expect(result.annotations?.title).toBe('custom.query.v2');
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.test.ts
@@ -52,7 +52,7 @@ const makeStaticIndexSearchTool = (
   type: ToolType.index_search,
   description: 'A custom index search tool',
   tags: [],
-  configuration: { index: 'logs-*' },
+  configuration: { pattern: 'logs-*' },
   ...overrides,
 });
 
@@ -63,7 +63,7 @@ const makeStaticWorkflowTool = (
   type: ToolType.workflow,
   description: 'A custom workflow tool',
   tags: [],
-  configuration: { workflowId: 'wf-1' },
+  configuration: { workflow_id: 'wf-1' },
   ...overrides,
 });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.test.ts
@@ -148,7 +148,7 @@ describe('convertTool (static/non-builtin) — default annotations', () => {
     const tool = makeStaticEsqlTool();
     const result = convertTool({
       tool,
-      definition: { ...nonBuiltinDefinition, toolType: ToolType.esql },
+      definition: nonBuiltinDefinition,
       context: baseContext,
       cache: new ToolAvailabilityCache(),
     });
@@ -165,7 +165,7 @@ describe('convertTool (static/non-builtin) — default annotations', () => {
     const tool = makeStaticIndexSearchTool();
     const result = convertTool({
       tool,
-      definition: { ...nonBuiltinDefinition, toolType: ToolType.index_search },
+      definition: nonBuiltinDefinition,
       context: baseContext,
       cache: new ToolAvailabilityCache(),
     });
@@ -182,7 +182,7 @@ describe('convertTool (static/non-builtin) — default annotations', () => {
     const tool = makeStaticWorkflowTool();
     const result = convertTool({
       tool,
-      definition: { ...nonBuiltinDefinition, toolType: ToolType.workflow },
+      definition: nonBuiltinDefinition,
       context: baseContext,
       cache: new ToolAvailabilityCache(),
     });
@@ -199,7 +199,7 @@ describe('convertTool (static/non-builtin) — default annotations', () => {
     const tool = makeStaticEsqlTool({ id: 'custom.query.v2' });
     const result = convertTool({
       tool,
-      definition: { ...nonBuiltinDefinition, toolType: ToolType.esql },
+      definition: nonBuiltinDefinition,
       context: baseContext,
       cache: new ToolAvailabilityCache(),
     });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/converter.ts
@@ -8,6 +8,7 @@
 import { ToolType } from '@kbn/agent-builder-common';
 import type {
   BuiltinToolDefinition,
+  McpToolAnnotations,
   StaticToolRegistration,
   InternalToolDefinition,
 } from '@kbn/agent-builder-server/tools';
@@ -91,6 +92,7 @@ export const convertTool = ({
       },
       summarizeToolReturn: tool.summarizeToolReturn,
       maxResultTokens: tool.maxResultTokens,
+      annotations: getDefaultAnnotationsForToolType(tool),
     };
   }
 
@@ -104,4 +106,23 @@ export const isBuiltinToolRegistration = (
   tool: StaticToolRegistration
 ): tool is BuiltinToolDefinition => {
   return tool.type === ToolType.builtin;
+};
+
+const READ_ONLY_DEFAULTS: Omit<McpToolAnnotations, 'title'> = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+};
+
+const DESTRUCTIVE_DEFAULTS: Omit<McpToolAnnotations, 'title'> = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: false,
+};
+
+const getDefaultAnnotationsForToolType = (tool: StaticToolRegistration): McpToolAnnotations => {
+  const defaults = tool.type === ToolType.workflow ? DESTRUCTIVE_DEFAULTS : READ_ONLY_DEFAULTS;
+  return { title: tool.id, ...defaults };
 };


### PR DESCRIPTION
## Summary

Adds inferred default MCP annotations for user-created tool types (`StaticEsqlTool`, `StaticIndexSearchTool`, `StaticWorkflowTool`) in the converter, so they carry annotations when exposed via the MCP server.

**Defaults by tool type:**
- **ESQL** and **IndexSearch** tools: read-only (`readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`)
- **Workflow** tools: destructive (`readOnlyHint: false`, `destructiveHint: true`) — conservative, since workflow content is opaque and may mutate state
- **Title**: set to `tool.id` for all three types
- **openWorldHint**: `false` for all (these tools operate within Kibana/ES)

This is a low-effort solution agreed upon in [this Slack thread](https://elastic.slack.com/archives/C0BL3S6F9GA/p1786558256094869) — a fuller solution with UI form fields and saved-object migration is deferred.

Builds on the Phase 1 framework PR (#284764).

## Test plan

- [x] Converter tests: 9 pass (4 new annotation tests covering all 3 tool types + title derivation)
- [x] MCP route tests: 20 pass (unchanged)
- [ ] CI validation

Generated with [Claude Code](https://claude.com/claude-code)
