### PR TITLE
[Alerting v2] Add OAS examples for rule API key rotation and change-history 400

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rule_change_history/get_rule_change_history_event_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rule_change_history/get_rule_change_history_event_oas_example.ts
@@ -7,7 +7,10 @@
 
 import type { RuleChangeHistoryDetail } from '@kbn/alerting-v2-schemas';
 import { ALERTING_ERROR_CODES } from '../../lib/errors/error_codes';
-import { RULE_RESPONSE } from '../rules/rule_oas_shared_examples';
+import {
+  INVALID_QUERY_PARAMETERS_RESPONSE,
+  RULE_RESPONSE,
+} from '../rules/rule_oas_shared_examples';
 import { buildOasOperation } from '../oas_utils';
 import type { AlertingOasOperationObject, OasExampleEntry } from '../oas_types';
 import { RULE_CHANGE_HISTORY_UNAVAILABLE_RESPONSE } from './list_rule_change_history_oas_example';
@@ -54,6 +57,7 @@ export const getRuleChangeHistoryEventOasExamples = (): AlertingOasOperationObje
         summary: 'Retrieved rule change-history event with snapshot',
         value: GET_RULE_CHANGE_HISTORY_EVENT_RESPONSE,
       },
+      400: INVALID_QUERY_PARAMETERS_RESPONSE,
       404: RULE_CHANGE_NOT_FOUND_RESPONSE,
       503: RULE_CHANGE_HISTORY_UNAVAILABLE_RESPONSE,
     },

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rule_change_history/get_rule_change_history_event_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rule_change_history/get_rule_change_history_event_oas_example.ts
@@ -7,12 +7,10 @@
 
 import type { RuleChangeHistoryDetail } from '@kbn/alerting-v2-schemas';
 import { ALERTING_ERROR_CODES } from '../../lib/errors/error_codes';
-import {
-  INVALID_QUERY_PARAMETERS_RESPONSE,
-  RULE_RESPONSE,
-} from '../rules/rule_oas_shared_examples';
-import { buildOasOperation } from '../oas_utils';
+import { buildOasOperation, invalidResponseExample } from '../oas_utils';
 import type { AlertingOasOperationObject, OasExampleEntry } from '../oas_types';
+import { INVALID_SCHEMA_OR_PARAMETERS_DESCRIPTION } from '../route_descriptions';
+import { RULE_RESPONSE } from '../rules/rule_oas_shared_examples';
 import { RULE_CHANGE_HISTORY_UNAVAILABLE_RESPONSE } from './list_rule_change_history_oas_example';
 
 const { version: _occVersion, ...RULE_SNAPSHOT } = RULE_RESPONSE;
@@ -38,6 +36,19 @@ export const GET_RULE_CHANGE_HISTORY_EVENT_RESPONSE: RuleChangeHistoryDetail = {
   },
 };
 
+const INVALID_PATH_PARAMETERS_RESPONSE = invalidResponseExample({
+  summary: INVALID_SCHEMA_OR_PARAMETERS_DESCRIPTION,
+  message: 'eventId: Too small: expected string to have >=1 characters',
+  details: {
+    errors: {
+      errors: [],
+      properties: {
+        eventId: { errors: ['Too small: expected string to have >=1 characters'] },
+      },
+    },
+  },
+});
+
 export const RULE_CHANGE_NOT_FOUND_RESPONSE: OasExampleEntry = {
   name: 'ruleChangeNotFound',
   summary: 'No change-history event exists for the given ID',
@@ -57,7 +68,7 @@ export const getRuleChangeHistoryEventOasExamples = (): AlertingOasOperationObje
         summary: 'Retrieved rule change-history event with snapshot',
         value: GET_RULE_CHANGE_HISTORY_EVENT_RESPONSE,
       },
-      400: INVALID_QUERY_PARAMETERS_RESPONSE,
+      400: INVALID_PATH_PARAMETERS_RESPONSE,
       404: RULE_CHANGE_NOT_FOUND_RESPONSE,
       503: RULE_CHANGE_HISTORY_UNAVAILABLE_RESPONSE,
     },

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_update_api_key_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_update_api_key_oas_example.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AlertingOasOperationObject } from '../oas_types';
+import { buildOasOperation } from '../oas_utils';
+import {
+  BULK_OPERATION_REQUEST,
+  BULK_OPERATION_RESPONSE,
+  INVALID_BULK_OPERATION_RESPONSE,
+} from './rule_oas_shared_examples';
+
+export const bulkUpdateApiKeyOasExamples = (): AlertingOasOperationObject =>
+  buildOasOperation({
+    requestBody: {
+      name: 'bulkUpdateApiKeyRequest',
+      summary: 'Rotate API keys for two rules by ID',
+      value: BULK_OPERATION_REQUEST,
+    },
+    responses: {
+      200: {
+        name: 'bulkUpdateApiKeyResponse',
+        summary: 'Rotated API keys for both requested rules',
+        value: BULK_OPERATION_RESPONSE,
+      },
+      400: INVALID_BULK_OPERATION_RESPONSE,
+    },
+  });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_update_api_key_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_update_api_key_route.ts
@@ -16,6 +16,7 @@ import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
 import { ALERTING_V2_RULE_API_PATH } from '../constants';
 import { BaseAlertingRoute } from '../base_alerting_route';
 import { AlertingRouteContext } from '../alerting_route_context';
