### PR TITLE
[Cases] Enable assignee population in Serverless

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/create.ts
@@ -249,8 +249,7 @@ export const create = async (
 
     // Server-derived assignee identity: resolve profile uids to username /
     // full_name / email so downstream consumers (e.g. cases-as-data analytics)
-    // can read human-readable assignees. Gated until the MV10 mapping is rolled
-    // out fleet-wide (off by default on serverless).
+    // can read human-readable assignees. Gated by feature flag `assigneeIdentity`.
     if (clientArgs.config.assigneeIdentity.enabled) {
       attributes.assignees =
         (await populateAssigneesIdentity(

--- a/x-pack/platform/plugins/shared/cases/server/client/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/mocks.ts
@@ -291,7 +291,7 @@ export const createCasesClientMockArgs = () => {
     // the broad create/update suites keep asserting uid-only assignees.
     config: {
       ...ConfigSchema.validate({}),
-      assigneeIdentity: { enabled: false },
+      assigneeIdentity: { enabled: true },
     },
     casesEventBus: createCasesEventBusMock(),
     request: httpServerMock.createKibanaRequest(),

--- a/x-pack/platform/plugins/shared/cases/server/client/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/mocks.ts
@@ -287,8 +287,7 @@ export const createCasesClientMockArgs = () => {
     ),
     savedObjectsSerializer: createSavedObjectsSerializerMock(),
     fileService: createFileServiceMock(),
-    // Assignee-identity population is opt-in per test; keep it off by default so
-    // the broad create/update suites keep asserting uid-only assignees.
+    // Assignee-identity population is on by default
     config: {
       ...ConfigSchema.validate({}),
       assigneeIdentity: { enabled: true },

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -19,10 +19,7 @@ export const ConfigSchema = schema.object({
    * `full_name`, `email`) on the cases saved object at write time.
    */
   assigneeIdentity: schema.object({
-    enabled: offeringBasedSchema({
-      serverless: schema.boolean({ defaultValue: false }),
-      traditional: schema.boolean({ defaultValue: true }),
-    }),
+    enabled: schema.boolean({ defaultValue: true }),
   }),
   analytics: schema.object({
     index: schema.object({


### PR DESCRIPTION
## Summary

A followup to https://github.com/elastic/kibana/pull/281579 that enabled assignee enrichment in serverless. In Cases as data V2, user can now see full name, user name and email.


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->