### PR TITLE
[9.5] [As Code] Sort response in dashboard list endpoint by `updated_at` descending (#282363)

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/search/search.test.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/search/search.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { RequestHandlerContext } from '@kbn/core/server';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+import { search } from './search';
+
+jest.mock('../get_use_ga_schemas', () => ({
+  getUseGASchemas: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../transforms', () => ({
+  transformDashboardOut: jest.fn().mockReturnValue({
+    dashboardState: {
+      title: 'Test',
+      description: undefined,
+      tags: undefined,
+      time_range: undefined,
+    },
+  }),
+}));
+
+describe('dashboard search sort options', () => {
+  const savedObjectsClient = savedObjectsClientMock.create();
+
+  const createRequestCtx = (): RequestHandlerContext =>
+    ({
+      resolve: jest.fn().mockResolvedValue({
+        core: { savedObjects: { client: savedObjectsClient } },
+      }),
+    } as unknown as RequestHandlerContext);
+
+  beforeEach(() => {
+    savedObjectsClient.find.mockResolvedValue({
+      saved_objects: [],
+      total: 0,
+      page: 1,
+      per_page: 20,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes updated_at desc when query is omitted', async () => {
+    await search(createRequestCtx(), { page: 1, per_page: 20 }, jest.fn() as never, true);
+
+    expect(savedObjectsClient.find.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        sortField: 'updated_at',
+        sortOrder: 'desc',
+      })
+    );
+  });
+
+  it('omits sort options when query is present', async () => {
+    await search(
+      createRequestCtx(),
+      { page: 1, per_page: 20, query: 'sales' },
+      jest.fn() as never,
+      true
+    );
+
+    const findOptions = savedObjectsClient.find.mock.calls[0][0];
+    expect(findOptions).not.toHaveProperty('sortField');
+    expect(findOptions).not.toHaveProperty('sortOrder');
+    expect(findOptions).toHaveProperty('search');
+  });
+});

--- a/src/platform/plugins/shared/dashboard/server/api/search/search.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/search/search.ts
@@ -38,6 +38,11 @@ export async function search(
   const includedTags = normalizeToArray(searchParams.tags);
   const excludedTags = normalizeToArray(searchParams.excluded_tags);
 
+  // Plain listings get a deterministic newest-first order; search requests keep relevance.
+  const sortOptions = searchParams.query
+    ? {}
+    : { sortField: 'updated_at', sortOrder: 'desc' as const };
+
   const soResponse = await core.savedObjects.client.find<DashboardSavedObjectAttributes>({
     type: DASHBOARD_SAVED_OBJECT_TYPE,
     searchFields: ['title^3', 'description'],
@@ -54,6 +59,7 @@ export async function search(
     page: searchParams.page,
     defaultSearchOperator: 'AND',
     ...tagsToFindOptions({ included: includedTags, excluded: excludedTags }),
+    ...sortOptions,
   });
 
   const useGASchemas = await getUseGASchemas(core);

--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/search_dashboards.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/search_dashboards.spec.ts
@@ -58,7 +58,6 @@ apiTest.describe('dashboards - search', { tag: tags.deploymentAgnostic }, () => 
     expect(response.body.meta.page).toBe(1);
     expect(response.body.meta.per_page).toBe(20);
     expect(response.body.data).toHaveLength(20);
-    expect(response.body.data[0].id).toBe('test-dashboard-00');
   });
 
   apiTest('should narrow results by query', async ({ apiClient }) => {
@@ -121,7 +120,6 @@ apiTest.describe('dashboards - search', { tag: tags.deploymentAgnostic }, () => 
       expect(response.body.meta.page).toBe(5);
       expect(response.body.meta.per_page).toBe(10);
       expect(response.body.data).toHaveLength(10);
-      expect(response.body.data[0].id).toBe('test-dashboard-40');
     }
   );
 

--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/search_dashboards_legacy.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/search_dashboards_legacy.spec.ts
@@ -71,7 +71,6 @@ apiTest.describe('dashboards - search - LEGACY', { tag: tags.deploymentAgnostic 
     expect(response).toHaveStatusCode(200);
     expect(response.body.total).toBe(101);
     expect(response.body.dashboards).toHaveLength(20);
-    expect(response.body.dashboards[0].id).toBe('test-dashboard-00');
   });
 
   apiTest('should narrow results by query', async ({ apiClient }) => {
@@ -129,7 +128,6 @@ apiTest.describe('dashboards - search - LEGACY', { tag: tags.deploymentAgnostic 
       expect(response).toHaveStatusCode(200);
       expect(response.body.total).toBe(101);
       expect(response.body.dashboards).toHaveLength(10);
-      expect(response.body.dashboards[0].id).toBe('test-dashboard-40');
     }
   );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[As Code] Sort response in dashboard list endpoint by `updated_at` descending (#282363)](https://github.com/elastic/kibana/pull/282363)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Peihl","email":"nick.peihl@elastic.co"},"sourceCommit":{"committedDate":"2026-08-04T20:12:08Z","message":"[As Code] Sort response in dashboard list endpoint by `updated_at` descending (#282363)\n\nFixes https://github.com/elastic/kibana/issues/248303\n\n## Summary\n\nApplies a deterministic order to Dashboards list endpoint. When the\n`query` parameter is unset, the results are ordered by the\n`meta.updated_at` in descending order.\n\nIf `query` parameter is set, the results are ordered by relevance\nscoring.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"2be7a0279c182e94ceb0a77155fda1fa5f1d8c81","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","backport missing","backport:version","reviewer:scout","v9.6.0","v9.5.1"],"title":"[As Code] Sort response in dashboard list endpoint by `updated_at` descending","number":282363,"url":"https://github.com/elastic/kibana/pull/282363","mergeCommit":{"message":"[As Code] Sort response in dashboard list endpoint by `updated_at` descending (#282363)\n\nFixes https://github.com/elastic/kibana/issues/248303\n\n## Summary\n\nApplies a deterministic order to Dashboards list endpoint. When the\n`query` parameter is unset, the results are ordered by the\n`meta.updated_at` in descending order.\n\nIf `query` parameter is set, the results are ordered by relevance\nscoring.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"2be7a0279c182e94ceb0a77155fda1fa5f1d8c81"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282363","number":282363,"mergeCommit":{"message":"[As Code] Sort response in dashboard list endpoint by `updated_at` descending (#282363)\n\nFixes https://github.com/elastic/kibana/issues/248303\n\n## Summary\n\nApplies a deterministic order to Dashboards list endpoint. When the\n`query` parameter is unset, the results are ordered by the\n`meta.updated_at` in descending order.\n\nIf `query` parameter is set, the results are ordered by relevance\nscoring.\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"2be7a0279c182e94ceb0a77155fda1fa5f1d8c81"}},{"branch":"9.5","label":"v9.5.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->