### PR TITLE
[Cases] Use attachment displayName in activity feed removal entry

### DIFF
--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -17496,7 +17496,6 @@
     "xpack.cases.userActions.attachment": "Anhang",
     "xpack.cases.userActions.attachmentNotRegisteredErrorMsg": "Der Anhangstyp ist nicht registriert",
     "xpack.cases.userActions.attachmentRenderErrorMsg": "Dieser Anhang konnte nicht gerendert werden",
-    "xpack.cases.userActions.attachments.registeredAttachment.successToasterTitle": "Anhang löschen",
     "xpack.cases.userActions.comment.unsavedDraftComment": "Sie haben ungespeicherte Änderungen für diesen Kommentar",
     "xpack.cases.userActions.defaultEventAttachmentTitle": "hat einen Anhang vom Typ hinzugefügt",
     "xpack.cases.userActions.deleteAttachment": "Anhang löschen",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -17463,7 +17463,6 @@
     "xpack.cases.userActions.attachment": "Pièce jointe",
     "xpack.cases.userActions.attachmentNotRegisteredErrorMsg": "Le type de pièce jointe n'est pas enregistré",
     "xpack.cases.userActions.attachmentRenderErrorMsg": "Impossible d'afficher cette pièce jointe",
-    "xpack.cases.userActions.attachments.registeredAttachment.successToasterTitle": "Pièce jointe supprimée",
     "xpack.cases.userActions.comment.unsavedDraftComment": "Vous avez des modifications non enregistrées pour ce commentaire",
     "xpack.cases.userActions.defaultEventAttachmentTitle": "ajouté une pièce jointe de type",
     "xpack.cases.userActions.deleteAttachment": "Supprimer la pièce jointe",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -17543,7 +17543,6 @@
     "xpack.cases.userActions.attachment": "添付ファイル",
     "xpack.cases.userActions.attachmentNotRegisteredErrorMsg": "アラートタイプが登録されていません",
     "xpack.cases.userActions.attachmentRenderErrorMsg": "この添付ファイルをレンダリングできませんでした",
-    "xpack.cases.userActions.attachments.registeredAttachment.successToasterTitle": "削除された添付ファイル",
     "xpack.cases.userActions.comment.unsavedDraftComment": "このコメントに、保存されていない編集があります",
     "xpack.cases.userActions.defaultEventAttachmentTitle": "タイプの添付ファイルが追加されました",
     "xpack.cases.userActions.deleteAttachment": "添付ファイルの削除",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -17551,7 +17551,6 @@
     "xpack.cases.userActions.attachment": "附件",
     "xpack.cases.userActions.attachmentNotRegisteredErrorMsg": "未注册附件类型",
     "xpack.cases.userActions.attachmentRenderErrorMsg": "无法渲染此附件",
-    "xpack.cases.userActions.attachments.registeredAttachment.successToasterTitle": "已删除附件",
     "xpack.cases.userActions.comment.unsavedDraftComment": "此注释具有未保存编辑",
     "xpack.cases.userActions.defaultEventAttachmentTitle": "已添加以下类型的附件",
     "xpack.cases.userActions.deleteAttachment": "删除附件",

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.test.tsx
@@ -213,7 +213,7 @@ describe('createCommentUserActionBuilder', () => {
       expect(screen.getByText('removed endpoint attachment')).toBeInTheDocument();
     });
 
