### PR TITLE
[Agent Builder] Add filter parameter to execute_esql tool

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/esql/execute_esql.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/esql/execute_esql.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { errors } from '@elastic/elasticsearch';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { MAX_ES_RESPONSE_SIZE_BYTES } from '../../constants';
+import { executeEsql } from './execute_esql';
+
+describe('executeEsql', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+
+  const esqlResponse = {
+    columns: [{ name: 'foo', type: 'keyword' as const }],
+    values: [['bar']],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.esql.query.mockResolvedValue(esqlResponse);
+  });
+
+  const lastRequest = () => esClient.esql.query.mock.calls[0][0];
+
+  it('passes the query through with the standard request options', async () => {
+    const result = await executeEsql({ query: 'FROM idx', esClient });
+
+    expect(lastRequest()).toEqual({
+      query: 'FROM idx',
+      drop_null_columns: true,
+      allow_partial_results: true,
+    });
+    expect(esClient.esql.query.mock.calls[0][1]).toEqual({
+      maxResponseSize: MAX_ES_RESPONSE_SIZE_BYTES,
+    });
+    expect(result).toEqual(esqlResponse);
+  });
+
+  it('forwards the filter to Elasticsearch when one is provided', async () => {
+    const filter = { term: { status: 'open' } };
+
+    await executeEsql({ query: 'FROM idx', filter, esClient });
+
+    expect(lastRequest()).toEqual(expect.objectContaining({ filter }));
+  });
+
+  it('omits the filter key entirely when none is provided', async () => {
+    await executeEsql({ query: 'FROM idx', esClient });
+
+    expect(lastRequest()).not.toHaveProperty('filter');
+  });
+
+  it('omits the filter key when it is explicitly undefined', async () => {
+    await executeEsql({ query: 'FROM idx', filter: undefined, esClient });
+
+    expect(lastRequest()).not.toHaveProperty('filter');
+  });
+
+  it('sends params and filter together without either overwriting the other', async () => {
+    const filter = { range: { '@timestamp': { gte: 'now-1h' } } };
+
+    await executeEsql({
+      query: 'FROM idx | WHERE host == ?host',
+      params: [{ host: 'server-1' }],
+      filter,
+      esClient,
+    });
+
+    expect(lastRequest()).toEqual(
+      expect.objectContaining({
+        query: 'FROM idx | WHERE host == ?host',
+        params: [{ host: 'server-1' }],
+        filter,
+      })
+    );
+  });
+
+  it('applies the limit to the query while leaving the filter untouched', async () => {
+    const filter = { term: { status: 'open' } };
+
+    await executeEsql({ query: 'FROM idx', limit: 10, filter, esClient });
+
+    expect(lastRequest()).toEqual(
+      expect.objectContaining({ query: 'FROM idx | LIMIT 10', filter })
+    );
+  });
+
+  it('translates a maximum-response-size abort into an actionable error', async () => {
+    esClient.esql.query.mockRejectedValue(
+      new errors.RequestAbortedError(
+        'The content length (9000) is bigger than the maximum allowed buffer (42)'
+      )
+    );
+
+    await expect(executeEsql({ query: 'FROM idx', esClient })).rejects.toThrow(
+      /exceeded the maximum allowed size of 20MB/
+    );
+  });
+
+  it('rethrows any other Elasticsearch error unchanged', async () => {
+    const error = new Error('verification_exception: unknown column [missing]');
+    esClient.esql.query.mockRejectedValue(error);
+
+    await expect(
+      executeEsql({ query: 'FROM idx', filter: { term: { status: 'open' } }, esClient })
+    ).rejects.toThrow(error);
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/esql/execute_esql.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/esql/execute_esql.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import type { EsqlEsqlColumnInfo, FieldValue } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  EsqlEsqlColumnInfo,
+  FieldValue,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { isMaximumResponseSizeExceededError } from '@kbn/es-errors';
 import { MAX_ES_RESPONSE_SIZE_BYTES } from '../../constants';
@@ -25,16 +29,22 @@ export interface EsqlResponse {
  * When `limit` is provided, the query is rewritten so the ES|QL engine enforces the cap. If the
  * query already ends with a `LIMIT N`, the trailing limit becomes `min(N, limit)`; otherwise a
  * new `| LIMIT <limit>` pipe is appended. See `applyLimit` for full semantics.
+ *
+ * `filter` is a Query DSL container that only ever narrows the result set. It is not a `WHERE`
+ * clause and cannot reference `?named` params, because Elasticsearch parses it separately from the
+ * query text.
  */
 export const executeEsql = async ({
   query,
   params,
   limit,
+  filter,
   esClient,
 }: {
   query: string;
   params?: Array<Record<string, FieldValue>>;
   limit?: number;
+  filter?: QueryDslQueryContainer;
   esClient: ElasticsearchClient;
 }): Promise<EsqlResponse> => {
   const effectiveQuery = limit !== undefined ? applyLimit(query, limit) : query;
@@ -46,6 +56,7 @@ export const executeEsql = async ({
         drop_null_columns: true,
         allow_partial_results: true,
         ...(params && params.length > 0 ? { params: params as unknown as FieldValue[] } : {}),
+        ...(filter ? { filter } : {}),
       },
       { maxResponseSize: MAX_ES_RESPONSE_SIZE_BYTES }
     );

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.test.ts
@@ -126,4 +126,58 @@ describe('executeEsqlTool', () => {
     const esqlResults = result.results.find((r) => r.type === ToolResultType.esqlResults);
     expect(esqlResults?.data).not.toHaveProperty('time_range');
   });
+
+  describe('filter', () => {
+    it('forwards a supplied filter to the ES|QL helper', async () => {
+      const tool = executeEsqlTool();
+      const filter = { term: { status: 'open' } };
+
+      await tool.handler({ query: 'FROM logs', limit: 100, filter }, createHandlerContext() as any);
+
+      expect(executeEsqlMock.mock.calls[0][0]).toMatchObject({ filter });
+    });
+
+    it('passes no filter when the caller omits one', async () => {
+      const tool = executeEsqlTool();
+
+      await tool.handler({ query: 'FROM logs', limit: 100 }, createHandlerContext() as any);
+
+      expect(executeEsqlMock.mock.calls[0][0].filter).toBeUndefined();
+    });
+
+    it('keeps the filter out of the echoed ES|QL query', async () => {
+      const tool = executeEsqlTool();
+      const filter = { range: { '@timestamp': { gte: 'now-1h' } } };
+
+      const result = (await tool.handler(
+        {
+          query: 'FROM logs | WHERE host == ?host',
+          params: { host: 'server-1' },
+          limit: 100,
+          filter,
+        },
+        createHandlerContext() as any
+      )) as ToolHandlerStandardReturn;
+
+      expect(executeEsqlMock.mock.calls[0][0]).toMatchObject({
+        query: 'FROM logs | WHERE host == ?host',
+        filter,
+      });
+
+      const query = result.results.find((r) => r.type === ToolResultType.query);
+      expect((query?.data as { esql: string }).esql).not.toContain('range');
+    });
+
+    it('propagates a rejected filter so the runner can convert it into an error result', async () => {
+      const tool = executeEsqlTool();
+      executeEsqlMock.mockRejectedValue(new Error('parsing_exception: unknown query [nope]'));
+
+      await expect(
+        tool.handler(
+          { query: 'FROM logs', limit: 100, filter: { nope: {} } },
+          createHandlerContext() as any
+        )
+      ).rejects.toThrow('parsing_exception');
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.test.ts
@@ -168,6 +168,32 @@ describe('executeEsqlTool', () => {
       expect((query?.data as { esql: string }).esql).not.toContain('range');
     });
 
+    it('accepts a verbose filter that stays under the size limit', () => {
+      const filter = {
+        bool: {
+          should: Array.from({ length: 500 }, (_, i) => ({ term: { host: `server-${i}` } })),
+          minimum_should_match: 1,
+        },
+      };
+
+      expect(executeEsqlTool().schema.safeParse({ query: 'FROM logs', filter }).success).toBe(true);
+    });
+
+    it('rejects a filter that exceeds the size limit once serialized', () => {
+      const filter = {
+        bool: {
+          should: Array.from({ length: 5000 }, (_, i) => ({ term: { host: `server-${i}` } })),
+          minimum_should_match: 1,
+        },
+      };
+      expect(JSON.stringify(filter).length).toBeGreaterThan(100_000);
+
+      const result = executeEsqlTool().schema.safeParse({ query: 'FROM logs', filter });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain('at most 100000 characters');
+    });
+
     it('propagates a rejected filter so the runner can convert it into an error result', async () => {
       const tool = executeEsqlTool();
       executeEsqlMock.mockRejectedValue(new Error('parsing_exception: unknown query [nope]'));

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FieldValue } from '@elastic/elasticsearch/lib/api/types';
+import type { FieldValue, QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { z } from '@kbn/zod/v4';
 import { platformCoreTools, ToolType } from '@kbn/agent-builder-common';
 import { hasStartEndParams } from '@kbn/esql-utils';
@@ -41,6 +41,12 @@ const executeEsqlToolSchema = z.object({
     .optional()
     .default(100)
     .describe('(Optional) Can be set to limit the number of results to return. Defaults to 100.'),
+  filter: z
+    .record(z.string().max(1024), z.unknown())
+    .optional()
+    .describe(
+      '(Optional) An Elasticsearch Query DSL object combined with the query using AND, e.g. {"term": {"status": "open"}}. It can only narrow the results, never widen them. This is not a WHERE clause: it is pushed down to the data source, so it removes documents before any ES|QL command sees them, and it is parsed separately from the query text, so it cannot reference ?named parameters.'
+    ),
 });
 
 export const executeEsqlTool = (): BuiltinToolDefinition<typeof executeEsqlToolSchema> => {
@@ -65,10 +71,23 @@ If you need a query, use the \`${platformCoreTools.generateEsql}\` tool first.
 
 The \`limit\` parameter can be used to limit the number of results to return. It defaults to 100.
 You should avoid using a higher limit value unless explicitly asked by the user or if you know for sure the length of the data will not be a problem.
-Note that this option can't be used to increase the number of results if the query already defines a \`LIMIT\` clause - the lowest limit will always prevail.`,
+Note that this option can't be used to increase the number of results if the query already defines a \`LIMIT\` clause - the lowest limit will always prevail.
+
+### Using a filter
+
+The \`filter\` parameter takes an Elasticsearch Query DSL object that is combined with the query using AND, and can only narrow the results.
+Use it only when something outside the query itself requires the results to be narrowed; it is not a substitute for writing a \`WHERE\` clause in the query.
+It is parsed separately from the query text, so it cannot reference \`?named\` parameters.
+Prefer a filter that every targeted index can match: against a wildcard pattern such as \`FROM logs-*\`, a clause naming a field that only some indices have will drop the others from the results.`,
     schema: executeEsqlToolSchema,
     handler: async (
-      { query: esqlQuery, params: esqlParams = {}, time_range: explicitTimeRange, limit = 100 },
+      {
+        query: esqlQuery,
+        params: esqlParams = {},
+        time_range: explicitTimeRange,
+        limit = 100,
+        filter: esqlFilter,
+      },
       { esClient, attachments }
     ) => {
       const usesTimeRangeParams = hasStartEndParams(esqlQuery);
@@ -87,6 +106,7 @@ Note that this option can't be used to increase the number of results if the que
         params,
         esClient: esClient.asCurrentUser,
         limit,
+        filter: esqlFilter as QueryDslQueryContainer | undefined,
       });
 
       // need the interpolated query to return in the results / to display in the UI

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/execute_esql.ts
@@ -19,6 +19,13 @@ import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
 import { getToolResultId } from '@kbn/agent-builder-server/tools';
 import { resolveTimeRange } from './screen_context_utils';
 
+/**
+ * Elasticsearch caps a request body at 100MB; this is a courtesy bound well under it. It has to be
+ * checked against the serialized filter, since `z.record`'s key schema bounds key names only and
+ * leaves the value side unbounded.
+ */
+const MAX_FILTER_LENGTH = 100_000;
+
 const executeEsqlToolSchema = z.object({
   query: z.string().describe('The ES|QL query to execute'),
   params: z
@@ -42,7 +49,10 @@ const executeEsqlToolSchema = z.object({
     .default(100)
     .describe('(Optional) Can be set to limit the number of results to return. Defaults to 100.'),
   filter: z
-    .record(z.string().max(1024), z.unknown())
+    .record(z.string().max(MAX_FILTER_LENGTH), z.unknown())
+    .refine((filter) => JSON.stringify(filter).length <= MAX_FILTER_LENGTH, {
+      message: `Filters must be at most ${MAX_FILTER_LENGTH} characters once serialized for agent input`,
+    })
     .optional()
     .describe(
       '(Optional) An Elasticsearch Query DSL object combined with the query using AND, e.g. {"term": {"status": "open"}}. It can only narrow the results, never widen them. This is not a WHERE clause: it is pushed down to the data source, so it removes documents before any ES|QL command sees them, and it is parsed separately from the query text, so it cannot reference ?named parameters.'


### PR DESCRIPTION
## Summary

Adds an optional `filter` parameter to the `execute_esql` tool, forwarded to the ES|QL API's
[`filter`](https://www.elastic.co/docs/reference/query-languages/esql/esql-rest#esql-rest-filtering)
field via the shared `executeEsql` helper.

The filter is a Query DSL container that Elasticsearch ANDs into the query. It can only narrow a
result set, never widen one, and the query still runs as `asCurrentUser`, so it cannot affect
access.

Schema follows the existing convention for arbitrary objects (`execute_workflow`,
`resume_workflow_execution`, `ad_create_job`): `z.record(z.string().max(1024), z.unknown())`.
Malformed DSL is rejected by Elasticsearch, and `runInternalTool` already converts that into a
`ToolResultType.error` the model can retry from, so no bespoke validation is needed.

Groundwork only — a follow-up PR updates the agent system prompt to teach the model when to pass a
filter. No caller passes one today.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- The tool schema is model-facing, so a model may pass a filter before the prompt work lands.
  Bounded: a filter can only narrow results, and a bad one returns a recoverable tool error.
- Elasticsearch also uses this filter as the `index_filter` during field resolution, so under a
  wildcard pattern a clause naming a field only some indices have will drop the others. When the
  query names such a field, analysis fails and Elasticsearch transparently retries without the
  filter; only implicit projections lose columns silently. Documented in the helper docstring and
  in the model-facing description.