### PR TITLE
[ci] Only upload a single build for tests

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -30,7 +30,5 @@ node scripts/build "${BUILD_ARGS[@]}"
 wait $cleanup_pid || true
 
 echo "--- Archive Kibana Distribution"
-version="$(jq -r '.version' package.json)"
-linuxBuild="$KIBANA_DIR/target/kibana-$version-SNAPSHOT-linux-x86_64.tar.zst"
 mkdir -p "$KIBANA_BUILD_LOCATION"
-tar -xf "$linuxBuild" -I zstd -C "$KIBANA_BUILD_LOCATION" --strip=1
+tar -xf "$KIBANA_DIR/target/$KIBANA_TEST_SNAPSHOT_ARCHIVE" -I zstd -C "$KIBANA_BUILD_LOCATION" --strip=1

--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -30,6 +30,9 @@ if command -v jq >/dev/null 2>&1; then
 
   KIBANA_PKG_VERSION="$(jq -r .version "$KIBANA_DIR/package.json")"
   export KIBANA_PKG_VERSION
+
+  KIBANA_TEST_SNAPSHOT_ARCHIVE="$(kibana_test_snapshot_archive)"
+  export KIBANA_TEST_SNAPSHOT_ARCHIVE
 fi
 
 # Detects and exports the final target branch when using a merge queue

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -248,6 +248,19 @@ download_artifact() {
   retry 3 1 timeout 3m buildkite-agent artifact download "$@"
 }
 
+# Snapshot distributable that build_kibana.sh publishes for test steps to consume
+kibana_test_snapshot_archive() {
+  local hostArch distributionArch
+  hostArch="$(command uname -m)"
+  case "$hostArch" in
+    x86_64 | amd64) distributionArch="x86_64" ;;
+    aarch64 | arm64) distributionArch="aarch64" ;;
+    *) distributionArch="$hostArch" ;;
+  esac
+
+  echo "kibana-$(jq -r .version "${KIBANA_DIR:-.}/package.json")-SNAPSHOT-linux-$distributionArch.tar.zst"
+}
+
 GCS_CI_ARTIFACT_REGIONS=("asia-south2" "europe-west2" "northamerica-northeast2" "southamerica-east1" "us-central1" "us-east1" "us-west1")
 download_tmp_artifact() {
   local artifact_name="$1" dest_dir="$2" build_id="$3" fallback="${4:-true}"

--- a/.buildkite/scripts/download_build_artifacts.sh
+++ b/.buildkite/scripts/download_build_artifacts.sh
@@ -14,10 +14,10 @@ if [[ "${KIBANA_BUILD_ID:-}" != "false" ]]; then
     # Falls back to KIBANA_BUILD_ID or BUILDKITE_BUILD_ID for non-PR pipelines.
     EFFECTIVE_BUILD_ID=$(buildkite-agent meta-data get "kibana-effective-build-id" 2>/dev/null || echo "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}")
 
-    download_tmp_artifact kibana-default.tar.zst . "$EFFECTIVE_BUILD_ID"
+    download_tmp_artifact "$KIBANA_TEST_SNAPSHOT_ARCHIVE" . "$EFFECTIVE_BUILD_ID"
 
     mkdir -p "$KIBANA_BUILD_LOCATION"
-    tar -xf kibana-default.tar.zst -I zstd -C "$KIBANA_BUILD_LOCATION" --strip=1
+    tar -xf "$KIBANA_TEST_SNAPSHOT_ARCHIVE" -I zstd -C "$KIBANA_BUILD_LOCATION" --strip=1
 
     if is_pr_with_label "ci:build-example-plugins"; then
       # Testing against an example plugin distribution is not supported,

--- a/.buildkite/scripts/post_build_kibana.sh
+++ b/.buildkite/scripts/post_build_kibana.sh
@@ -38,11 +38,9 @@ fi
 
 echo "--- Upload Build Artifacts"
 # Moving to `target/` first will keep `buildkite-agent` from including directories in the artifact name
-version="$(jq -r '.version' package.json)"
 cd "$KIBANA_DIR/target"
-cp "kibana-$version-SNAPSHOT-linux-x86_64.tar.zst" kibana-default.tar.zst
 
-upload_tmp_artifact "$KIBANA_DIR/target/kibana-default.tar.zst" kibana-default.tar.zst "$BUILDKITE_BUILD_ID" &
+upload_tmp_artifact "$KIBANA_DIR/target/$KIBANA_TEST_SNAPSHOT_ARCHIVE" "$KIBANA_TEST_SNAPSHOT_ARCHIVE" "$BUILDKITE_BUILD_ID" &
 GCS_UPLOAD_PID=$!
 
 buildkite-agent artifact upload "./*.tar.zst;./*.tar.gz;./*.zip;./*.deb;./*.rpm"

--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -47,8 +47,7 @@ esac
 echo "--- Download Kibana Distribution"
 
 mkdir -p ./target
-download_tmp_artifact "kibana-default.tar.zst" ./target "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
-mv ./target/kibana-default.tar.zst ./target/kibana-$VERSION-linux-x86_64.tar.zst
+download_tmp_artifact "$KIBANA_TEST_SNAPSHOT_ARCHIVE" ./target "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
 echo "--- Build Cloud Distribution"
 ELASTICSEARCH_MANIFEST_URL="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/$(jq -r '.version' package.json)/manifest-latest-verified.json"

--- a/.buildkite/scripts/steps/cloud/build_cloud_image.sh
+++ b/.buildkite/scripts/steps/cloud/build_cloud_image.sh
@@ -8,13 +8,10 @@ source .buildkite/scripts/common/util.sh
 
 export KBN_NP_PLUGINS_BUILT=true
 
-VERSION="$(jq -r '.version' package.json)-SNAPSHOT"
-
 echo "--- Download Kibana Distribution"
 
 mkdir -p ./target
-download_tmp_artifact "kibana-default.tar.zst" ./target "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
-mv ./target/kibana-default.tar.zst ./target/kibana-$VERSION-linux-x86_64.tar.zst
+download_tmp_artifact "$KIBANA_TEST_SNAPSHOT_ARCHIVE" ./target "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
 echo "--- Build Cloud Distribution"
 

--- a/.buildkite/scripts/steps/fips/build.sh
+++ b/.buildkite/scripts/steps/fips/build.sh
@@ -8,8 +8,7 @@ source .buildkite/scripts/common/util.sh
 source .buildkite/scripts/steps/artifacts/env.sh
 
 mkdir -p target
-download_tmp_artifact "kibana-default.tar.zst" ./target "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
-mv ./target/kibana-default.tar.zst ./target/kibana-$FULL_VERSION-linux-x86_64.tar.zst
+download_tmp_artifact "$KIBANA_TEST_SNAPSHOT_ARCHIVE" ./target "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
 echo "--- Build FIPS image"
 node scripts/build \

--- a/.buildkite/scripts/steps/fips/build_cloud_fips_image.sh
+++ b/.buildkite/scripts/steps/fips/build_cloud_fips_image.sh
@@ -8,13 +8,10 @@ source .buildkite/scripts/common/util.sh
 
 export KBN_NP_PLUGINS_BUILT=true
 
-VERSION="$(jq -r '.version' package.json)-SNAPSHOT"
-
 echo "--- Download Kibana Distribution"
 
 mkdir -p ./target
-download_tmp_artifact "kibana-default.tar.zst" ./target "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
-mv ./target/kibana-default.tar.zst ./target/kibana-$VERSION-linux-x86_64.tar.zst
+download_tmp_artifact "$KIBANA_TEST_SNAPSHOT_ARCHIVE" ./target "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
 echo "--- Build Cloud FIPS Distribution"
 

--- a/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
+++ b/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
@@ -35,7 +35,9 @@ tar -czf "${OUTPUT_DIR}/scalability_traces.tar.gz" -C target scalability_traces
 buildkite-agent artifact upload "${OUTPUT_DIR}/scalability_traces.tar.gz"
 
 echo "--- Downloading Kibana artifacts used in tests"
-download_tmp_artifact kibana-default.tar.zst "${OUTPUT_DIR}/" "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
+download_tmp_artifact "$KIBANA_TEST_SNAPSHOT_ARCHIVE" "${OUTPUT_DIR}/" "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
+# The benchmarking pipeline reads this dataset back later, possibly at a different version
+mv "${OUTPUT_DIR}/$KIBANA_TEST_SNAPSHOT_ARCHIVE" "${OUTPUT_DIR}/kibana-default.tar.zst"
 
 echo "--- Adding commit info"
 echo "${BUILDKITE_COMMIT}" > "${OUTPUT_DIR}/KIBANA_COMMIT_HASH"

--- a/dev_docs/tutorials/performance/peak_memory_profiling.mdx
+++ b/dev_docs/tutorials/performance/peak_memory_profiling.mdx
@@ -85,7 +85,7 @@ The archive is created under each worktree's `target/` directory. Its platform a
 
 ### Option 2: Use Buildkite artifacts from PR CI
 
-PR CI uploads the Linux Kibana archive as `kibana-default.tar.zst` during the post-build step. The `ci:build-cloud-image` label triggers an additional cloud-image build that consumes that same archive, but the label is not the thing that creates the raw Kibana distributable.
+PR CI uploads the Linux Kibana archive as `kibana-<version>-SNAPSHOT-linux-x86_64.tar.zst` during the post-build step. The `ci:build-cloud-image` label triggers an additional cloud-image build that consumes that same archive, but the label is not the thing that creates the raw Kibana distributable.
 
 By default, this path is only feasible from a Linux host, Linux workstation, or Linux VM because the default PR CI artifacts include Linux binaries and cannot run directly on macOS. If you are working on macOS and want a CI-built macOS artifact, add the `ci:build-all-platforms` label to the PR, trigger a new PR CI run, and download the matching Darwin archive from that new build.
 
@@ -98,11 +98,11 @@ Use this option when you need the exact distributable artifact produced by CI. Y
 ![Buildkite Canvas with Build Kibana Distribution step](./assets/buildkite_canvas_build_kibana_distribution.png)
 
 4. Select the **Artifacts** tab for that step.
-5. Download `kibana-default.tar.zst`. This is the generic Linux Kibana distributable used by downstream CI steps.
+5. Download the `kibana-<version>-SNAPSHOT-linux-x86_64.tar.zst` archive, for example `kibana-9.5.0-SNAPSHOT-linux-x86_64.tar.zst`. This is the generic Linux Kibana distributable used by downstream CI steps.
 
 ![Buildkite Build Kibana Distribution artifacts tab](./assets/buildkite_distribution_artifacts.png)
 
-The step also uploads a versioned archive such as `kibana-9.5.0-SNAPSHOT-linux-x86_64.tar.zst`. Either archive can be used for profiling; `kibana-default.tar.zst` is stable to document and script against. These default PR artifacts are Linux artifacts, so run them on Linux.
+These default PR artifacts are Linux artifacts, so run them on Linux.
 
 For macOS users:
 
@@ -147,7 +147,7 @@ unpack_kibana_archive "$BASELINE_ARCHIVE" /tmp/kibana-memory-profile/baseline
 unpack_kibana_archive "$CANDIDATE_ARCHIVE" /tmp/kibana-memory-profile/candidate
 ```
 
-Replace `<baseline-kibana-archive>` and `<candidate-kibana-archive>` with the archive filenames from each `target/` directory. If you downloaded `kibana-default.tar.zst` from CI, use the downloaded file path instead.
+Replace `<baseline-kibana-archive>` and `<candidate-kibana-archive>` with the archive filenames from each `target/` directory. If you downloaded the archive from CI, use the downloaded file path instead.
 
 ## Create a local peak-memory probe
 

--- a/src/platform/packages/shared/kbn-core-server-benchmarks/ci_warm_start_memory/calibration_artifacts.ts
+++ b/src/platform/packages/shared/kbn-core-server-benchmarks/ci_warm_start_memory/calibration_artifacts.ts
@@ -19,8 +19,6 @@ export const KIBANA_ON_MERGE_PIPELINE_SLUG = 'kibana-on-merge';
  * Keep these constants in sync with run_calibration.sh.
  */
 
-export const KIBANA_DISTRIBUTABLE_ARTIFACT_FILENAME = 'kibana-default.tar.zst';
-
 export const CALIBRATION_WORK_DIR = 'target/ci-warm-start-memory-bench';
 
 export const CALIBRATION_MANIFEST_PATH = `${CALIBRATION_WORK_DIR}/warm_start_calibration_manifest.json`;
@@ -43,7 +41,8 @@ export interface WarmStartCalibrationArtifact {
   readonly buildId: string;
   readonly commitSha: string;
   readonly artifactId: string;
-  readonly artifactPath: typeof KIBANA_DISTRIBUTABLE_ARTIFACT_FILENAME;
+  // resolved at run time by run_calibration.sh, recorded in the manifest
+  readonly artifactPath?: string;
   readonly buildUrl: string;
   readonly sha1: string;
   readonly sha256: string;
@@ -56,7 +55,6 @@ export const WARM_START_CALIBRATION_ARTIFACT_A: WarmStartCalibrationArtifact = {
   buildId: '019f94c0-d0d9-4944-84fc-27beda66beb7',
   commitSha: 'c068037b308eaa40c835e1016392587e2680e914',
   artifactId: '019f94ce-f550-455f-aab2-e12c621e6221',
-  artifactPath: KIBANA_DISTRIBUTABLE_ARTIFACT_FILENAME,
   buildUrl: 'https://buildkite.com/elastic/kibana-on-merge/builds/104030',
   sha1: '04668f26ee720ff5f15af88188851e7382127c76',
   sha256: 'ca34fb9db6425c81c8c25b8aac382d9d39899fe2bdd57179f7aad13e8c272779',
@@ -69,7 +67,6 @@ export const WARM_START_CALIBRATION_ARTIFACT_B: WarmStartCalibrationArtifact = {
   buildId: '019f94c0-70a2-4080-9082-0837dd577955',
   commitSha: 'f34aaebb053fee8e04cbb673551356e532819b8f',
   artifactId: '019f94cf-911f-4059-9a1c-af5a7f30a521',
-  artifactPath: KIBANA_DISTRIBUTABLE_ARTIFACT_FILENAME,
   buildUrl: 'https://buildkite.com/elastic/kibana-on-merge/builds/104029',
   sha1: 'ae342f24aa51285ac5d7ea94de0a15ce1c202ad5',
   sha256: '2e12f9a5fa18ebf59121ff9ee3d80cbdbd273c77d8f83ce189793f119a050ca2',

--- a/src/platform/packages/shared/kbn-core-server-benchmarks/ci_warm_start_memory/run_calibration.sh
+++ b/src/platform/packages/shared/kbn-core-server-benchmarks/ci_warm_start_memory/run_calibration.sh
@@ -37,7 +37,6 @@ LEFT_BUILD_DIR="${WORK_DIR}/left"
 RIGHT_BUILD_DIR="${WORK_DIR}/right"
 BENCH_CONFIG_PATH="src/platform/packages/shared/kbn-core-server-benchmarks/ci_warm_start_memory.benchmark.config.ts"
 PIPELINE_SLUG="kibana-on-merge"
-ARTIFACT_FILENAME="kibana-default.tar.zst"
 
 A_BUILD_ID="019f94c0-d0d9-4944-84fc-27beda66beb7"
 A_BUILD_NUMBER="104030"
@@ -413,6 +412,8 @@ main() {
     # shellcheck source=/dev/null
     source .buildkite/scripts/common/util.sh
   fi
+
+  ARTIFACT_FILENAME="$(kibana_test_snapshot_archive)"
 
   ORIENTATION="$(printf '%s' "${ORIENTATION}" | tr '[:upper:]' '[:lower:]')"
   resolve_orientation "${ORIENTATION}"


### PR DESCRIPTION
We've been uploading two copies of the same kibana artifact for use on CI.  This removes kibana-default.tar.zst; it isn't needed.