+import { bulkUpdateApiKeyOasExamples } from './bulk_update_api_key_oas_example';
 
 @injectable()
 export class BulkUpdateApiKeyRoute extends BaseAlertingRoute {
@@ -30,6 +31,7 @@ export class BulkUpdateApiKeyRoute extends BaseAlertingRoute {
     summary: 'Update the API key of rules in bulk by ID',
     description:
       'Rotates each rule executor task API key to one derived from the current user’s credentials.',
+    oasOperationObject: bulkUpdateApiKeyOasExamples,
   } as const;
   static schemas = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/update_api_key_by_query_oas_example.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/update_api_key_by_query_oas_example.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AlertingOasOperationObject } from '../oas_types';
+import { buildOasOperation } from '../oas_utils';
+import {
+  BULK_BY_QUERY_REQUEST,
+  DRY_RUN_RESPONSE,
+  INVALID_BULK_BY_QUERY_RESPONSE,
+} from './rule_oas_shared_examples';
+
+export const updateApiKeyByQueryOasExamples = (): AlertingOasOperationObject =>
+  buildOasOperation({
+    requestBody: {
+      name: 'updateApiKeyByQueryRequest',
+      summary:
+        'Rotate API keys for rules tagged production (dry-run by default, or set `force: true` to execute)',
+      value: BULK_BY_QUERY_REQUEST,
+    },
+    responses: {
+      200: {
+        name: 'updateApiKeyByQueryDryRunResponse',
+        summary: 'Dry-run preview of matching rules; set `force: true` on the request to execute',
+        value: DRY_RUN_RESPONSE,
+      },
+      400: INVALID_BULK_BY_QUERY_RESPONSE,
+    },
+  });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/update_api_key_by_query_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/update_api_key_by_query_route.ts
@@ -20,6 +20,7 @@ import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
 import { ALERTING_V2_RULE_API_PATH } from '../constants';
 import { BaseAlertingRoute } from '../base_alerting_route';
 import { AlertingRouteContext } from '../alerting_route_context';
+import { updateApiKeyByQueryOasExamples } from './update_api_key_by_query_oas_example';
 
 @injectable()
 export class UpdateApiKeyByQueryRoute extends BaseAlertingRoute {
@@ -34,6 +35,7 @@ export class UpdateApiKeyByQueryRoute extends BaseAlertingRoute {
     summary: 'Update the API key of rules matching a query (dry-run by default)',
     description:
       'Rotates each matching rule executor task API key to one derived from the current user’s credentials.',
+    oasOperationObject: updateApiKeyByQueryOasExamples,
   } as const;
   static schemas = {
     request: {


### PR DESCRIPTION
## Summary
- Adds typed OAS examples for `POST /api/alerting/v2/rules/_bulk_update_api_key` (request, 200, 400) and `POST /api/alerting/v2/rules/_update_api_key_by_query` (request, 200, 400).
- Adds a 400 example on `GET /api/alerting/v2/rules/{id}/history/{eventId}` (auto-declared by request validation).
- Covers this domain’s remaining missing-example validation slots without bumping the OAS error baseline.

These are typed code examples for the OpenAPI surface. They will be picked up for OAS generation by #279519 once that work and this PR land together.

Follow-up to the Alerting v2 OAS publication work in #279519.

Relates to elastic/rna-program#665
Part of epic elastic/rna-program#655

## Test plan
- [ ] `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/rule_oas_examples.test.ts x-pack/platform/plugins/shared/alerting_v2/server/routes/rule_change_history/rule_change_history_oas_examples.test.ts`
- [ ] After #279519 includes `/api/alerting/v2/` in the OAS snapshot, `node ./scripts/validate_oas_docs.js --assert-no-error-increase --skip-printing-issues` does not report a +7 error increase on these routes
- [ ] `node ./scripts/validate_oas_docs.js --only traditional --path /api/alerting/v2/rules/_bulk_update_api_key --path /api/alerting/v2/rules/_update_api_key_by_query --path /api/alerting/v2/rules/{id}/history/{eventId}` reports no missing-`examples` errors


Made with [Cursor](https://cursor.com)