### PR TITLE
Simplify Infra E2E & API tests

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/api/fixtures/constants.ts
@@ -99,5 +99,20 @@ export const emptyQuery = {
   },
 };
 
+export const ECS_ARCHIVE_HOSTS = [
+  'gke-observability-8--observability-8--bc1afd95-f0zc',
+  'gke-observability-8--observability-8--bc1afd95-ngmh',
+  'gke-observability-8--observability-8--bc1afd95-nhhw',
+] as const;
+
+export const buildHostNameQuery = (hostNames: readonly string[]): Record<string, unknown> => ({
+  bool: {
+    must: [],
+    filter: [{ terms: { 'host.name': [...hostNames] } }],
+    should: [],
+    must_not: [],
+  },
+});
+
 /** Collapse newlines / multi-space runs so validation error assertions stay stable. */
 export const normalizeNewLine = (text: string): string => text.replaceAll(/(\s{2,}|\n\s)/g, ' ');

--- a/x-pack/solutions/observability/plugins/infra/test/scout/api/tests/infra_count.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/api/tests/infra_count.spec.ts
@@ -51,7 +51,7 @@ apiTest.describe(
         headers,
         responseType: 'json',
         body: {
-          query: testData.emptyQuery,
+          query: testData.buildHostNameQuery(testData.ECS_ARCHIVE_HOSTS),
           from: ecsTimeRange.from,
           to: ecsTimeRange.to,
           schema: 'ecs',
@@ -69,7 +69,9 @@ apiTest.describe(
         headers,
         responseType: 'json',
         body: {
-          query: testData.emptyQuery,
+          query: testData.buildHostNameQuery(
+            testData.SEMCONV_HOSTS.map(({ hostName }) => hostName)
+          ),
           from: testData.SEMCONV_HOSTS_DATA_FROM,
           to: testData.SEMCONV_HOSTS_DATA_TO,
           schema: 'semconv',
@@ -92,7 +94,11 @@ apiTest.describe(
       const response = await apiClient.post('api/infra/host/count', {
         headers,
         responseType: 'json',
-        body: { query: testData.emptyQuery, ...wideTimerange, schema: 'ecs' },
+        body: {
+          query: testData.buildHostNameQuery(testData.ECS_ARCHIVE_HOSTS),
+          ...wideTimerange,
+          schema: 'ecs',
+        },
       });
 
       expect(response).toHaveStatusCode(200);
@@ -106,7 +112,13 @@ apiTest.describe(
         const response = await apiClient.post('api/infra/host/count', {
           headers,
           responseType: 'json',
-          body: { query: testData.emptyQuery, ...wideTimerange, schema: 'semconv' },
+          body: {
+            query: testData.buildHostNameQuery(
+              testData.SEMCONV_HOSTS.map(({ hostName }) => hostName)
+            ),
+            ...wideTimerange,
+            schema: 'semconv',
+          },
         });
 
         expect(response).toHaveStatusCode(200);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/api/tests/infra_metrics_mixed.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/api/tests/infra_metrics_mixed.spec.ts
@@ -74,6 +74,7 @@ apiTest.describe(
           ...basePayload,
           metrics: ['cpuV2'],
           ...wideTimerange,
+          query: testData.buildHostNameQuery(testData.ECS_ARCHIVE_HOSTS),
           schema: 'ecs',
         },
       });
@@ -83,11 +84,7 @@ apiTest.describe(
         .map((p) => p.name)
         .sort();
 
-      expect(names).toStrictEqual([
-        'gke-observability-8--observability-8--bc1afd95-f0zc',
-        'gke-observability-8--observability-8--bc1afd95-ngmh',
-        'gke-observability-8--observability-8--bc1afd95-nhhw',
-      ]);
+      expect(names).toStrictEqual([...testData.ECS_ARCHIVE_HOSTS].sort());
       for (const name of names) {
         expect(testData.SEMCONV_HOSTS.map((h) => h.hostName)).not.toContain(name);
       }
@@ -101,7 +98,9 @@ apiTest.describe(
           limit: 10,
           metrics: ['cpuV2'],
           ...wideTimerange,
-          query: { bool: { must_not: [], filter: [], should: [], must: [] } },
+          query: testData.buildHostNameQuery(
+            testData.SEMCONV_HOSTS.map(({ hostName }) => hostName)
+          ),
           schema: 'semconv',
         },
       });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -57,6 +57,8 @@ export const HOSTS = [
     cpuValue: 0.4,
   },
 ];
+export const HOSTS_QUERY = HOSTS.map(({ hostName }) => `host.name: "${hostName}"`).join(' or ');
+
 export const DEFAULT_HOSTS_INVENTORY_VIEW_NAME = 'Hosts Default View';
 
 export const DATE_WITH_HOSTS_WITHOUT_DATA_FROM = '2024-03-29T18:20:00.000Z';

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/hosts_page.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/hosts_page.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import rison from '@kbn/rison';
 import type { KibanaUrl, Locator, ScoutPage } from '@kbn/scout-oblt';
 import { EXTENDED_TIMEOUT, KPI_METRICS } from '../constants';
 
@@ -91,16 +92,23 @@ export class HostsPage {
     to,
     preferredSchema = null,
     skipLoadWait = false,
+    initialQuery = '',
   }: {
     from: string;
     to: string;
     preferredSchema?: PreferredSchema;
     skipLoadWait?: boolean;
+    initialQuery?: string;
   }) {
     const baseUrl = this.kbnUrl.app('metrics');
-    const schemaPart =
-      preferredSchema === null ? 'preferredSchema:!n' : `preferredSchema:${preferredSchema}`;
-    const risonState = `(dateRange:(from:'${from}',to:'${to}'),filters:!(),limit:100,panelFilters:!(),${schemaPart},query:(language:kuery,query:''))`;
+    const risonState = rison.encodeUnknown({
+      dateRange: { from, to },
+      filters: [],
+      limit: 100,
+      panelFilters: [],
+      preferredSchema,
+      query: { language: 'kuery', query: initialQuery },
+    });
     await this.page.goto(`${baseUrl}/hosts?_a=${risonState}`);
     if (!skipLoadWait) {
       await this.waitForTableToLoad();
@@ -112,16 +120,23 @@ export class HostsPage {
     rangeTo,
     preferredSchema = null,
     skipLoadWait = false,
+    initialQuery = '',
   }: {
     rangeFrom: string;
     rangeTo: string;
     preferredSchema?: PreferredSchema;
     skipLoadWait?: boolean;
+    initialQuery?: string;
   }) {
     const baseUrl = this.kbnUrl.app('metrics');
-    const schemaPart =
-      preferredSchema === null ? 'preferredSchema:!n' : `preferredSchema:${preferredSchema}`;
-    const risonState = `(dateRange:(from:'${rangeFrom}',to:'${rangeTo}'),filters:!(),limit:100,panelFilters:!(),${schemaPart},query:(language:kuery,query:''))`;
+    const risonState = rison.encodeUnknown({
+      dateRange: { from: rangeFrom, to: rangeTo },
+      filters: [],
+      limit: 100,
+      panelFilters: [],
+      preferredSchema,
+      query: { language: 'kuery', query: initialQuery },
+    });
     await this.page.goto(`${baseUrl}/hosts?_a=${risonState}`);
     if (!skipLoadWait) {
       await this.waitForTableToLoad();

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_alerts.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_alerts.spec.ts
@@ -12,10 +12,8 @@ import {
   HOST1_NAME,
   HOST2_NAME,
   HOST3_NAME,
-  HOSTS,
   DATE_WITH_HOSTS_DATA_FROM,
   DATE_WITH_HOSTS_DATA_TO,
-  EXTENDED_TIMEOUT,
 } from '../../fixtures/constants';
 import {
   ACTIVE_ALERTS,
@@ -47,9 +45,7 @@ test.describe(
         to: DATE_WITH_HOSTS_DATA_TO,
         preferredSchema: 'ecs',
       });
-      await expect(hostsPage.tableRows).toHaveCount(HOSTS.length, {
-        timeout: EXTENDED_TIMEOUT,
-      });
+      await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible();
     });
 
     test.afterAll(async ({ esClient, apiServices }) => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_content.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_content.spec.ts
@@ -9,7 +9,6 @@ import { tags } from '@kbn/scout-oblt';
 import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 import {
-  HOSTS,
   HOST1_NAME,
   DATE_WITH_HOSTS_DATA_FROM,
   DATE_WITH_HOSTS_DATA_TO,
@@ -29,7 +28,7 @@ test.describe(
       });
 
       await test.step('wait for table and KPIs to load', async () => {
-        await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+        await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible();
         await hostsPage.waitForKPILoadingToFinish(EXTENDED_TIMEOUT);
       });
     });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_metadata_filter.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_metadata_filter.spec.ts
@@ -10,7 +10,6 @@ import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 import {
   HOST1_NAME,
-  HOSTS,
   HOSTS_METADATA_FIELD,
   DATE_WITH_HOSTS_DATA_FROM,
   DATE_WITH_HOSTS_DATA_TO,
@@ -72,8 +71,8 @@ test.describe(
     test('Adding a metadata filter hides other hosts from the table', async ({
       pageObjects: { hostsPage, assetDetailsPage, toasts },
     }) => {
-      await test.step('verify all hosts are visible before filtering', async () => {
-        await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+      await test.step('verify the fixture host is visible before filtering', async () => {
+        await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible();
       });
 
       await test.step('open host flyout, add a filter for host.name', async () => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_search.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_search.spec.ts
@@ -11,6 +11,7 @@ import { test } from '../../fixtures';
 import {
   HOST1_NAME,
   HOSTS,
+  HOSTS_QUERY,
   HOSTS_METADATA_FIELD,
   DATE_WITH_HOSTS_DATA_FROM,
   DATE_WITH_HOSTS_DATA_TO,
@@ -27,6 +28,7 @@ test.describe(
         from: DATE_WITH_HOSTS_DATA_FROM,
         to: DATE_WITH_HOSTS_DATA_TO,
         preferredSchema: 'ecs',
+        initialQuery: HOSTS_QUERY,
       });
 
       await test.step('verify all hosts are visible before filtering', async () => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_search_query.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_search_query.spec.ts
@@ -12,7 +12,6 @@ import {
   HOST1_NAME,
   HOST2_NAME,
   HOST3_NAME,
-  HOSTS,
   DATE_WITH_HOSTS_DATA_FROM,
   DATE_WITH_HOSTS_DATA_TO,
   EXTENDED_TIMEOUT,
@@ -33,7 +32,7 @@ test.describe(
         to: DATE_WITH_HOSTS_DATA_TO,
         preferredSchema: 'ecs',
       });
-      await expect(hostsPage.tableRows).toHaveCount(HOSTS.length, {
+      await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible({
         timeout: EXTENDED_TIMEOUT,
       });
       await hostsPage.waitForKPILoadingToFinish(EXTENDED_TIMEOUT);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_table.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_table.spec.ts
@@ -15,6 +15,7 @@ import {
   HOST5_NAME,
   HOST6_NAME,
   HOSTS,
+  HOSTS_QUERY,
   DATE_WITH_HOSTS_DATA_FROM,
   DATE_WITH_HOSTS_DATA_TO,
   KPI_RENDER_TIMEOUT,
@@ -36,6 +37,7 @@ test.describe(
         from: DATE_WITH_HOSTS_DATA_FROM,
         to: DATE_WITH_HOSTS_DATA_TO,
         preferredSchema: 'ecs',
+        initialQuery: HOSTS_QUERY,
       });
 
       await test.step('wait for table and KPIs to load', async () => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_time_drift.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/hosts/hosts_page_time_drift.spec.ts
@@ -9,7 +9,7 @@ import { tags } from '@kbn/scout-oblt';
 import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../fixtures';
 import {
-  HOSTS,
+  HOST1_NAME,
   DATE_WITH_HOSTS_DATA_MIDPOINT,
   KPI_RENDER_TIMEOUT,
   KPI_METRICS,
@@ -45,8 +45,8 @@ test.describe(
         });
       });
 
-      await test.step('all hosts and KPIs render with data', async () => {
-        await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+      await test.step('the fixture host and KPIs render with data', async () => {
+        await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible();
         await hostsPage.waitForHostKPIChartsToLoad(KPI_METRICS, KPI_RENDER_TIMEOUT);
         for (const metric of KPI_METRICS) {
           // Non-empty and not the regression symptom 'N/A'.
@@ -64,7 +64,7 @@ test.describe(
       });
 
       await test.step('table still has data and KPIs never show N/A', async () => {
-        await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+        await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible();
         await hostsPage.waitForHostKPIChartsToLoad(KPI_METRICS, KPI_RENDER_TIMEOUT);
         for (const metric of KPI_METRICS) {
           await expect(hostsPage.getHostKPIChartValueLocator(metric)).toHaveAttribute(
@@ -93,7 +93,7 @@ test.describe(
       });
 
       await test.step('initial state has data', async () => {
-        await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+        await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible();
         await hostsPage.waitForHostKPIChartsToLoad(KPI_METRICS, KPI_RENDER_TIMEOUT);
       });
 
@@ -106,7 +106,7 @@ test.describe(
         for (const step of driftSteps) {
           await page.clock.fastForward(step);
           await hostsPage.clickRefresh();
-          await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+          await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible();
           const snapshot = await hostsPage.getKPIValuesSnapshot(KPI_RENDER_TIMEOUT);
           for (const metric of KPI_METRICS) {
             expect(snapshot[metric]).not.toBe('N/A');

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/hosts/hosts_flyout.spec.ts
@@ -86,7 +86,7 @@ test.describe(
         to: HOSTS_FLYOUT_DATA_TO,
         preferredSchema: 'ecs',
       });
-      await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+      await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible();
     });
 
     test.afterEach(async ({ kbnClient }) => {
@@ -251,7 +251,7 @@ test.describe(
         to: HOSTS_FLYOUT_DATA_TO,
         preferredSchema: 'ecs',
       });
-      await expect(hostsPage.tableRows).toHaveCount(HOSTS.length);
+      await expect(hostsPage.getHostRow(HOST1_NAME)).toBeVisible();
       await hostsPage.openHostFlyout(HOST1_NAME);
 
       await test.step('navigate to dashboards tab', async () => {


### PR DESCRIPTION
## Summary

- Changed count validations for most tests, and where it's needed, pre-filter the page to have proper tests even with polluted data.

### How to run tests

#### Server


```bash
node scripts/scout.js start-server --arch stateful --domain classic
```

#### Client

```bash
node scripts/playwright test --config x-pack/solutions/observability/plugins/infra/test/scout/api/playwright.config.ts --project local

node scripts/playwright test --config x-pack/solutions/observability/plugins/infra/test/scout/ui/playwright.config.ts --project local

node scripts/playwright test --config x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel.playwright.config.ts --project local
```


### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed