### PR TITLE
chore(deps): bump `socket.io-parser` from `4.2.6` to `4.2.7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "**/remark-parse/trim": "1.0.1",
     "**/serialize-javascript": "7.0.5",
     "**/sharp": "0.35.2",
-    "**/socket.io-parser": "4.2.6",
+    "**/socket.io-parser": "4.2.7",
     "**/typescript": "6.0.3",
     "**/util": "0.12.5",
     "**/yauzl": "3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31553,10 +31553,10 @@ socket.io-adapter@~2.5.2:
     debug "~4.4.1"
     ws "~8.21.0"
 
-socket.io-parser@4.2.6, socket.io-parser@~4.2.4:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.6.tgz#19156bf179af3931abd05260cfb1491822578a6f"
-  integrity sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==
+socket.io-parser@4.2.7, socket.io-parser@~4.2.4:
+  version "4.2.7"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.7.tgz#679e51fe24d1c81df90fc5f7efe4a5f432fe99c0"
+  integrity sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.4.1"


### PR DESCRIPTION
## Summary

Bump `socket.io-parser` from `4.2.6` to `4.2.7`.





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->