### PR TITLE
[9.5] [Entity Store] Drop Okta name fragments from related.user alias resolution (#280868)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/left.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/left.ts
@@ -23,6 +23,22 @@ const OKTA_MANAGER_FIELDS = [
   'user.profile.manager',
   'entityanalytics_okta.user.profile.manager.name',
 ] as const;
+// Okta appends personal name fragments into related.user. Bare values like
+// "Emily" / "Stone" collide across unrelated people when matched against
+// user.name / user.full_name. Display name is intentionally kept for
+// display-name bridging; only the fragment fields are excluded.
+const OKTA_NAME_FRAGMENT_FIELDS = [
+  'user.profile.first_name',
+  'user.profile.last_name',
+  'entityanalytics_okta.user.profile.first_name',
+  'entityanalytics_okta.user.profile.last_name',
+  'entityanalytics_okta.user.profile.middle_name',
+  'entityanalytics_okta.user.profile.nick_name',
+] as const;
+const OKTA_EXCLUDED_RELATED_USER_FIELDS = [
+  ...OKTA_MANAGER_FIELDS,
+  ...OKTA_NAME_FRAGMENT_FIELDS,
+] as const;
 
 const toStringValues = (value: unknown): string[] => {
   if (Array.isArray(value)) {
@@ -119,6 +135,8 @@ export const readRelatedUserBundleForSeed = async ({
 
   return {
     relatedUsers: getFieldStringValues(source, RELATED_USER_FIELD),
-    excludedValues: OKTA_MANAGER_FIELDS.flatMap((field) => getFieldStringValues(source, field)),
+    excludedValues: OKTA_EXCLUDED_RELATED_USER_FIELDS.flatMap((field) =>
+      getFieldStringValues(source, field)
+    ),
   };
 };

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/run.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/run.test.ts
@@ -224,7 +224,7 @@ describe('runRelatedUserAliasResolution', () => {
         }),
       })
     );
-    expect(cascadeLinkEntities).toHaveBeenCalledWith('user:ad', ['user:seed@example.com@entra_id']);
+    expect(cascadeLinkEntities).toHaveBeenCalledWith('user:seed@example.com@entra_id', ['user:ad']);
     expect(result.lastRun).toMatchObject({ linksCreated: 1 });
   });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/run.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/rules/maintainers/related_user_alias_resolution/run.test.ts
@@ -156,6 +156,78 @@ describe('runRelatedUserAliasResolution', () => {
     expect(result.lastRun).toMatchObject({ linksCreated: 0 });
   });
 
