### PR TITLE
[scout] fix eslint rule for namespaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3017,9 +3017,9 @@ module.exports = {
     {
       // Platform & Solutions API Tests
       files: [
-        'src/platform/plugins/**/test/{scout,scout_*}/api/**/*.ts',
-        'x-pack/platform/**/plugins/**/test/{scout,scout_*}/api/**/*.ts',
-        'x-pack/solutions/**/plugins/**/test/{scout,scout_*}/api/**/*.ts',
+        'src/platform/plugins/**/test/{scout,scout_*}/**/api/**/*.ts',
+        'x-pack/platform/**/plugins/**/test/{scout,scout_*}/**/api/**/*.ts',
+        'x-pack/solutions/**/plugins/**/test/{scout,scout_*}/**/api/**/*.ts',
       ],
       rules: {
         '@kbn/eslint/scout_require_api_client_in_api_test': [


### PR DESCRIPTION
## Summary

Updating ESLint rule for `esClient` usage in scout tests to respect namespaces





<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->