### PR TITLE
[dashboard] remove unused classes

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
@@ -174,11 +174,9 @@ export function DashboardRenderer({
 
   const isDashboardViewportLoading = !dashboardApi && !error;
 
-  const viewportClasses = classNames(
-    'dashboardViewport',
-    { 'dashboardViewport--screenshotMode': screenshotModeService.isScreenshotMode() },
-    { 'dashboardViewport--loading': isDashboardViewportLoading }
-  );
+  const viewportClasses = classNames('dashboardViewport', {
+    'dashboardViewport--loading': isDashboardViewportLoading,
+  });
 
   const loadingSpinner = showPlainSpinner ? (
     <EuiLoadingSpinner size="xxl" />
@@ -208,7 +206,6 @@ export function DashboardRenderer({
 
     return dashboardApi && dashboardInternalApi ? (
       <div
-        className="dashboardContainer"
         data-test-subj="dashboardContainer"
         css={styles.renderer}
         ref={(e) => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
@@ -33,7 +33,7 @@ import { loadDashboardApi } from '../dashboard_api/load_dashboard_api';
 import { DashboardContext } from '../dashboard_api/use_dashboard_api';
 import { DashboardInternalContext } from '../dashboard_api/use_dashboard_internal_api';
 import type { DashboardRedirect } from '../dashboard_app/types';
-import { coreServices, screenshotModeService, uiActionsService } from '../services/kibana_services';
+import { coreServices, uiActionsService } from '../services/kibana_services';
 
 import { Dashboard404Page } from './dashboard_404';
 import { DashboardViewport } from './viewport/dashboard_viewport';

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid.tsx
@@ -204,7 +204,8 @@ export const DashboardGrid = () => {
   return (
     <div
       ref={layoutRef}
-      className={classNames(viewMode === 'edit' ? 'dshLayout--editing' : 'dshLayout--viewing', {
+      className={classNames({
+        'dshLayout--editing': viewMode === 'edit',
         'dshLayout-withoutMargins': !useMargins,
         'dshLayout-isMaximizedPanel': expandedPanelId !== undefined,
       })}


### PR DESCRIPTION
3 unused CSS classes removed:

- dshLayout--viewing (dashboard_grid.tsx) — was applied when viewMode !== 'edit' but no CSS selector ever targeted it. The :not(.dshLayout--editing) pattern in the grid styles already handles the viewing case implicitly.
- dashboardViewport--screenshotMode (dashboard_renderer.tsx) — was conditionally applied in screenshot mode but had no associated styles and no external references anywhere in the repo.
- className="dashboardContainer" (dashboard_renderer.tsx) — redundant next to data-test-subj="dashboardContainer" on the same element; no CSS targeted the class and tests use testSubjects (which matches data-test-subj).

All other class names in the plugin were verified as actively used — either in Emotion style selectors, external plugin CSS, or test assertions.