### PR TITLE
Add MCP annotations to observability tools (Phase 2e)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_alerts/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_alerts/tool.ts
@@ -83,6 +83,13 @@ export function createGetAlertsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getAlertsSchema> = {
     id: OBSERVABILITY_GET_ALERTS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Alerts',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Retrieves Observability alerts within a specified time range.
 
 When to use:

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_anomaly_detection_jobs/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_anomaly_detection_jobs/tool.ts
@@ -104,6 +104,13 @@ export function createGetAnomalyDetectionJobsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getAnomalyDetectionJobsSchema> = {
     id: OBSERVABILITY_GET_ANOMALY_DETECTION_JOBS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Anomaly Detection Jobs',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Retrieves Machine Learning anomaly detection jobs and their top anomaly records.
 
 When to use:

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_apm_correlations/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_apm_correlations/tool.ts
@@ -94,6 +94,13 @@ export function createGetApmCorrelationsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getApmCorrelationsSchema> = {
     id: OBSERVABILITY_GET_APM_CORRELATIONS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get APM Correlations',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Analyzes APM transaction correlations to identify which dimensions are most associated with slow, failed, or throughput-anomalous transactions, or which infrastructure entities host slow transactions.
 
 This is a "unified correlations" style tool intended to support investigations where you already have a scoped set of transactions and want to find what stands out within them.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_hosts/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_hosts/tool.ts
@@ -62,6 +62,13 @@ export function createGetHostsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getHostsSchema> = {
     id: OBSERVABILITY_GET_HOSTS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Hosts',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Retrieves a list of hosts with their infrastructure metrics (CPU, memory, disk, network). Use this tool to get an overview of host health and resource utilization.
 
 When to use:

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_index_info/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_index_info/tool.ts
@@ -80,6 +80,13 @@ export function createGetIndexInfoTool({
   const toolDefinition: BuiltinToolDefinition<typeof getIndexInfoSchema> = {
     id: OBSERVABILITY_GET_INDEX_INFO_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Index Info',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: dedent(`
       Discovers observability index patterns, fields, and field values in the user's Elasticsearch cluster.
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_log_change_points/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_log_change_points/tool.ts
@@ -61,6 +61,13 @@ export function createGetLogChangePointsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getLogChangePointsSchema> = {
     id: OBSERVABILITY_GET_LOG_CHANGE_POINTS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Log Change Points',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Analyzes logs to detect statistically significant changes in log message patterns over time.
 
 When to use:

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_log_groups/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_log_groups/tool.ts
@@ -86,6 +86,13 @@ export function createGetLogGroupsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getLogsSchema> = {
     id: OBSERVABILITY_GET_LOG_GROUPS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Log Groups',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: dedent`
       Returns categorized log messages and exceptions from logs and spans within a specified time range.
       

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_logs/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_logs/tool.ts
@@ -90,6 +90,13 @@ export function createGetLogsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getLogsSchema, GetLogsHandlerResult> = {
     id: OBSERVABILITY_GET_LOGS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Logs',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: dedent(
       `Searches and filters logs, returning a histogram trend, total count, compact log samples, and message pattern categories in a single query.
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_metric_change_points/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_metric_change_points/tool.ts
@@ -73,6 +73,13 @@ export function createGetMetricChangePointsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getMetricChangePointsSchema> = {
     id: OBSERVABILITY_GET_METRIC_CHANGE_POINTS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Metric Change Points',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Detects statistically significant changes in metrics across groups (e.g., by service, host, or custom fields).
 
 When to use:

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_runtime_metrics/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_runtime_metrics/tool.ts
@@ -73,6 +73,13 @@ export function createGetRuntimeMetricsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getRuntimeMetricsToolSchema> = {
     id: OBSERVABILITY_GET_RUNTIME_METRICS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Runtime Metrics',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Retrieves runtime metrics for services, including CPU usage, memory consumption, thread counts, and GC duration.
 
 Currently supports JVM (Java) metrics. Returns for each service node (application instance):

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_service_topology/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_service_topology/tool.ts
@@ -66,6 +66,13 @@ export function createGetServiceTopologyTool({
   const toolDefinition: BuiltinToolDefinition<typeof getServiceTopologyToolSchema> = {
     id: OBSERVABILITY_GET_SERVICE_TOPOLOGY_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Service Topology',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Retrieves the service topology (dependency graph) for a service, with RED metrics (latency, throughput, error rate) per connection.
 
 Returns connections with source/target nodes and RED metrics. Supports downstream, upstream, or both directions.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_services/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_services/tool.ts
@@ -65,6 +65,13 @@ export function createGetServicesTool({
   const toolDefinition: BuiltinToolDefinition<typeof getServicesSchema> = {
     id: OBSERVABILITY_GET_SERVICES_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Services',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Retrieves a list of services from APM, logs, and metrics data sources.
     
 For APM services, includes anomaly severity, active alert counts, and key performance metrics (latency, transaction error rate, throughput).

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_trace_change_points/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_trace_change_points/tool.ts
@@ -64,6 +64,13 @@ export function createGetTraceChangePointsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getTraceChangePointsSchema> = {
     id: OBSERVABILITY_GET_TRACE_CHANGE_POINTS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Trace Change Points',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Analyzes traces to detect statistically significant change points in latency, throughput, and failure rate across group (e.g., service, transaction, host).
 Trace metrics:
 - Latency: avg/p95/p99 response time.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_trace_metrics/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_trace_metrics/tool.ts
@@ -60,7 +60,14 @@ export function createGetTraceMetricsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getTraceMetricsSchema> = {
     id: OBSERVABILITY_GET_TRACE_METRICS_TOOL_ID,
     type: ToolType.builtin,
-    description: `Retrieves trace metrics (throughput, failure rate, latency) for APM data with flexible filtering and grouping. 
+    annotations: {
+      title: 'Get Trace Metrics',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    description: `Retrieves trace metrics (throughput, failure rate, latency) for APM data with flexible filtering and grouping.
         
 Trace metrics are:
 - Throughput: requests per minute

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_traces/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_traces/tool.ts
@@ -83,6 +83,13 @@ export function createGetTracesTool({
   const toolDefinition: BuiltinToolDefinition<typeof getTracesSchema> = {
     id: OBSERVABILITY_GET_TRACES_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Get Traces',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Retrieves Observability documents (logs, transactions, spans, and errors) for one or more traces.
 
   This tool is KQL-driven: it searches for matching Observability documents within the time range, extracts one or more trace.id values, then returns Observability documents grouped by trace.id.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/run_log_rate_analysis/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/run_log_rate_analysis/tool.ts
@@ -56,6 +56,13 @@ export function createRunLogRateAnalysisTool({
   const toolDefinition: BuiltinToolDefinition<typeof logRateAnalysisSchema> = {
     id: OBSERVABILITY_RUN_LOG_RATE_ANALYSIS_TOOL_ID,
     type: ToolType.builtin,
+    annotations: {
+      title: 'Run Log Rate Analysis',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: `Analyzes which log fields or message patterns correlate with changes in log throughput (spikes or drops).
 
 When to use:


### PR DESCRIPTION
## Summary

Adds MCP tool annotations to all 16 observability tools (Phase 2e).

All 16 tools are read-only: get_alerts, get_services, get_logs, get_traces, get_hosts, get_trace_metrics, get_log_change_points, get_metric_change_points, get_index_info, get_trace_change_points, get_service_topology, get_runtime_metrics, get_apm_correlations, get_anomaly_detection_jobs, run_log_rate_analysis, get_log_groups.

Builds on the Phase 1 framework PR (#284764).

## Test plan
- [ ] CI validation

Generated with [Claude Code](https://claude.com/claude-code)
