### PR TITLE
[Security Solution][Attacks] Replace deprecated iInCircle icon with info

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/alerts_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/alerts_tab.tsx
@@ -131,7 +131,7 @@ export const AlertsTab = React.memo<AlertsTabProps>(
             <EuiCallOut
               announceOnMount
               color="primary"
-              iconType="iInCircle"
+              iconType="info"
               data-test-subj={ALERTS_TAB_CALLOUT_TEST_ID}
             >
               <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>


### PR DESCRIPTION
## Summary

The Attacks alerts-tab callout used the removed EUI icon `iInCircle`, which rendered as a broken image.

EUI renamed `iInCircle` to `info` and later dropped the alias. `EuiCallOut` still accepts arbitrary strings as `iconType`, so this compiled but failed at runtime. This PR switches the callout to `iconType="info"`.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->