### PR TITLE
[Transforms] Remove outdated CPS banner

### DIFF
--- a/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/transform_management_section.test.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/transform_management_section.test.tsx
@@ -8,27 +8,12 @@
 import React from 'react';
 import { renderWithI18n } from '@kbn/test-jest-helpers';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
-import { fireEvent } from '@testing-library/react';
-import { UrlStateProvider } from '@kbn/ml-url-state';
-import { Router } from '@kbn/shared-ux-router';
-import { createMemoryHistory } from 'history';
 
-import { TransformManagement, TransformManagementSection } from './transform_management_section';
+import { TransformManagementSection } from './transform_management_section';
 
 jest.mock('../../services/navigation');
 
 const queryClient = new QueryClient();
-
-const mockStorage = {
-  get: jest.fn(),
-  set: jest.fn(),
-};
-
-const mockUseAppDependencies = jest.fn();
-
-jest.mock('../../app_dependencies', () => ({
-  useAppDependencies: () => mockUseAppDependencies(),
-}));
 
 jest.mock('../../hooks', () => ({
   useDocumentationLinks: () => ({ esTransform: 'https://example.test' }),
@@ -77,17 +62,6 @@ jest.mock('./components/dangling_task_warning/dangling_task_warning', () => ({
 }));
 
 describe('Transform: <TransformManagementSection />', () => {
-  beforeEach(() => {
-    mockStorage.get.mockReset();
-    mockStorage.set.mockReset();
-    mockUseAppDependencies.mockReset();
-    mockUseAppDependencies.mockReturnValue({
-      dataViewEditor: undefined,
-      cps: { cpsManager: {}, isTierEligible: true },
-      storage: mockStorage,
-    });
-  });
-
   test('Minimal initialization', () => {
     const { container } = renderWithI18n(
       <QueryClientProvider client={queryClient}>
@@ -96,71 +70,5 @@ describe('Transform: <TransformManagementSection />', () => {
     );
 
     expect(container.textContent).toContain('Missing permission');
-  });
-
-  test('Shows CPS unsupported callout when CPS is enabled and allows dismissing it', () => {
-    mockStorage.get.mockReturnValue(false);
-    const history = createMemoryHistory({ initialEntries: ['/'] });
-
-    const { container } = renderWithI18n(
-      <QueryClientProvider client={queryClient}>
-        <Router history={history}>
-          <UrlStateProvider>
-            <TransformManagement />
-          </UrlStateProvider>
-        </Router>
-      </QueryClientProvider>
-    );
-
-    expect(
-      container.querySelector('[data-test-subj="transformCpsUnsupportedCallout"]')
-    ).not.toBeNull();
-
-    const dismissButton = container.querySelector(
-      '[data-test-subj="transformCpsUnsupportedCalloutDismiss"]'
-    ) as HTMLButtonElement | null;
-    expect(dismissButton).not.toBeNull();
-
-    fireEvent.click(dismissButton!);
-    expect(mockStorage.set).toHaveBeenCalledWith('transform.cpsUnsupportedCalloutDismissed', true);
-    expect(container.querySelector('[data-test-subj="transformCpsUnsupportedCallout"]')).toBeNull();
-  });
-
-  test('Does not show CPS unsupported callout when dismissed in storage', () => {
-    mockStorage.get.mockReturnValue(true);
-    const history = createMemoryHistory({ initialEntries: ['/'] });
-
-    const { container } = renderWithI18n(
-      <QueryClientProvider client={queryClient}>
-        <Router history={history}>
-          <UrlStateProvider>
-            <TransformManagement />
-          </UrlStateProvider>
-        </Router>
-      </QueryClientProvider>
-    );
-
-    expect(container.querySelector('[data-test-subj="transformCpsUnsupportedCallout"]')).toBeNull();
-  });
-
-  test('Does not show CPS unsupported callout when CPS is not enabled', () => {
-    mockUseAppDependencies.mockReturnValue({
-      dataViewEditor: undefined,
-      cps: undefined,
-      storage: mockStorage,
-    });
-    const history = createMemoryHistory({ initialEntries: ['/'] });
-
-    const { container } = renderWithI18n(
-      <QueryClientProvider client={queryClient}>
-        <Router history={history}>
-          <UrlStateProvider>
-            <TransformManagement />
-          </UrlStateProvider>
-        </Router>
-      </QueryClientProvider>
-    );
-
-    expect(container.querySelector('[data-test-subj="transformCpsUnsupportedCallout"]')).toBeNull();
   });
 });

--- a/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/transform_management_section.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/transform_management/transform_management_section.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { type FC, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { type FC, useCallback, useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import {
@@ -26,7 +26,6 @@ import {
   type PageUrlState,
 } from '@kbn/ml-url-state';
 
-import { useAppDependencies } from '../../app_dependencies';
 import type { TransformListRow } from '../../common';
 import type { TransformFunction } from '../../../../common/constants';
 import { isTransformStats } from '../../../../common/types/transform_stats';
@@ -54,8 +53,6 @@ import {
   TransformAlertFlyoutWrapper,
 } from '../../../alerting/transform_alerting_flyout';
 import { DanglingTasksWarning } from './components/dangling_task_warning/dangling_task_warning';
-
-const CPS_UNSUPPORTED_CALLOUT_STORAGE_KEY = 'transform.cpsUnsupportedCalloutDismissed';
 
 const getDefaultTransformListState = (): ListingPageUrlState => ({
   pageIndex: 0,
@@ -92,22 +89,11 @@ const ErrorMessageCallout: FC<{
 export const TransformManagement: FC = () => {
   const { esTransform } = useDocumentationLinks();
   const { showNodeInfo } = useEnabledFeatures();
-  const { cps, storage } = useAppDependencies();
   const history = useHistory();
   const [transformPageState, setTransformPageState] = usePageUrlState<PageUrlState>(
     'transform',
     getDefaultTransformListState()
   );
-
-  const isCpsEnabled = Boolean(cps?.cpsManager);
-  const [isCpsUnsupportedCalloutDismissed, setIsCpsUnsupportedCalloutDismissed] = useState(() => {
-    return isCpsEnabled ? storage.get(CPS_UNSUPPORTED_CALLOUT_STORAGE_KEY) === true : false;
-  });
-
-  const onDismissCpsUnsupportedCallout = useCallback(() => {
-    setIsCpsUnsupportedCalloutDismissed(true);
-    storage.set(CPS_UNSUPPORTED_CALLOUT_STORAGE_KEY, true);
-  }, [storage]);
 
   const {
     isInitialLoading: transformNodesInitialLoading,
@@ -286,30 +272,6 @@ export const TransformManagement: FC = () => {
               />
             ) : null}
             <EuiSpacer size="s" />
-
-            {isCpsEnabled && !isCpsUnsupportedCalloutDismissed && (
-              <>
-                <EuiSpacer size="m" />
-                <EuiCallOut
-                  title={i18n.translate('xpack.transform.cpsUnsupportedCallout.title', {
-                    defaultMessage: 'Cross-project search for transforms coming soon',
-                  })}
-                  iconType="info"
-                  onDismiss={onDismissCpsUnsupportedCallout}
-                  dismissButtonProps={{ 'data-test-subj': 'transformCpsUnsupportedCalloutDismiss' }}
-                  data-test-subj="transformCpsUnsupportedCallout"
-                  announceOnMount
-                >
-                  <p>
-                    <FormattedMessage
-                      id="xpack.transform.cpsUnsupportedCallout.description"
-                      defaultMessage="While we're working on this feature, all transform search scope will be limited to the current project."
-                    />
-                  </p>
-                </EuiCallOut>
-                <EuiSpacer size="m" />
-              </>
-            )}
 
             <TransformStatsBar transformNodes={transformNodes} transformsList={transforms} />
             <EuiSpacer size="s" />

--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -1291,7 +1291,10 @@
     "core.euiFlyoutManaged.defaultTitle": "Unbekanntes Flyout",
     "core.euiFlyoutMenu.back": "Zurück",
     "core.euiFlyoutMenu.history": "Verlauf",
+    "core.euiFlyoutMenu.history.tooltip": "Kürzlich besucht",
     "core.euiFlyoutMenu.pagination.counter": "{position} von {total}",
+    "core.euiFlyoutMenu.pagination.first": "Erste",
+    "core.euiFlyoutMenu.pagination.last": "Letzte",
     "core.euiFlyoutMenu.pagination.next": "Weiter",
     "core.euiFlyoutMenu.pagination.previous": "Vorherige",
     "core.euiForm.addressFormErrors": "Bitte beheben Sie die markierten Fehler.",
@@ -57838,8 +57841,6 @@
     "xpack.transform.clone.fetchErrorPromptText": "Die Kibana-Datenansichts-ID konnte nicht abgerufen werden.",
     "xpack.transform.clone.noDataViewErrorPromptText": "Die Transformation {transformId} konnte nicht geklont werden. Es existiert keine Datenansicht für {dataViewTitle}.",
     "xpack.transform.cloneTransform.breadcrumbTitle": "Transformierung klonen",
-    "xpack.transform.cpsUnsupportedCallout.description": "Solange wir an diesem Feature arbeiten, ist der Suchbereich für alle Transformationen auf das aktuelle Projekt beschränkt.",
-    "xpack.transform.cpsUnsupportedCallout.title": "Projektübergreifende Suche nach Transformationen bald verfügbar",
     "xpack.transform.createTransform.breadcrumbTitle": "Transformation erstellen",
     "xpack.transform.danglingTasksError": "{count} {count, plural, one {transform is} other {Transformationen sind}} fehlende Konfigurationsdetails: [{transformIds}] {count, plural, one {It} other {Sie}} können nicht wiederhergestellt werden und sollten gelöscht werden.",
     "xpack.transform.deleteTransform.deleteAnalyticsWithDataViewErrorMessage": "Beim Löschen der Datenansicht {destinationIndex} ist ein Fehler aufgetreten",
@@ -60564,9 +60565,6 @@
     "xpack.watcher.watchActions.webhook.portIsRequiredValidationMessage": "Der Webhook-Port ist erforderlich.",
     "xpack.watcher.watchActions.webhook.usernameIsRequiredIfPasswordValidationMessage": "Der Nutzername ist erforderlich.",
     "xpack.watcher.watchEdit.thresholdWatchExpression.aggType.fieldIsRequiredValidationMessage": "Dies ist ein Pflichtfeld.",
-    "xpack.watcher.watcherDescription": "Erkennen Sie Änderungen an Ihren Daten, indem Sie Alerts erstellen, verwalten und überwachen.",
-    "core.euiFlyoutMenu.history.tooltip": "Kürzlich besucht",
-    "core.euiFlyoutMenu.pagination.first": "Erste",
-    "core.euiFlyoutMenu.pagination.last": "Letzte"
+    "xpack.watcher.watcherDescription": "Erkennen Sie Änderungen an Ihren Daten, indem Sie Alerts erstellen, verwalten und überwachen."
   }
 }

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -1291,7 +1291,10 @@
     "core.euiFlyoutManaged.defaultTitle": "Volet inconnu",
     "core.euiFlyoutMenu.back": "Retour",
     "core.euiFlyoutMenu.history": "Historique",
+    "core.euiFlyoutMenu.history.tooltip": "Récemment visité",
     "core.euiFlyoutMenu.pagination.counter": "{position} sur {total}",
+    "core.euiFlyoutMenu.pagination.first": "Premier",
+    "core.euiFlyoutMenu.pagination.last": "Dernier",
     "core.euiFlyoutMenu.pagination.next": "Suivant",
     "core.euiFlyoutMenu.pagination.previous": "Précédent",
     "core.euiForm.addressFormErrors": "Veuillez remédier aux erreurs signalées en surbrillance.",
@@ -57585,8 +57588,6 @@
     "xpack.transform.clone.fetchErrorPromptText": "Impossible de récupérer l'ID de vue des données Kibana.",
     "xpack.transform.clone.noDataViewErrorPromptText": "Impossible de cloner la transformation {transformId}. Il n'existe aucune vue de données pour {dataViewTitle}.",
     "xpack.transform.cloneTransform.breadcrumbTitle": "Cloner la transformation",
-    "xpack.transform.cpsUnsupportedCallout.description": "Pendant que nous travaillons sur cette fonctionnalité, toutes les recherches de transformation seront limitées au projet en cours.",
-    "xpack.transform.cpsUnsupportedCallout.title": "La recherche de transformations interprojets sera bientôt disponible",
     "xpack.transform.createTransform.breadcrumbTitle": "Créer une transformation",
     "xpack.transform.deleteTransform.deleteAnalyticsWithDataViewErrorMessage": "Une erreur s'est produite lors de la suppression de la vue de données {destinationIndex}",
     "xpack.transform.deleteTransform.deleteAnalyticsWithIndexErrorMessage": "Une erreur s'est produite lors de la suppression de l'index de destination {destinationIndex}",
@@ -60309,9 +60310,6 @@
     "xpack.watcher.watchActions.webhook.portIsRequiredValidationMessage": "Le port webhook est requis.",
     "xpack.watcher.watchActions.webhook.usernameIsRequiredIfPasswordValidationMessage": "Le nom d'utilisateur est requis.",
     "xpack.watcher.watchEdit.thresholdWatchExpression.aggType.fieldIsRequiredValidationMessage": "Ce champ est requis.",
-    "xpack.watcher.watcherDescription": "Détectez les modifications survenant dans vos données en créant, gérant et monitorant des alertes.",
-    "core.euiFlyoutMenu.history.tooltip": "Récemment visité",
-    "core.euiFlyoutMenu.pagination.first": "Premier",
-    "core.euiFlyoutMenu.pagination.last": "Dernier"
+    "xpack.watcher.watcherDescription": "Détectez les modifications survenant dans vos données en créant, gérant et monitorant des alertes."
   }
 }

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -1293,7 +1293,10 @@
     "core.euiFlyoutManaged.defaultTitle": "不明なフライアウト",
     "core.euiFlyoutMenu.back": "戻る",
     "core.euiFlyoutMenu.history": "履歴",
+    "core.euiFlyoutMenu.history.tooltip": "最近アクセスしたページ",
     "core.euiFlyoutMenu.pagination.counter": "{position}/{total}",
+    "core.euiFlyoutMenu.pagination.first": "最初",
+    "core.euiFlyoutMenu.pagination.last": "最後",
     "core.euiFlyoutMenu.pagination.next": "次へ",
     "core.euiFlyoutMenu.pagination.previous": "前へ",
     "core.euiForm.addressFormErrors": "ハイライトされたエラーを修正してください。",
@@ -58020,8 +58023,6 @@
     "xpack.transform.clone.fetchErrorPromptText": "KibanaデータビューIDを取得できませんでした。",
     "xpack.transform.clone.noDataViewErrorPromptText": "トランスフォーム{transformId}を複製できません。{dataViewTitle}のデータビューは存在しません。",
     "xpack.transform.cloneTransform.breadcrumbTitle": "変換のクローンを作成",
-    "xpack.transform.cpsUnsupportedCallout.description": "この機能の開発中は、すべての変換検索範囲は現在のプロジェクトに限定されます。",
-    "xpack.transform.cpsUnsupportedCallout.title": "プロジェクト横断的な変換検索機能が近日公開予定",
     "xpack.transform.createTransform.breadcrumbTitle": "変換を作成",
     "xpack.transform.danglingTasksError": "{count} {count, plural, one {transform is} other {件の変換に}}に構成の詳細がありません：[{transformIds}] {count, plural, one {It} other {これら}}は復元できないため、削除する必要があります。",
     "xpack.transform.deleteTransform.deleteAnalyticsWithDataViewErrorMessage": "データビュー{destinationIndex}の削除中にエラーが発生しました",
@@ -60770,9 +60771,6 @@
     "xpack.watcher.watchActions.webhook.portIsRequiredValidationMessage": "Webフックポートが必要です。",
     "xpack.watcher.watchActions.webhook.usernameIsRequiredIfPasswordValidationMessage": "ユーザー名が必要です。",
     "xpack.watcher.watchEdit.thresholdWatchExpression.aggType.fieldIsRequiredValidationMessage": "フィールドを選択してください。",
-    "xpack.watcher.watcherDescription": "アラートの作成、管理、監視によりデータへの変更を検知します。",
-    "core.euiFlyoutMenu.history.tooltip": "最近アクセスしたページ",
-    "core.euiFlyoutMenu.pagination.first": "最初",
-    "core.euiFlyoutMenu.pagination.last": "最後"
+    "xpack.watcher.watcherDescription": "アラートの作成、管理、監視によりデータへの変更を検知します。"
   }
 }

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -1292,7 +1292,10 @@
     "core.euiFlyoutManaged.defaultTitle": "未知浮出控件",
     "core.euiFlyoutMenu.back": "返回",
     "core.euiFlyoutMenu.history": "历史记录",
+    "core.euiFlyoutMenu.history.tooltip": "最近访问",
     "core.euiFlyoutMenu.pagination.counter": "{position} 次（共 {total} 次）",
+    "core.euiFlyoutMenu.pagination.first": "第一页",
+    "core.euiFlyoutMenu.pagination.last": "最后一页",
     "core.euiFlyoutMenu.pagination.next": "下一步",
     "core.euiFlyoutMenu.pagination.previous": "上一步",
     "core.euiForm.addressFormErrors": "请解决突出显示的错误。",
@@ -58023,8 +58026,6 @@
     "xpack.transform.clone.fetchErrorPromptText": "无法提取 Kibana 数据视图 ID。",
     "xpack.transform.clone.noDataViewErrorPromptText": "无法克隆转换 {transformId}。对于 {dataViewTitle}，不存在数据视图。",
     "xpack.transform.cloneTransform.breadcrumbTitle": "克隆转换",
-    "xpack.transform.cpsUnsupportedCallout.description": "在我们开发此功能期间，所有转换搜索范围将仅限于当前项目。",
-    "xpack.transform.cpsUnsupportedCallout.title": "转换的跨项目搜索即将推出",
     "xpack.transform.createTransform.breadcrumbTitle": "创建转换",
     "xpack.transform.danglingTasksError": "{count} 个{count, plural, one {transform is} other {转换}}缺少配置详情：[ {transformIds} ] {count, plural, one {其} other {其}}无法恢复，应予以删除。",
     "xpack.transform.deleteTransform.deleteAnalyticsWithDataViewErrorMessage": "删除数据视图 {destinationIndex} 时发生错误",
@@ -60773,9 +60774,6 @@
     "xpack.watcher.watchActions.webhook.portIsRequiredValidationMessage": "Webhook 端口必填。",
     "xpack.watcher.watchActions.webhook.usernameIsRequiredIfPasswordValidationMessage": "“用户名”必填。",
     "xpack.watcher.watchEdit.thresholdWatchExpression.aggType.fieldIsRequiredValidationMessage": "此字段必填。",
-    "xpack.watcher.watcherDescription": "通过创建、管理和监测警报来检测数据中的更改。",
-    "core.euiFlyoutMenu.history.tooltip": "最近访问",
-    "core.euiFlyoutMenu.pagination.first": "第一页",
-    "core.euiFlyoutMenu.pagination.last": "最后一页"
+    "xpack.watcher.watcherDescription": "通过创建、管理和监测警报来检测数据中的更改。"
   }
 }


### PR DESCRIPTION
Closes #284933

## Summary

Removes the obsolete “Cross-project search for transforms coming soon” banner from the Transform management page.

- Removes the banner UI now that CPS support has been added to Transforms.
- Removes the related dismiss/storage state.
- Cleans up the management section test by dropping obsolete banner coverage.

## Manual Test Plan

1. Start Kibana with CPS local setup: `node scripts/scout start-server --arch serverless --domain security_complete --serverConfigSet cps_local`
2. Open **Stack Management > Transforms**.
3. Verify the “Cross-project search for transforms coming soon” banner is no longer shown.
4. Verify the Transform list still loads normally.



