### PR TITLE
Draft: Security ML job settings unification & rule↔job upgrade consent

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/public/plugin.ts
+++ b/x-pack/solutions/security/plugins/entity_store/public/plugin.ts
@@ -12,6 +12,12 @@ import { registerStepDefinitions } from './workflow/steps';
 
 export class EntityStorePlugin implements Plugin {
   public setup(core: CoreSetup, deps: AppPluginSetupDependencies) {
+    // Guard: required plugin can be missing on the browser when plugin bundles fail to
+    // load/compile (incomplete node_modules, optimizer errors). Avoid hard-crashing Kibana.
+    if (!deps.workflowsExtensions) {
+      return;
+    }
+
     registerTriggerDefinitions(deps.workflowsExtensions);
     registerStepDefinitions(deps.workflowsExtensions);
 

--- a/x-pack/solutions/security/plugins/entity_store/public/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/public/types.ts
@@ -10,5 +10,5 @@ import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extens
 
 export interface AppPluginSetupDependencies {
   developerExamples: DeveloperExamplesSetup;
-  workflowsExtensions: WorkflowsExtensionsPublicPluginSetup;
+  workflowsExtensions?: WorkflowsExtensionsPublicPluginSetup;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/__snapshots__/upgrade_contents.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/__snapshots__/upgrade_contents.test.tsx.snap
@@ -1,12 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`JobsTableFilters renders correctly against snapshot 1`] = `
-<PopoverContentsDiv
+<div
   data-test-subj="ml-popover-upgrade-contents"
 >
-  <EuiPopoverTitle>
-    Upgrade to Elastic Platinum
-  </EuiPopoverTitle>
   <EuiText
     size="s"
   >
@@ -57,5 +54,5 @@ exports[`JobsTableFilters renders correctly against snapshot 1`] = `
       </EuiButton>
     </EuiFlexItem>
   </EuiFlexGroup>
-</PopoverContentsDiv>
+</div>
 `;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/api.ts
@@ -44,14 +44,20 @@ export const checkRecognizer = async ({
   );
 
 /**
- * Returns ML Module for given moduleId. Returns all modules if no moduleId specified
+ * Returns ML Module for given moduleId. Returns all modules if no moduleId specified.
+ * Matches Machine Learning → Supplied configurations when called without a filter.
  *
  * @param moduleId id of the module to retrieve
+ * @param filter optional tag filter (e.g. `security`)
  * @param signal to cancel request
  *
  * @throws An error if response is not OK
  */
-export const getModules = async ({ moduleId = '', signal }: GetModulesProps): Promise<Module[]> =>
+export const getModules = async ({
+  moduleId = '',
+  filter,
+  signal,
+}: GetModulesProps): Promise<Module[]> =>
   KibanaServices.get().http.fetch<Module[]>(
     `/internal/ml/modules/get_module/${encodeURIComponent(moduleId)}`,
     {
@@ -59,9 +65,34 @@ export const getModules = async ({ moduleId = '', signal }: GetModulesProps): Pr
       version: '1',
       asSystemRequest: true,
       signal,
-      query: { filter: 'security' },
+      query: {
+        ...(filter ? { filter } : {}),
+      },
     }
   );
+
+/**
+ * Returns ML modules installed via Fleet packages (`ml-module` saved objects).
+ * These are the integration-packaged configs — distinct from file-based stack modules.
+ */
+export const getFleetMlModules = async ({
+  signal,
+}: {
+  signal?: AbortSignal;
+} = {}): Promise<Module[]> => {
+  const response = await KibanaServices.get().http.fetch<{
+    saved_objects: Array<{ attributes: Module }>;
+  }>('/api/saved_objects/_find', {
+    method: 'GET',
+    signal,
+    query: {
+      type: 'ml-module',
+      per_page: 10000,
+    },
+  });
+
+  return response.saved_objects.map((savedObject) => savedObject.attributes);
+};
 
 /**
  * Creates ML Jobs + Datafeeds for the given configTemplate + indexPatternName

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_fetch_fleet_ml_modules_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_fetch_fleet_ml_modules_query.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseQueryOptions } from '@kbn/react-query';
+import { useQuery, useQueryClient } from '@kbn/react-query';
+import { useCallback } from 'react';
+import { getFleetMlModules } from '../api';
+import type { Module } from '../types';
+
+const ONE_MINUTE = 60000;
+export const GET_FLEET_ML_MODULES_QUERY_KEY = ['GET', '/api/saved_objects/_find', 'ml-module'];
+
+export const useFetchFleetMlModulesQuery = (options?: UseQueryOptions<Module[]>) => {
+  return useQuery<Module[]>(
+    GET_FLEET_ML_MODULES_QUERY_KEY,
+    async ({ signal }) => getFleetMlModules({ signal }),
+    {
+      refetchIntervalInBackground: false,
+      staleTime: ONE_MINUTE * 5,
+      retry: false,
+      ...options,
+    }
+  );
+};
+
+export const useInvalidateFetchFleetMlModulesQuery = () => {
+  const queryClient = useQueryClient();
+
+  return useCallback(() => {
+    queryClient.invalidateQueries(GET_FLEET_ML_MODULES_QUERY_KEY, { refetchType: 'active' });
+  }, [queryClient]);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs.test.ts
@@ -12,7 +12,7 @@ import { useAppToasts } from '../../../hooks/use_app_toasts';
 import { useAppToastsMock } from '../../../hooks/use_app_toasts.mock';
 import { TestProviders } from '../../../mock';
 import { getJobsSummary } from '../../ml/api/get_jobs_summary';
-import { checkRecognizer, getModules } from '../api';
+import { checkRecognizer, getFleetMlModules, getModules } from '../api';
 import {
   checkRecognizerSuccess,
   mockGetModuleResponse,
@@ -43,6 +43,7 @@ describe('useSecurityJobs', () => {
       (hasMlLicense as jest.Mock).mockReturnValue(true);
       (getJobsSummary as jest.Mock).mockResolvedValue(mockJobsSummaryResponse);
       (getModules as jest.Mock).mockResolvedValue(mockGetModuleResponse);
+      (getFleetMlModules as jest.Mock).mockResolvedValue([]);
       (checkRecognizer as jest.Mock).mockResolvedValue(checkRecognizerSuccess);
     });
 
@@ -60,6 +61,7 @@ describe('useSecurityJobs', () => {
         isCompatible: true,
         isElasticJob: false,
         isInstalled: true,
+        isIntegrationJob: false,
         isSingleMetricViewerJob: true,
         jobState: 'closed',
         jobTags: {},
@@ -116,6 +118,8 @@ describe('useSecurityJobs', () => {
       });
 
       expect(result.current.jobs).toEqual([]);
+      expect(result.current.integrationJobs).toEqual([]);
+      expect(result.current.fleetModules).toEqual([]);
       expect(result.current.isMlAdmin).toEqual(false);
       expect(result.current.isLicensed).toEqual(false);
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs.ts
@@ -16,13 +16,19 @@ import { useFetchJobsSummaryQuery } from '../../ml/hooks/use_fetch_jobs_summary_
 import { useMlCapabilities } from '../../ml/hooks/use_ml_capabilities';
 import * as i18n from '../../ml/translations';
 import type { SecurityJob } from '../types';
+import type { Module } from '../types';
+import { useFetchFleetMlModulesQuery } from './use_fetch_fleet_ml_modules_query';
 import { useFetchModulesQuery } from './use_fetch_modules_query';
 import { useFetchRecognizerQuery } from './use_fetch_recognizer_query';
-import { createSecurityJobs } from './use_security_jobs_helpers';
+import { createSecurityJobsBySource } from './use_security_jobs_helpers';
 
 export interface UseSecurityJobsReturn {
   loading: boolean;
   jobs: SecurityJob[];
+  /** ML jobs from Fleet packages (`ml-module` saved objects). */
+  integrationJobs: SecurityJob[];
+  /** Fleet `ml-module` packages available for the Integration jobs tab. */
+  fleetModules: Module[];
   isMlAdmin: boolean;
   isLicensed: boolean;
   refetch: inputsModel.Refetch;
@@ -66,6 +72,12 @@ export const useSecurityJobs = (): UseSecurityJobsReturn => {
   } = useFetchModulesQuery({}, { enabled: isMlEnabled, onError });
 
   const {
+    data: fleetModules,
+    isFetching: isFleetModulesFetching,
+    refetch: refetchFleetModules,
+  } = useFetchFleetMlModulesQuery({ enabled: isMlEnabled, onError });
+
+  const {
     data: compatibleModules,
     isFetching: isRecognizerFetching,
     refetch: refetchRecognizer,
@@ -77,21 +89,33 @@ export const useSecurityJobs = (): UseSecurityJobsReturn => {
   const refetch = useCallback(() => {
     refetchJobsSummary();
     refetchModules();
+    refetchFleetModules();
     refetchRecognizer();
-  }, [refetchJobsSummary, refetchModules, refetchRecognizer]);
+  }, [refetchFleetModules, refetchJobsSummary, refetchModules, refetchRecognizer]);
 
-  const jobs = useMemo(() => {
-    if (jobSummaryData && modulesData && compatibleModules) {
-      return createSecurityJobs(jobSummaryData, modulesData, compatibleModules);
+  const { jobs, integrationJobs } = useMemo(() => {
+    if (jobSummaryData && modulesData && compatibleModules && fleetModules) {
+      return createSecurityJobsBySource(
+        jobSummaryData,
+        modulesData,
+        compatibleModules,
+        fleetModules
+      );
     }
-    return [];
-  }, [compatibleModules, jobSummaryData, modulesData]);
+    return { jobs: [], integrationJobs: [] };
+  }, [compatibleModules, fleetModules, jobSummaryData, modulesData]);
 
   return {
     isLicensed,
     isMlAdmin,
     jobs,
-    loading: isJobSummaryFetching || isModulesFetching || isRecognizerFetching,
+    integrationJobs,
+    fleetModules: fleetModules ?? [],
+    loading:
+      isJobSummaryFetching ||
+      isModulesFetching ||
+      isFleetModulesFetching ||
+      isRecognizerFetching,
     refetch,
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs_helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs_helpers.test.tsx
@@ -8,6 +8,7 @@
 import {
   composeModuleAndInstalledJobs,
   createSecurityJobs,
+  createSecurityJobsBySource,
   getAugmentedFields,
   getInstalledJobs,
   getModuleJobs,
@@ -43,6 +44,7 @@ describe('useSecurityJobsHelpers', () => {
         isCompatible: false,
         isElasticJob: true,
         isInstalled: false,
+        isIntegrationJob: false,
         isSingleMetricViewerJob: false,
         jobState: 'closed',
         jobTags: {},
@@ -87,7 +89,9 @@ describe('useSecurityJobsHelpers', () => {
           defaultIndexPattern: 'auditbeat-*',
           isCompatible: true,
           isElasticJob: true,
+          isIntegrationJob: false,
           moduleId: 'security_linux_v3',
+          packagedJobRevision: undefined,
         });
       });
     });
@@ -128,6 +132,82 @@ describe('useSecurityJobsHelpers', () => {
           checkRecognizerSuccess
         );
         expect(securityJobs.length).toEqual(6);
+      });
+    });
+
+    describe('createSecurityJobsBySource', () => {
+      test('limits integration jobs to Fleet ml-module saved objects', () => {
+        const fleetModule = {
+          ...mockGetModuleResponse[0],
+          id: 'nginx_data_stream',
+          title: 'Nginx access logs',
+          jobs: mockGetModuleResponse[0].jobs.slice(0, 1),
+        };
+        // File-based module outside the SIEM allowlist must not appear as integration
+        const legacyFileModule = {
+          ...mockGetModuleResponse[0],
+          id: 'apache_ecs',
+          title: 'Apache access logs',
+          jobs: mockGetModuleResponse[0].jobs.slice(0, 1),
+        };
+
+        const { jobs, integrationJobs } = createSecurityJobsBySource(
+          mockJobsSummaryResponse,
+          [...mockGetModuleResponse, fleetModule, legacyFileModule],
+          checkRecognizerSuccess,
+          [fleetModule]
+        );
+
+        expect(jobs.length).toEqual(6);
+        expect(integrationJobs).toHaveLength(1);
+        expect(integrationJobs[0].moduleId).toEqual('nginx_data_stream');
+        expect(integrationJobs[0].isIntegrationJob).toEqual(true);
+        expect(integrationJobs.every((job) => job.moduleId !== 'apache_ecs')).toEqual(true);
+      });
+
+      test('marks installed jobs outdated when packaged job_revision is newer', () => {
+        const moduleWithRevision = {
+          ...mockGetModuleResponse[0],
+          jobs: mockGetModuleResponse[0].jobs.map((job, index) =>
+            index === 0
+              ? {
+                  ...job,
+                  config: {
+                    ...job.config,
+                    custom_settings: {
+                      ...job.config.custom_settings,
+                      job_revision: 5,
+                    },
+                  },
+                }
+              : job
+          ),
+        };
+        const installedWithOldRevision = mockJobsSummaryResponse.map((job, index) =>
+          index === 0
+            ? {
+                ...job,
+                id: moduleWithRevision.jobs[0].id,
+                customSettings: {
+                  ...(job.customSettings ?? {}),
+                  job_revision: 1,
+                },
+              }
+            : job
+        );
+
+        const { jobs } = createSecurityJobsBySource(
+          installedWithOldRevision,
+          [moduleWithRevision],
+          checkRecognizerSuccess,
+          []
+        );
+
+        const outdated = jobs.find((job) => job.id === moduleWithRevision.jobs[0].id);
+        expect(outdated?.isInstalled).toEqual(true);
+        expect(outdated?.installedJobRevision).toEqual(1);
+        expect(outdated?.packagedJobRevision).toEqual(5);
+        expect(outdated?.isUpdateAvailable).toEqual(true);
       });
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs_helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/hooks/use_security_jobs_helpers.tsx
@@ -17,16 +17,31 @@ import type {
 import { mlModules } from '../ml_modules';
 
 /**
+ * True when the installed job's revision is behind the packaged definition.
+ * Works for OOTB Kibana modules and Fleet `ml-module` jobs that ship `job_revision`.
+ */
+export const isJobUpdateAvailable = (
+  installedJobRevision: number | undefined,
+  packagedJobRevision: number | undefined
+): boolean =>
+  packagedJobRevision != null && (installedJobRevision ?? 0) < packagedJobRevision;
+
+/**
  * Helper function for converting from ModuleJob -> SecurityJob
  * @param module
  * @param moduleJob
  * @param isCompatible
+ * @param fleetModuleIds module ids installed via Fleet `ml-module` saved objects
  */
 export const moduleToSecurityJob = (
   module: Module,
   moduleJob: ModuleJob,
-  isCompatible: boolean
+  isCompatible: boolean,
+  fleetModuleIds: Set<string> = new Set()
 ): SecurityJob => {
+  const isElasticJob = mlModules.includes(module.id);
+  const packagedJobRevision = moduleJob.config.custom_settings?.job_revision;
+
   return {
     datafeedId: '',
     datafeedIndices: [],
@@ -43,11 +58,15 @@ export const moduleToSecurityJob = (
     moduleId: module.id,
     isCompatible,
     isInstalled: false,
-    isElasticJob: true,
+    isElasticJob,
+    isIntegrationJob: fleetModuleIds.has(module.id),
     awaitingNodeAssignment: false,
     jobTags: {},
     bucketSpanSeconds: 900,
     customSettings: moduleJob.config.custom_settings,
+    packagedJobRevision,
+    installedJobRevision: undefined,
+    isUpdateAvailable: false,
   };
 };
 
@@ -69,13 +88,16 @@ export const getAugmentedFields = (
         moduleId: moduleJob.moduleId,
         defaultIndexPattern: moduleJob.defaultIndexPattern,
         isCompatible: compatibleModuleIds.includes(moduleJob.moduleId),
-        isElasticJob: true,
+        isElasticJob: moduleJob.isElasticJob,
+        isIntegrationJob: moduleJob.isIntegrationJob,
+        packagedJobRevision: moduleJob.packagedJobRevision,
       }
     : {
         moduleId: '',
         defaultIndexPattern: '',
         isCompatible: true,
         isElasticJob: false,
+        isIntegrationJob: false,
       };
 };
 
@@ -88,13 +110,42 @@ export const getAugmentedFields = (
  */
 export const getModuleJobs = (
   modulesData: Module[],
-  compatibleModuleIds: string[]
+  compatibleModuleIds: string[],
+  fleetModuleIds: Set<string> = new Set()
 ): SecurityJob[] =>
   modulesData
     .filter((module) => mlModules.includes(module.id))
     .map((module) => [
       ...module.jobs.map((moduleJob) =>
-        moduleToSecurityJob(module, moduleJob, compatibleModuleIds.includes(module.id))
+        moduleToSecurityJob(
+          module,
+          moduleJob,
+          compatibleModuleIds.includes(module.id),
+          fleetModuleIds
+        )
+      ),
+    ])
+    .flat();
+
+/**
+ * Process Modules[] into SecurityJobs[] for Fleet integration-packaged ML modules
+ * (`ml-module` saved objects installed with Fleet packages).
+ */
+export const getIntegrationModuleJobs = (
+  modulesData: Module[],
+  compatibleModuleIds: string[],
+  fleetModuleIds: Set<string>
+): SecurityJob[] =>
+  modulesData
+    .filter((module) => fleetModuleIds.has(module.id))
+    .map((module) => [
+      ...module.jobs.map((moduleJob) =>
+        moduleToSecurityJob(
+          module,
+          moduleJob,
+          compatibleModuleIds.includes(module.id),
+          fleetModuleIds
+        )
       ),
     ])
     .flat();
@@ -112,11 +163,51 @@ export const getInstalledJobs = (
   moduleJobs: SecurityJob[],
   compatibleModuleIds: string[]
 ): SecurityJob[] =>
-  jobSummaryData.filter(isSecurityJob).map((jobSummary) => ({
-    ...jobSummary,
-    ...getAugmentedFields(jobSummary.id, moduleJobs, compatibleModuleIds),
-    isInstalled: true,
-  }));
+  jobSummaryData.filter(isSecurityJob).map((jobSummary) => {
+    const augmented = getAugmentedFields(jobSummary.id, moduleJobs, compatibleModuleIds);
+    const installedJobRevision = jobSummary.customSettings?.job_revision as number | undefined;
+    const packagedJobRevision = augmented.packagedJobRevision;
+
+    return {
+      ...jobSummary,
+      ...augmented,
+      isInstalled: true,
+      installedJobRevision,
+      packagedJobRevision,
+      isUpdateAvailable: isJobUpdateAvailable(installedJobRevision, packagedJobRevision),
+    };
+  });
+
+/**
+ * Installed jobs that belong to the given module job list (any ML group), used for
+ * Fleet integration modules outside the Security group.
+ */
+export const getInstalledJobsForModules = (
+  jobSummaryData: MlSummaryJob[],
+  moduleJobs: SecurityJob[],
+  compatibleModuleIds: string[]
+): SecurityJob[] => {
+  const moduleJobIds = new Set(moduleJobs.map((job) => job.id));
+
+  return jobSummaryData
+    .filter((jobSummary) => moduleJobIds.has(jobSummary.id))
+    .map((jobSummary) => {
+      const augmented = getAugmentedFields(jobSummary.id, moduleJobs, compatibleModuleIds);
+      const installedJobRevision = jobSummary.customSettings?.job_revision as number | undefined;
+      const packagedJobRevision =
+        augmented.packagedJobRevision ??
+        moduleJobs.find((job) => job.id === jobSummary.id)?.packagedJobRevision;
+
+      return {
+        ...jobSummary,
+        ...augmented,
+        isInstalled: true,
+        installedJobRevision,
+        packagedJobRevision,
+        isUpdateAvailable: isJobUpdateAvailable(installedJobRevision, packagedJobRevision),
+      };
+    });
+};
 
 /**
  * Combines installed jobs + moduleSecurityJobs that don't overlap and sorts by name asc
@@ -135,6 +226,65 @@ export const composeModuleAndInstalledJobs = (
     ...moduleSecurityJobs.filter((mj) => !installedJobsIds.includes(mj.id)),
   ].sort((a, b) => a.id.localeCompare(b.id));
 };
+
+export interface SecurityJobsBySource {
+  jobs: SecurityJob[];
+  integrationJobs: SecurityJob[];
+}
+
+/**
+ * Creates SecurityJobs split by source: SIEM pre-built/custom jobs vs Fleet
+ * integration-packaged ML modules (`ml-module` saved objects).
+ */
+export const createSecurityJobsBySource = (
+  jobSummaryData: MlSummaryJob[],
+  modulesData: Module[],
+  compatibleModules: RecognizerModule[],
+  fleetModules: Module[] = []
+): SecurityJobsBySource => {
+  const compatibleModuleIds = compatibleModules.map((module) => module.id);
+  const fleetModuleIds = new Set(fleetModules.map((module) => module.id));
+
+  // Prefer get_module payloads (same job shape as pre-built); fall back to SO attributes
+  // when a Fleet module is not yet present in the recognizer response.
+  const modulesById = new Map(modulesData.map((module) => [module.id, module]));
+  for (const fleetModule of fleetModules) {
+    if (!modulesById.has(fleetModule.id)) {
+      modulesById.set(fleetModule.id, fleetModule);
+    }
+  }
+  const modulesWithFleet = [...modulesById.values()];
+
+  const prebuiltModuleJobs = getModuleJobs(modulesWithFleet, compatibleModuleIds, fleetModuleIds);
+  const integrationModuleJobs = getIntegrationModuleJobs(
+    modulesWithFleet,
+    compatibleModuleIds,
+    fleetModuleIds
+  );
+  const allModuleJobs = [...prebuiltModuleJobs, ...integrationModuleJobs];
+
+  const securityGroupInstalledJobs = getInstalledJobs(
+    jobSummaryData,
+    allModuleJobs,
+    compatibleModuleIds
+  );
+
+  const integrationModuleIdSet = new Set(integrationModuleJobs.map((job) => job.moduleId));
+  const prebuiltInstalledJobs = securityGroupInstalledJobs.filter(
+    (job) => !integrationModuleIdSet.has(job.moduleId)
+  );
+  const integrationInstalledJobs = getInstalledJobsForModules(
+    jobSummaryData,
+    integrationModuleJobs,
+    compatibleModuleIds
+  );
+
+  return {
+    jobs: composeModuleAndInstalledJobs(prebuiltInstalledJobs, prebuiltModuleJobs),
+    integrationJobs: composeModuleAndInstalledJobs(integrationInstalledJobs, integrationModuleJobs),
+  };
+};
+
 /**
  * Creates a list of SecurityJobs by composing jobs summaries (installed jobs) and Module
  * jobs (pre-packaged Security jobs) into a single job object that can be used throughout the Security app
@@ -146,17 +296,7 @@ export const composeModuleAndInstalledJobs = (
 export const createSecurityJobs = (
   jobSummaryData: MlSummaryJob[],
   modulesData: Module[],
-  compatibleModules: RecognizerModule[]
-): SecurityJob[] => {
-  // Create lookup of compatible modules
-  const compatibleModuleIds = compatibleModules.map((module) => module.id);
-
-  // Process modulesData: Filter to Security specific modules, and unpack jobs from modules
-  const moduleSecurityJobs = getModuleJobs(modulesData, compatibleModuleIds);
-
-  // Process jobSummaryData: Filter to Security jobs, and augment with moduleId/defaultIndexPattern/isCompatible
-  const installedJobs = getInstalledJobs(jobSummaryData, moduleSecurityJobs, compatibleModuleIds);
-
-  // Combine installed jobs + moduleSecurityJobs that don't overlap, and sort by name asc
-  return composeModuleAndInstalledJobs(installedJobs, moduleSecurityJobs);
-};
+  compatibleModules: RecognizerModule[],
+  fleetModules: Module[] = []
+): SecurityJob[] =>
+  createSecurityJobsBySource(jobSummaryData, modulesData, compatibleModules, fleetModules).jobs;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/integration_jobs_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/integration_jobs_panel.tsx
@@ -1,0 +1,282 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiSearchBarProps } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCard,
+  EuiEmptyPrompt,
+  EuiFlexGrid,
+  EuiFlexItem,
+  EuiIcon,
+  EuiSearchBar,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import React, { useCallback, useMemo, useState } from 'react';
+import { MLJobsAwaitingNodeWarning, MlNodeAvailableWarningShared } from '@kbn/ml-plugin/public';
+import { useAddIntegrationsUrl } from '../../hooks/use_add_integrations_url';
+import { searchFilter } from './helpers';
+import { JobUpdatesCallout } from './job_updates_callout';
+import type { Module, SecurityJob } from './types';
+import { JobsTable } from './jobs_table/jobs_table';
+import { ShowingCount } from './jobs_table/showing_count';
+import * as filtersI18n from './jobs_table/filters/translations';
+import * as i18n from './jobs_table/translations';
+
+interface IntegrationPackageCard {
+  module: Module;
+  jobs: SecurityJob[];
+  installedCount: number;
+  updateCount: number;
+}
+
+interface IntegrationJobsPanelProps {
+  jobs: SecurityJob[];
+  fleetModules: Module[];
+  isLoading: boolean;
+  mlNodesAvailable: boolean;
+  onMlNodesAvailable: (available: boolean) => void;
+  onJobStateChange: (job: SecurityJob, latestTimestampMs: number, enable: boolean) => Promise<void>;
+}
+
+const IntegrationJobsEmptyPrompt = React.memo(() => {
+  const { onClick } = useAddIntegrationsUrl();
+
+  return (
+    <EuiEmptyPrompt
+      data-test-subj="ml-integration-jobs-empty"
+      title={<h3>{i18n.NO_INTEGRATION_JOBS_TEXT}</h3>}
+      titleSize="xs"
+      actions={
+        <EuiButton
+          onClick={onClick}
+          iconType="plusInCircle"
+          size="s"
+          data-test-subj="browse-integrations-for-ml-jobs"
+        >
+          {i18n.BROWSE_INTEGRATIONS}
+        </EuiButton>
+      }
+    />
+  );
+});
+
+IntegrationJobsEmptyPrompt.displayName = 'IntegrationJobsEmptyPrompt';
+
+const truncateDescription = (description: string, max = 120) =>
+  description.length > max ? `${description.substring(0, max)}...` : description;
+
+export const IntegrationJobsPanel = React.memo(
+  ({
+    jobs,
+    fleetModules = [],
+    isLoading,
+    mlNodesAvailable,
+    onMlNodesAvailable,
+    onJobStateChange,
+  }: IntegrationJobsPanelProps) => {
+    const [filterQuery, setFilterQuery] = useState('');
+    const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
+
+    const handleChange = useCallback<NonNullable<EuiSearchBarProps['onChange']>>((query) => {
+      setFilterQuery(query.queryText.trim());
+    }, []);
+
+    const clearSelectedModule = useCallback(() => {
+      setSelectedModuleId(null);
+      setFilterQuery('');
+    }, []);
+
+    const packages = useMemo((): IntegrationPackageCard[] => {
+      const jobsByModule = jobs.reduce<Record<string, SecurityJob[]>>((acc, job) => {
+        const moduleJobs = acc[job.moduleId] ?? [];
+        moduleJobs.push(job);
+        acc[job.moduleId] = moduleJobs;
+        return acc;
+      }, {});
+
+      return fleetModules
+        .map((module) => {
+          const moduleJobs = jobsByModule[module.id] ?? [];
+          return {
+            module,
+            jobs: moduleJobs,
+            installedCount: moduleJobs.filter((job) => job.isInstalled).length,
+            updateCount: moduleJobs.filter((job) => job.isUpdateAvailable).length,
+          };
+        })
+        .sort((a, b) => (a.module.title ?? '').localeCompare(b.module.title ?? ''));
+    }, [fleetModules, jobs]);
+
+    const filteredPackages = useMemo(() => {
+      if (!filterQuery) {
+        return packages;
+      }
+      const query = filterQuery.toLowerCase();
+      return packages.filter(
+        ({ module }) =>
+          (module.title ?? '').toLowerCase().includes(query) ||
+          (module.description ?? '').toLowerCase().includes(query) ||
+          (module.id ?? '').toLowerCase().includes(query)
+      );
+    }, [filterQuery, packages]);
+
+    const selectedPackage = useMemo(
+      () => packages.find((pkg) => pkg.module.id === selectedModuleId) ?? null,
+      [packages, selectedModuleId]
+    );
+
+    const selectedJobs = selectedPackage?.jobs ?? [];
+    const filteredSelectedJobs = useMemo(
+      () => searchFilter(selectedJobs, filterQuery),
+      [filterQuery, selectedJobs]
+    );
+
+    const installedJobsIds = useMemo(
+      () => jobs.filter((job) => job.isInstalled).map((job) => job.id),
+      [jobs]
+    );
+
+    if (packages.length === 0 && !isLoading) {
+      return (
+        <div data-test-subj="ml-integration-jobs-panel">
+          <MlNodeAvailableWarningShared size="s" nodeAvailableCallback={onMlNodesAvailable} />
+          <IntegrationJobsEmptyPrompt />
+        </div>
+      );
+    }
+
+    if (selectedPackage) {
+      return (
+        <div data-test-subj="ml-integration-jobs-panel">
+          <EuiButtonEmpty
+            flush="left"
+            iconType="arrowLeft"
+            size="s"
+            onClick={clearSelectedModule}
+            data-test-subj="integration-jobs-back-to-packages"
+          >
+            {i18n.BACK_TO_INTEGRATION_PACKAGES}
+          </EuiButtonEmpty>
+
+          <EuiSpacer size="s" />
+
+          <EuiTitle size="xs">
+            <h3 data-test-subj="integration-package-jobs-title">{selectedPackage.module.title}</h3>
+          </EuiTitle>
+          <EuiText size="s" color="subdued">
+            <p>{selectedPackage.module.description}</p>
+          </EuiText>
+
+          <EuiSpacer size="m" />
+
+          <EuiSearchBar
+            data-test-subj="integration-jobs-filter-bar"
+            box={{
+              placeholder: filtersI18n.FILTER_PLACEHOLDER,
+              incremental: true,
+              fullWidth: true,
+            }}
+            onChange={handleChange}
+          />
+
+          <ShowingCount filterResultsLength={filteredSelectedJobs.length} />
+
+          <EuiSpacer size="m" />
+
+          <JobUpdatesCallout jobs={filteredSelectedJobs} />
+
+          <MLJobsAwaitingNodeWarning jobIds={installedJobsIds} />
+          <MlNodeAvailableWarningShared size="s" nodeAvailableCallback={onMlNodesAvailable} />
+
+          <JobsTable
+            isLoading={isLoading}
+            jobs={filteredSelectedJobs}
+            onJobStateChange={onJobStateChange}
+            mlNodesAvailable={mlNodesAvailable}
+            noItemsMessage={<IntegrationJobsEmptyPrompt />}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div data-test-subj="ml-integration-jobs-panel">
+        <EuiSearchBar
+          data-test-subj="integration-packages-filter-bar"
+          box={{
+            placeholder: i18n.SEARCH_INTEGRATION_PACKAGES_PLACEHOLDER,
+            incremental: true,
+            fullWidth: true,
+          }}
+          onChange={handleChange}
+        />
+
+        <EuiSpacer size="m" />
+
+        <MlNodeAvailableWarningShared size="s" nodeAvailableCallback={onMlNodesAvailable} />
+
+        {filteredPackages.length === 0 ? (
+          <EuiEmptyPrompt
+            title={<h3>{i18n.NO_MATCHING_INTEGRATION_PACKAGES}</h3>}
+            titleSize="xs"
+          />
+        ) : (
+          <EuiFlexGrid gutterSize="m" columns={1} data-test-subj="integration-packages-grid">
+            {filteredPackages.map(({ module, jobs: moduleJobs, installedCount, updateCount }) => (
+              <EuiFlexItem key={module.id}>
+                <EuiCard
+                  data-test-subj={`integration-package-card-${module.id}`}
+                  layout="horizontal"
+                  titleSize="xs"
+                  icon={
+                    module.logo?.icon ? (
+                      <EuiIcon aria-hidden={true} size="xl" type={module.logo.icon} />
+                    ) : (
+                      <EuiIcon aria-hidden={true} size="xl" type="machineLearningApp" />
+                    )
+                  }
+                  title={module.title}
+                  description={
+                    <>
+                      {truncateDescription(module.description ?? '')}
+                      <EuiSpacer size="s" />
+                      <EuiBadge color="hollow">
+                        {i18n.INTEGRATION_PACKAGE_JOB_COUNT(moduleJobs.length)}
+                      </EuiBadge>{' '}
+                      <EuiBadge color="hollow">
+                        {i18n.INTEGRATION_PACKAGE_INSTALLED_COUNT(installedCount)}
+                      </EuiBadge>
+                      {updateCount > 0 && (
+                        <>
+                          {' '}
+                          <EuiBadge color="primary" data-test-subj="integration-package-update-badge">
+                            {i18n.INTEGRATION_PACKAGE_UPDATES_COUNT(updateCount)}
+                          </EuiBadge>
+                        </>
+                      )}
+                    </>
+                  }
+                  onClick={() => {
+                    setFilterQuery('');
+                    setSelectedModuleId(module.id);
+                  }}
+                />
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGrid>
+        )}
+      </div>
+    );
+  }
+);
+
+IntegrationJobsPanel.displayName = 'IntegrationJobsPanel';

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/job_updates_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/job_updates_callout.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import type { SecurityJob } from './types';
+import * as i18n from './translations';
+
+interface JobUpdatesCalloutProps {
+  jobs: SecurityJob[];
+}
+
+export const JobUpdatesCallout = React.memo(({ jobs }: JobUpdatesCalloutProps) => {
+  const outdatedCount = useMemo(
+    () => jobs.filter((job) => job.isInstalled && job.isUpdateAvailable).length,
+    [jobs]
+  );
+
+  if (outdatedCount === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <EuiCallOut
+        announceOnMount={false}
+        data-test-subj="ml-job-updates-available-callout"
+        title={i18n.JOB_UPDATES_AVAILABLE_TITLE(outdatedCount)}
+        color="primary"
+        iconType="refresh"
+        size="s"
+      >
+        <p>{i18n.JOB_UPDATES_AVAILABLE_DESCRIPTION}</p>
+      </EuiCallOut>
+      <EuiSpacer size="m" />
+    </>
+  );
+});
+
+JobUpdatesCallout.displayName = 'JobUpdatesCallout';

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/jobs_table_filters.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/jobs_table_filters.test.tsx
@@ -19,27 +19,18 @@ describe('JobsTableFilters', () => {
     securityJobs = cloneDeep(mockSecurityJobs);
   });
 
-  test('when you click Elastic Jobs filter, state is updated and it is selected', () => {
+  test('defaults to Elastic jobs filter selected', () => {
     const onFilterChanged = jest.fn();
     const wrapper = mount(
       <JobsTableFiltersComponent securityJobs={securityJobs} onFilterChanged={onFilterChanged} />
     );
 
-    wrapper
-      .find('button[data-test-subj="show-elastic-jobs-filter-button"]')
-      .first()
-      .simulate('click');
-    wrapper.update();
-
     expect(
-      wrapper
-        .find('[data-test-subj="show-elastic-jobs-filter-button"]')
-        .first()
-        .prop('hasActiveFilters')
-    ).toEqual(true);
+      wrapper.find('[data-test-subj="prebuilt-jobs-filter-button-group"]').first().prop('idSelected')
+    ).toEqual('elastic');
   });
 
-  test('when you click Custom Jobs filter, state is updated and it is selected', () => {
+  test('when you select Custom jobs, filter selection changes', () => {
     const onFilterChanged = jest.fn();
     const wrapper = mount(
       <JobsTableFiltersComponent securityJobs={securityJobs} onFilterChanged={onFilterChanged} />
@@ -52,68 +43,7 @@ describe('JobsTableFilters', () => {
     wrapper.update();
 
     expect(
-      wrapper
-        .find('[data-test-subj="show-custom-jobs-filter-button"]')
-        .first()
-        .prop('hasActiveFilters')
-    ).toEqual(true);
-  });
-
-  test('when you click Custom Jobs filter once, then Elastic Jobs filter, state is updated and  selected changed', () => {
-    const onFilterChanged = jest.fn();
-    const wrapper = mount(
-      <JobsTableFiltersComponent securityJobs={securityJobs} onFilterChanged={onFilterChanged} />
-    );
-
-    wrapper
-      .find('button[data-test-subj="show-custom-jobs-filter-button"]')
-      .first()
-      .simulate('click');
-    wrapper.update();
-
-    wrapper
-      .find('button[data-test-subj="show-elastic-jobs-filter-button"]')
-      .first()
-      .simulate('click');
-    wrapper.update();
-
-    expect(
-      wrapper
-        .find('[data-test-subj="show-custom-jobs-filter-button"]')
-        .first()
-        .prop('hasActiveFilters')
-    ).toEqual(false);
-    expect(
-      wrapper
-        .find('[data-test-subj="show-elastic-jobs-filter-button"]')
-        .first()
-        .prop('hasActiveFilters')
-    ).toEqual(true);
-  });
-
-  test('when you click Custom Jobs filter twice, state is updated and it is revert', () => {
-    const onFilterChanged = jest.fn();
-    const wrapper = mount(
-      <JobsTableFiltersComponent securityJobs={securityJobs} onFilterChanged={onFilterChanged} />
-    );
-
-    wrapper
-      .find('button[data-test-subj="show-custom-jobs-filter-button"]')
-      .first()
-      .simulate('click');
-    wrapper.update();
-
-    wrapper
-      .find('button[data-test-subj="show-custom-jobs-filter-button"]')
-      .first()
-      .simulate('click');
-    wrapper.update();
-
-    expect(
-      wrapper
-        .find('[data-test-subj="show-custom-jobs-filter-button"]')
-        .first()
-        .prop('hasActiveFilters')
-    ).toEqual(false);
+      wrapper.find('[data-test-subj="prebuilt-jobs-filter-button-group"]').first().prop('idSelected')
+    ).toEqual('custom');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/jobs_table_filters.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/jobs_table_filters.tsx
@@ -6,19 +6,22 @@
  */
 
 import type { Dispatch, SetStateAction } from 'react';
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 
 import {
-  EuiFilterButton,
+  EuiButtonGroup,
   EuiFilterGroup,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSearchBar,
+  EuiSpacer,
 } from '@elastic/eui';
 import type { EuiSearchBarQuery } from '../../../../../timelines/components/open_timeline/types';
 import * as i18n from './translations';
 import type { JobsFilters, SecurityJob } from '../../types';
 import { GroupsFilterPopover } from './groups_filter_popover';
+
+type PrebuiltJobsFilter = 'elastic' | 'custom';
 
 interface JobsTableFiltersProps {
   securityJobs: SecurityJob[];
@@ -26,11 +29,7 @@ interface JobsTableFiltersProps {
 }
 
 /**
- * Collection of filters for filtering data within the JobsTable. Contains search bar, Elastic/Custom
- * Jobs filter button toggle, and groups selection
- *
- * @param securityJobs jobs to fetch groups from to display for filtering
- * @param onFilterChanged change listener to be notified on filter changes
+ * Filters for the Pre-built jobs tab: search, groups, and Elastic / Custom button group.
  */
 export const JobsTableFiltersComponent = ({
   securityJobs,
@@ -38,12 +37,19 @@ export const JobsTableFiltersComponent = ({
 }: JobsTableFiltersProps) => {
   const [filterQuery, setFilterQuery] = useState<string>('');
   const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
-  const [showCustomJobs, setShowCustomJobs] = useState<boolean>(false);
-  const [showElasticJobs, setShowElasticJobs] = useState<boolean>(false);
+  const [prebuiltFilter, setPrebuiltFilter] = useState<PrebuiltJobsFilter>('elastic');
 
-  // Propagate filter changes to parent
+  const showElasticJobs = prebuiltFilter === 'elastic';
+  const showCustomJobs = prebuiltFilter === 'custom';
+
   useEffect(() => {
-    onFilterChanged({ filterQuery, showCustomJobs, showElasticJobs, selectedGroups });
+    onFilterChanged((current) => ({
+      ...current,
+      filterQuery,
+      showCustomJobs,
+      showElasticJobs,
+      selectedGroups,
+    }));
   }, [filterQuery, selectedGroups, showCustomJobs, showElasticJobs, onFilterChanged]);
 
   const handleChange = useCallback(
@@ -51,62 +57,59 @@ export const JobsTableFiltersComponent = ({
     [setFilterQuery]
   );
 
-  const handleElasticJobsClick = useCallback(() => {
-    setShowElasticJobs(!showElasticJobs);
-    setShowCustomJobs(false);
-  }, [setShowElasticJobs, showElasticJobs, setShowCustomJobs]);
-
-  const handleCustomJobsClick = useCallback(() => {
-    setShowCustomJobs(!showCustomJobs);
-    setShowElasticJobs(false);
-  }, [setShowElasticJobs, showCustomJobs, setShowCustomJobs]);
+  const prebuiltFilterOptions = useMemo(
+    () => [
+      {
+        id: 'elastic',
+        label: i18n.SHOW_ELASTIC_JOBS,
+        'data-test-subj': 'show-elastic-jobs-filter-button',
+      },
+      {
+        id: 'custom',
+        label: i18n.SHOW_CUSTOM_JOBS,
+        'data-test-subj': 'show-custom-jobs-filter-button',
+      },
+    ],
+    []
+  );
 
   return (
-    <EuiFlexGroup gutterSize="m" justifyContent="flexEnd">
-      <EuiFlexItem grow={true}>
-        <EuiSearchBar
-          data-test-subj="jobs-filter-bar"
-          box={{
-            placeholder: i18n.FILTER_PLACEHOLDER,
-            incremental: true,
-          }}
-          onChange={handleChange}
-        />
-      </EuiFlexItem>
-
-      <EuiFlexItem grow={false}>
-        <EuiFilterGroup>
-          <GroupsFilterPopover
-            securityJobs={securityJobs}
-            onSelectedGroupsChanged={setSelectedGroups}
+    <>
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={true}>
+          <EuiSearchBar
+            data-test-subj="jobs-filter-bar"
+            box={{
+              placeholder: i18n.FILTER_PLACEHOLDER,
+              incremental: true,
+              fullWidth: true,
+            }}
+            onChange={handleChange}
           />
-        </EuiFilterGroup>
-      </EuiFlexItem>
+        </EuiFlexItem>
 
-      <EuiFlexItem grow={false}>
-        <EuiFilterGroup>
-          <EuiFilterButton
-            isToggle
-            isSelected={showElasticJobs}
-            hasActiveFilters={showElasticJobs}
-            onClick={handleElasticJobsClick}
-            data-test-subj="show-elastic-jobs-filter-button"
-            withNext
-          >
-            {i18n.SHOW_ELASTIC_JOBS}
-          </EuiFilterButton>
-          <EuiFilterButton
-            isToggle
-            isSelected={showCustomJobs}
-            hasActiveFilters={showCustomJobs}
-            onClick={handleCustomJobsClick}
-            data-test-subj="show-custom-jobs-filter-button"
-          >
-            {i18n.SHOW_CUSTOM_JOBS}
-          </EuiFilterButton>
-        </EuiFilterGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+        <EuiFlexItem grow={false}>
+          <EuiFilterGroup>
+            <GroupsFilterPopover
+              securityJobs={securityJobs}
+              onSelectedGroupsChanged={setSelectedGroups}
+            />
+          </EuiFilterGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="m" />
+
+      <EuiButtonGroup
+        legend={i18n.SHOW_PREBUILT_JOBS}
+        options={prebuiltFilterOptions}
+        idSelected={prebuiltFilter}
+        onChange={(id) => setPrebuiltFilter(id as PrebuiltJobsFilter)}
+        buttonSize="compressed"
+        color="text"
+        data-test-subj="prebuilt-jobs-filter-button-group"
+      />
+    </>
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/filters/translations.ts
@@ -41,3 +41,17 @@ export const SHOW_CUSTOM_JOBS = i18n.translate(
     defaultMessage: 'Custom jobs',
   }
 );
+
+export const SHOW_PREBUILT_JOBS = i18n.translate(
+  'xpack.securitySolution.components.mlPopover.jobsTable.filters.showPrebuiltJobsLabel',
+  {
+    defaultMessage: 'Pre-built jobs',
+  }
+);
+
+export const SHOW_INTEGRATION_JOBS = i18n.translate(
+  'xpack.securitySolution.components.mlPopover.jobsTable.filters.showIntegrationJobsLabel',
+  {
+    defaultMessage: 'Integration jobs',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/jobs_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/jobs_table.tsx
@@ -39,9 +39,19 @@ interface JobNameProps {
   id: string;
   name?: string;
   description: string;
+  isUpdateAvailable?: boolean;
+  installedJobRevision?: number;
+  packagedJobRevision?: number;
 }
 
-const JobName = ({ id, name, description }: JobNameProps) => {
+const JobName = ({
+  id,
+  name,
+  description,
+  isUpdateAvailable,
+  installedJobRevision,
+  packagedJobRevision,
+}: JobNameProps) => {
   const {
     services: { ml },
   } = useKibana();
@@ -59,6 +69,19 @@ const JobName = ({ id, name, description }: JobNameProps) => {
         <EuiLink data-test-subj="jobs-table-link" href={jobUrl} target="_blank">
           {name ?? id}
         </EuiLink>
+        {isUpdateAvailable && (
+          <>
+            {' '}
+            <EuiBadge color="primary" data-test-subj="ml-job-update-available-badge">
+              {i18n.UPDATE_AVAILABLE_BADGE}
+              {packagedJobRevision != null && (
+                <>
+                  {` (r${installedJobRevision ?? 0} → r${packagedJobRevision})`}
+                </>
+              )}
+            </EuiBadge>
+          </>
+        )}
       </EuiText>
       <EuiText color="subdued" size="xs">
         {description.length > truncateThreshold
@@ -70,15 +93,26 @@ const JobName = ({ id, name, description }: JobNameProps) => {
 };
 const getJobsTableColumns = (
   isLoading: boolean,
-  onJobStateChange: (job: SecurityJob, latestTimestampMs: number, enable: boolean) => Promise<void>
+  onJobStateChange: (job: SecurityJob, latestTimestampMs: number, enable: boolean) => Promise<void>,
+  mlNodesAvailable: boolean
 ) => [
   {
     name: i18n.COLUMN_JOB_NAME,
-    render: ({ id, description, customSettings }: SecurityJob) => (
+    render: ({
+      id,
+      description,
+      customSettings,
+      isUpdateAvailable,
+      installedJobRevision,
+      packagedJobRevision,
+    }: SecurityJob) => (
       <JobName
         id={id}
         name={customSettings?.security_app_display_name ?? id}
         description={description}
+        isUpdateAvailable={isUpdateAvailable}
+        installedJobRevision={installedJobRevision}
+        packagedJobRevision={packagedJobRevision}
       />
     ),
   },
@@ -106,8 +140,14 @@ const getJobsTableColumns = (
 
   {
     name: i18n.COLUMN_RUN_JOB,
-    render: (job: SecurityJob) =>
-      job.isCompatible ? (
+    render: (job: SecurityJob) => {
+      // Show the on/off switch when ML nodes exist and the job can be run: either the
+      // module matches available data, the job is already installed (start/stop), or it
+      // is a Fleet integration job (compatibility is against package indices, not SIEM defaults).
+      const showSwitch =
+        mlNodesAvailable && (job.isCompatible || job.isInstalled || Boolean(job.isIntegrationJob));
+
+      return showSwitch ? (
         <JobSwitch
           job={job}
           isSecurityJobsLoading={isLoading}
@@ -115,7 +155,8 @@ const getJobsTableColumns = (
         />
       ) : (
         <EuiIcon aria-label="Warning" size="s" type="warning" color="warning" />
-      ),
+      );
+    },
     align: CENTER_ALIGNMENT,
     width: '80px',
   } as const,
@@ -132,6 +173,7 @@ export interface JobTableProps {
   jobs: SecurityJob[];
   mlNodesAvailable: boolean;
   onJobStateChange: (job: SecurityJob, latestTimestampMs: number, enable: boolean) => Promise<void>;
+  noItemsMessage?: React.ReactNode;
 }
 
 export const JobsTableComponent = ({
@@ -139,6 +181,7 @@ export const JobsTableComponent = ({
   jobs,
   onJobStateChange,
   mlNodesAvailable,
+  noItemsMessage,
 }: JobTableProps) => {
   const [pageIndex, setPageIndex] = useState(0);
   const pageSize = 5;
@@ -158,14 +201,10 @@ export const JobsTableComponent = ({
     <EuiBasicTable
       data-test-subj="jobs-table"
       tableCaption={i18n.JOBS_TABLE_CAPTION}
-      columns={getJobsTableColumns(isLoading, onJobStateChange)}
-      items={getPaginatedItems(
-        jobs.map((j) => ({ ...j, isCompatible: mlNodesAvailable ? j.isCompatible : false })),
-        pageIndex,
-        pageSize
-      )}
+      columns={getJobsTableColumns(isLoading, onJobStateChange, mlNodesAvailable)}
+      items={getPaginatedItems(jobs, pageIndex, pageSize)}
       loading={isLoading}
-      noItemsMessage={<NoItemsMessage />}
+      noItemsMessage={noItemsMessage ?? <NoItemsMessage />}
       pagination={pagination}
       responsiveBreakpoint={false}
       onChange={({ page }: { page: { index: number } }) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/jobs_table/translations.ts
@@ -42,9 +42,76 @@ export const CREATE_CUSTOM_JOB = i18n.translate(
   }
 );
 
+export const NO_INTEGRATION_JOBS_TEXT = i18n.translate(
+  'xpack.securitySolution.components.mlPopup.jobsTable.noIntegrationJobsDescription',
+  {
+    defaultMessage:
+      'No integration ML jobs found. Install Security integrations that ship anomaly detection jobs, then enable them here.',
+  }
+);
+
+export const BROWSE_INTEGRATIONS = i18n.translate(
+  'xpack.securitySolution.components.mlPopup.jobsTable.browseIntegrationsButtonLabel',
+  {
+    defaultMessage: 'Browse integrations',
+  }
+);
+
 export const JOBS_TABLE_CAPTION = i18n.translate(
   'xpack.securitySolution.components.mlPopup.jobsTable.caption',
   {
     defaultMessage: 'ML jobs',
   }
 );
+
+export const UPDATE_AVAILABLE_BADGE = i18n.translate(
+  'xpack.securitySolution.components.mlPopup.jobsTable.updateAvailableBadge',
+  {
+    defaultMessage: 'Update available',
+  }
+);
+
+export const BACK_TO_INTEGRATION_PACKAGES = i18n.translate(
+  'xpack.securitySolution.components.mlPopup.jobsTable.backToIntegrationPackagesButtonLabel',
+  {
+    defaultMessage: 'Back to integration packages',
+  }
+);
+
+export const SEARCH_INTEGRATION_PACKAGES_PLACEHOLDER = i18n.translate(
+  'xpack.securitySolution.components.mlPopup.jobsTable.searchIntegrationPackagesPlaceholder',
+  {
+    defaultMessage: 'Search integration packages',
+  }
+);
+
+export const NO_MATCHING_INTEGRATION_PACKAGES = i18n.translate(
+  'xpack.securitySolution.components.mlPopup.jobsTable.noMatchingIntegrationPackagesDescription',
+  {
+    defaultMessage: 'No integration packages match your search',
+  }
+);
+
+export const INTEGRATION_PACKAGE_JOB_COUNT = (count: number) =>
+  i18n.translate('xpack.securitySolution.components.mlPopup.jobsTable.integrationPackageJobCount', {
+    values: { count },
+    defaultMessage: '{count} {count, plural, one {job} other {jobs}}',
+  });
+
+export const INTEGRATION_PACKAGE_INSTALLED_COUNT = (count: number) =>
+  i18n.translate(
+    'xpack.securitySolution.components.mlPopup.jobsTable.integrationPackageInstalledCount',
+    {
+      values: { count },
+      defaultMessage: '{count} installed',
+    }
+  );
+
+export const INTEGRATION_PACKAGE_UPDATES_COUNT = (count: number) =>
+  i18n.translate(
+    'xpack.securitySolution.components.mlPopup.jobsTable.integrationPackageUpdatesCount',
+    {
+      values: { count },
+      defaultMessage: '{count} {count, plural, one {update} other {updates}} available',
+    }
+  );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/ml_popover.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/ml_popover.test.tsx
@@ -14,7 +14,7 @@ import { TestProviders } from '../../mock';
 jest.mock('../../lib/kibana');
 
 describe('MlPopover', () => {
-  test('shows upgrade popover on mouse click', async () => {
+  test('shows upgrade flyout on mouse click', async () => {
     const { getByTestId } = render(<MlPopover />, {
       wrapper: TestProviders,
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
@@ -8,48 +8,46 @@
 import {
   EuiHeaderSectionItemButton,
   EuiCallOut,
-  EuiPopover,
-  EuiPopoverTitle,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
   EuiSpacer,
+  EuiTab,
+  EuiTabs,
+  EuiTitle,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useState, useMemo } from 'react';
-import styled from 'styled-components';
 import { MLJobsAwaitingNodeWarning, MlNodeAvailableWarningShared } from '@kbn/ml-plugin/public';
 import { useKibana } from '../../lib/kibana';
 import { filterJobs } from './helpers';
+import { IntegrationJobsPanel } from './integration_jobs_panel';
+import { JobUpdatesCallout } from './job_updates_callout';
 import { JobsTableFilters } from './jobs_table/filters/jobs_table_filters';
+import * as filtersI18n from './jobs_table/filters/translations';
 import { JobsTable } from './jobs_table/jobs_table';
 import { ShowingCount } from './jobs_table/showing_count';
 import { PopoverDescription } from './popover_description';
 import * as i18n from './translations';
-import type { JobsFilters, SecurityJob } from './types';
+import type { JobsFilters, MlJobsTab, SecurityJob } from './types';
 import { UpgradeContents } from './upgrade_contents';
 import { useSecurityJobs } from './hooks/use_security_jobs';
 import { useEnableDataFeed } from './hooks/use_enable_data_feed';
 
-const PopoverContentsDiv = styled.div`
-  max-width: 684px;
-  max-height: 90vh;
-  overflow-y: auto;
-  overflow-x: hidden;
-  padding-bottom: 15px;
-`;
-
-PopoverContentsDiv.displayName = 'PopoverContentsDiv';
-
 const defaultFilterProps: JobsFilters = {
   filterQuery: '',
   showCustomJobs: false,
-  showElasticJobs: false,
+  showElasticJobs: true,
   selectedGroups: [],
+  selectedTab: 'prebuilt',
 };
 
 export const MlPopover = React.memo(() => {
-  const mlPopoverTitleId = useGeneratedHtmlId();
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const mlFlyoutTitleId = useGeneratedHtmlId();
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
   const [filterProperties, setFilterProperties] = useState(defaultFilterProps);
+  const [selectedTab, setSelectedTab] = useState<MlJobsTab>('prebuilt');
   const [mlNodesAvailable, setMlNodesAvailable] = useState(false);
 
   const {
@@ -57,6 +55,8 @@ export const MlPopover = React.memo(() => {
     isLicensed,
     loading: isLoadingSecurityJobs,
     jobs,
+    integrationJobs,
+    fleetModules,
     refetch: refreshJobs,
   } = useSecurityJobs();
 
@@ -79,6 +79,17 @@ export const MlPopover = React.memo(() => {
     [refreshJobs, enableDatafeed, disableDatafeed]
   );
 
+  const closeFlyout = useCallback(() => setIsFlyoutOpen(false), []);
+
+  const toggleFlyout = useCallback(() => {
+    setIsFlyoutOpen((open) => !open);
+  }, []);
+
+  const handleTabChange = useCallback((tab: MlJobsTab) => {
+    setSelectedTab(tab);
+    setFilterProperties((current) => ({ ...current, selectedTab: tab }));
+  }, []);
+
   const filteredJobs = filterJobs({
     jobs,
     ...filterProperties,
@@ -93,115 +104,157 @@ export const MlPopover = React.memo(() => {
   if (!isLicensed) {
     // If the user does not have platinum show upgrade UI
     return (
-      <EuiPopover
-        anchorPosition="downRight"
-        aria-label={i18n.ML_JOB_SETTINGS}
-        id="integrations-popover"
-        button={
-          <EuiHeaderSectionItemButton
-            aria-expanded={isPopoverOpen}
-            aria-haspopup="true"
-            aria-label={i18n.ML_JOB_SETTINGS}
-            color="primary"
-            data-test-subj="integrations-button"
-            iconType="chevronSingleDown"
-            iconSide="right"
-            onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-            textProps={{ style: { fontSize: '1rem' } }}
-          >
-            {i18n.ML_JOB_SETTINGS}
-          </EuiHeaderSectionItemButton>
-        }
-        isOpen={isPopoverOpen}
-        closePopover={() => setIsPopoverOpen(!isPopoverOpen)}
-        repositionOnScroll
-      >
-        <UpgradeContents />
-      </EuiPopover>
+      <>
+        <EuiHeaderSectionItemButton
+          aria-expanded={isFlyoutOpen}
+          aria-haspopup="dialog"
+          aria-label={i18n.ML_JOB_SETTINGS}
+          color="primary"
+          data-test-subj="integrations-button"
+          onClick={toggleFlyout}
+          textProps={{ style: { fontSize: '1rem' } }}
+        >
+          {i18n.ML_JOB_SETTINGS}
+        </EuiHeaderSectionItemButton>
+        {isFlyoutOpen && (
+          <EuiFlyout size="s" onClose={closeFlyout} aria-labelledby={mlFlyoutTitleId} ownFocus>
+            <EuiFlyoutHeader hasBorder>
+              <EuiTitle size="s">
+                <h2 id={mlFlyoutTitleId}>{i18n.UPGRADE_TITLE}</h2>
+              </EuiTitle>
+            </EuiFlyoutHeader>
+            <EuiFlyoutBody>
+              <UpgradeContents />
+            </EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
     );
   } else if (isMlAdmin) {
     // If the user has Platinum License & ML Admin Permissions, show Anomaly Detection button & full config UI
     return (
-      <EuiPopover
-        anchorPosition="downRight"
-        aria-labelledby={mlPopoverTitleId}
-        id="integrations-popover"
-        button={
-          <EuiHeaderSectionItemButton
-            aria-expanded={isPopoverOpen}
-            aria-haspopup="true"
-            aria-label={i18n.ML_JOB_SETTINGS}
-            color="primary"
-            data-test-subj="integrations-button"
-            iconType="chevronSingleDown"
-            iconSide="right"
-            onClick={() => {
-              setIsPopoverOpen(!isPopoverOpen);
-              refreshJobs();
-            }}
-            textProps={{ style: { fontSize: '1rem' } }}
+      <>
+        <EuiHeaderSectionItemButton
+          aria-expanded={isFlyoutOpen}
+          aria-haspopup="dialog"
+          aria-label={i18n.ML_JOB_SETTINGS}
+          color="primary"
+          data-test-subj="integrations-button"
+          onClick={() => {
+            toggleFlyout();
+            refreshJobs();
+          }}
+          textProps={{ style: { fontSize: '1rem' } }}
+        >
+          {i18n.ML_JOB_SETTINGS}
+        </EuiHeaderSectionItemButton>
+        {isFlyoutOpen && (
+          <EuiFlyout
+            size="m"
+            onClose={closeFlyout}
+            aria-labelledby={mlFlyoutTitleId}
+            ownFocus
+            data-test-subj="ml-job-settings-flyout"
           >
-            {i18n.ML_JOB_SETTINGS}
-          </EuiHeaderSectionItemButton>
-        }
-        isOpen={isPopoverOpen}
-        closePopover={() => setIsPopoverOpen(!isPopoverOpen)}
-        repositionOnScroll
-      >
-        <PopoverContentsDiv data-test-subj="ml-popover-contents">
-          <EuiPopoverTitle id={mlPopoverTitleId}>{i18n.ML_JOB_SETTINGS}</EuiPopoverTitle>
-          <PopoverDescription />
+            <EuiFlyoutHeader hasBorder>
+              <EuiTitle size="s">
+                <h2 id={mlFlyoutTitleId}>{i18n.ML_JOB_SETTINGS}</h2>
+              </EuiTitle>
+            </EuiFlyoutHeader>
+            <EuiFlyoutBody>
+              <div data-test-subj="ml-popover-contents">
+                <PopoverDescription />
 
-          <EuiSpacer />
+                <EuiSpacer />
 
-          <JobsTableFilters securityJobs={jobs} onFilterChanged={setFilterProperties} />
+                <EuiTabs size="s" bottomBorder data-test-subj="ml-jobs-tabs">
+                  <EuiTab
+                    isSelected={selectedTab === 'prebuilt'}
+                    onClick={() => handleTabChange('prebuilt')}
+                    data-test-subj="prebuilt-jobs-tab"
+                  >
+                    {filtersI18n.SHOW_PREBUILT_JOBS}
+                  </EuiTab>
+                  <EuiTab
+                    isSelected={selectedTab === 'integration'}
+                    onClick={() => handleTabChange('integration')}
+                    data-test-subj="show-integration-jobs-tab"
+                  >
+                    {filtersI18n.SHOW_INTEGRATION_JOBS}
+                  </EuiTab>
+                </EuiTabs>
 
-          <ShowingCount filterResultsLength={filteredJobs.length} />
+                <EuiSpacer />
 
-          <EuiSpacer size="m" />
-
-          {incompatibleJobCount > 0 && (
-            <>
-              <EuiCallOut
-                announceOnMount={false}
-                title={i18n.MODULE_NOT_COMPATIBLE_TITLE(incompatibleJobCount)}
-                color="warning"
-                iconType="warning"
-                size="s"
-              >
-                <p>
-                  <FormattedMessage
-                    defaultMessage="We could not find any data, see {mlDocs} for more information on Machine Learning job requirements."
-                    id="xpack.securitySolution.components.mlPopup.moduleNotCompatibleDescription"
-                    values={{
-                      mlDocs: (
-                        <a
-                          href={`${docLinks.links.siem.ml}`}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          {i18n.ANOMALY_DETECTION_DOCS}
-                        </a>
-                      ),
-                    }}
+                {selectedTab === 'integration' ? (
+                  <IntegrationJobsPanel
+                    jobs={integrationJobs}
+                    fleetModules={fleetModules}
+                    isLoading={isLoadingSecurityJobs || isLoadingEnableDataFeed}
+                    mlNodesAvailable={mlNodesAvailable}
+                    onMlNodesAvailable={setMlNodesAvailable}
+                    onJobStateChange={handleJobStateChange}
                   />
-                </p>
-              </EuiCallOut>
+                ) : (
+                  <>
+                    <JobsTableFilters securityJobs={jobs} onFilterChanged={setFilterProperties} />
 
-              <EuiSpacer size="m" />
-            </>
-          )}
+                    <ShowingCount filterResultsLength={filteredJobs.length} />
 
-          <MLJobsAwaitingNodeWarning jobIds={installedJobsIds} />
-          <MlNodeAvailableWarningShared size="s" nodeAvailableCallback={setMlNodesAvailable} />
-          <JobsTable
-            isLoading={isLoadingSecurityJobs || isLoadingEnableDataFeed}
-            jobs={filteredJobs}
-            onJobStateChange={handleJobStateChange}
-            mlNodesAvailable={mlNodesAvailable}
-          />
-        </PopoverContentsDiv>
-      </EuiPopover>
+                    <EuiSpacer size="m" />
+
+                    <JobUpdatesCallout jobs={filteredJobs} />
+
+                    {incompatibleJobCount > 0 && (
+                      <>
+                        <EuiCallOut
+                          announceOnMount={false}
+                          title={i18n.MODULE_NOT_COMPATIBLE_TITLE(incompatibleJobCount)}
+                          color="warning"
+                          iconType="warning"
+                          size="s"
+                        >
+                          <p>
+                            <FormattedMessage
+                              defaultMessage="We could not find any data, see {mlDocs} for more information on Machine Learning job requirements."
+                              id="xpack.securitySolution.components.mlPopup.moduleNotCompatibleDescription"
+                              values={{
+                                mlDocs: (
+                                  <a
+                                    href={`${docLinks.links.siem.ml}`}
+                                    rel="noopener noreferrer"
+                                    target="_blank"
+                                  >
+                                    {i18n.ANOMALY_DETECTION_DOCS}
+                                  </a>
+                                ),
+                              }}
+                            />
+                          </p>
+                        </EuiCallOut>
+
+                        <EuiSpacer size="m" />
+                      </>
+                    )}
+
+                    <MLJobsAwaitingNodeWarning jobIds={installedJobsIds} />
+                    <MlNodeAvailableWarningShared
+                      size="s"
+                      nodeAvailableCallback={setMlNodesAvailable}
+                    />
+                    <JobsTable
+                      isLoading={isLoadingSecurityJobs || isLoadingEnableDataFeed}
+                      jobs={filteredJobs}
+                      onJobStateChange={handleJobStateChange}
+                      mlNodesAvailable={mlNodesAvailable}
+                    />
+                  </>
+                )}
+              </div>
+            </EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
     );
   } else {
     // If the user has Platinum License & not ML Admin, hide Anomaly Detection button as they don't have permissions to configure

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/ml_popover.tsx
@@ -117,7 +117,12 @@ export const MlPopover = React.memo(() => {
           {i18n.ML_JOB_SETTINGS}
         </EuiHeaderSectionItemButton>
         {isFlyoutOpen && (
-          <EuiFlyout size="s" onClose={closeFlyout} aria-labelledby={mlFlyoutTitleId} ownFocus>
+          <EuiFlyout
+            size="s"
+            onClose={closeFlyout}
+            aria-labelledby={mlFlyoutTitleId}
+            ownFocus={false}
+          >
             <EuiFlyoutHeader hasBorder>
               <EuiTitle size="s">
                 <h2 id={mlFlyoutTitleId}>{i18n.UPGRADE_TITLE}</h2>
@@ -153,7 +158,7 @@ export const MlPopover = React.memo(() => {
             size="m"
             onClose={closeFlyout}
             aria-labelledby={mlFlyoutTitleId}
-            ownFocus
+            ownFocus={false}
             data-test-subj="ml-job-settings-flyout"
           >
             <EuiFlyoutHeader hasBorder>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/translations.ts
@@ -48,3 +48,18 @@ export const ANOMALY_DETECTION_DOCS = i18n.translate(
     defaultMessage: 'Anomaly Detection with Machine Learning',
   }
 );
+
+export const JOB_UPDATES_AVAILABLE_TITLE = (count: number) =>
+  i18n.translate('xpack.securitySolution.components.mlPopup.jobUpdatesAvailableTitle', {
+    values: { count },
+    defaultMessage:
+      '{count} {count, plural, =1 {job has} other {jobs have}} a newer definition available',
+  });
+
+export const JOB_UPDATES_AVAILABLE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.components.mlPopup.jobUpdatesAvailableDescription',
+  {
+    defaultMessage:
+      'Recreate outdated jobs to pick up enhancements and fixes from the latest packaged revision. Recreating a job removes previously detected anomalies for that job.',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/types.ts
@@ -31,6 +31,8 @@ export interface RecognizerModule {
 
 export interface GetModulesProps {
   moduleId?: string;
+  /** When set, limits modules to those matching the tag (e.g. `security`). Omit for all modules. */
+  filter?: string;
   signal?: AbortSignal;
 }
 
@@ -39,7 +41,12 @@ export interface Module {
   title: string;
   description: string;
   type: string;
-  logoFile: string;
+  /** Present on file-based (stack) modules; omitted on Fleet `ml-module` saved objects. */
+  logoFile?: string;
+  /** Present on Fleet `ml-module` saved objects (e.g. `{ icon: 'logoNginx' }`). */
+  logo?: {
+    icon: string;
+  };
   defaultIndexPattern: string;
   query: Record<string, object>;
   jobs: ModuleJob[];
@@ -75,6 +82,9 @@ export interface ModuleJob {
       created_by: string;
       custom_urls: CustomURL[];
       security_app_display_name?: string;
+      /** Incremented when the packaged job definition changes. */
+      job_revision?: number;
+      managed?: boolean;
     };
     job_type: string;
   };
@@ -122,8 +132,19 @@ export interface SecurityJob extends MlSummaryJob {
   isCompatible: boolean;
   isInstalled: boolean;
   isElasticJob: boolean;
+  /** Job comes from a Fleet package `ml-module` saved object. */
+  isIntegrationJob?: boolean;
+  /** Packaged `custom_settings.job_revision` from get_module / Fleet ml-module. */
+  packagedJobRevision?: number;
+  /** Installed job's `customSettings.job_revision` from jobs_summary. */
+  installedJobRevision?: number;
+  /** True when packaged revision is newer than the installed job. */
+  isUpdateAvailable?: boolean;
   customSettings?: {
     security_app_display_name?: string;
+    job_revision?: number;
+    created_by?: string;
+    managed?: boolean;
   };
 }
 
@@ -132,6 +153,8 @@ export interface AugmentedSecurityJobFields {
   defaultIndexPattern: string;
   isCompatible: boolean;
   isElasticJob: boolean;
+  isIntegrationJob?: boolean;
+  packagedJobRevision?: number;
 }
 
 export interface SetupMlResponseJob {
@@ -178,9 +201,12 @@ export interface CloseJobsResponse {
   };
 }
 
+export type MlJobsTab = 'prebuilt' | 'integration';
+
 export interface JobsFilters {
   filterQuery: string;
   showCustomJobs: boolean;
   showElasticJobs: boolean;
   selectedGroups: string[];
+  selectedTab: MlJobsTab;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/upgrade_contents.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/ml_popover/upgrade_contents.tsx
@@ -7,29 +7,13 @@
 
 import React from 'react';
 
-import styled from 'styled-components';
-import {
-  EuiButton,
-  EuiPopoverTitle,
-  EuiSpacer,
-  EuiText,
-  EuiLink,
-  EuiFlexGroup,
-  EuiFlexItem,
-} from '@elastic/eui';
+import { EuiButton, EuiSpacer, EuiText, EuiLink, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useBasePath } from '../../lib/kibana';
 import * as i18n from './translations';
 
-const PopoverContentsDiv = styled.div`
-  width: 384px;
-`;
-
-PopoverContentsDiv.displayName = 'PopoverContentsDiv';
-
 export const UpgradeContentsComponent = () => (
-  <PopoverContentsDiv data-test-subj="ml-popover-upgrade-contents">
-    <EuiPopoverTitle>{i18n.UPGRADE_TITLE}</EuiPopoverTitle>
+  <div data-test-subj="ml-popover-upgrade-contents">
     <EuiText size="s">
       <FormattedMessage
         id="xpack.securitySolution.components.mlPopup.upgradeDescription"
@@ -68,7 +52,7 @@ export const UpgradeContentsComponent = () => (
         </EuiButton>
       </EuiFlexItem>
     </EuiFlexGroup>
-  </PopoverContentsDiv>
+  </div>
 );
 
 export const UpgradeContents = React.memo(UpgradeContentsComponent);

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
@@ -135,15 +135,23 @@ export function usePrebuiltRulesUpgrade({
     usePrebuiltRulesUpgradeState(upgradeableRules);
   const ruleUpgradeStates = useMemo(() => Object.values(rulesUpgradeState), [rulesUpgradeState]);
 
-  const {
-    modal: confirmLegacyMlJobsUpgradeModal,
-    confirmLegacyMLJobs,
-    isLoading: areMlJobsLoading,
-  } = useOutdatedMlJobsUpgradeModal();
+  const { modal: confirmLegacyMlJobsUpgradeModal, confirmMlRuleJobUpgrade } =
+    useOutdatedMlJobsUpgradeModal();
   const { modal: upgradeConflictsModal, confirmConflictsUpgrade } = useUpgradeWithConflictsModal();
 
   const { mutateAsync: upgradeRulesRequest } = usePerformUpgradeRules();
   const upgradeRulesWithDryRun = useRulesUpgradeWithDryRun(confirmConflictsUpgrade);
+
+  const confirmLinkedMlJobUpgrades = useCallback(
+    async (ruleIds: RuleSignatureId[]) => {
+      const rulesForConfirm = ruleIds
+        .map((ruleId) => rulesUpgradeState[ruleId])
+        .filter((rule): rule is RuleUpgradeState => rule != null);
+
+      return confirmMlRuleJobUpgrade(rulesForConfirm);
+    },
+    [confirmMlRuleJobUpgrade, rulesUpgradeState]
+  );
 
   const upgradeRulesToResolved = useCallback(
     async (ruleIds: RuleSignatureId[]) => {
@@ -157,8 +165,8 @@ export function usePrebuiltRulesUpgrade({
       setLoadingRules((prev) => [...prev, ...ruleIds]);
 
       try {
-        // Handle MLJobs modal
-        if (!(await confirmLegacyMLJobs())) {
+        // Tie ML job updates to rule upgrades when linked job IDs change.
+        if ((await confirmLinkedMlJobUpgrades(ruleIds)) === false) {
           return;
         }
 
@@ -179,7 +187,7 @@ export function usePrebuiltRulesUpgrade({
         setLoadingRules((prev) => prev.filter((id) => !upgradedRuleIdsSet.has(id)));
       }
     },
-    [rulesUpgradeState, confirmLegacyMLJobs, upgradeRulesWithDryRun, onUpgrade]
+    [rulesUpgradeState, confirmLinkedMlJobUpgrades, upgradeRulesWithDryRun, onUpgrade]
   );
 
   const upgradeRulesToTarget = useCallback(
@@ -193,8 +201,8 @@ export function usePrebuiltRulesUpgrade({
       setLoadingRules((prev) => [...prev, ...ruleIds]);
 
       try {
-        // Handle MLJobs modal
-        if (!(await confirmLegacyMLJobs())) {
+        // Tie ML job updates to rule upgrades when linked job IDs change.
+        if ((await confirmLinkedMlJobUpgrades(ruleIds)) === false) {
           return;
         }
 
@@ -215,7 +223,7 @@ export function usePrebuiltRulesUpgrade({
         setLoadingRules((prev) => prev.filter((id) => !upgradedRuleIdsSet.has(id)));
       }
     },
-    [confirmLegacyMLJobs, onUpgrade, rulesUpgradeState, upgradeRulesRequest]
+    [confirmLinkedMlJobUpgrades, onUpgrade, rulesUpgradeState, upgradeRulesRequest]
   );
 
   const upgradeRules = useCallback(
@@ -238,8 +246,8 @@ export function usePrebuiltRulesUpgrade({
     setLoadingRules((prev) => [...prev, ...upgradeableRules.map((rule) => rule.rule_id)]);
 
     try {
-      // Handle MLJobs modal
-      if (!(await confirmLegacyMLJobs())) {
+      // Tie ML job updates to rule upgrades when linked job IDs change.
+      if ((await confirmMlRuleJobUpgrade(upgradeableRules)) === false) {
         return;
       }
 
@@ -269,7 +277,7 @@ export function usePrebuiltRulesUpgrade({
     upgradeableRules,
     upgradeRulesWithDryRun,
     upgradeRulesRequest,
-    confirmLegacyMLJobs,
+    confirmMlRuleJobUpgrade,
     isRulesCustomizationEnabled,
     performUpgradeFilter,
   ]);
@@ -451,7 +459,7 @@ export function usePrebuiltRulesUpgrade({
     ruleUpgradeStates,
     upgradeReviewResponse,
     isFetched,
-    isLoading: isLoading || areMlJobsLoading,
+    isLoading,
     isFetching,
     isRefetching,
     isInitializingPrebuiltRulesPackage,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -146,6 +146,9 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
                 data-test-subj="rules-upgrades-table"
                 columns={rulesColumns}
                 onChange={handleTableChange}
+                tableLayout="auto"
+                scrollableInline
+                responsiveBreakpoint={false}
               />
             </>
           )

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_ml_jobs_upgrade_modal/job_upgrade_items.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_ml_jobs_upgrade_modal/job_upgrade_items.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleUpgradeState } from '../../../../../rule_management/model/prebuilt_rule_upgrade';
+
+export type MlLinkedJobUpgradeKind =
+  /** Target jobs differ — install/start new jobs as part of rule upgrade */
+  | 'job_id_change'
+  /**
+   * Structural job migration (e.g. non-EA → Entity Analytics `_ea` jobs).
+   * Requires an explicit breaking-change warning before proceeding.
+   */
+  | 'breaking_job_change';
+
+export interface MlLinkedJobUpgradeItem {
+  ruleId: string;
+  ruleName: string;
+  currentJobIds: string[];
+  targetJobIds: string[];
+  kind: MlLinkedJobUpgradeKind;
+}
+
+const toJobIdList = (value: string | string[] | undefined): string[] => {
+  if (value == null) {
+    return [];
+  }
+  return (Array.isArray(value) ? value : [value]).filter(Boolean);
+};
+
+const sameJobIds = (a: string[], b: string[]): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((id, index) => id === sortedB[index]);
+};
+
+const isEntityAnalyticsMigration = (currentJobIds: string[], targetJobIds: string[]): boolean => {
+  if (currentJobIds.length === 0 || targetJobIds.length === 0) {
+    return false;
+  }
+  const currentHasEa = currentJobIds.some((id) => id.endsWith('_ea'));
+  const targetHasEa = targetJobIds.some((id) => id.endsWith('_ea'));
+  return !currentHasEa && targetHasEa;
+};
+
+/**
+ * Builds the ML job actions that should be confirmed when upgrading the given rules.
+ * Only rules whose `machine_learning_job_id` changes are included.
+ */
+export const buildMlLinkedJobUpgradeItems = (
+  rules: Array<Pick<RuleUpgradeState, 'rule_id' | 'current_rule' | 'target_rule'>>
+): MlLinkedJobUpgradeItem[] => {
+  const items: MlLinkedJobUpgradeItem[] = [];
+
+  for (const rule of rules) {
+    if (rule.current_rule.type !== 'machine_learning' && rule.target_rule.type !== 'machine_learning') {
+      continue;
+    }
+
+    const currentJobIds = toJobIdList(
+      'machine_learning_job_id' in rule.current_rule
+        ? rule.current_rule.machine_learning_job_id
+        : undefined
+    );
+    const targetJobIds = toJobIdList(
+      'machine_learning_job_id' in rule.target_rule
+        ? rule.target_rule.machine_learning_job_id
+        : undefined
+    );
+
+    if (sameJobIds(currentJobIds, targetJobIds)) {
+      continue;
+    }
+
+    items.push({
+      ruleId: rule.rule_id,
+      ruleName: rule.target_rule.name || rule.current_rule.name,
+      currentJobIds,
+      targetJobIds,
+      kind: isEntityAnalyticsMigration(currentJobIds, targetJobIds)
+        ? 'breaking_job_change'
+        : 'job_id_change',
+    });
+  }
+
+  return items;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_ml_jobs_upgrade_modal/ml_jobs_upgrade_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_ml_jobs_upgrade_modal/ml_jobs_upgrade_modal.tsx
@@ -5,66 +5,167 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
-import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
-import type { MlSummaryJob } from '@kbn/ml-common-types/anomaly_detection_jobs/summary_job';
-import styled from 'styled-components';
-import { rgba } from 'polished';
+import React, { memo, useCallback, useState } from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiCheckbox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import type { MlLinkedJobUpgradeItem } from './job_upgrade_items';
 import * as i18n from './translations';
 
-const JobsUL = styled.ul`
-  max-height: 200px;
-  overflow-y: auto;
-
-  &::-webkit-scrollbar {
-    height: ${({ theme }) => theme.eui.euiScrollBar};
-    width: ${({ theme }) => theme.eui.euiScrollBar};
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-clip: content-box;
-    background-color: ${({ theme }) => rgba(theme.eui.euiColorDarkShade, 0.5)};
-    border: ${({ theme }) => theme.eui.euiScrollBarCorner} solid transparent;
-  }
-
-  &::-webkit-scrollbar-corner,
-  &::-webkit-scrollbar-track {
-    background-color: transparent;
-  }
-`;
-
-interface OutdatedMlJobsUpgradeModalProps {
-  jobs: MlSummaryJob[];
-  onCancel: () => void;
-  onConfirm: () => void;
+export interface MlRuleJobUpgradeConfirmResult {
+  updateJobs: boolean;
+  duplicateOldJobs: boolean;
 }
 
-export const OutdatedMlJobsUpgradeModal = memo(function LegacyMlJobsUpgradeModal({
-  jobs,
+interface MlRuleJobUpgradeModalProps {
+  items: MlLinkedJobUpgradeItem[];
+  onCancel: () => void;
+  onConfirm: (result: MlRuleJobUpgradeConfirmResult) => void;
+}
+
+export const MlRuleJobUpgradeModal = memo(function MlRuleJobUpgradeModal({
+  items,
   onCancel,
   onConfirm,
-}: OutdatedMlJobsUpgradeModalProps): JSX.Element {
-  const modalTitleId = useGeneratedHtmlId();
+}: MlRuleJobUpgradeModalProps): JSX.Element {
+  const titleId = useGeneratedHtmlId();
+  const duplicateCheckboxId = useGeneratedHtmlId({ prefix: 'duplicateOldMlJobs' });
+  const [duplicateOldJobs, setDuplicateOldJobs] = useState(false);
+
+  const hasBreaking = items.some((item) => item.kind === 'breaking_job_change');
+
+  const handleConfirmWithJobs = useCallback(() => {
+    onConfirm({ updateJobs: true, duplicateOldJobs });
+  }, [duplicateOldJobs, onConfirm]);
+
+  const handleRulesOnly = useCallback(() => {
+    onConfirm({ updateJobs: false, duplicateOldJobs: false });
+  }, [onConfirm]);
 
   return (
-    <EuiConfirmModal
-      aria-labelledby={modalTitleId}
-      title={i18n.ML_JOB_UPGRADE_MODAL_TITLE}
-      titleProps={{ id: modalTitleId }}
-      onCancel={onCancel}
-      onConfirm={onConfirm}
-      cancelButtonText={i18n.ML_JOB_UPGRADE_MODAL_CANCEL}
-      confirmButtonText={i18n.ML_JOB_UPGRADE_MODAL_CONFIRM}
-      buttonColor="danger"
-      defaultFocusedButton="confirm"
+    <EuiModal
+      aria-labelledby={titleId}
+      onClose={onCancel}
+      maxWidth={640}
+      data-test-subj="mlRuleJobUpgradeModal"
     >
-      <i18n.MlJobUpgradeModalBody />
-      {i18n.ML_JOB_UPGRADE_MODAL_AFFECTED_JOBS}
-      <JobsUL>
-        {jobs.map((j) => {
-          return <li key={j.id}>{j.id}</li>;
-        })}
-      </JobsUL>
-    </EuiConfirmModal>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={titleId}>{i18n.ML_RULE_JOB_UPGRADE_MODAL_TITLE}</EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <EuiText size="s">
+          <p>{i18n.ML_RULE_JOB_UPGRADE_MODAL_DESCRIPTION}</p>
+        </EuiText>
+
+        <EuiSpacer size="m" />
+
+        {hasBreaking && (
+          <>
+            <EuiCallOut
+              title={i18n.ML_RULE_JOB_UPGRADE_MODAL_BREAKING_TITLE}
+              color="warning"
+              iconType="warning"
+              size="s"
+              data-test-subj="mlRuleJobUpgradeBreakingCallout"
+            >
+              <p>{i18n.ML_RULE_JOB_UPGRADE_MODAL_BREAKING_BODY}</p>
+            </EuiCallOut>
+            <EuiSpacer size="m" />
+          </>
+        )}
+
+        <EuiCallOut
+          title={i18n.ML_RULE_JOB_UPGRADE_MODAL_AUTO_TITLE}
+          color="primary"
+          iconType="iInCircle"
+          size="s"
+        >
+          <p>{i18n.ML_RULE_JOB_UPGRADE_MODAL_AUTO_BODY}</p>
+        </EuiCallOut>
+
+        <EuiSpacer size="m" />
+
+        <EuiTitle size="xs">
+          <h3>{i18n.ML_RULE_JOB_UPGRADE_MODAL_JOBS_SECTION}</h3>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+
+        <EuiFlexGroup direction="column" gutterSize="m">
+          {items.map((item) => (
+            <EuiFlexItem key={item.ruleId} grow={false}>
+              <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                <EuiFlexItem grow={true}>
+                  <EuiText size="s">
+                    <strong>{item.ruleName}</strong>
+                  </EuiText>
+                </EuiFlexItem>
+                {item.kind === 'breaking_job_change' && (
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="warning">{i18n.ML_RULE_JOB_UPGRADE_MODAL_BREAKING_BADGE}</EuiBadge>
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
+              <EuiSpacer size="xs" />
+              <EuiText size="xs" color="subdued">
+                <div>
+                  {i18n.ML_RULE_JOB_UPGRADE_MODAL_CURRENT}:{' '}
+                  <code>{i18n.jobIdsLabel(item.currentJobIds)}</code>
+                </div>
+                <div>
+                  {i18n.ML_RULE_JOB_UPGRADE_MODAL_TARGET}:{' '}
+                  <code>{i18n.jobIdsLabel(item.targetJobIds)}</code>
+                </div>
+              </EuiText>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+
+        <EuiSpacer size="m" />
+
+        <EuiCheckbox
+          id={duplicateCheckboxId}
+          label={i18n.ML_RULE_JOB_UPGRADE_MODAL_DUPLICATE_LABEL}
+          checked={duplicateOldJobs}
+          onChange={(e) => setDuplicateOldJobs(e.target.checked)}
+          data-test-subj="mlRuleJobUpgradeDuplicateCheckbox"
+        />
+        <EuiSpacer size="xs" />
+        <EuiText size="xs" color="subdued">
+          <p>{i18n.ML_RULE_JOB_UPGRADE_MODAL_DUPLICATE_HELP}</p>
+        </EuiText>
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButtonEmpty onClick={onCancel} data-test-subj="mlRuleJobUpgradeCancel">
+          {i18n.ML_RULE_JOB_UPGRADE_MODAL_CANCEL}
+        </EuiButtonEmpty>
+        <EuiButtonEmpty onClick={handleRulesOnly} data-test-subj="mlRuleJobUpgradeRulesOnly">
+          {i18n.ML_RULE_JOB_UPGRADE_MODAL_RULES_ONLY}
+        </EuiButtonEmpty>
+        <EuiButton
+          fill
+          onClick={handleConfirmWithJobs}
+          data-test-subj="mlRuleJobUpgradeConfirm"
+        >
+          {i18n.ML_RULE_JOB_UPGRADE_MODAL_CONFIRM}
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_ml_jobs_upgrade_modal/translations.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_ml_jobs_upgrade_modal/translations.tsx
@@ -5,66 +5,123 @@
  * 2.0.
  */
 
-import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { MlJobCompatibilityLink } from '../../../../../../common/components/links_to_docs';
 
-export const ML_JOB_UPGRADE_MODAL_TITLE = i18n.translate(
-  'xpack.securitySolution.detectionEngine.mlJobUpgradeModal.messageTitle',
+export const ML_RULE_JOB_UPGRADE_MODAL_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.title',
   {
-    defaultMessage: 'ML rule updates may override your existing rules',
+    defaultMessage: 'Update rules and ML jobs together',
   }
 );
 
-export const ML_JOB_UPGRADE_MODAL_CANCEL = i18n.translate(
-  'xpack.securitySolution.detectionEngine.mlJobUpgradeModal.cancelTitle',
+export const ML_RULE_JOB_UPGRADE_MODAL_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.description',
+  {
+    defaultMessage:
+      'These detection rule updates change the linked ML jobs. Update the jobs in the same flow so rules and jobs stay in sync — separate job notifications should not be required.',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_BREAKING_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.breakingTitle',
+  {
+    defaultMessage: 'Breaking job changes',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_BREAKING_BODY = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.breakingBody',
+  {
+    defaultMessage:
+      'Some jobs move to Entity Analytics (`_ea`) variants. Influencers and anomaly behavior can change. Existing anomaly history on the old jobs will not carry over to the new jobs.',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_AUTO_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.autoTitle',
+  {
+    defaultMessage: 'Automated job update',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_AUTO_BODY = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.autoBody',
+  {
+    defaultMessage:
+      'Compatible settings (index patterns, query filters, and model memory limits when possible) will be carried over from the current jobs to the new ones.',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_DUPLICATE_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.duplicateLabel',
+  {
+    defaultMessage: 'Duplicate existing jobs to preserve current configuration and anomaly history',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_DUPLICATE_HELP = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.duplicateHelp',
+  {
+    defaultMessage:
+      'When selected, the system duplicates the old jobs for you before creating the updated ones. You do not need to recreate them manually.',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_JOBS_SECTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.jobsSection',
+  {
+    defaultMessage: 'Jobs linked to this update',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_CURRENT = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.currentJobs',
+  {
+    defaultMessage: 'Current',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_TARGET = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.targetJobs',
+  {
+    defaultMessage: 'After update',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_BREAKING_BADGE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.breakingBadge',
+  {
+    defaultMessage: 'Breaking',
+  }
+);
+
+export const ML_RULE_JOB_UPGRADE_MODAL_CANCEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.cancel',
   {
     defaultMessage: 'Cancel',
   }
 );
 
-export const ML_JOB_UPGRADE_MODAL_CONFIRM = i18n.translate(
-  'xpack.securitySolution.detectionEngine.mlJobUpgradeModal.confirmTitle',
+export const ML_RULE_JOB_UPGRADE_MODAL_RULES_ONLY = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.rulesOnly',
   {
-    defaultMessage: 'Load rules',
+    defaultMessage: 'Update rules only',
   }
 );
 
-export const ML_JOB_UPGRADE_MODAL_AFFECTED_JOBS = i18n.translate(
-  'xpack.securitySolution.detectionEngine.mlJobUpgradeModal.affectedJobsTitle',
+export const ML_RULE_JOB_UPGRADE_MODAL_CONFIRM = i18n.translate(
+  'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.confirm',
   {
-    defaultMessage: 'Affected jobs:',
+    defaultMessage: 'Update rules and jobs',
   }
 );
 
-export const MlJobUpgradeModalBody = () => (
-  <FormattedMessage
-    id="xpack.securitySolution.detectionEngine.mlJobUpgradeModal.messageBody"
-    defaultMessage="{summary} Documentation: {docs}"
-    values={{
-      summary: (
-        <p>
-          <FormattedMessage
-            id="xpack.securitySolution.detectionEngine.mlJobUpgradeModal.messageBody.summary"
-            defaultMessage="New V3 machine learning jobs have been released,
-            and the latest corresponding prebuilt detection rules now use these
-            new ML jobs. You're currently running one or more V1/V2 jobs, which
-            only work with legacy prebuilt rules. To ensure continued coverage using
-            V1/V2 jobs, you may need to duplicate or create new rules before
-            updating your Elastic prebuilt detection rules. Check the documentation
-            below for instructions on how to keep using the V1/V2 jobs, and how to
-            start using the new V3 jobs."
-          />
-        </p>
-      ),
-      docs: (
-        <ul>
-          <li>
-            <MlJobCompatibilityLink />
-          </li>
-        </ul>
-      ),
-    }}
-  />
-);
+export const jobIdsLabel = (jobIds: string[]) =>
+  jobIds.length > 0
+    ? jobIds.join(', ')
+    : i18n.translate(
+        'xpack.securitySolution.detectionEngine.mlRuleJobUpgradeModal.noJobs',
+        {
+          defaultMessage: 'None',
+        }
+      );

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_ml_jobs_upgrade_modal/use_ml_jobs_upgrade_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_ml_jobs_upgrade_modal/use_ml_jobs_upgrade_modal.tsx
@@ -6,41 +6,69 @@
  */
 
 import type { ReactNode } from 'react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useBoolean } from '@kbn/react-hooks';
-import { useInstalledSecurityJobs } from '../../../../../../common/components/ml/hooks/use_installed_security_jobs';
-import { affectedJobIds } from '../../../../../../../common/machine_learning/affected_job_ids';
+import type { RuleUpgradeState } from '../../../../../rule_management/model/prebuilt_rule_upgrade';
 import { useAsyncConfirmation } from '../../rules_table/use_async_confirmation';
-import { OutdatedMlJobsUpgradeModal } from './ml_jobs_upgrade_modal';
+import {
+  buildMlLinkedJobUpgradeItems,
+  type MlLinkedJobUpgradeItem,
+} from './job_upgrade_items';
+import {
+  MlRuleJobUpgradeModal,
+  type MlRuleJobUpgradeConfirmResult,
+} from './ml_jobs_upgrade_modal';
 
-interface UseOutdatedMlJobsUpgradeModalResult {
+export type { MlRuleJobUpgradeConfirmResult } from './ml_jobs_upgrade_modal';
+
+interface UseMlRuleJobUpgradeModalResult {
   modal: ReactNode;
-  isLoading: boolean;
-  confirmLegacyMLJobs: () => Promise<boolean>;
+  /**
+   * Opens the ML rule↔job upgrade consent modal when the selected rules
+   * change linked ML jobs. Resolves `false` on cancel.
+   */
+  confirmMlRuleJobUpgrade: (
+    rules: Array<Pick<RuleUpgradeState, 'rule_id' | 'current_rule' | 'target_rule'>>
+  ) => Promise<false | MlRuleJobUpgradeConfirmResult>;
 }
 
-export function useOutdatedMlJobsUpgradeModal(): UseOutdatedMlJobsUpgradeModalResult {
+/**
+ * Consent flow for tying ML job updates to detection rule upgrades.
+ * Replaces the legacy V1/V2 → V3 warning-only modal for this prototype path.
+ */
+export function useOutdatedMlJobsUpgradeModal(): UseMlRuleJobUpgradeModalResult {
   const [isVisible, { on: showModal, off: hideModal }] = useBoolean(false);
-  const { loading, jobs } = useInstalledSecurityJobs();
-  const legacyJobsInstalled = jobs.filter((job) => affectedJobIds.includes(job.id));
-  const [confirmLegacyMLJobs, confirm, cancel] = useAsyncConfirmation({
+  const [items, setItems] = useState<MlLinkedJobUpgradeItem[]>([]);
+
+  const [initConfirmation, confirm, cancel] = useAsyncConfirmation<MlRuleJobUpgradeConfirmResult>({
     onInit: showModal,
     onFinish: hideModal,
   });
 
-  const handleLegacyMLJobsConfirm = useCallback(async () => {
-    if (legacyJobsInstalled.length > 0) {
-      return confirmLegacyMLJobs();
-    }
+  const confirmMlRuleJobUpgrade = useCallback(
+    async (
+      rules: Array<Pick<RuleUpgradeState, 'rule_id' | 'current_rule' | 'target_rule'>>
+    ): Promise<false | MlRuleJobUpgradeConfirmResult> => {
+      const nextItems = buildMlLinkedJobUpgradeItems(rules);
+      if (nextItems.length === 0) {
+        // No linked job changes — proceed without blocking the user.
+        return { updateJobs: false, duplicateOldJobs: false };
+      }
 
-    return true;
-  }, [confirmLegacyMLJobs, legacyJobsInstalled]);
+      setItems(nextItems);
+      const result = await initConfirmation();
+      if (result === false) {
+        return false;
+      }
+      return result as MlRuleJobUpgradeConfirmResult;
+    },
+    [initConfirmation]
+  );
 
   return {
     modal: isVisible && (
-      <OutdatedMlJobsUpgradeModal jobs={jobs} onConfirm={confirm} onCancel={cancel} />
+      <MlRuleJobUpgradeModal items={items} onConfirm={confirm} onCancel={cancel} />
     ),
-    confirmLegacyMLJobs: handleLegacyMLJobsConfirm,
-    isLoading: loading,
+    confirmMlRuleJobUpgrade,
   };
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
@@ -65,7 +65,8 @@ const RULE_NAME_COLUMN: TableColumn = {
   ),
   sortable: true,
   truncateText: true,
-  width: '60%',
+  minWidth: '12em',
+  width: '18em',
   align: 'left',
 };
 
@@ -236,7 +237,7 @@ const createUpgradeButtonColumn = (
       </EuiButtonEmpty>
     );
   },
-  width: '10%',
+  width: '120px',
   align: 'center',
 });
 
@@ -277,7 +278,7 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
         sortable: ({ current_rule: { severity } }: RuleUpgradeState) =>
           getNormalizedSeverity(severity),
         truncateText: true,
-        width: '10%',
+        width: '100px',
       },
       ...(canEditRules
         ? [


### PR DESCRIPTION
⚠️ Design POC  

## Summary
- Unify Security ML job settings into Pre-built and Integration tabs, with update notices (`job_revision`) and Fleet integration job visibility before create.
- Tie prebuilt rule upgrades to related ML job upgrades via a consent modal (sync list, carry settings, optional duplicate, breaking-upgrade callouts).
- Polish ML settings UX (filters, jobs table, Rule Updates table layout) for the ROOS ML Jobs prototype.

## Test plan
- [ ] Open **Rules management → ML job settings**; confirm Pre-built / Integration tabs and job lists load
- [ ] Pre-built: search, Groups, Elastic/Custom filters, Run job toggles, update badges/callout
- [ ] Integration: package cards → jobs; jobs visible before create when Fleet `ml-module` packages are installed
- [ ] Rule Updates: upgrade rules that reference ML jobs; confirm consent modal (rules only vs rules + jobs, duplicate option, breaking callout)
- [ ] Cancel / dismiss paths leave rules and jobs unchanged


Made with [Cursor](https://cursor.com)