### PR TITLE
[SigEvent]: bound compact `ki_search` response metadata

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.test.ts
@@ -11,7 +11,11 @@ import type { COMPUTED_FEATURE_TYPES } from '@kbn/significant-events-schema';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import type { StreamsClient } from '@kbn/streams-plugin/server';
 import type { KnowledgeIndicatorClient } from '../../../lib/knowledge_indicators';
-import { searchKnowledgeIndicatorsToolHandler, type StrippedFeatureKeys } from './handler';
+import {
+  searchKnowledgeIndicatorsToolHandler,
+  type CompactFeature,
+  type StrippedFeatureKeys,
+} from './handler';
 
 const STRIPPED_FEATURE_KEYS = [
   'uuid',
@@ -301,7 +305,7 @@ describe('searchKnowledgeIndicatorsToolHandler', () => {
       kiClient.getQueryLinks = jest.fn().mockResolvedValue([]);
     }
 
-    async function getCompactFeature(feature: Feature) {
+    async function getCompactFeature(feature: Feature): Promise<CompactFeature> {
       setupFeatureStream(feature);
       const result = await searchKnowledgeIndicatorsToolHandler({
         streamsClient,
@@ -310,7 +314,7 @@ describe('searchKnowledgeIndicatorsToolHandler', () => {
         params: { kind: ['feature'] },
         view: 'compact',
       });
-      expect(result.view).toBe('compact');
+      if (result.view !== 'compact') throw new Error('Expected compact view');
       const ki = result.knowledge_indicators[0];
       if (ki.kind !== 'feature') throw new Error('Expected feature KI');
       return ki.feature;
@@ -363,6 +367,126 @@ describe('searchKnowledgeIndicatorsToolHandler', () => {
         patterns_count: 3,
         truncated: true,
       });
+    });
+
+    it('truncates evidence to MAX_FEATURE_ARRAY_ITEMS and sets evidence_count', async () => {
+      const evidence = Array.from({ length: 15 }, (_, i) => `evidence item ${i}`);
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', evidence }));
+      expect(feature.evidence).toHaveLength(10);
+      expect(feature.evidence_count).toBe(15);
+    });
+
+    it('truncates tags to MAX_FEATURE_ARRAY_ITEMS and sets tags_count', async () => {
+      const tags = Array.from({ length: 15 }, (_, i) => `tag-${i}`);
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', tags }));
+      expect(feature.tags).toHaveLength(10);
+      expect(feature.tags_count).toBe(15);
+    });
+
+    it('does not set evidence_count when evidence is exactly MAX_FEATURE_ARRAY_ITEMS', async () => {
+      const evidence = Array.from({ length: 10 }, (_, i) => `evidence item ${i}`);
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', evidence }));
+      expect(feature.evidence).toHaveLength(10);
+      expect(feature).not.toHaveProperty('evidence_count');
+    });
+
+    it('does not set evidence_count when evidence has fewer than MAX_FEATURE_ARRAY_ITEMS', async () => {
+      const evidence = Array.from({ length: 5 }, (_, i) => `evidence item ${i}`);
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', evidence }));
+      expect(feature.evidence).toHaveLength(5);
+      expect(feature).not.toHaveProperty('evidence_count');
+    });
+
+    it('does not set tags_count when tags is exactly MAX_FEATURE_ARRAY_ITEMS', async () => {
+      const tags = Array.from({ length: 10 }, (_, i) => `tag-${i}`);
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', tags }));
+      expect(feature.tags).toHaveLength(10);
+      expect(feature).not.toHaveProperty('tags_count');
+    });
+
+    it('does not set tags_count when tags has fewer than MAX_FEATURE_ARRAY_ITEMS', async () => {
+      const tags = Array.from({ length: 5 }, (_, i) => `tag-${i}`);
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', tags }));
+      expect(feature.tags).toHaveLength(5);
+      expect(feature).not.toHaveProperty('tags_count');
+    });
+
+    it('samples array-valued meta keys to MAX_COMPACT_META_ARRAY_SAMPLE and preserves scalars', async () => {
+      const meta = {
+        observed_clusters: Array.from({ length: 15 }, (_, i) => `cluster-${i}`),
+        observed_regions: Array.from({ length: 12 }, (_, i) => `region-${i}`),
+        runtime: 'containerd',
+        version: '0.41.0',
+      };
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', meta }));
+      expect(feature.meta?.observed_clusters).toEqual(['cluster-0', 'cluster-1', 'cluster-2']);
+      expect(feature.meta?.observed_regions).toEqual(['region-0', 'region-1', 'region-2']);
+      expect(feature.meta?.runtime).toBe('containerd');
+      expect(feature.meta?.version).toBe('0.41.0');
+      expect(feature).not.toHaveProperty('meta_keys_omitted');
+      expect(feature.meta_array_items_omitted).toEqual({
+        observed_clusters: 12,
+        observed_regions: 9,
+      });
+    });
+
+    it('drops meta keys beyond MAX_COMPACT_META_KEYS and sets meta_keys_omitted', async () => {
+      const meta = Object.fromEntries(
+        Array.from({ length: 40 }, (_, i) => [`key_${String(i).padStart(2, '0')}`, `value-${i}`])
+      );
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', meta }));
+      const keptKeys = Object.keys(feature.meta ?? {});
+      expect(keptKeys).toHaveLength(10);
+      expect(feature.meta_keys_omitted).toBe(30);
+      // insertion order preserved: the first keys survive
+      expect(keptKeys[0]).toBe('key_00');
+      expect(keptKeys[9]).toBe('key_09');
+    });
+
+    it('keeps small meta intact without meta_keys_omitted', async () => {
+      const meta = { port: '5560', endpoint_paths: ['/accounts/projects'], note: 'internal HTTP' };
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', meta }));
+      expect(feature.meta).toEqual(meta);
+      expect(feature).not.toHaveProperty('meta_keys_omitted');
+    });
+
+    it('truncates nested meta values and records omitted array items', async () => {
+      const meta = {
+        nested: {
+          deeper: {
+            value: 'omitted',
+          },
+        },
+        ports: [443, 8443, 9200, 9300],
+      };
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', meta }));
+      expect(feature.meta?.nested).toEqual({
+        deeper: '[nested metadata truncated]',
+      });
+      expect(feature.meta?.ports).toEqual([443, 8443, 9200]);
+      expect(feature.meta_array_items_omitted).toEqual({ ports: 1 });
+    });
+
+    it('passes through undefined meta without error', async () => {
+      const feature = await getCompactFeature(makeFeature({ type: 'entity', meta: undefined }));
+      expect(feature.meta).toBeUndefined();
+      expect(feature).not.toHaveProperty('meta_keys_omitted');
+      expect(feature).not.toHaveProperty('meta_array_items_omitted');
+    });
+
+    it('passes through undefined evidence and tags without count fields or error', async () => {
+      const feature = await getCompactFeature(
+        makeFeature({ type: 'entity', evidence: undefined, tags: undefined })
+      );
+      expect(feature).not.toHaveProperty('evidence_count');
+      expect(feature).not.toHaveProperty('tags_count');
+    });
+
+    it('truncates evidence on non-entity inferred type (infrastructure)', async () => {
+      const evidence = Array.from({ length: 15 }, (_, i) => `evidence item ${i}`);
+      const feature = await getCompactFeature(makeFeature({ type: 'infrastructure', evidence }));
+      expect(feature.evidence).toHaveLength(10);
+      expect(feature.evidence_count).toBe(15);
     });
 
     it('omits filter for entity but preserves it for non-entity types', async () => {

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.test.ts
@@ -450,19 +450,11 @@ describe('searchKnowledgeIndicatorsToolHandler', () => {
       expect(feature).not.toHaveProperty('meta_keys_omitted');
     });
 
-    it('truncates nested meta values and records omitted array items', async () => {
+    it('samples top-level array values and records omitted items', async () => {
       const meta = {
-        nested: {
-          deeper: {
-            value: 'omitted',
-          },
-        },
         ports: [443, 8443, 9200, 9300],
       };
       const feature = await getCompactFeature(makeFeature({ type: 'entity', meta }));
-      expect(feature.meta?.nested).toEqual({
-        deeper: '[nested metadata truncated]',
-      });
       expect(feature.meta?.ports).toEqual([443, 8443, 9200]);
       expect(feature.meta_array_items_omitted).toEqual({ ports: 1 });
     });

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.ts
@@ -13,7 +13,11 @@ import type {
   SearchKnowledgeIndicatorsInput,
 } from '@kbn/streams-ai';
 import type { Feature, StreamQuery } from '@kbn/significant-events-schema';
-import { COMPUTED_FEATURE_TYPES, INFERRED_FEATURE_TYPES } from '@kbn/significant-events-schema';
+import {
+  COMPUTED_FEATURE_TYPES,
+  INFERRED_FEATURE_TYPES,
+  MAX_FEATURE_ARRAY_ITEMS,
+} from '@kbn/significant-events-schema';
 import type { Logger } from '@kbn/core/server';
 import type { StreamsClient } from '@kbn/streams-plugin/server';
 import type {
@@ -34,7 +38,12 @@ export type StrippedFeatureKeys = keyof Pick<
   'uuid' | 'run_id' | 'updated_at' | 'expires_at' | 'confidence' | 'evidence_doc_ids'
 >;
 
-export type CompactFeature = Omit<Feature, StrippedFeatureKeys>;
+export type CompactFeature = Omit<Feature, StrippedFeatureKeys> & {
+  evidence_count?: number;
+  tags_count?: number;
+  meta_keys_omitted?: number;
+  meta_array_items_omitted?: Record<string, number>;
+};
 
 export type CompactQuery = StreamQuery;
 
@@ -75,6 +84,61 @@ function isComputedFeatureType(type: string): type is ComputedFeatureType {
 const MAX_DATASET_ANALYSIS_FIELDS = 10;
 const MAX_LOG_SAMPLES = 1;
 const MAX_LOG_PATTERNS = 1;
+export const MAX_COMPACT_META_ARRAY_SAMPLE = 3;
+export const MAX_COMPACT_META_KEYS = 10;
+export const MAX_COMPACT_META_DEPTH = 2;
+
+// Feature meta is free-form model output merged across runs; large features accumulate
+// dozens of near-synonym keys. Keep the first MAX_COMPACT_META_KEYS keys with array
+// values sampled to MAX_COMPACT_META_ARRAY_SAMPLE — dropped keys are surfaced via
+// meta_keys_omitted.
+function truncateMeta(meta: Record<string, unknown>): {
+  meta: Record<string, unknown>;
+  omittedKeys: number;
+  arrayItemsOmitted: Record<string, number>;
+} {
+  const entries = Object.entries(meta);
+  const arrayItemsOmitted: Record<string, number> = {};
+  const kept = entries.slice(0, MAX_COMPACT_META_KEYS).map(([key, value]) => {
+    if (!Array.isArray(value)) {
+      return [key, value];
+    }
+
+    if (value.length > MAX_COMPACT_META_ARRAY_SAMPLE) {
+      arrayItemsOmitted[key] = value.length - MAX_COMPACT_META_ARRAY_SAMPLE;
+    }
+
+    return [key, truncateMetaValue(value, 1)];
+  });
+
+  return {
+    meta: Object.fromEntries(kept),
+    omittedKeys: Math.max(0, entries.length - MAX_COMPACT_META_KEYS),
+    arrayItemsOmitted,
+  };
+}
+
+function truncateMetaValue(value: unknown, depth: number): unknown {
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, MAX_COMPACT_META_ARRAY_SAMPLE)
+      .map((item) => truncateMetaValue(item, depth + 1));
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    if (depth >= MAX_COMPACT_META_DEPTH) {
+      return '[nested metadata truncated]';
+    }
+
+    return Object.fromEntries(
+      Object.entries(value)
+        .slice(0, MAX_COMPACT_META_KEYS)
+        .map(([key, nestedValue]) => [key, truncateMetaValue(nestedValue, depth + 1)])
+    );
+  }
+
+  return value;
+}
 
 function truncateComputedProperties(
   type: ComputedFeatureType,
@@ -126,11 +190,37 @@ function toCompactFeatureKI(ki: KnowledgeIndicatorFeature): CompactKnowledgeIndi
     ? truncateComputedProperties(rest.type, rest.properties)
     : rest.properties;
 
+  const evidenceOriginalLength = rest.evidence?.length;
+  const evidenceTruncated =
+    evidenceOriginalLength !== undefined && evidenceOriginalLength > MAX_FEATURE_ARRAY_ITEMS;
+  const evidence =
+    evidenceTruncated && rest.evidence
+      ? rest.evidence.slice(0, MAX_FEATURE_ARRAY_ITEMS)
+      : rest.evidence;
+
+  const tagsOriginalLength = rest.tags?.length;
+  const tagsTruncated =
+    tagsOriginalLength !== undefined && tagsOriginalLength > MAX_FEATURE_ARRAY_ITEMS;
+  const tags = tagsTruncated && rest.tags ? rest.tags.slice(0, MAX_FEATURE_ARRAY_ITEMS) : rest.tags;
+
+  const metaResult = rest.meta ? truncateMeta(rest.meta) : undefined;
+
   return {
     kind: 'feature',
     feature: {
       ...rest,
       properties,
+      evidence,
+      tags,
+      meta: metaResult?.meta,
+      ...(evidenceTruncated ? { evidence_count: evidenceOriginalLength } : {}),
+      ...(tagsTruncated ? { tags_count: tagsOriginalLength } : {}),
+      ...(metaResult && metaResult.omittedKeys > 0
+        ? { meta_keys_omitted: metaResult.omittedKeys }
+        : {}),
+      ...(metaResult && Object.keys(metaResult.arrayItemsOmitted).length > 0
+        ? { meta_array_items_omitted: metaResult.arrayItemsOmitted }
+        : {}),
       // filter is omitted for entity features; restored for all other inferred types
       ...(rest.type !== 'entity' && filter !== undefined ? { filter } : {}),
     },

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.ts
@@ -100,11 +100,7 @@ function truncateMeta(meta: Record<string, unknown>): {
   const entries = Object.entries(meta);
   const arrayItemsOmitted: Record<string, number> = {};
   const kept = entries.slice(0, MAX_COMPACT_META_KEYS).map(([key, value]) => {
-    if (!Array.isArray(value)) {
-      return [key, value];
-    }
-
-    if (value.length > MAX_COMPACT_META_ARRAY_SAMPLE) {
+    if (Array.isArray(value) && value.length > MAX_COMPACT_META_ARRAY_SAMPLE) {
       arrayItemsOmitted[key] = value.length - MAX_COMPACT_META_ARRAY_SAMPLE;
     }
 

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.ts
@@ -178,6 +178,19 @@ function truncateComputedProperties(
   return properties;
 }
 
+interface BoundedArray<T> {
+  items: T[] | undefined;
+  count?: number;
+}
+
+function boundArray<T>(values: T[] | undefined): BoundedArray<T> {
+  if (values === undefined || values.length <= MAX_FEATURE_ARRAY_ITEMS) {
+    return { items: values };
+  }
+
+  return { items: values.slice(0, MAX_FEATURE_ARRAY_ITEMS), count: values.length };
+}
+
 function toCompactFeatureKI(ki: KnowledgeIndicatorFeature): CompactKnowledgeIndicatorFeature {
   const { uuid, run_id, updated_at, expires_at, confidence, evidence_doc_ids, filter, ...rest } =
     ki.feature;
@@ -186,18 +199,8 @@ function toCompactFeatureKI(ki: KnowledgeIndicatorFeature): CompactKnowledgeIndi
     ? truncateComputedProperties(rest.type, rest.properties)
     : rest.properties;
 
-  const evidenceOriginalLength = rest.evidence?.length;
-  const evidenceTruncated =
-    evidenceOriginalLength !== undefined && evidenceOriginalLength > MAX_FEATURE_ARRAY_ITEMS;
-  const evidence =
-    evidenceTruncated && rest.evidence
-      ? rest.evidence.slice(0, MAX_FEATURE_ARRAY_ITEMS)
-      : rest.evidence;
-
-  const tagsOriginalLength = rest.tags?.length;
-  const tagsTruncated =
-    tagsOriginalLength !== undefined && tagsOriginalLength > MAX_FEATURE_ARRAY_ITEMS;
-  const tags = tagsTruncated && rest.tags ? rest.tags.slice(0, MAX_FEATURE_ARRAY_ITEMS) : rest.tags;
+  const { items: evidence, count: evidenceCount } = boundArray(rest.evidence);
+  const { items: tags, count: tagsCount } = boundArray(rest.tags);
 
   const metaResult = rest.meta ? truncateMeta(rest.meta) : undefined;
 
@@ -209,8 +212,8 @@ function toCompactFeatureKI(ki: KnowledgeIndicatorFeature): CompactKnowledgeIndi
       evidence,
       tags,
       meta: metaResult?.meta,
-      ...(evidenceTruncated ? { evidence_count: evidenceOriginalLength } : {}),
-      ...(tagsTruncated ? { tags_count: tagsOriginalLength } : {}),
+      ...(evidenceCount !== undefined ? { evidence_count: evidenceCount } : {}),
+      ...(tagsCount !== undefined ? { tags_count: tagsCount } : {}),
       ...(metaResult && metaResult.omittedKeys > 0
         ? { meta_keys_omitted: metaResult.omittedKeys }
         : {}),

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/handler.ts
@@ -86,12 +86,11 @@ const MAX_LOG_SAMPLES = 1;
 const MAX_LOG_PATTERNS = 1;
 export const MAX_COMPACT_META_ARRAY_SAMPLE = 3;
 export const MAX_COMPACT_META_KEYS = 10;
-export const MAX_COMPACT_META_DEPTH = 2;
 
-// Feature meta is free-form model output merged across runs; large features accumulate
-// dozens of near-synonym keys. Keep the first MAX_COMPACT_META_KEYS keys with array
-// values sampled to MAX_COMPACT_META_ARRAY_SAMPLE — dropped keys are surfaced via
-// meta_keys_omitted.
+// Feature meta is a flat Record<string, scalar | array> — see baseFeatureSchema in
+// kbn-significant-events-schema. Keep the first MAX_COMPACT_META_KEYS keys; sample
+// array values to MAX_COMPACT_META_ARRAY_SAMPLE items and record omissions in
+// meta_array_items_omitted. Unexpected object values are left as-is (schema violation).
 function truncateMeta(meta: Record<string, unknown>): {
   meta: Record<string, unknown>;
   omittedKeys: number;
@@ -100,11 +99,15 @@ function truncateMeta(meta: Record<string, unknown>): {
   const entries = Object.entries(meta);
   const arrayItemsOmitted: Record<string, number> = {};
   const kept = entries.slice(0, MAX_COMPACT_META_KEYS).map(([key, value]) => {
-    if (Array.isArray(value) && value.length > MAX_COMPACT_META_ARRAY_SAMPLE) {
-      arrayItemsOmitted[key] = value.length - MAX_COMPACT_META_ARRAY_SAMPLE;
+    if (Array.isArray(value)) {
+      if (value.length > MAX_COMPACT_META_ARRAY_SAMPLE) {
+        arrayItemsOmitted[key] = value.length - MAX_COMPACT_META_ARRAY_SAMPLE;
+        return [key, value.slice(0, MAX_COMPACT_META_ARRAY_SAMPLE)];
+      }
+      return [key, value];
     }
 
-    return [key, truncateMetaValue(value, 1)];
+    return [key, value];
   });
 
   return {
@@ -112,28 +115,6 @@ function truncateMeta(meta: Record<string, unknown>): {
     omittedKeys: Math.max(0, entries.length - MAX_COMPACT_META_KEYS),
     arrayItemsOmitted,
   };
-}
-
-function truncateMetaValue(value: unknown, depth: number): unknown {
-  if (Array.isArray(value)) {
-    return value
-      .slice(0, MAX_COMPACT_META_ARRAY_SAMPLE)
-      .map((item) => truncateMetaValue(item, depth + 1));
-  }
-
-  if (typeof value === 'object' && value !== null) {
-    if (depth >= MAX_COMPACT_META_DEPTH) {
-      return '[nested metadata truncated]';
-    }
-
-    return Object.fromEntries(
-      Object.entries(value)
-        .slice(0, MAX_COMPACT_META_KEYS)
-        .map(([key, nestedValue]) => [key, truncateMetaValue(nestedValue, depth + 1)])
-    );
-  }
-
-  return value;
 }
 
 function truncateComputedProperties(

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/tool.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/tool.ts
@@ -7,6 +7,7 @@
 
 import { z } from '@kbn/zod/v4';
 import {
+  MAX_FEATURE_ARRAY_ITEMS,
   MAX_ID_LENGTH,
   MAX_TEXT_LENGTH,
   QUERY_TYPE_MATCH,
@@ -25,7 +26,13 @@ import type { StreamsServer } from '@kbn/streams-plugin/server/types';
 import { DEFAULT_SEARCH_KNOWLEDGE_INDICATORS_PER_PAGE } from '@kbn/streams-ai';
 import type { GetScopedClients } from '../../../routes/types';
 import { assertSignificantEventsAccess } from '../../../routes/utils/assert_significant_events_access';
-import { KNOWLEDGE_INDICATOR_FEATURE_TYPES, searchKnowledgeIndicatorsToolHandler } from './handler';
+import {
+  KNOWLEDGE_INDICATOR_FEATURE_TYPES,
+  MAX_COMPACT_META_ARRAY_SAMPLE,
+  MAX_COMPACT_META_DEPTH,
+  MAX_COMPACT_META_KEYS,
+  searchKnowledgeIndicatorsToolHandler,
+} from './handler';
 
 export const SIGNIFICANT_EVENTS_KNOWLEDGE_INDICATORS_SEARCH_TOOL_ID =
   platformSignificantEventsTools.searchKnowledgeIndicators;
@@ -106,8 +113,8 @@ const searchKnowledgeIndicatorsSchema = z.object({
     .default('compact')
     .describe(
       dedent`Response detail level.
-      - 'compact' (default): strips unused metadata fields and truncates computed feature types (dataset_analysis, error_logs, log_patterns, log_samples). Maximum ${MAX_SEARCH_KNOWLEDGE_INDICATORS_PER_PAGE} per page.
-      - 'full': returns all fields verbatim. Use with specific \`feature_ids\` to retrieve complete computed-type properties. Maximum ${KI_SEARCH_MAX_PER_PAGE_FULL} per page.`
+      - 'compact' (default): strips unused metadata fields and truncates computed feature types (dataset_analysis, error_logs, log_patterns, log_samples). Bounds \`evidence\` and \`tags\` to ${MAX_FEATURE_ARRAY_ITEMS} items on all feature KIs; \`evidence_count\` and \`tags_count\` are present when those arrays were truncated. \`meta\` keeps the first ${MAX_COMPACT_META_KEYS} keys in JavaScript property-enumeration order, samples array values to ${MAX_COMPACT_META_ARRAY_SAMPLE} items, records omitted array items in \`meta_array_items_omitted\`, and truncates nested values beyond depth ${MAX_COMPACT_META_DEPTH}. \`meta_keys_omitted\` counts dropped keys. Maximum ${MAX_SEARCH_KNOWLEDGE_INDICATORS_PER_PAGE} per page.
+      - 'full': returns all fields verbatim. Use with specific \`feature_ids\` to retrieve untruncated evidence, tags, metadata, and computed-type properties. Maximum ${KI_SEARCH_MAX_PER_PAGE_FULL} per page.`
     ),
 });
 

--- a/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/tool.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/agent_builder/tools/search_knowledge_indicators/tool.ts
@@ -29,7 +29,6 @@ import { assertSignificantEventsAccess } from '../../../routes/utils/assert_sign
 import {
   KNOWLEDGE_INDICATOR_FEATURE_TYPES,
   MAX_COMPACT_META_ARRAY_SAMPLE,
-  MAX_COMPACT_META_DEPTH,
   MAX_COMPACT_META_KEYS,
   searchKnowledgeIndicatorsToolHandler,
 } from './handler';
@@ -113,7 +112,7 @@ const searchKnowledgeIndicatorsSchema = z.object({
     .default('compact')
     .describe(
       dedent`Response detail level.
-      - 'compact' (default): strips unused metadata fields and truncates computed feature types (dataset_analysis, error_logs, log_patterns, log_samples). Bounds \`evidence\` and \`tags\` to ${MAX_FEATURE_ARRAY_ITEMS} items on all feature KIs; \`evidence_count\` and \`tags_count\` are present when those arrays were truncated. \`meta\` keeps the first ${MAX_COMPACT_META_KEYS} keys in JavaScript property-enumeration order, samples array values to ${MAX_COMPACT_META_ARRAY_SAMPLE} items, records omitted array items in \`meta_array_items_omitted\`, and truncates nested values beyond depth ${MAX_COMPACT_META_DEPTH}. \`meta_keys_omitted\` counts dropped keys. Maximum ${MAX_SEARCH_KNOWLEDGE_INDICATORS_PER_PAGE} per page.
+      - 'compact' (default): strips unused metadata fields and truncates computed feature types (dataset_analysis, error_logs, log_patterns, log_samples). Bounds \`evidence\` and \`tags\` to ${MAX_FEATURE_ARRAY_ITEMS} items on all feature KIs; \`evidence_count\` and \`tags_count\` are present when those arrays were truncated. \`meta\` is a flat key→value map; keeps the first ${MAX_COMPACT_META_KEYS} keys in JavaScript property-enumeration order, samples array values to ${MAX_COMPACT_META_ARRAY_SAMPLE} items, and records omitted array items in \`meta_array_items_omitted\`. \`meta_keys_omitted\` counts dropped keys. Maximum ${MAX_SEARCH_KNOWLEDGE_INDICATORS_PER_PAGE} per page.
       - 'full': returns all fields verbatim. Use with specific \`feature_ids\` to retrieve untruncated evidence, tags, metadata, and computed-type properties. Maximum ${KI_SEARCH_MAX_PER_PAGE_FULL} per page.`
     ),
 });


### PR DESCRIPTION
closes https://github.com/elastic/nightshift-program/issues/1080

## Summary

The `ki_search` compact view now bounds evidence, tags, and metadata to prevent oversized agent responses while exposing omission counts when information is truncated. Full view remains unchanged.

### How to test

- Verify compact feature responses cap evidence and tags at 10 items.
- Verify omission counts are present only when truncation occurs.
- Verify metadata key, array, and nested-value bounds.
- Verify full view returns fields unmodified.
- Automated: targeted Jest and ESLint commands were attempted but exited 134 under Node 24.19.0; IDE lint diagnostics and `git diff --check` pass.

### Checklist

- [x] Unit tests were updated or added.
- [x] No plugin configuration keys changed.
- [x] No visual changes.

### Identify risks

The compact response intentionally omits excess metadata and array entries; omission counts and full view provide recovery paths.