### PR TITLE
[APM] Fix silent APM waterfall re-rooting on truncated traces.

### DIFF
--- a/src/platform/packages/shared/kbn-apm-ui-shared/src/components/trace_waterfall/trace_warning.test.tsx
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/src/components/trace_waterfall/trace_warning.test.tsx
@@ -50,6 +50,24 @@ describe('TraceWarning', () => {
     expect(trace).toBeInTheDocument();
   });
 
+  it('renders a warning for a missing selected transaction, and shows the fallback trace', () => {
+    render(
+      <TraceWaterfallContext.Provider
+        value={{ traceState: TraceDataState.MissingEntry } as TraceWaterfallContextProps}
+      >
+        <TraceWarning>
+          <div>Trace</div>
+        </TraceWarning>
+      </TraceWaterfallContext.Provider>
+    );
+
+    const warning = screen.queryByTestId('traceWarning');
+    const trace = screen.queryByText('Trace');
+
+    expect(warning).toBeInTheDocument();
+    expect(trace).toBeInTheDocument();
+  });
+
   it('renders a warning for an empty trace, and does not show the trace', () => {
     render(
       <TraceWaterfallContext.Provider

--- a/src/platform/packages/shared/kbn-apm-ui-shared/src/components/trace_waterfall/trace_warning.tsx
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/src/components/trace_waterfall/trace_warning.tsx
@@ -17,6 +17,7 @@ export function TraceWarning({ children }: { children: React.ReactNode }) {
 
   switch (traceState) {
     case TraceDataState.Partial:
+    case TraceDataState.MissingEntry:
       return (
         <EuiFlexGroup direction="column">
           <EuiFlexItem grow={false}>

--- a/src/platform/packages/shared/kbn-apm-ui-shared/src/components/trace_waterfall/use_trace_watefall.test.ts
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/src/components/trace_waterfall/use_trace_watefall.test.ts
@@ -856,6 +856,38 @@ describe('getRootItemOrFallback', () => {
     expect(result.traceState).toBe(TraceDataState.Full);
     expect(result.orphans).toEqual([]);
   });
+
+  it('should return a FULL state rooted at the selected entry transaction', () => {
+    const traceData = [root, child1, child2, grandchild];
+
+    const result = getRootItemOrFallback(
+      getTraceParentChildrenMap(traceData, false),
+      traceData,
+      child1.id
+    );
+
+    expect(result.rootItem).toEqual(child1);
+    expect(result.traceState).toBe(TraceDataState.Full);
+    expect(result.orphans).toEqual([]);
+  });
+
+  it('should return MissingEntry instead of silently re-rooting when the selected id is absent', () => {
+    const otherRoot: TraceItem = {
+      ...root,
+      id: 'other-root',
+      name: 'other-root',
+    };
+    const traceData = [otherRoot, child2];
+
+    const result = getRootItemOrFallback(
+      getTraceParentChildrenMap(traceData, false),
+      traceData,
+      'missing-entry-id'
+    );
+
+    expect(result.rootItem).toEqual(otherRoot);
+    expect(result.traceState).toBe(TraceDataState.MissingEntry);
+  });
 });
 
 describe('getTraceWaterfallDuration', () => {

--- a/src/platform/packages/shared/kbn-apm-ui-shared/src/components/trace_waterfall/use_trace_waterfall.ts
+++ b/src/platform/packages/shared/kbn-apm-ui-shared/src/components/trace_waterfall/use_trace_waterfall.ts
@@ -32,6 +32,14 @@ const INSTRUMENTATION_WARNING = i18n.translate(
   }
 );
 
+const MISSING_ENTRY_WARNING = i18n.translate(
+  'apmUiShared.traceWaterfallItem.warningMessage.missingEntryWarning',
+  {
+    defaultMessage:
+      'The selected transaction is missing from this truncated waterfall. A different transaction from the same trace is shown instead.',
+  }
+);
+
 export interface TraceWaterfallItem extends TraceItem {
   depth: number;
   offset: number;
@@ -100,7 +108,7 @@ export function useTraceWaterfall({
       return {
         rootItem,
         traceState,
-        message: traceState !== TraceDataState.Full ? FALLBACK_WARNING : undefined,
+        message: getTraceStateMessage(traceState),
         traceWaterfall,
         duration: getTraceWaterfallDuration(traceWaterfall),
         maxDepth: Math.max(...traceWaterfall.map((item) => item.depth)),
@@ -260,6 +268,31 @@ export enum TraceDataState {
   Partial = 'partial',
   Empty = 'empty',
   Invalid = 'invalid',
+  MissingEntry = 'missingEntry',
+}
+
+function getTraceStateMessage(traceState: TraceDataState): string | undefined {
+  switch (traceState) {
+    case TraceDataState.MissingEntry:
+      return MISSING_ENTRY_WARNING;
+    case TraceDataState.Partial:
+    case TraceDataState.Empty:
+      return FALLBACK_WARNING;
+    case TraceDataState.Invalid:
+      return INSTRUMENTATION_WARNING;
+    case TraceDataState.Full:
+      return undefined;
+  }
+}
+
+function getOrphanItems(traceItems: TraceItem[], rootItem: TraceItem | undefined): TraceItem[] {
+  const parentIds = new Set(traceItems.map(({ id }) => id));
+  return traceItems.filter((item) => {
+    if (item.id === rootItem?.id || !item.parentId) {
+      return false;
+    }
+    return !parentIds.has(item.parentId);
+  });
 }
 
 export function getRootItemOrFallback(
@@ -274,20 +307,20 @@ export function getRootItemOrFallback(
   }
 
   const entryTransactionRootItem = entryTransactionId
-    ? traceItems?.find((item) => item.id === entryTransactionId)
+    ? traceItems.find((item) => item.id === entryTransactionId)
     : undefined;
 
-  const rootItem = entryTransactionRootItem
-    ? entryTransactionRootItem
-    : traceParentChildrenMap.root?.[0];
+  if (entryTransactionId && !entryTransactionRootItem) {
+    const fallbackRoot = traceParentChildrenMap.root?.[0];
+    return {
+      traceState: TraceDataState.MissingEntry,
+      rootItem: fallbackRoot,
+      orphans: getOrphanItems(traceItems, fallbackRoot),
+    };
+  }
 
-  const parentIds = new Set(traceItems.map(({ id }) => id));
-  // TODO: Reuse waterfall util methods where possible or if logic is the same
-  const orphans = traceItems.filter(
-    (item) =>
-      // Root cannot be an orphan.
-      item.id !== rootItem?.id && item.parentId && !parentIds.has(item.parentId)
-  );
+  const rootItem = entryTransactionRootItem ?? traceParentChildrenMap.root?.[0];
+  const orphans = getOrphanItems(traceItems, rootItem);
 
   if (rootItem) {
     return {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/ensure_focused_trace_hits.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/ensure_focused_trace_hits.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { APMEventClient } from '@kbn/apm-data-access-plugin/server';
+import { PARENT_ID, SPAN_ID, TRANSACTION_ID } from '../../../common/es_fields/apm';
+import { ensureFocusedTraceHits, getTraceHitId } from './ensure_focused_trace_hits';
+
+function createHit({ id, parentId }: { id: string; parentId?: string }): {
+  fields: Record<string, unknown>;
+} {
+  return {
+    fields: {
+      [SPAN_ID]: [id],
+      [TRANSACTION_ID]: [id],
+      ...(parentId ? { [PARENT_ID]: [parentId] } : {}),
+    },
+  };
+}
+
+describe('getTraceHitId', () => {
+  it('prefers span.id over transaction.id', () => {
+    expect(
+      getTraceHitId({
+        fields: {
+          [SPAN_ID]: ['span-1'],
+          [TRANSACTION_ID]: ['txn-1'],
+        },
+      })
+    ).toBe('span-1');
+  });
+
+  it('falls back to transaction.id', () => {
+    expect(
+      getTraceHitId({
+        fields: {
+          [TRANSACTION_ID]: ['txn-1'],
+        },
+      })
+    ).toBe('txn-1');
+  });
+});
+
+describe('ensureFocusedTraceHits', () => {
+  const search = jest.fn();
+  const apmEventClient = { search } as unknown as APMEventClient;
+
+  beforeEach(() => {
+    search.mockReset();
+  });
+
+  it('does not search when the focused document and ancestors are already present', async () => {
+    const parent = createHit({ id: 'parent' });
+    const focused = createHit({ id: 'focused', parentId: 'parent' });
+
+    const result = await ensureFocusedTraceHits({
+      apmEventClient,
+      hits: [parent, focused],
+      focusedDocId: 'focused',
+      maxTraceItems: 2,
+      traceId: 'trace-1',
+      start: 0,
+      end: 1000,
+      ecsOnly: true,
+    });
+
+    expect(search).not.toHaveBeenCalled();
+    expect(result.map(getTraceHitId)).toEqual(['parent', 'focused']);
+  });
+
+  it('fetches a missing focused document and drops ranked hits to stay at maxTraceItems', async () => {
+    const rootA = createHit({ id: 'root-a' });
+    const rootB = createHit({ id: 'root-b' });
+    const focused = createHit({ id: 'focused', parentId: 'root-a' });
+
+    search.mockResolvedValueOnce({
+      hits: { hits: [focused] },
+    });
+
+    const result = await ensureFocusedTraceHits({
+      apmEventClient,
+      hits: [rootA, rootB],
+      focusedDocId: 'focused',
+      maxTraceItems: 2,
+      traceId: 'trace-1',
+      start: 0,
+      end: 1000,
+      ecsOnly: true,
+    });
+
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(search.mock.calls[0][0]).toBe('get_focused_trace_items');
+    expect(result.map(getTraceHitId)).toEqual(['focused', 'root-a']);
+  });
+
+  it('walks missing ancestors after fetching the focused document', async () => {
+    const rankedRoot = createHit({ id: 'other-root' });
+    const parent = createHit({ id: 'parent' });
+    const focused = createHit({ id: 'focused', parentId: 'parent' });
+
+    search
+      .mockResolvedValueOnce({ hits: { hits: [focused] } })
+      .mockResolvedValueOnce({ hits: { hits: [parent] } });
+
+    const result = await ensureFocusedTraceHits({
+      apmEventClient,
+      hits: [rankedRoot],
+      focusedDocId: 'focused',
+      maxTraceItems: 2,
+      traceId: 'trace-1',
+      start: 0,
+      end: 1000,
+      ecsOnly: true,
+    });
+
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(result.map(getTraceHitId)).toEqual(['focused', 'parent']);
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/ensure_focused_trace_hits.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/ensure_focused_trace_hits.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import type { APMEventClient } from '@kbn/apm-data-access-plugin/server';
+import { ProcessorEvent } from '@kbn/observability-plugin/common';
+import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
+import {
+  PARENT_ID,
+  SPAN_ID,
+  TRACE_ID,
+  TRANSACTION_ID,
+  TRANSACTION_MARKS_AGENT,
+} from '../../../common/es_fields/apm';
+import { ecsOnlyOptionalFields, fields, optionalFields } from './get_unified_trace_items_page';
+
+const MAX_ANCESTOR_HOPS = 50;
+
+export type FocusedTraceHit = Pick<SearchHit, 'fields'>;
+
+export function getTraceHitId(hit: FocusedTraceHit): string | undefined {
+  return firstStringField(hit.fields, SPAN_ID) ?? firstStringField(hit.fields, TRANSACTION_ID);
+}
+
+export function getTraceHitParentId(hit: FocusedTraceHit): string | undefined {
+  return firstStringField(hit.fields, PARENT_ID);
+}
+
+function firstStringField(hitFields: SearchHit['fields'], fieldName: string): string | undefined {
+  if (!hitFields) {
+    return undefined;
+  }
+
+  const value = Reflect.get(hitFields, fieldName);
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+
+  if (Array.isArray(value) && typeof value[0] === 'string' && value[0].length > 0) {
+    return value[0];
+  }
+
+  return undefined;
+}
+
+/**
+ * Ranked waterfall pagination can drop the focused transaction when a large
+ * multi-root trace spends `maxTraceItems` on long sibling roots. Fetch the
+ * focused document and its ancestors, then merge them into the ranked hits
+ * while staying at `maxTraceItems`.
+ */
+export async function ensureFocusedTraceHits<THit extends FocusedTraceHit>({
+  apmEventClient,
+  hits,
+  focusedDocId,
+  maxTraceItems,
+  traceId,
+  start,
+  end,
+  ecsOnly,
+}: {
+  apmEventClient: APMEventClient;
+  hits: THit[];
+  focusedDocId: string;
+  maxTraceItems: number;
+  traceId: string;
+  start: number;
+  end: number;
+  ecsOnly: boolean;
+}): Promise<THit[]> {
+  const hitsById = new Map<string, THit>();
+  for (const hit of hits) {
+    const id = getTraceHitId(hit);
+    if (id) {
+      hitsById.set(id, hit);
+    }
+  }
+
+  const reserved: THit[] = [];
+  let idsToFetch = hitsById.has(focusedDocId) ? [] : [focusedDocId];
+  let currentId = focusedDocId;
+
+  for (let hop = 0; hop < MAX_ANCESTOR_HOPS; hop++) {
+    if (idsToFetch.length > 0) {
+      const fetchedHits = await fetchTraceHitsByIds({
+        apmEventClient,
+        traceId,
+        start,
+        end,
+        ids: idsToFetch,
+        ecsOnly,
+      });
+
+      for (const fetchedHit of fetchedHits) {
+        const id = getTraceHitId(fetchedHit);
+        if (!id || hitsById.has(id)) {
+          continue;
+        }
+        // Intentional `as THit` type assertion as apmEventClient.search returns generic Elasticsearch SearchHit documents;
+        const typedHit = fetchedHit as THit;
+        hitsById.set(id, typedHit);
+        reserved.push(typedHit);
+      }
+    }
+
+    const currentHit = hitsById.get(currentId);
+    const parentId = currentHit ? getTraceHitParentId(currentHit) : undefined;
+    if (!parentId || hitsById.has(parentId)) {
+      break;
+    }
+
+    currentId = parentId;
+    idsToFetch = [parentId];
+  }
+
+  if (reserved.length === 0) {
+    return hits;
+  }
+
+  const reservedIds = new Set(
+    reserved.flatMap((hit) => {
+      const id = getTraceHitId(hit);
+      return id ? [id] : [];
+    })
+  );
+  const rankedRemainder = hits.filter((hit) => {
+    const id = getTraceHitId(hit);
+    return id !== undefined && !reservedIds.has(id);
+  });
+  const remainingSlots = Math.max(0, maxTraceItems - reserved.length);
+
+  return [...reserved, ...rankedRemainder.slice(0, remainingSlots)];
+}
+
+async function fetchTraceHitsByIds({
+  apmEventClient,
+  traceId,
+  start,
+  end,
+  ids,
+  ecsOnly,
+}: {
+  apmEventClient: APMEventClient;
+  traceId: string;
+  start: number;
+  end: number;
+  ids: string[];
+  ecsOnly: boolean;
+}): Promise<FocusedTraceHit[]> {
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const response = await apmEventClient.search(
+    'get_focused_trace_items',
+    {
+      apm: {
+        events: [ProcessorEvent.span, ProcessorEvent.transaction],
+      },
+      track_total_hits: false,
+      size: ids.length,
+      query: {
+        bool: {
+          filter: [...termQuery(TRACE_ID, traceId), ...rangeQuery(start, end)],
+          should: [{ terms: { [TRANSACTION_ID]: ids } }, { terms: { [SPAN_ID]: ids } }],
+          minimum_should_match: 1,
+        },
+      },
+      fields: [...fields, ...(ecsOnly ? ecsOnlyOptionalFields : optionalFields)],
+      _source: [TRANSACTION_MARKS_AGENT],
+    },
+    { skipProcessorEventFilter: !ecsOnly }
+  );
+
+  return response.hits.hits;
+}

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
@@ -1667,3 +1667,91 @@ describe('getTraceItemIcon', () => {
     });
   });
 });
+
+describe('getUnifiedTraceItems focused document reservation', () => {
+  const mockApmEventClient = {
+    search: jest.fn(),
+  } as unknown as APMEventClient;
+
+  const mockLogsClient = {} as LogsClient;
+
+  const defaultParams = {
+    apmEventClient: mockApmEventClient,
+    logsClient: mockLogsClient,
+    traceId: 'test-trace-id',
+    start: 0,
+    end: 1000,
+    maxTraceItems: 1,
+  };
+
+  const defaultSearchFields = {
+    [AT_TIMESTAMP]: ['2023-01-01T00:00:00.000Z'],
+    [TRACE_ID]: ['test-trace-id'],
+    [SERVICE_NAME]: ['test-service'],
+    [TIMESTAMP_US]: [1672531200000000],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getUnifiedTraceErrors as jest.Mock).mockResolvedValue({
+      apmErrors: [],
+      unprocessedOtelErrors: [],
+      totalErrors: 0,
+    });
+    (getSpanLinksCountById as jest.Mock).mockResolvedValue({});
+  });
+
+  it('merges a missing focused transaction into truncated ranked hits', async () => {
+    const rankedRoot = {
+      _source: {},
+      fields: {
+        ...defaultSearchFields,
+        [PROCESSOR_EVENT]: ProcessorEvent.transaction,
+        [SPAN_ID]: ['root-1'],
+        [TRANSACTION_ID]: ['root-1'],
+        [TRANSACTION_NAME]: ['long-root'],
+        [TRANSACTION_DURATION]: [1_000_000],
+      },
+    };
+    const focusedChild = {
+      _source: {},
+      fields: {
+        ...defaultSearchFields,
+        [PROCESSOR_EVENT]: ProcessorEvent.transaction,
+        [SPAN_ID]: ['focused-1'],
+        [TRANSACTION_ID]: ['focused-1'],
+        [TRANSACTION_NAME]: ['short-child'],
+        [TRANSACTION_DURATION]: [2000],
+        [PARENT_ID]: ['root-1'],
+      },
+    };
+
+    (mockApmEventClient.search as jest.Mock).mockImplementation((operationName: string) => {
+      if (operationName === 'get_focused_trace_items') {
+        return Promise.resolve({
+          hits: { hits: [focusedChild], total: { value: 1, relation: 'eq' } },
+        });
+      }
+
+      return Promise.resolve({
+        hits: {
+          hits: [rankedRoot],
+          total: { value: 2, relation: 'eq' },
+        },
+      });
+    });
+
+    const result = await getUnifiedTraceItems({
+      ...defaultParams,
+      focusedDocId: 'focused-1',
+    });
+
+    expect(result.traceItems.map((item) => item.id)).toEqual(['focused-1']);
+    expect(result.traceDocsTotal).toBe(2);
+    expect(
+      (mockApmEventClient.search as jest.Mock).mock.calls.some(
+        (call) => call[0] === 'get_focused_trace_items'
+      )
+    ).toBe(true);
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
@@ -97,6 +97,7 @@ export async function getUnifiedTraceItems({
   end,
   serviceName,
   ecsOnly = false,
+  focusedDocId,
 }: {
   apmEventClient: APMEventClient;
   logsClient: LogsClient;
@@ -106,6 +107,7 @@ export async function getUnifiedTraceItems({
   end: number;
   serviceName?: string;
   ecsOnly?: boolean;
+  focusedDocId?: string;
 }): Promise<{
   traceItems: TraceItem[];
   unifiedTraceErrors: UnifiedTraceErrors;
@@ -128,6 +130,7 @@ export async function getUnifiedTraceItems({
       end,
       serviceName,
       ecsOnly,
+      focusedDocId,
     }),
     getSpanLinksCountById({
       traceId,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items_page.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items_page.ts
@@ -46,6 +46,7 @@ import {
   TRANSACTION_RESULT,
 } from '../../../common/es_fields/apm';
 import { asMutableArray } from '../../../common/utils/as_mutable_array';
+import { ensureFocusedTraceHits, getTraceHitId } from './ensure_focused_trace_hits';
 import { MAX_ITEMS_PER_PAGE } from './trace_constants';
 
 export const fields = asMutableArray(['@timestamp', 'trace.id', 'service.name'] as const);
@@ -221,9 +222,7 @@ async function paginate({
   // more than once in the same response. Previously handled with collapse, which only works
   // within a single page. seenIds deduplicates across both within-page and cross-page results.
   const newHits = response.hits.filter((hit) => {
-    const id = (hit.fields?.[SPAN_ID]?.[0] ?? hit.fields?.[TRANSACTION_ID]?.[0]) as
-      | string
-      | undefined;
+    const id = getTraceHitId(hit);
     if (!id || seenIds.has(id)) return false;
     seenIds.add(id);
     return true;
@@ -259,7 +258,7 @@ async function paginate({
   });
 }
 
-export function getUnifiedTraceItemsPaginated({
+export async function getUnifiedTraceItemsPaginated({
   apmEventClient,
   maxTraceItems,
   traceId,
@@ -267,6 +266,7 @@ export function getUnifiedTraceItemsPaginated({
   end,
   serviceName,
   ecsOnly = false,
+  focusedDocId,
 }: {
   apmEventClient: APMEventClient;
   maxTraceItems: number;
@@ -275,8 +275,9 @@ export function getUnifiedTraceItemsPaginated({
   end: number;
   serviceName?: string;
   ecsOnly?: boolean;
-}) {
-  return paginate({
+  focusedDocId?: string;
+}): Promise<{ hits: PageHits; total: number }> {
+  const result = await paginate({
     apmEventClient,
     maxTraceItems,
     traceId,
@@ -287,4 +288,21 @@ export function getUnifiedTraceItemsPaginated({
     seenIds: new Set(),
     ecsOnly,
   });
+
+  if (!focusedDocId) {
+    return result;
+  }
+
+  const hits = await ensureFocusedTraceHits({
+    apmEventClient,
+    hits: result.hits,
+    focusedDocId,
+    maxTraceItems,
+    traceId,
+    start,
+    end,
+    ecsOnly,
+  });
+
+  return { hits, total: result.total };
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/route.ts
@@ -104,6 +104,7 @@ const unifiedTracesByIdRoute = createApmServerRoute({
           maxTraceItems,
           serviceName,
           ecsOnly: ecsOnly ?? false,
+          focusedDocId: entryTransactionId,
         }),
         entryTransactionId
           ? getTransaction({
@@ -152,6 +153,7 @@ const unifiedTracesByIdSummaryRoute = createApmServerRoute({
         start,
         end,
         maxTraceItems,
+        focusedDocId: docId,
       }),
       getTraceSummaryCount({ apmEventClient, start, end, traceId }),
     ]);


### PR DESCRIPTION
Fixes #282960

## Summary

Fixes silent APM waterfall re-rooting on truncated traces ([#282960](https://github.com/elastic/kibana/issues/282960)).

When a trace has more documents than `xpack.apm.ui.maxTraceItems`, ranked pagination (`_score` roots-first, then duration) can drop the selected transaction. The page header still comes from `getTransaction(entryTransactionId)`, and the waterfall falls back to `root[0]`. The size callout frames this as “seeing less of the trace,” not “viewing a different transaction.”

This change:

- Reserves the focused document and its ancestor chain in the unified waterfall hit set, then drops ranked hits from the end so the response stays at `maxTraceItems`.
- Passes `entryTransactionId` / summary `docId` through as `focusedDocId`.
- If the selected id is still missing, reports `TraceDataState.MissingEntry` and shows a dedicated warning instead of treating the fallback as a full trace.

Raising `maxTraceItems` is not a workaround. The same mismatch still reproduces after raising the setting through 20000. The config is already unbounded.

### Before

Header / breadcrumb stay on the selected short transaction. Waterfall roots at a sibling from the same `trace.id`. Size callout is present.

![Before: waterfall rooted at a sibling while the selected transaction remains in the header](https://github.com/user-attachments/assets/7a6a725d-380c-4ee6-8082-dbfa07e3bac3)

The extra “selected transaction is missing” callout in this screenshot is the client safety net from this PR, captured with server reservation temporarily disabled so the unfixed document set is visible.

### After

Waterfall roots at the selected transaction (`GET focused-short-child`, 2.0 ms). Size callout remains (`5102 > 5000`) because truncation is still expected. Missing-entry warning is gone.

![After: waterfall rooted at the selected transaction](https://github.com/user-attachments/assets/1424331a-1ff2-4aff-b3e6-690ff12ff41b)

### Testing

See "Reproduction" section  in https://github.com/elastic/kibana/issues/282960#issuecomment-5283115346.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- Extra ES search (`get_focused_trace_items`) only when the focused id is absent from the ranked page. Bounded to the focused doc plus at most 50 ancestor hops.
- Response shape is unchanged: still `maxTraceItems` hits; `traceDocsTotal` remains the ranked total so the existing size callout still fires.
- 9.3.x transaction details still use the legacy traces route. There is no further 9.3.x release planned, so a 9.3 backport is not the path. **9.4 uses the unified waterfall by default** (`observability:apmUseUnifiedTraceWaterfall` defaults to `true`); backport this change to 9.4 (target 9.4.6).

## Release note

Fixes APM transaction waterfalls that showed a different top-level transaction than the one selected when the trace exceeded `xpack.apm.ui.maxTraceItems`.
