### PR TITLE
Add MCP annotations to Cases tools (Phase 2b)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/attachment_tools.ts
+++ b/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/attachment_tools.ts
@@ -128,6 +128,13 @@ export const attachmentsTool = (
     id: platformCoreCasesTools.attachments,
     type: ToolType.builtin,
     description: `Case attachments. Modes: \`add_comment\` (user comment), \`add_alerts\` (link SIEM/detection alerts), \`add_events\` (link log/event docs), \`add_attachments\` (generic bulk — comments, alerts, and saved-object attachments like dashboards, lens, maps), \`get_all\` (fetch all comments, alerts, events). See \`mode\` field for required inputs.\n\n${CASES_SOLUTION_CONTEXT_INSTRUCTION}${CASES_TOOL_TEXT_INSTRUCTION}`,
+    annotations: {
+      title: 'Case Attachments',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     schema,
     tags: ['cases'],
     handler: async (args, toolContext) => {

--- a/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/manage_cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/manage_cases.ts
@@ -135,6 +135,13 @@ export const manageCasesTool = (
     description: `Cases CRUD + assign/tags/custom fields${
       isTemplatesEnabled ? '/extended fields' : ''
     }. Modes: ${modesDescription}. See \`mode\` field for required inputs.\n\n${CASES_SOLUTION_CONTEXT_INSTRUCTION}${CASES_TOOL_TEXT_INSTRUCTION}`,
+    annotations: {
+      title: 'Manage Cases',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     schema: manageCasesSchema,
     tags: ['cases'],
     handler: async (args, toolContext) => {

--- a/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/observable_tools.ts
+++ b/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/observable_tools.ts
@@ -48,6 +48,13 @@ export const observablesTool = (
     id: platformCoreCasesTools.observables,
     type: ToolType.builtin,
     description: `Case observables — IOCs/indicators (IPs, domains, file hashes, URLs, emails, registry keys). Modes: \`add\`, \`update\`, \`delete\`. See \`mode\` field for required inputs.\n\n${CASES_SOLUTION_CONTEXT_INSTRUCTION}${CASES_TOOL_TEXT_INSTRUCTION}`,
+    annotations: {
+      title: 'Case Observables',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     schema: observablesSchema,
     tags: ['cases'],
     handler: async (args, toolContext) => {


### PR DESCRIPTION
## Summary

Adds MCP tool annotations to the 3 Cases CRUD builtin tools (Phase 2b).

| Tool | Title | readOnly | destructive | idempotent | openWorld |
|------|-------|----------|-------------|------------|-----------|
| `cases.manage` | Manage Cases | false | true | false | false |
| `cases.attachments` | Case Attachments | false | false | false | false |
| `cases.observables` | Case Observables | false | true | false | false |

**Classification rationale:**
- `cases.manage`: destructive — includes `delete` mode alongside create/update/assign
- `cases.attachments`: non-destructive write — adds comments/alerts/events and reads them (`get_all`), no delete
- `cases.observables`: destructive — includes `delete` mode alongside add/update

Builds on the Phase 1 framework PR (#284764).

## Test plan

- [x] Cases agent_builder tests: 48 pass
- [ ] CI validation

Generated with [Claude Code](https://claude.com/claude-code)
