### PR TITLE
[9.5] [One workflows] Do not require `read` to execute a workflow (#284822)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -65417,7 +65417,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a single step from a workflow definition in test mode.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a single step from a workflow definition in test mode.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-step-test
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -65530,7 +65530,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a workflow in test mode without requiring it to be saved or enabled. Provide either a workflow ID to test a saved workflow, a YAML definition to test an unsaved draft, or both to test a modified version of an existing workflow.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a workflow in test mode without requiring it to be saved or enabled. Provide either a workflow ID to test a saved workflow, a YAML definition to test an unsaved draft, or both to test a modified version of an existing workflow.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-test
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -66124,7 +66124,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a workflow by its ID with the provided inputs. The workflow must be enabled and have a valid definition. Returns an execution ID that can be used to monitor progress.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a workflow by its ID with the provided inputs. The workflow must be enabled and have a valid definition. Returns an execution ID that can be used to monitor progress.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-workflow-id-run
       parameters:
         - description: A required header to protect against CSRF attacks

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -73372,7 +73372,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a single step from a workflow definition in test mode.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a single step from a workflow definition in test mode.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-step-test
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -73485,7 +73485,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a workflow in test mode without requiring it to be saved or enabled. Provide either a workflow ID to test a saved workflow, a YAML definition to test an unsaved draft, or both to test a modified version of an existing workflow.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a workflow in test mode without requiring it to be saved or enabled. Provide either a workflow ID to test a saved workflow, a YAML definition to test an unsaved draft, or both to test a modified version of an existing workflow.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-test
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -74079,7 +74079,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Execute a workflow by its ID with the provided inputs. The workflow must be enabled and have a valid definition. Returns an execution ID that can be used to monitor progress.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute AND workflowsManagement:read.
+        Execute a workflow by its ID with the provided inputs. The workflow must be enabled and have a valid definition. Returns an execution ID that can be used to monitor progress.<br/><br/>[Required authorization] Route required privileges: workflowsManagement:execute.
       operationId: post-workflows-workflow-id-run
       parameters:
         - description: A required header to protect against CSRF attacks

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/tests/route_privilege_consistency.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/tests/route_privilege_consistency.test.ts
@@ -145,6 +145,11 @@ const INTERNAL_READ_EXCEPTIONS: Record<string, string[]> = {
   'POST:/api/workflows': [WORKFLOWS_INDEX],
   // Existence check before cancelAllActiveWorkflowExecutions (see WorkflowsManagementApi.cancelAllActiveWorkflowExecutions)
   'POST:/api/workflows/workflow/{workflowId}/executions/cancel': [WORKFLOWS_INDEX],
+  // Executing a persisted workflow loads its document to build the execution
+  // model. The definition is never returned to the caller (only an execution
+  // id), so running a workflow does not require the `read` privilege.
+  'POST:/api/workflows/workflow/{id}/run': [WORKFLOWS_INDEX],
+  'POST:/api/workflows/test': [WORKFLOWS_INDEX],
   // Resume resolves the waiting `waitForInput` step (by run id) before claiming
   // it — an internal lookup intrinsic to the resume action, not data exposed to
   // the caller. See WorkflowsManagementApi.resumeWorkflowExecution →

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/route_security.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/route_security.ts
@@ -103,7 +103,7 @@ export const WORKFLOW_DELETE_SECURITY: RouteSecurity = {
 };
 export const WORKFLOW_EXECUTE_SECURITY: RouteSecurity = {
   authz: {
-    requiredPrivileges: [WorkflowsManagementApiActions.execute, WorkflowsManagementApiActions.read],
+    requiredPrivileges: [WorkflowsManagementApiActions.execute],
   },
 };
 export const WORKFLOW_EXECUTION_READ_SECURITY: RouteSecurity = {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.test.ts
@@ -62,16 +62,13 @@ describe('workflow privilege checks', () => {
   });
 
   describe('hasWorkflowExecutePrivilege', () => {
-    it('requires both execute and read', async () => {
+    it('requires execute only, so a workflow can be run without reading its definition', async () => {
       const { security, atSpace } = createSecurityMock(true);
 
       await expect(hasWorkflowExecutePrivilege({ security, request, spaceId })).resolves.toBe(true);
 
       expect(atSpace).toHaveBeenCalledWith(spaceId, {
-        kibana: [
-          `api:${WorkflowsManagementApiActions.execute}`,
-          `api:${WorkflowsManagementApiActions.read}`,
-        ],
+        kibana: [`api:${WorkflowsManagementApiActions.execute}`],
       });
     });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.ts
@@ -50,10 +50,9 @@ export const hasWorkflowReadPrivilege = (params: CheckWorkflowPrivilegeParams): 
   hasAllApiPrivileges({ ...params, actions: [WorkflowsManagementApiActions.read] });
 
 /**
- * Verifies the caller holds the `workflowsManagement:execute` and
- * `workflowsManagement:read` privileges before a workflow is executed through
- * Agent Builder. Mirrors the privileges required by the direct Workflows
- * `.../run` HTTP route.
+ * Verifies the caller holds the `workflowsManagement:execute`
+ * privileges before a workflow is executed through Agent Builder.
+ * Mirrors the privileges required by the direct Workflows `.../run` HTTP route.
  */
 export const hasWorkflowExecutePrivilege = (
   params: CheckWorkflowPrivilegeParams

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-tools-base/workflows/check_privileges.ts
@@ -60,5 +60,5 @@ export const hasWorkflowExecutePrivilege = (
 ): Promise<boolean> =>
   hasAllApiPrivileges({
     ...params,
-    actions: [WorkflowsManagementApiActions.execute, WorkflowsManagementApiActions.read],
+    actions: [WorkflowsManagementApiActions.execute],
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[One workflows] Do not require `read` to execute a workflow (#284822)](https://github.com/elastic/kibana/pull/284822)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Massaneda","email":"sergi.massaneda@elastic.co"},"sourceCommit":{"committedDate":"2026-08-13T09:37:22Z","message":"[One workflows] Do not require `read` to execute a workflow (#284822)\n\n## Summary\n\nExecuting a workflow no longer requires the `workflowsManagement:read`\nprivilege, and the privileges required by each Workflows Management\noperation now live in one shared place.\n\nRunning a workflow loads its document to build the execution model, but\nthe definition never reaches the caller — the run API returns an\nexecution id. Requiring `read` was an implementation detail leaking into\nthe RBAC model, and it blocked a legitimate authorization model: letting\nusers execute approved workflows (typically as Agent Builder / MCP\ntools) without being able to read definitions that may contain sensitive\nimplementation or configuration details.\n\nThis is the same rule the route security config already documented and\nthe privilege/ES-operation guard test already enforced for mutating\nroutes (\"internal reads performed as part of the operation do not\nrequire `read`\"), and the same rule `WORKFLOW_EXECUTION_RESUME_SECURITY`\nalready followed. Execute was the exception.\n\n### What changed\n\n- **New `WorkflowsManagementOperationPrivileges` in `@kbn/workflows`**\nmaps each operation to the API actions it requires. It is the single\nsource of truth for both the Workflows Management HTTP routes and the\nplugins that perform the same operations through the server-side API and\ncheck privileges themselves.\n- It exports plain readonly action arrays, not `RouteSecurity` objects:\n`@kbn/workflows/common` is imported by browser code, so it must stay\nfree of server-only types, and consumers need to compose the actions\nwith their own (route `anyRequired` / `extendedPrivileges`, Agent\nBuilder's `checkPrivileges` calls).\n- **`workflows_management`**: every `*_SECURITY` constant in\n`route_security.ts` is now built from the map. Only\n`WORKFLOW_EXECUTE_SECURITY` changes behaviour (`execute` + `read` →\n`execute`), affecting `POST /api/workflows/workflow/{id}/run`, `POST\n/api/workflows/test` and `POST /api/workflows/step/test`.\n- **Agent Builder**: `hasWorkflowReadPrivilege`,\n`hasWorkflowExecutePrivilege`, `hasWorkflowExecutionReadPrivilege` and\nthe workflow SML type permissions all read from the map, so the two\nsides can no longer drift. The \"execute and read privileges are\nrequired\" error messages were updated.\n\n`resumeExecution` is mapped to `execute`, which is what the resume route\nalready required — resume acts on an execution that is already running\nand needs its own privilege model, so it is deliberately left unchanged\nhere.\n\nNo feature privilege definitions changed, so no role or `features.ts`\nmigration is involved: this only relaxes what the execute routes demand.\n\n## Testing\n\n- `route_privilege_consistency.test.ts`: the run and test routes are now\ndeclared internal-read exceptions (they read `WORKFLOWS_INDEX` without\nexposing it). I verified both entries are load-bearing — removing them\nfails the suite — and that `POST /api/workflows/step/test` needs none,\nsince it executes caller-supplied YAML and never touches the index.\n- `check_privileges.test.ts` asserts execute-only.\n- Ran Jest for `workflows_management/server/api`, `kbn-workflows`,\n`agent-builder-tools-base`, `agent_builder_workflows/server` and the\nAgent Builder workflow tool type; all pass. ESLint and type checks pass\non the touched projects.\n\n## Follow-up\n\nAttack Discovery pairs `execute` with `read` in its own constants\n(`WORKFLOW_EXECUTION_REQUIRED_API_PRIVILEGES` and the discoveries\nroutes) for the same reason — it loads the workflow only to run it. That\nis owned by @elastic/security-threat-hunting, so adopting the shared map\nthere will be proposed in a separate issue once this merges.\n\n## References\n\nReported in [this\nthread](https://elastic.slack.com/archives/C08U04SUN49/p1786526494970749?thread_ts=1786458584.765169&cid=C08U04SUN49)\nafter a customer hit it upgrading to 9.5 (privileges enforced on\nworkflow tools by #277389). They expose workflows to users exclusively\nas MCP tools and need execute-without-read.\n\nCloses elastic/security-team#18853\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2143f4b1ef94597ccce9fa96e319de8261fd4cc6","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","Team:One Workflow","v9.5.0","v9.6.0"],"title":"[One workflows] Do not require `read` to execute a workflow","number":284822,"url":"https://github.com/elastic/kibana/pull/284822","mergeCommit":{"message":"[One workflows] Do not require `read` to execute a workflow (#284822)\n\n## Summary\n\nExecuting a workflow no longer requires the `workflowsManagement:read`\nprivilege, and the privileges required by each Workflows Management\noperation now live in one shared place.\n\nRunning a workflow loads its document to build the execution model, but\nthe definition never reaches the caller — the run API returns an\nexecution id. Requiring `read` was an implementation detail leaking into\nthe RBAC model, and it blocked a legitimate authorization model: letting\nusers execute approved workflows (typically as Agent Builder / MCP\ntools) without being able to read definitions that may contain sensitive\nimplementation or configuration details.\n\nThis is the same rule the route security config already documented and\nthe privilege/ES-operation guard test already enforced for mutating\nroutes (\"internal reads performed as part of the operation do not\nrequire `read`\"), and the same rule `WORKFLOW_EXECUTION_RESUME_SECURITY`\nalready followed. Execute was the exception.\n\n### What changed\n\n- **New `WorkflowsManagementOperationPrivileges` in `@kbn/workflows`**\nmaps each operation to the API actions it requires. It is the single\nsource of truth for both the Workflows Management HTTP routes and the\nplugins that perform the same operations through the server-side API and\ncheck privileges themselves.\n- It exports plain readonly action arrays, not `RouteSecurity` objects:\n`@kbn/workflows/common` is imported by browser code, so it must stay\nfree of server-only types, and consumers need to compose the actions\nwith their own (route `anyRequired` / `extendedPrivileges`, Agent\nBuilder's `checkPrivileges` calls).\n- **`workflows_management`**: every `*_SECURITY` constant in\n`route_security.ts` is now built from the map. Only\n`WORKFLOW_EXECUTE_SECURITY` changes behaviour (`execute` + `read` →\n`execute`), affecting `POST /api/workflows/workflow/{id}/run`, `POST\n/api/workflows/test` and `POST /api/workflows/step/test`.\n- **Agent Builder**: `hasWorkflowReadPrivilege`,\n`hasWorkflowExecutePrivilege`, `hasWorkflowExecutionReadPrivilege` and\nthe workflow SML type permissions all read from the map, so the two\nsides can no longer drift. The \"execute and read privileges are\nrequired\" error messages were updated.\n\n`resumeExecution` is mapped to `execute`, which is what the resume route\nalready required — resume acts on an execution that is already running\nand needs its own privilege model, so it is deliberately left unchanged\nhere.\n\nNo feature privilege definitions changed, so no role or `features.ts`\nmigration is involved: this only relaxes what the execute routes demand.\n\n## Testing\n\n- `route_privilege_consistency.test.ts`: the run and test routes are now\ndeclared internal-read exceptions (they read `WORKFLOWS_INDEX` without\nexposing it). I verified both entries are load-bearing — removing them\nfails the suite — and that `POST /api/workflows/step/test` needs none,\nsince it executes caller-supplied YAML and never touches the index.\n- `check_privileges.test.ts` asserts execute-only.\n- Ran Jest for `workflows_management/server/api`, `kbn-workflows`,\n`agent-builder-tools-base`, `agent_builder_workflows/server` and the\nAgent Builder workflow tool type; all pass. ESLint and type checks pass\non the touched projects.\n\n## Follow-up\n\nAttack Discovery pairs `execute` with `read` in its own constants\n(`WORKFLOW_EXECUTION_REQUIRED_API_PRIVILEGES` and the discoveries\nroutes) for the same reason — it loads the workflow only to run it. That\nis owned by @elastic/security-threat-hunting, so adopting the shared map\nthere will be proposed in a separate issue once this merges.\n\n## References\n\nReported in [this\nthread](https://elastic.slack.com/archives/C08U04SUN49/p1786526494970749?thread_ts=1786458584.765169&cid=C08U04SUN49)\nafter a customer hit it upgrading to 9.5 (privileges enforced on\nworkflow tools by #277389). They expose workflows to users exclusively\nas MCP tools and need execute-without-read.\n\nCloses elastic/security-team#18853\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2143f4b1ef94597ccce9fa96e319de8261fd4cc6"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284822","number":284822,"mergeCommit":{"message":"[One workflows] Do not require `read` to execute a workflow (#284822)\n\n## Summary\n\nExecuting a workflow no longer requires the `workflowsManagement:read`\nprivilege, and the privileges required by each Workflows Management\noperation now live in one shared place.\n\nRunning a workflow loads its document to build the execution model, but\nthe definition never reaches the caller — the run API returns an\nexecution id. Requiring `read` was an implementation detail leaking into\nthe RBAC model, and it blocked a legitimate authorization model: letting\nusers execute approved workflows (typically as Agent Builder / MCP\ntools) without being able to read definitions that may contain sensitive\nimplementation or configuration details.\n\nThis is the same rule the route security config already documented and\nthe privilege/ES-operation guard test already enforced for mutating\nroutes (\"internal reads performed as part of the operation do not\nrequire `read`\"), and the same rule `WORKFLOW_EXECUTION_RESUME_SECURITY`\nalready followed. Execute was the exception.\n\n### What changed\n\n- **New `WorkflowsManagementOperationPrivileges` in `@kbn/workflows`**\nmaps each operation to the API actions it requires. It is the single\nsource of truth for both the Workflows Management HTTP routes and the\nplugins that perform the same operations through the server-side API and\ncheck privileges themselves.\n- It exports plain readonly action arrays, not `RouteSecurity` objects:\n`@kbn/workflows/common` is imported by browser code, so it must stay\nfree of server-only types, and consumers need to compose the actions\nwith their own (route `anyRequired` / `extendedPrivileges`, Agent\nBuilder's `checkPrivileges` calls).\n- **`workflows_management`**: every `*_SECURITY` constant in\n`route_security.ts` is now built from the map. Only\n`WORKFLOW_EXECUTE_SECURITY` changes behaviour (`execute` + `read` →\n`execute`), affecting `POST /api/workflows/workflow/{id}/run`, `POST\n/api/workflows/test` and `POST /api/workflows/step/test`.\n- **Agent Builder**: `hasWorkflowReadPrivilege`,\n`hasWorkflowExecutePrivilege`, `hasWorkflowExecutionReadPrivilege` and\nthe workflow SML type permissions all read from the map, so the two\nsides can no longer drift. The \"execute and read privileges are\nrequired\" error messages were updated.\n\n`resumeExecution` is mapped to `execute`, which is what the resume route\nalready required — resume acts on an execution that is already running\nand needs its own privilege model, so it is deliberately left unchanged\nhere.\n\nNo feature privilege definitions changed, so no role or `features.ts`\nmigration is involved: this only relaxes what the execute routes demand.\n\n## Testing\n\n- `route_privilege_consistency.test.ts`: the run and test routes are now\ndeclared internal-read exceptions (they read `WORKFLOWS_INDEX` without\nexposing it). I verified both entries are load-bearing — removing them\nfails the suite — and that `POST /api/workflows/step/test` needs none,\nsince it executes caller-supplied YAML and never touches the index.\n- `check_privileges.test.ts` asserts execute-only.\n- Ran Jest for `workflows_management/server/api`, `kbn-workflows`,\n`agent-builder-tools-base`, `agent_builder_workflows/server` and the\nAgent Builder workflow tool type; all pass. ESLint and type checks pass\non the touched projects.\n\n## Follow-up\n\nAttack Discovery pairs `execute` with `read` in its own constants\n(`WORKFLOW_EXECUTION_REQUIRED_API_PRIVILEGES` and the discoveries\nroutes) for the same reason — it loads the workflow only to run it. That\nis owned by @elastic/security-threat-hunting, so adopting the shared map\nthere will be proposed in a separate issue once this merges.\n\n## References\n\nReported in [this\nthread](https://elastic.slack.com/archives/C08U04SUN49/p1786526494970749?thread_ts=1786458584.765169&cid=C08U04SUN49)\nafter a customer hit it upgrading to 9.5 (privileges enforced on\nworkflow tools by #277389). They expose workflows to users exclusively\nas MCP tools and need execute-without-read.\n\nCloses elastic/security-team#18853\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2143f4b1ef94597ccce9fa96e319de8261fd4cc6"}}]}] BACKPORT-->