+  it('drops okta name-fragment values before candidate lookup', async () => {
+    esClient.search
+      .mockResolvedValueOnce(createSearchResponse([createSeed()]) as never)
+      .mockResolvedValueOnce(
+        createSearchResponse([
+          createSourceDoc(['Emily', 'Stone', 'Marie', 'Em'], {
+            'user.profile.first_name': 'Emily',
+            'user.profile.last_name': 'Stone',
+            'entityanalytics_okta.user.profile.first_name': 'Emily',
+            'entityanalytics_okta.user.profile.last_name': 'Stone',
+            'entityanalytics_okta.user.profile.middle_name': 'Marie',
+            'entityanalytics_okta.user.profile.nick_name': 'Em',
+          }),
+        ]) as never
+      );
+
+    const result = await runRelatedUserAliasResolution(createDeps({ esClient, resolutionClient }));
+
+    expect(esClient.search).toHaveBeenCalledTimes(2);
+    expect(cascadeLinkEntities).not.toHaveBeenCalled();
+    expect(result.lastRun).toMatchObject({ linksCreated: 0 });
+  });
+
+  it('keeps display_name for intentional display-name bridging after dropping fragments', async () => {
+    esClient.search
+      .mockResolvedValueOnce(createSearchResponse([createSeed()]) as never)
+      .mockResolvedValueOnce(
+        createSearchResponse([
+          createSourceDoc(['Emily', 'Stone', 'Emily Stone'], {
+            'user.profile.first_name': 'Emily',
+            'user.profile.last_name': 'Stone',
+            'entityanalytics_okta.user.profile.display_name': 'Emily Stone',
+          }),
+        ]) as never
+      )
+      .mockResolvedValueOnce(
+        createSearchResponse([
+          {
+            ...createCandidate('user:ad', 'active_directory', 'other-login'),
+            'user.full_name': 'Emily Stone',
+          },
+        ]) as never
+      );
+
+    const result = await runRelatedUserAliasResolution(createDeps({ esClient, resolutionClient }));
+
+    expect(esClient.search).toHaveBeenCalledTimes(3);
+    expect(esClient.search.mock.calls[2][0]).toEqual(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          bool: expect.objectContaining({
+            filter: expect.arrayContaining([
+              expect.objectContaining({
+                bool: expect.objectContaining({
+                  should: expect.arrayContaining([
+                    {
+                      term: {
+                        'user.full_name': { value: 'Emily Stone', case_insensitive: true },
+                      },
+                    },
+                  ]),
+                }),
+              }),
+            ]),
+          }),
+        }),
+      })
+    );
+    expect(cascadeLinkEntities).toHaveBeenCalledWith('user:ad', ['user:seed@example.com@entra_id']);
+    expect(result.lastRun).toMatchObject({ linksCreated: 1 });
+  });
+
   it('drops well-known SID and generic service account values before candidate lookup', async () => {
     esClient.search
       .mockResolvedValueOnce(createSearchResponse([createSeed()]) as never)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Entity Store] Drop Okta name fragments from related.user alias resolution (#280868)](https://github.com/elastic/kibana/pull/280868)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Kholod","email":"maxim.kholod@elastic.co"},"sourceCommit":{"committedDate":"2026-08-06T18:22:32Z","message":"[Entity Store] Drop Okta name fragments from related.user alias resolution (#280868)\n\n## Summary\n\nFixes #278418.\n\nThe `related_user_alias_resolution` bridge rule reads a seed's\n`related.user` list and links entities whose identity fields match those\nvalues. Okta's ingest pipeline appends personal name fragments\n(`first_name`, `last_name`, `middle_name`, `nick_name`) into\n`related.user`, which are far more collision-prone than stable\nidentifiers and can create false alias links between unrelated people\nwho share a common name.\n\nThis change extends the existing Okta exclusion path (already used for\nmanager fields) so those name-fragment source values are dropped before\ncandidate lookup. Display name is intentionally kept for display-name\nbridging.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n**False-negative alias links (low):** Dropping name fragments means we\nno longer bridge solely on bare given/family/nick names. Mitigation:\nidentifiers (`user.id`, login, email) and display name remain; the rule\nis still OFF by default. Severity: low — preferred over false-positive\nlinks across unrelated people.","sha":"d946adf09ffa0f23ff5a4a5495205057b18b3e44","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Cloud Security","backport:version","v9.5.0","v9.6.0"],"title":"[Entity Store] Drop Okta name fragments from related.user alias resolution","number":280868,"url":"https://github.com/elastic/kibana/pull/280868","mergeCommit":{"message":"[Entity Store] Drop Okta name fragments from related.user alias resolution (#280868)\n\n## Summary\n\nFixes #278418.\n\nThe `related_user_alias_resolution` bridge rule reads a seed's\n`related.user` list and links entities whose identity fields match those\nvalues. Okta's ingest pipeline appends personal name fragments\n(`first_name`, `last_name`, `middle_name`, `nick_name`) into\n`related.user`, which are far more collision-prone than stable\nidentifiers and can create false alias links between unrelated people\nwho share a common name.\n\nThis change extends the existing Okta exclusion path (already used for\nmanager fields) so those name-fragment source values are dropped before\ncandidate lookup. Display name is intentionally kept for display-name\nbridging.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n**False-negative alias links (low):** Dropping name fragments means we\nno longer bridge solely on bare given/family/nick names. Mitigation:\nidentifiers (`user.id`, login, email) and display name remain; the rule\nis still OFF by default. Severity: low — preferred over false-positive\nlinks across unrelated people.","sha":"d946adf09ffa0f23ff5a4a5495205057b18b3e44"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/280868","number":280868,"mergeCommit":{"message":"[Entity Store] Drop Okta name fragments from related.user alias resolution (#280868)\n\n## Summary\n\nFixes #278418.\n\nThe `related_user_alias_resolution` bridge rule reads a seed's\n`related.user` list and links entities whose identity fields match those\nvalues. Okta's ingest pipeline appends personal name fragments\n(`first_name`, `last_name`, `middle_name`, `nick_name`) into\n`related.user`, which are far more collision-prone than stable\nidentifiers and can create false alias links between unrelated people\nwho share a common name.\n\nThis change extends the existing Okta exclusion path (already used for\nmanager fields) so those name-fragment source values are dropped before\ncandidate lookup. Display name is intentionally kept for display-name\nbridging.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n**False-negative alias links (low):** Dropping name fragments means we\nno longer bridge solely on bare given/family/nick names. Mitigation:\nidentifiers (`user.id`, login, email) and display name remain; the rule\nis still OFF by default. Severity: low — preferred over false-positive\nlinks across unrelated people.","sha":"d946adf09ffa0f23ff5a4a5495205057b18b3e44"}}]}] BACKPORT-->