-    it('falls back to the common label for a registered type without a removal object', async () => {
+    it('falls back to the attachment displayName for a registered type without a removal object', async () => {
       const unifiedAttachmentTypeRegistry = new UnifiedAttachmentTypeRegistry();
       unifiedAttachmentTypeRegistry.register(getCommentAttachmentType());
       unifiedAttachmentTypeRegistry.register({
@@ -246,7 +246,7 @@ describe('createCommentUserActionBuilder', () => {
       const createdUserAction = builder.build();
       renderWithTestingProviders(<EuiCommentList comments={createdUserAction} />);
 
-      expect(screen.getByText('removed attachment')).toBeInTheDocument();
+      expect(screen.getByText('removed endpoint')).toBeInTheDocument();
     });
 
     it('renders correctly when deleting a unified value attachment', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.test.tsx
@@ -246,7 +246,7 @@ describe('createCommentUserActionBuilder', () => {
       const createdUserAction = builder.build();
       renderWithTestingProviders(<EuiCommentList comments={createdUserAction} />);
 
-      expect(screen.getByText('removed endpoint')).toBeInTheDocument();
+      expect(screen.getByText('removed endpoint attachment')).toBeInTheDocument();
     });
 
     it('renders correctly when deleting a unified value attachment', async () => {
@@ -857,7 +857,7 @@ describe('createCommentUserActionBuilder', () => {
         await waitFor(() => {
           expect(builderArgs.handleDeleteComment).toHaveBeenCalledWith(
             'persistable-state-comment-id',
-            'Deleted attachment'
+            'Deleted Lens attachment'
           );
         });
       });

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.test.tsx
@@ -246,7 +246,7 @@ describe('createCommentUserActionBuilder', () => {
       const createdUserAction = builder.build();
       renderWithTestingProviders(<EuiCommentList comments={createdUserAction} />);
 
-      expect(screen.getByText('removed endpoint attachment')).toBeInTheDocument();
+      expect(screen.getByText('removed Endpoint attachment')).toBeInTheDocument();
     });
 
     it('renders correctly when deleting a unified value attachment', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.tsx
@@ -83,7 +83,7 @@ const getDeleteLabelFromRegistry = ({
 
   return attachmentLabel != null
     ? attachmentLabel
-    : `${i18n.REMOVED_FIELD} ${attachmentType.displayName.toLowerCase()}`;
+    : `${i18n.REMOVED_FIELD} ${attachmentType.displayName.toLowerCase()} ${i18n.ATTACHMENT.toLowerCase()}`;
 };
 
 const getDeleteCommentUserAction = ({

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.tsx
@@ -81,7 +81,9 @@ const getDeleteLabelFromRegistry = ({
   const attachmentType = registry.get(attachmentTypeId);
   const attachmentLabel = attachmentType.getAttachmentRemovalObject?.(props).event ?? null;
 
-  return attachmentLabel != null ? attachmentLabel : registeredAttachmentCommonLabel;
+  return attachmentLabel != null
+    ? attachmentLabel
+    : `${i18n.REMOVED_FIELD} ${attachmentType.displayName.toLowerCase()}`;
 };
 
 const getDeleteCommentUserAction = ({

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.tsx
@@ -83,7 +83,9 @@ const getDeleteLabelFromRegistry = ({
 
   return attachmentLabel != null
     ? attachmentLabel
-    : `${i18n.REMOVED_FIELD} ${attachmentType.displayName.toLowerCase()} ${i18n.ATTACHMENT.toLowerCase()}`;
+    : `${
+        i18n.REMOVED_FIELD
+      } ${attachmentType.displayName.toLowerCase()} ${i18n.ATTACHMENT.toLowerCase()}`;
 };
 
 const getDeleteCommentUserAction = ({

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/comment.tsx
@@ -83,9 +83,7 @@ const getDeleteLabelFromRegistry = ({
 
   return attachmentLabel != null
     ? attachmentLabel
-    : `${
-        i18n.REMOVED_FIELD
-      } ${attachmentType.displayName.toLowerCase()} ${i18n.ATTACHMENT.toLowerCase()}`;
+    : i18n.getRemovedRegisteredAttachmentLabel(attachmentType.displayName);
 };
 
 const getDeleteCommentUserAction = ({

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/registered_attachments.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/registered_attachments.tsx
@@ -31,7 +31,6 @@ import type { SnakeToCamelCase } from '../../../../common/types';
 import {
   ATTACHMENT_NOT_REGISTERED_ERROR,
   DEFAULT_EVENT_ATTACHMENT_TITLE,
-  DELETE_REGISTERED_ATTACHMENT,
   getDeleteRegisteredAttachmentTitle,
 } from './translations';
 import { UserActionContentToolbar } from '../content_toolbar';

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/registered_attachments.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/registered_attachments.tsx
@@ -32,6 +32,7 @@ import {
   ATTACHMENT_NOT_REGISTERED_ERROR,
   DEFAULT_EVENT_ATTACHMENT_TITLE,
   DELETE_REGISTERED_ATTACHMENT,
+  getDeleteRegisteredAttachmentTitle,
 } from './translations';
 import { UserActionContentToolbar } from '../content_toolbar';
 import { HoverableUserWithAvatarResolver } from '../../user_profiles/hoverable_user_with_avatar_resolver';
@@ -133,7 +134,8 @@ export const createRegisteredAttachmentUserActionBuilder = <
 
     const attachmentViewObject = attachmentType.getAttachmentViewObject(props);
     const deleteSuccessTitle =
-      attachmentViewObject.deleteSuccessTitle ?? DELETE_REGISTERED_ATTACHMENT;
+      attachmentViewObject.deleteSuccessTitle ??
+      getDeleteRegisteredAttachmentTitle(attachmentType.displayName);
 
     const renderer = getAttachmentRenderer(userAction.id);
     const actions = attachmentViewObject.getActions?.(props) ?? [];

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/translations.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/translations.tsx
@@ -51,7 +51,7 @@ export const getDeleteRegisteredAttachmentTitle = (displayName: string) =>
   i18n.translate(
     'xpack.cases.userActions.attachments.registeredAttachment.successToasterTitleWithType',
     {
-      defaultMessage: 'Deleted {displayName}',
+      defaultMessage: 'Deleted {displayName} attachment',
       values: { displayName },
     }
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/translations.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/translations.tsx
@@ -46,3 +46,12 @@ export const DELETE_REGISTERED_ATTACHMENT = i18n.translate(
     defaultMessage: 'Deleted attachment',
   }
 );
+
+export const getDeleteRegisteredAttachmentTitle = (displayName: string) =>
+  i18n.translate(
+    'xpack.cases.userActions.attachments.registeredAttachment.successToasterTitleWithType',
+    {
+      defaultMessage: 'Deleted {displayName}',
+      values: { displayName },
+    }
+  );

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/translations.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/comment/translations.tsx
@@ -40,13 +40,6 @@ export const UNSAVED_DRAFT_COMMENT = i18n.translate(
   }
 );
 
-export const DELETE_REGISTERED_ATTACHMENT = i18n.translate(
-  'xpack.cases.userActions.attachments.registeredAttachment.successToasterTitle',
-  {
-    defaultMessage: 'Deleted attachment',
-  }
-);
-
 export const getDeleteRegisteredAttachmentTitle = (displayName: string) =>
   i18n.translate(
     'xpack.cases.userActions.attachments.registeredAttachment.successToasterTitleWithType',
@@ -55,3 +48,9 @@ export const getDeleteRegisteredAttachmentTitle = (displayName: string) =>
       values: { displayName },
     }
   );
+
+export const getRemovedRegisteredAttachmentLabel = (displayName: string) =>
+  i18n.translate('xpack.cases.userActions.removedAttachmentTypeLabel', {
+    defaultMessage: 'removed {displayName} attachment',
+    values: { displayName },
+  });


### PR DESCRIPTION
## Summary

Deleting an attachment type that hasn't implemented its own labels shows a generic **"removed attachment"** / **"Deleted attachment"**. 

This PR uses `displayName` (already required on every registered type) as the default, so Endpoint, Lens, Indicators, Entity, and any future type get a typed activity entry and success toast without implementing `getAttachmentRemovalObject` or `deleteSuccessTitle`.

- Activity: `removed Endpoint attachment`
- Toast: `Deleted Endpoint attachment`

Types that already set those APIs (alerts, events, timelines) are unchanged; their labels still win. Unregistered types still fall back to `removed attachment`.

**NB:** The word **attachment** stays in the default so `Deleted Entities` isn't read as deleting the entities themselves. `displayName` is the collection label (Alerts, Entities, Files), so this default is not count-aware - types that need `Deleted 2 alerts` should keep implementing `deleteSuccessTitle`, as alerts already do.

### Before vs After

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/f17ef5d9-5f3e-4030-93d5-1b0779af0b3d"></video> | <video src="https://github.com/user-attachments/assets/97c895c2-8123-432f-997d-3cca208b581a"></video> |

## Testing

- Delete a registered type without custom delete labels → activity `removed <displayName> attachment`, toast `Deleted <displayName> attachment`
- Delete a type that implements `deleteSuccessTitle` / `getAttachmentRemovalObject` (e.g. alert) → existing labels unchanged
- Delete an unregistered type → still `removed attachment`
