### PR TITLE
[kbn-es] Refactor snapshot install

### DIFF
--- a/.buildkite/scripts/packer_cache.sh
+++ b/.buildkite/scripts/packer_cache.sh
@@ -13,7 +13,7 @@ yarn kbn bootstrap
 cd .buildkite && npm ci && cd ..
 
 for version in $(cat versions.json | jq -r '.versions[].version'); do
-  node scripts/es snapshot --download-only --base-path "$ES_CACHE_DIR" --version "$version"
+  node scripts/es snapshot --install-only --base-path "$ES_CACHE_DIR" --version "$version"
 done
 
 for version in $(cat versions.json | jq -r '.versions[].version'); do

--- a/.buildkite/scripts/setup_es_snapshot_cache.sh
+++ b/.buildkite/scripts/setup_es_snapshot_cache.sh
@@ -4,13 +4,10 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-# If cached snapshots are baked into the agent, move them into our workspace first
-# We are doing this rather than simply changing the ES base path because many workers
-#   run with the workspace mounted in memory or on a local ssd
-cacheDir="$ES_CACHE_DIR/cache"
-if [[ -d "$cacheDir" ]]; then
-  mkdir -p .es/cache
-  echo "--- Move ES snapshot cache"
-  echo "Moving cached snapshots from $cacheDir to .es/cache"
-  mv "$cacheDir"/* .es/cache/
-fi
+for dir in cache installs; do
+  srcDir="$ES_CACHE_DIR/$dir"
+  if [[ -d "$srcDir" ]] && [[ -n "$(ls -A "$srcDir")" ]]; then
+    mkdir -p ".es/$dir"
+    mv "$srcDir"/* ".es/$dir/"
+  fi
+done

--- a/src/platform/packages/shared/kbn-dev-utils/src/extract.ts
+++ b/src/platform/packages/shared/kbn-dev-utils/src/extract.ts
@@ -14,6 +14,7 @@ import { pipeline } from 'stream';
 import { promisify } from 'util';
 
 import * as tar from 'tar';
+import execa from 'execa';
 import type { ZipFile, Entry } from 'yauzl';
 import Yauzl from 'yauzl';
 import * as Rx from 'rxjs';
@@ -25,6 +26,18 @@ const strComplete = (obs: Rx.Observable<unknown>) =>
   });
 
 const asyncPipeline = promisify(pipeline);
+
+let systemTar: Promise<boolean> | undefined;
+
+const hasSystemTar = () => {
+  if (!systemTar) {
+    systemTar = execa('tar', ['--version'])
+      .then(({ stdout }) => /GNU tar|bsdtar/i.test(stdout))
+      .catch(() => false);
+  }
+
+  return systemTar;
+};
 
 interface Options {
   /**
@@ -63,6 +76,17 @@ export async function extract({
   await Fs.mkdir(targetDir, { recursive: true });
 
   if (archivePath.endsWith('.tar') || archivePath.endsWith('.tar.gz')) {
+    if (await hasSystemTar()) {
+      await execa('tar', [
+        '-xf',
+        archivePath,
+        '-C',
+        targetDir,
+        `--strip-components=${stripComponents}`,
+      ]);
+      return;
+    }
+
     return await tar.extract({
       file: archivePath,
       cwd: targetDir,

--- a/src/platform/packages/shared/kbn-es/index.ts
+++ b/src/platform/packages/shared/kbn-es/index.ts
@@ -31,7 +31,11 @@ export {
   readRolesDescriptorsFromResource,
 } from './src/utils';
 export type { ArtifactLicense } from './src/artifact';
-export { SERVERLESS_ROLES_ROOT_PATH, STATEFUL_ROLES_ROOT_PATH } from './src/paths';
+export {
+  SERVERLESS_ROLES_ROOT_PATH,
+  STATEFUL_ROLES_ROOT_PATH,
+  getEsInstallPath,
+} from './src/paths';
 export {
   EIS_QA_URL,
   EIS_ES_ARG,

--- a/src/platform/packages/shared/kbn-es/src/artifact.test.js
+++ b/src/platform/packages/shared/kbn-es/src/artifact.test.js
@@ -71,7 +71,12 @@ const createArtifactDest = () => {
   return path.join(dir, MOCK_FILENAME);
 };
 
-const createCachedArtifact = ({ contents, etag = 'etag' }) => {
+const statVerifiedState = (dest) => {
+  const { size, mtimeMs } = fs.statSync(dest);
+  return { size, mtimeMs };
+};
+
+const createCachedArtifact = ({ contents, etag = 'etag', markVerified = false }) => {
   const dest = createArtifactDest();
   fs.writeFileSync(dest, contents);
   fs.writeFileSync(
@@ -80,6 +85,7 @@ const createCachedArtifact = ({ contents, etag = 'etag' }) => {
       {
         ts: new Date().toISOString(),
         etag,
+        ...(markVerified ? { verified: statVerifiedState(dest) } : {}),
       },
       null,
       2
@@ -192,8 +198,56 @@ describe('Artifact', () => {
       await artifact.download(dest);
 
       expect(fs.readFileSync(dest)).toEqual(validContents);
-      expect(JSON.parse(fs.readFileSync(`${dest}.meta`, 'utf8')).etag).toBe('fresh-etag');
+      const meta = JSON.parse(fs.readFileSync(`${dest}.meta`, 'utf8'));
+      expect(meta.etag).toBe('fresh-etag');
+      expect(meta.verified).toEqual(statVerifiedState(dest));
       expect(fetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('skips checksum verification on a 304 when the file is unchanged since a previous verification', async () => {
+      const artifact = new Artifact(log, {
+        url: MOCK_URL,
+        filename: MOCK_FILENAME,
+        checksumUrl: `${MOCK_URL}.sha512`,
+        checksumType: 'sha512',
+      });
+      const cachedContents = Buffer.from('cached artifact');
+      const dest = createCachedArtifact({ contents: cachedContents, markVerified: true });
+
+      fetch.mockReturnValueOnce(Promise.resolve(new Response('', { status: 304 })));
+
+      await artifact.download(dest);
+
+      expect(fs.readFileSync(dest)).toEqual(cachedContents);
+      // only the conditional GET; no checksum fetch
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-verifies on a 304 when the file changed since the last verification', async () => {
+      const artifact = new Artifact(log, {
+        url: MOCK_URL,
+        filename: MOCK_FILENAME,
+        checksumUrl: `${MOCK_URL}.sha512`,
+        checksumType: 'sha512',
+      });
+      const cachedContents = Buffer.from('cached artifact');
+      const dest = createCachedArtifact({ contents: cachedContents, markVerified: true });
+      // invalidate the recorded state by touching the file
+      const stat = fs.statSync(dest);
+      fs.utimesSync(dest, new Date(stat.atimeMs), new Date(stat.mtimeMs + 1000));
+
+      fetch
+        .mockReturnValueOnce(Promise.resolve(new Response('', { status: 304 })))
+        .mockReturnValueOnce(
+          Promise.resolve(new Response(`${getChecksum(cachedContents)}  ${MOCK_FILENAME}`))
+        );
+
+      await artifact.download(dest);
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(fs.readFileSync(`${dest}.meta`, 'utf8')).verified).toEqual(
+        statVerifiedState(dest)
+      );
     });
 
     it('reuses a cached artifact when the checksum endpoint is unavailable', async () => {
@@ -269,7 +323,9 @@ describe('Artifact', () => {
       await artifact.download(dest);
 
       expect(fs.readFileSync(dest)).toEqual(validContents);
-      expect(JSON.parse(fs.readFileSync(`${dest}.meta`, 'utf8')).etag).toBe('fresh-etag');
+      const meta = JSON.parse(fs.readFileSync(`${dest}.meta`, 'utf8'));
+      expect(meta.etag).toBe('fresh-etag');
+      expect(meta.verified).toEqual(statVerifiedState(dest));
       expect(fetch).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/platform/packages/shared/kbn-es/src/artifact.ts
+++ b/src/platform/packages/shared/kbn-es/src/artifact.ts
@@ -256,9 +256,16 @@ export class Artifact {
         // A 304 means the remote etag matches, but the file on disk may still be
         // corrupt, e.g. if an ES snapshot was promoted while a CI VM image was
         // being built, the cached file could have been overwritten mid-download.
-        // Verify the checksum before trusting the cache.
+        // Verify the checksum before trusting the cache, unless the file is
+        // unchanged since a previous successful verification.
+        if (this.wasVerifiedSinceLastChange(dest, cacheMeta.verified)) {
+          this.log.info('cached artifact previously verified, skipping checksum');
+          return;
+        }
+
         try {
           await this.verifyExistingFileChecksum(dest);
+          cache.writeMeta(dest, { etag: cacheMeta.etag, ...this.getVerifiedState(dest) });
           return;
         } catch (error) {
           if (
@@ -282,11 +289,8 @@ export class Artifact {
 
         const redownloadedArtifact = await this.downloadAndVerify(tmpPath, cacheMeta.ts);
 
-        // cache the etag for future downloads
-        cache.writeMeta(dest, { etag: redownloadedArtifact.etag });
-
-        // rename temp download to the destination location
         fs.renameSync(tmpPath, dest);
+        cache.writeMeta(dest, { etag: redownloadedArtifact.etag, ...this.getVerifiedState(dest) });
         return;
       }
 
@@ -298,11 +302,8 @@ export class Artifact {
         throw error;
       }
 
-      // cache the etag for future downloads
-      cache.writeMeta(dest, { etag: artifactResp.etag });
-
-      // rename temp download to the destination location
       fs.renameSync(tmpPath, dest);
+      cache.writeMeta(dest, { etag: artifactResp.etag, ...this.getVerifiedState(dest) });
     });
   }
 
@@ -480,14 +481,38 @@ export class Artifact {
     return expectedChecksum;
   }
 
-  private async verifyExistingFileChecksum(dest: string) {
-    const hash = createHash(this.spec.checksumType);
-    for await (const chunk of fs.createReadStream(dest)) {
-      hash.update(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  private getVerifiedState(dest: string) {
+    const { size, mtimeMs } = fs.statSync(dest);
+    return { verified: { size, mtimeMs } };
+  }
+
+  private wasVerifiedSinceLastChange(dest: string, verified?: { size: number; mtimeMs: number }) {
+    if (!verified) {
+      return false;
     }
 
-    const expectedChecksum = await this.fetchExpectedChecksum();
-    const actualChecksum = hash.digest('hex');
+    try {
+      const { size, mtimeMs } = fs.statSync(dest);
+      return size === verified.size && mtimeMs === verified.mtimeMs;
+    } catch {
+      return false;
+    }
+  }
+
+  private async verifyExistingFileChecksum(dest: string) {
+    const hashFile = async () => {
+      const hash = createHash(this.spec.checksumType);
+      for await (const chunk of fs.createReadStream(dest)) {
+        hash.update(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      return hash.digest('hex');
+    };
+
+    const [expectedChecksum, actualChecksum] = await Promise.all([
+      this.fetchExpectedChecksum(),
+      hashFile(),
+    ]);
+
     if (actualChecksum !== expectedChecksum) {
       throw createTaggedError(
         `cached artifact at ${dest} checksum mismatch: expected ${expectedChecksum}, got ${actualChecksum}`,

--- a/src/platform/packages/shared/kbn-es/src/cli_commands/archive.ts
+++ b/src/platform/packages/shared/kbn-es/src/cli_commands/archive.ts
@@ -11,6 +11,7 @@ import dedent from 'dedent';
 import getopts from 'getopts';
 import { Cluster } from '../cluster';
 import { createCliError } from '../errors';
+import { defaultToSingleNodeDiscovery } from '../settings';
 import { parseTimeoutToMs } from '../utils';
 
 export const archive = {
@@ -61,6 +62,8 @@ export const archive = {
     if (!path || !path.endsWith('tar.gz')) {
       throw createCliError('you must provide a path to an ES tar file');
     }
+
+    options.esArgs = defaultToSingleNodeDiscovery(options.esArgs);
 
     const { installPath } = await cluster.installArchive(path, {
       basePath: options.basePath,

--- a/src/platform/packages/shared/kbn-es/src/cli_commands/snapshot.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/cli_commands/snapshot.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import path from 'path';
+
+import { Cluster } from '../cluster';
+import { resolveCcmApiKey } from '../eis/eis_setup';
+import { snapshot } from './snapshot';
+
+jest.mock('@kbn/ci-stats-reporter', () => ({
+  getTimeReporter: () => jest.fn(),
+}));
+jest.mock('../cluster');
+jest.mock('../eis/eis_setup', () => ({
+  EIS_ES_ARG: 'xpack.inference.eis.enabled=true',
+  resolveCcmApiKey: jest.fn(),
+  setCcmApiKey: jest.fn(),
+}));
+
+const ClusterMock = Cluster as jest.Mock;
+const resolveCcmApiKeyMock = resolveCcmApiKey as jest.Mock;
+const installSnapshotMock = jest.fn();
+const originalArgv = process.argv;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  ClusterMock.mockImplementation(() => ({
+    installSnapshot: installSnapshotMock,
+  }));
+  installSnapshotMock.mockResolvedValue({
+    installPath: '/install',
+    disableEsTmpDir: false,
+    configPath: undefined,
+  });
+});
+
+afterEach(() => {
+  process.argv = originalArgv;
+});
+
+test('--install-only uses the shared cache without resolving EIS runtime credentials', async () => {
+  const basePath = '/base';
+  process.argv = [
+    'node',
+    'scripts/es',
+    'snapshot',
+    '--install-only',
+    '--eis',
+    '--version',
+    '9.6.0',
+    '--base-path',
+    basePath,
+  ];
+
+  await snapshot.run({});
+
+  expect(resolveCcmApiKeyMock).not.toHaveBeenCalled();
+  expect(installSnapshotMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      installPath: path.resolve(basePath, 'installs', '9.6.0'),
+    })
+  );
+});

--- a/src/platform/packages/shared/kbn-es/src/cli_commands/snapshot.ts
+++ b/src/platform/packages/shared/kbn-es/src/cli_commands/snapshot.ts
@@ -7,12 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import fs from 'fs';
+import path from 'path';
+
 import dedent from 'dedent';
 import getopts from 'getopts';
 import { ToolingLog } from '@kbn/tooling-log';
 import { getTimeReporter } from '@kbn/ci-stats-reporter';
 
 import { Cluster } from '../cluster';
+import { getEsInstallPath } from '../paths';
+import { defaultToSingleNodeDiscovery } from '../settings';
 import { parseTimeoutToMs } from '../utils';
 import { configureMockIdpSamlRealm } from '../utils/configure_mock_idp_saml_realm';
 import { createCliError } from '../errors';
@@ -36,6 +41,7 @@ export const snapshot: Command = {
       --password.[user] Sets password for native realm user [default: ${password}]
       -E                Additional key=value settings to pass to Elasticsearch
       --download-only   Download the snapshot but don't actually start it
+      --install-only    Download and extract the snapshot but don't actually start it
       --port            The port to bind to on 127.0.0.1 [default: 9200]
       --kill            Kill running ES Docker containers before starting
       --ssl             Sets up SSL on Elasticsearch
@@ -76,7 +82,7 @@ export const snapshot: Command = {
       },
 
       string: ['version', 'ready-timeout', 'es-log-level'],
-      boolean: ['download-only', 'use-cached', 'skip-ready-check', 'kill', 'eis'],
+      boolean: ['download-only', 'install-only', 'use-cached', 'skip-ready-check', 'kill', 'eis'],
 
       default: defaults,
     });
@@ -95,9 +101,9 @@ export const snapshot: Command = {
         : [];
       options.esArgs = [EIS_ES_ARG, ...eisUserEsArgs];
 
-      // Skip key resolution for download-only runs — the key is only needed
+      // Skip key resolution when ES will not start — the key is only needed
       // when starting ES and setting up CCM.
-      if (!options['download-only']) {
+      if (!options['download-only'] && !options['install-only']) {
         eisApiKey = await resolveCcmApiKey(log);
       }
     }
@@ -116,6 +122,23 @@ export const snapshot: Command = {
         log,
         useCached: options.useCached,
       });
+    } else if (options['install-only']) {
+      const throwawayConfigPath = path.resolve(options.basePath, '.install-only-config');
+
+      try {
+        await cluster.installSnapshot({
+          version: options.version,
+          license: options.license,
+          basePath: options.basePath,
+          installPath: getEsInstallPath(options.basePath, options.version),
+          configPath: throwawayConfigPath,
+          log,
+          useCached: options.useCached,
+          password: options.password,
+        });
+      } finally {
+        fs.rmSync(throwawayConfigPath, { recursive: true, force: true });
+      }
     } else {
       // Collect user-provided esArgs
       const userEsArgs: string[] = Array.isArray(options.esArgs)
@@ -129,7 +152,7 @@ export const snapshot: Command = {
         license: options.license,
         log,
       });
-      options.esArgs = samlEsArgs;
+      options.esArgs = defaultToSingleNodeDiscovery(samlEsArgs);
 
       const installStartTime = Date.now();
       const { installPath } = await cluster.installSnapshot({
@@ -144,7 +167,7 @@ export const snapshot: Command = {
       });
 
       if (options.dataArchive) {
-        await cluster.extractDataDirectory(installPath, options.dataArchive);
+        await cluster.extractDataDirectory(path.resolve(installPath, 'data'), options.dataArchive);
       }
       if (options.plugins) {
         await cluster.installPlugins(installPath, options.plugins, options.esJavaOpts);

--- a/src/platform/packages/shared/kbn-es/src/cli_commands/source.ts
+++ b/src/platform/packages/shared/kbn-es/src/cli_commands/source.ts
@@ -7,10 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import path from 'path';
+
 import dedent from 'dedent';
 import getopts from 'getopts';
 import { ToolingLog } from '@kbn/tooling-log';
 import { Cluster } from '../cluster';
+import { defaultToSingleNodeDiscovery } from '../settings';
 import { parseTimeoutToMs } from '../utils';
 import { configureMockIdpSamlRealm } from '../utils/configure_mock_idp_saml_realm';
 import type { Command } from './types';
@@ -81,7 +84,7 @@ export const source: Command = {
       license: options.license,
       log,
     });
-    options.esArgs = samlEsArgs;
+    options.esArgs = defaultToSingleNodeDiscovery(samlEsArgs);
 
     const cluster = new Cluster({ ssl: options.ssl });
     const { installPath } = await cluster.installSource({
@@ -95,7 +98,7 @@ export const source: Command = {
     });
 
     if (options.dataArchive) {
-      await cluster.extractDataDirectory(installPath, options.dataArchive);
+      await cluster.extractDataDirectory(path.resolve(installPath, 'data'), options.dataArchive);
     }
     if (options.plugins) {
       await cluster.installPlugins(installPath, options.plugins, options.esJavaOpts);

--- a/src/platform/packages/shared/kbn-es/src/cluster.ts
+++ b/src/platform/packages/shared/kbn-es/src/cluster.ts
@@ -21,7 +21,7 @@ import type { ToolingLog } from '@kbn/tooling-log';
 import treeKill from 'tree-kill';
 import { MOCK_IDP_REALM_NAME, ensureSAMLRoleMapping } from '@kbn/mock-idp-utils';
 import { downloadSnapshot, installSnapshot, installSource, installArchive } from './install';
-import { ES_BIN, ES_PLUGIN_BIN, ES_KEYSTORE_BIN } from './paths';
+import { ES_BIN, ES_PLUGIN_BIN, ES_KEYSTORE_BIN, ES_CONFIG_DIRNAME } from './paths';
 import type { DockerOptions, ServerlessOptions } from './utils';
 import {
   extractConfigFiles,
@@ -137,9 +137,12 @@ export class Cluster {
   async installSource(options: InstallSourceOptions) {
     this.log.info(chalk.bold('Installing from source'));
     return await this.log.indent(4, async () => {
-      const { installPath, disableEsTmpDir } = await installSource({ log: this.log, ...options });
+      const { installPath, disableEsTmpDir, configPath } = await installSource({
+        log: this.log,
+        ...options,
+      });
 
-      return { installPath, disableEsTmpDir };
+      return { installPath, disableEsTmpDir, configPath };
     });
   }
 
@@ -164,12 +167,12 @@ export class Cluster {
   async installSnapshot(options: InstallSnapshotOptions) {
     this.log.info(chalk.bold('Installing from snapshot'));
     return await this.log.indent(4, async () => {
-      const { installPath, disableEsTmpDir } = await installSnapshot({
+      const { installPath, disableEsTmpDir, configPath } = await installSnapshot({
         log: this.log,
         ...options,
       });
 
-      return { installPath, disableEsTmpDir };
+      return { installPath, disableEsTmpDir, configPath };
     });
   }
 
@@ -179,24 +182,23 @@ export class Cluster {
   async installArchive(archivePath: string, options?: InstallArchiveOptions) {
     this.log.info(chalk.bold('Installing from an archive'));
     return await this.log.indent(4, async () => {
-      const { installPath, disableEsTmpDir } = await installArchive(archivePath, {
+      const { installPath, disableEsTmpDir, configPath } = await installArchive(archivePath, {
         log: this.log,
         ...(options || {}),
       });
 
-      return { installPath, disableEsTmpDir };
+      return { installPath, disableEsTmpDir, configPath };
     });
   }
 
   /**
    * Unpacks a tar or zip file containing the data directory for an ES cluster.
    */
-  async extractDataDirectory(installPath: string, archivePath: string, extractDirName = 'data') {
+  async extractDataDirectory(extractPath: string, archivePath: string) {
     this.log.info(chalk.bold(`Extracting data directory`));
     await this.log.indent(4, async () => {
       // stripComponents=1 excludes the root directory as that is how our archives are
       // structured. This works in our favor as we can explicitly extract into the data dir
-      const extractPath = path.resolve(installPath, extractDirName);
       this.log.info(`Data archive: ${archivePath}`);
       this.log.info(`Extract path: ${extractPath}`);
 
@@ -226,9 +228,13 @@ export class Cluster {
 
   async configureKeystoreWithSecureSettingsFiles(
     installPath: string,
-    secureSettingsFiles: string[][]
+    secureSettingsFiles: string[][],
+    configPath?: string
   ) {
-    const env = { JAVA_HOME: '' };
+    const env = {
+      JAVA_HOME: '',
+      ...(configPath ? { ES_PATH_CONF: configPath } : {}),
+    };
     for (const [secureSettingName, secureSettingFile] of secureSettingsFiles) {
       this.log.info(
         `setting secure setting %s to %s`,
@@ -372,6 +378,8 @@ export class Cluster {
       readyTimeout,
       writeLogsToPath,
       disableEsTmpDir,
+      esTmpDir,
+      configPath,
       ...options
     } = opts;
 
@@ -425,10 +433,12 @@ export class Cluster {
       }
     }
 
+    const esConfigPath = configPath ?? path.resolve(installPath, ES_CONFIG_DIRNAME);
+
     const args = parseSettings(
       extractConfigFiles(
         Array.from(esArgs).map((e) => e.join('=')),
-        installPath,
+        esConfigPath,
         { log: this.log }
       ),
       {
@@ -448,12 +458,14 @@ export class Cluster {
     this.process = execa(ES_BIN, args, {
       cwd: installPath,
       env: {
-        ...(installPath && !disableEsTmpDir
-          ? { ES_TMPDIR: path.resolve(installPath, 'ES_TMPDIR') }
-          : {}),
         ...process.env,
         JAVA_HOME: '', // By default, we want to always unset JAVA_HOME so that the bundled JDK will be used
         ES_JAVA_OPTS: esJavaOpts,
+        // After process.env so a stale value can't redirect ES to another run's paths
+        ...(installPath && !disableEsTmpDir
+          ? { ES_TMPDIR: esTmpDir ?? path.resolve(installPath, 'ES_TMPDIR') }
+          : {}),
+        ...(configPath ? { ES_PATH_CONF: configPath } : {}),
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/src/platform/packages/shared/kbn-es/src/cluster_exec_options.ts
+++ b/src/platform/packages/shared/kbn-es/src/cluster_exec_options.ts
@@ -29,4 +29,8 @@ export interface EsClusterExecOptions {
   esStdoutLogLevel?: 'all' | 'info' | 'warn' | 'error' | 'silent';
   /** Disable creating a temp directory, allowing ES to write to OS's /tmp directory */
   disableEsTmpDir?: boolean;
+  /** Path to use as `ES_TMPDIR`. Ignored when `disableEsTmpDir` is set */
+  esTmpDir?: string;
+  /** Path to this run's config directory, passed to ES as `ES_PATH_CONF` */
+  configPath?: string;
 }

--- a/src/platform/packages/shared/kbn-es/src/install/install_archive.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/install/install_archive.test.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import stripAnsi from 'strip-ansi';
+import { ToolingLog, ToolingLogCollectingWriter } from '@kbn/tooling-log';
+import { installArchive } from './install_archive';
+
+jest.mock('execa');
+const execa = jest.requireMock('execa') as jest.MockedFunction<typeof import('execa')>;
+
+jest.mock('@kbn/dev-utils', () => ({
+  extract: jest.fn(),
+}));
+const { extract } = jest.requireMock('@kbn/dev-utils') as { extract: jest.Mock };
+
+const makeLog = () => {
+  const log = new ToolingLog();
+  const writer = new ToolingLogCollectingWriter();
+  log.setWriters([writer]);
+  return { log, writer };
+};
+
+const logged = (writer: ToolingLogCollectingWriter, text: string) =>
+  writer.messages.some((message) => stripAnsi(message).includes(text));
+
+const keystoreArgs = () =>
+  (execa.mock.calls as Array<[string, string[]]>)
+    .filter(([bin]) => bin.includes('elasticsearch-keystore'))
+    .map(([, args]) => args);
+
+let tmpDir: string;
+let installPath: string;
+let archivePath: string;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kbn-es-install-test-'));
+  installPath = path.join(tmpDir, 'es-install');
+  archivePath = path.join(tmpDir, 'fake-es.tar.gz');
+  fs.writeFileSync(archivePath, 'fake');
+
+  // Materialize the config dir the real tarball would produce
+  extract.mockImplementation(async ({ targetDir }: { targetDir: string }) => {
+    fs.mkdirSync(path.join(targetDir, 'config'), { recursive: true });
+    fs.writeFileSync(path.join(targetDir, 'config', 'elasticsearch.yml'), '');
+  });
+  execa.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 } as any);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('installArchive keystore caching', () => {
+  test('fresh install: extracts, bakes keystore into pristine, writes stamp', async () => {
+    const { log, writer } = makeLog();
+    await installArchive(archivePath, { log, installPath, disableEsTmpDir: true });
+
+    expect(logged(writer, 'extracting')).toBe(true);
+    expect(logged(writer, 'reusing install')).toBe(false);
+
+    const ks = keystoreArgs();
+    expect(ks.some((a) => a[0] === 'create')).toBe(true);
+    expect(ks.some((a) => a[0] === 'add' && a.includes('bootstrap.password'))).toBe(true);
+
+    expect(fs.existsSync(path.join(installPath, '.pristine_config'))).toBe(true);
+    expect(fs.existsSync(path.join(installPath, '.kbn_es_install_stamp'))).toBe(true);
+  });
+
+  test('reuse, default password, no extra esArgs: skips extraction and keystore entirely', async () => {
+    const { log: log1 } = makeLog();
+    await installArchive(archivePath, { log: log1, installPath, disableEsTmpDir: true });
+    jest.clearAllMocks();
+
+    const { log: log2, writer: writer2 } = makeLog();
+    await installArchive(archivePath, { log: log2, installPath, disableEsTmpDir: true });
+
+    expect(logged(writer2, 'reusing install')).toBe(true);
+    expect(logged(writer2, 'extracting')).toBe(false);
+    expect(keystoreArgs()).toHaveLength(0);
+  });
+
+  test('concurrent callers publish one shared install', async () => {
+    const { log: log1 } = makeLog();
+    const { log: log2 } = makeLog();
+
+    await Promise.all([
+      installArchive(archivePath, {
+        log: log1,
+        installPath,
+        configPath: path.join(tmpDir, 'runtime-1'),
+        disableEsTmpDir: true,
+      }),
+      installArchive(archivePath, {
+        log: log2,
+        installPath,
+        configPath: path.join(tmpDir, 'runtime-2'),
+        disableEsTmpDir: true,
+      }),
+    ]);
+
+    expect(extract).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(path.join(installPath, '.kbn_es_install_stamp'))).toBe(true);
+    expect(fs.existsSync(`${installPath}.lock`)).toBe(false);
+  });
+
+  test('reuse, non-default password: skips extraction, adds password to existing keystore', async () => {
+    const { log: log1 } = makeLog();
+    await installArchive(archivePath, { log: log1, installPath, disableEsTmpDir: true });
+    jest.clearAllMocks();
+
+    const { log: log2, writer: writer2 } = makeLog();
+    await installArchive(archivePath, {
+      log: log2,
+      installPath,
+      password: 'hunter2',
+      disableEsTmpDir: true,
+    });
+
+    expect(logged(writer2, 'reusing install')).toBe(true);
+    expect(logged(writer2, 'extracting')).toBe(false);
+    expect(logged(writer2, 'setting secure setting bootstrap.password')).toBe(true);
+
+    const ks = keystoreArgs();
+    expect(ks.some((a) => a[0] === 'create')).toBe(false);
+    expect(ks.some((a) => a.includes('--force') && a.includes('bootstrap.password'))).toBe(true);
+  });
+
+  test('reuse, extra secure esArg: adds only the extra setting, not bootstrap.password', async () => {
+    const { log: log1 } = makeLog();
+    await installArchive(archivePath, { log: log1, installPath, disableEsTmpDir: true });
+    jest.clearAllMocks();
+
+    const { log: log2, writer: writer2 } = makeLog();
+    await installArchive(archivePath, {
+      log: log2,
+      installPath,
+      esArgs: ['telemetry.secret_token=abc123'],
+      disableEsTmpDir: true,
+    });
+
+    expect(logged(writer2, 'reusing install')).toBe(true);
+    expect(logged(writer2, 'extracting')).toBe(false);
+
+    const ks = keystoreArgs();
+    expect(ks.some((a) => a[0] === 'create')).toBe(false);
+    expect(ks.some((a) => a.includes('--force') && a.includes('telemetry.secret_token'))).toBe(
+      true
+    );
+    expect(ks.some((a) => a.includes('bootstrap.password'))).toBe(false);
+  });
+
+  test('fresh install: sweeps stale temp dirs from crashed runs, keeps recent ones', async () => {
+    const staleTmp = `${installPath}.tmp-999-0`;
+    const recentTmp = `${installPath}.tmp-998-0`;
+    fs.mkdirSync(staleTmp, { recursive: true });
+    fs.mkdirSync(recentTmp, { recursive: true });
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    fs.utimesSync(staleTmp, twoHoursAgo, twoHoursAgo);
+
+    const { log } = makeLog();
+    await installArchive(archivePath, { log, installPath, disableEsTmpDir: true });
+
+    expect(fs.existsSync(staleTmp)).toBe(false);
+    expect(fs.existsSync(recentTmp)).toBe(true);
+  });
+
+  test('stale stamp: re-extracts and re-bakes keystore', async () => {
+    const { log: log1 } = makeLog();
+    await installArchive(archivePath, { log: log1, installPath, disableEsTmpDir: true });
+    jest.clearAllMocks();
+
+    // Invalidate the stamp by changing the archive's mtime
+    const stat = fs.statSync(archivePath);
+    fs.utimesSync(archivePath, new Date(stat.atimeMs), new Date(stat.mtimeMs + 1000));
+
+    const { log: log2, writer: writer2 } = makeLog();
+    await installArchive(archivePath, { log: log2, installPath, disableEsTmpDir: true });
+
+    expect(logged(writer2, 'extracting')).toBe(true);
+    expect(logged(writer2, 'reusing install')).toBe(false);
+
+    const ks = keystoreArgs();
+    expect(ks.some((a) => a[0] === 'create')).toBe(true);
+    expect(ks.some((a) => a[0] === 'add' && a.includes('bootstrap.password'))).toBe(true);
+  });
+
+  test('configPath: writes run config there and leaves the install config pristine', async () => {
+    const configPath = path.join(tmpDir, 'runtime-config');
+    const { log } = makeLog();
+    await installArchive(archivePath, { log, installPath, configPath, disableEsTmpDir: true });
+
+    const configFile = (dir: string) =>
+      fs.readFileSync(path.join(dir, 'elasticsearch.yml'), 'utf8');
+    expect(configFile(configPath)).toContain('xpack.security.enabled: true');
+    expect(configFile(path.join(installPath, 'config'))).toBe('');
+  });
+});

--- a/src/platform/packages/shared/kbn-es/src/install/install_archive.ts
+++ b/src/platform/packages/shared/kbn-es/src/install/install_archive.ts
@@ -16,7 +16,7 @@ import del from 'del';
 import { extract } from '@kbn/dev-utils';
 import type { ToolingLog } from '@kbn/tooling-log';
 
-import { BASE_PATH, ES_CONFIG, ES_KEYSTORE_BIN } from '../paths';
+import { BASE_PATH, ES_CONFIG_DIRNAME, ES_CONFIG_FILENAME, ES_KEYSTORE_BIN } from '../paths';
 import { Artifact } from '../artifact';
 import { parseSettings, SettingsFilter } from '../settings';
 import { log as defaultLog, isFile, copyFileSync } from '../utils';
@@ -27,6 +27,148 @@ const isHttpUrl = (str: string) => {
     return ['http:', 'https:'].includes(new URL(str).protocol);
   } catch {
     return false;
+  }
+};
+
+/** Copy of `config/` as extracted, restored before each run writes its own settings */
+const PRISTINE_CONFIG_DIRNAME = '.pristine_config';
+
+/** Identifies the archive an install came from; reuse requires an exact match */
+const INSTALL_STAMP_FILENAME = '.kbn_es_install_stamp';
+
+/** Bump when the layout written below changes, so existing installs are re-extracted */
+const INSTALL_FORMAT_VERSION = 1;
+
+/** Any other password costs a keystore write on top of the baked-in one */
+const BAKED_BOOTSTRAP_PASSWORD = 'changeme';
+
+const INSTALL_LOCK_RETRY_MS = 100;
+const INSTALL_LOCK_MAX_AGE_MS = 60 * 60 * 1000;
+
+let tmpInstallId = 0;
+let installLockId = 0;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isProcessAlive = (pid: number) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+};
+
+const getInstallLockState = (lockPath: string): 'active' | 'stale' | 'missing' => {
+  let mtimeMs: number;
+  try {
+    ({ mtimeMs } = fs.statSync(lockPath));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return 'missing';
+    }
+    return 'active';
+  }
+
+  try {
+    const { pid } = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    return typeof pid === 'number' && !isProcessAlive(pid) ? 'stale' : 'active';
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return 'missing';
+    }
+    return Date.now() - mtimeMs > INSTALL_LOCK_MAX_AGE_MS ? 'stale' : 'active';
+  }
+};
+
+const acquireInstallLock = async (installPath: string, log: ToolingLog) => {
+  const lockPath = `${installPath}.lock`;
+  const owner = JSON.stringify({ pid: process.pid, id: installLockId++ });
+  let waiting = false;
+
+  fs.mkdirSync(path.dirname(installPath), { recursive: true });
+
+  while (true) {
+    try {
+      fs.writeFileSync(lockPath, owner, { flag: 'wx' });
+      return () => {
+        try {
+          if (fs.readFileSync(lockPath, 'utf8') === owner) {
+            fs.rmSync(lockPath);
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw error;
+          }
+        }
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error;
+      }
+    }
+
+    const lockState = getInstallLockState(lockPath);
+    if (lockState === 'missing') {
+      continue;
+    }
+    if (lockState === 'stale') {
+      fs.rmSync(lockPath, { force: true });
+      continue;
+    }
+
+    if (!waiting) {
+      log.info('waiting for another process to install at %s', chalk.bold(installPath));
+      waiting = true;
+    }
+    await delay(INSTALL_LOCK_RETRY_MS);
+  }
+};
+
+const removeStaleTmpInstalls = async (installPath: string) => {
+  const parent = path.dirname(installPath);
+  const prefix = `${path.basename(installPath)}.tmp-`;
+  // recent temp dirs may belong to an install still in progress
+  const staleBefore = Date.now() - 60 * 60 * 1000;
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(parent);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix)) {
+      continue;
+    }
+
+    const tmpPath = path.resolve(parent, entry);
+    try {
+      if (fs.statSync(tmpPath).mtimeMs < staleBefore) {
+        await del(tmpPath, { force: true });
+      }
+    } catch {
+      // may have been removed by a concurrent run
+    }
+  }
+};
+
+const getArchiveStamp = (archivePath: string) => {
+  const { size, mtimeMs } = fs.statSync(archivePath);
+  return JSON.stringify({
+    format: INSTALL_FORMAT_VERSION,
+    archive: path.basename(archivePath),
+    size,
+    mtimeMs,
+  });
+};
+
+const readInstallStamp = (stampPath: string) => {
+  try {
+    return fs.readFileSync(stampPath, 'utf8');
+  } catch {
+    return undefined;
   }
 };
 
@@ -43,6 +185,7 @@ export async function installArchive(archive: string, options?: InstallArchiveOp
     esArgs = [],
     disableEsTmpDir = process.env.FTR_DISABLE_ES_TMPDIR?.toLowerCase() === 'true',
     resources,
+    configPath,
   } = options || {};
 
   let dest = archive;
@@ -52,25 +195,77 @@ export async function installArchive(archive: string, options?: InstallArchiveOp
     await artifact.download(dest);
   }
 
-  if (fs.existsSync(installPath)) {
-    log.info('install directory already exists, removing');
-    await del(installPath, { force: true });
+  const pristineConfigPath = path.resolve(installPath, PRISTINE_CONFIG_DIRNAME);
+  const stampPath = path.resolve(installPath, INSTALL_STAMP_FILENAME);
+  const stamp = getArchiveStamp(dest);
+  const canReuseInstall = () =>
+    readInstallStamp(stampPath) === stamp && fs.existsSync(pristineConfigPath);
+
+  if (canReuseInstall()) {
+    log.info('reusing install at %s', chalk.bold(installPath));
+  } else {
+    const releaseInstallLock = await acquireInstallLock(installPath, log);
+    try {
+      if (canReuseInstall()) {
+        log.info('reusing install at %s', chalk.bold(installPath));
+      } else {
+        const tmpInstallPath = `${installPath}.tmp-${process.pid}-${tmpInstallId++}`;
+        await del(tmpInstallPath, { force: true });
+        await removeStaleTmpInstalls(installPath);
+
+        log.info('extracting %s', chalk.bold(dest));
+        await extract({
+          archivePath: dest,
+          targetDir: tmpInstallPath,
+          stripComponents: 1,
+        });
+
+        const tmpConfigPath = path.resolve(tmpInstallPath, ES_CONFIG_DIRNAME);
+        await createKeystore(tmpInstallPath, tmpConfigPath, log, [
+          ['bootstrap.password', BAKED_BOOTSTRAP_PASSWORD],
+        ]);
+        fs.cpSync(tmpConfigPath, path.resolve(tmpInstallPath, PRISTINE_CONFIG_DIRNAME), {
+          recursive: true,
+        });
+        fs.writeFileSync(path.resolve(tmpInstallPath, INSTALL_STAMP_FILENAME), stamp, 'utf8');
+
+        if (fs.existsSync(installPath)) {
+          log.info('install directory already exists, removing');
+          fs.rmSync(stampPath, { force: true });
+          await del(installPath, { force: true });
+        }
+
+        fs.renameSync(tmpInstallPath, installPath);
+        log.info('extracted to %s', chalk.bold(installPath));
+      }
+    } finally {
+      releaseInstallLock();
+    }
   }
 
-  log.info('extracting %s', chalk.bold(dest));
-  await extract({
-    archivePath: dest,
-    targetDir: installPath,
-    stripComponents: 1,
-  });
-  log.info('extracted to %s', chalk.bold(installPath));
+  const esConfigPath = configPath ?? path.resolve(installPath, ES_CONFIG_DIRNAME);
+  await del(esConfigPath, { force: true });
+  fs.cpSync(pristineConfigPath, esConfigPath, { recursive: true });
+
+  if (configPath) {
+    log.info('using %s as ES_PATH_CONF', chalk.bold(configPath));
+  } else {
+    // Drop run state a fresh extract wouldn't have had
+    await del(
+      ['data', 'logs', 'ES_TMPDIR', 'plugins'].map((p) => path.resolve(installPath, p)),
+      { force: true }
+    );
+    fs.mkdirSync(path.resolve(installPath, 'plugins'));
+  }
 
   /**
    * If we're running inside a Vagrant VM, and this is running in a synced folder,
    * ES will fail to start due to ML being unable to write a pipe in the synced folder.
    * Disabling allows ES to write to the OS's /tmp directory.
+   *
+   * Skipped when `configPath` is set: those callers pass their own `esTmpDir`.
    */
-  if (!disableEsTmpDir) {
+  if (!disableEsTmpDir && !configPath) {
     const tmpdir = path.resolve(installPath, 'ES_TMPDIR');
     fs.mkdirSync(tmpdir, { recursive: true });
     log.info('created %s', chalk.bold(tmpdir));
@@ -78,13 +273,17 @@ export async function installArchive(archive: string, options?: InstallArchiveOp
 
   // starting in 6.3, security is disabled by default. Since we bootstrap
   // the keystore, we can enable security ourselves.
-  await appendToConfig(installPath, 'xpack.security.enabled', 'true');
+  await appendToConfig(esConfigPath, 'xpack.security.enabled', 'true');
 
-  await appendToConfig(installPath, 'xpack.license.self_generated.type', license);
-  await configureKeystore(installPath, log, [
-    ['bootstrap.password', password],
-    ...parseSettings(esArgs, { filter: SettingsFilter.SecureOnly }),
-  ]);
+  await appendToConfig(esConfigPath, 'xpack.license.self_generated.type', license);
+
+  const keystoreOverrides = parseSettings(esArgs, { filter: SettingsFilter.SecureOnly });
+  if (password !== BAKED_BOOTSTRAP_PASSWORD) {
+    keystoreOverrides.unshift(['bootstrap.password', password]);
+  }
+  if (keystoreOverrides.length) {
+    await addKeystoreSettings(installPath, esConfigPath, log, keystoreOverrides);
+  }
 
   // copy resources to ES config directory
   if (resources) {
@@ -96,44 +295,54 @@ export async function installArchive(archive: string, options?: InstallArchiveOp
       }
 
       const filename = path.basename(resource);
-      const destPath = path.resolve(installPath, 'config', filename);
+      const destPath = path.resolve(esConfigPath, filename);
 
       copyFileSync(resource, destPath);
       log.info('moved %s in config to %s', resource, destPath);
     });
   }
 
-  return { installPath, disableEsTmpDir };
+  return { installPath, disableEsTmpDir, configPath };
 }
 
 /**
  * Appends single line to elasticsearch.yml config file
  */
-async function appendToConfig(installPath: string, key: string, value: string) {
-  fs.appendFileSync(path.resolve(installPath, ES_CONFIG), `${key}: ${value}\n`, 'utf8');
+async function appendToConfig(esConfigPath: string, key: string, value: string) {
+  fs.appendFileSync(path.resolve(esConfigPath, ES_CONFIG_FILENAME), `${key}: ${value}\n`, 'utf8');
 }
 
-/**
- * Creates and configures Keystore
- */
-async function configureKeystore(
-  installPath: string,
-  log: ToolingLog = defaultLog,
-  secureSettings: Array<[string, string]>
-) {
-  const env = { JAVA_HOME: '' };
-  await execa(ES_KEYSTORE_BIN, ['create'], { cwd: installPath, env });
+const keystoreEnv = (esConfigPath: string) => ({ JAVA_HOME: '', ES_PATH_CONF: esConfigPath });
 
-  for (const [secureSettingName, secureSettingValue] of secureSettings) {
+async function addKeystoreSettings(
+  installPath: string,
+  esConfigPath: string,
+  log: ToolingLog,
+  settings: Array<[string, string]>
+) {
+  for (const [secureSettingName, secureSettingValue] of settings) {
     log.info(
       `setting secure setting %s to %s`,
       chalk.bold(secureSettingName),
       chalk.bold(secureSettingValue)
     );
-    await execa(ES_KEYSTORE_BIN, ['add', secureSettingName, '-x'], {
+    await execa(ES_KEYSTORE_BIN, ['add', '--force', secureSettingName, '-x'], {
       input: secureSettingValue,
       cwd: installPath,
-      env,
+      env: keystoreEnv(esConfigPath),
     });
   }
+}
+
+async function createKeystore(
+  installPath: string,
+  esConfigPath: string,
+  log: ToolingLog,
+  settings: Array<[string, string]>
+) {
+  await execa(ES_KEYSTORE_BIN, ['create'], {
+    cwd: installPath,
+    env: keystoreEnv(esConfigPath),
+  });
+  await addKeystoreSettings(installPath, esConfigPath, log, settings);
 }

--- a/src/platform/packages/shared/kbn-es/src/install/install_snapshot.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/install/install_snapshot.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import path from 'path';
+
+import { Artifact } from '../artifact';
+import { installArchive } from './install_archive';
+import { installSnapshot } from './install_snapshot';
+
+jest.mock('../artifact');
+jest.mock('./install_archive');
+
+const getSnapshotMock = Artifact.getSnapshot as jest.Mock;
+const installArchiveMock = installArchive as jest.Mock;
+const downloadMock = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getSnapshotMock.mockResolvedValue({
+    spec: { filename: 'elasticsearch.tar.gz' },
+    download: downloadMock,
+  });
+  installArchiveMock.mockResolvedValue({
+    installPath: '/install',
+    disableEsTmpDir: false,
+    configPath: undefined,
+  });
+});
+
+test('defaults to the established version directory under the base path', async () => {
+  const basePath = '/base';
+
+  await installSnapshot({ version: '9.6.0', basePath });
+
+  expect(installArchiveMock).toHaveBeenCalledWith(
+    path.resolve(basePath, 'cache', 'elasticsearch.tar.gz'),
+    expect.objectContaining({
+      installPath: path.resolve(basePath, '9.6.0'),
+    })
+  );
+});

--- a/src/platform/packages/shared/kbn-es/src/install/install_snapshot.ts
+++ b/src/platform/packages/shared/kbn-es/src/install/install_snapshot.ts
@@ -72,6 +72,7 @@ export async function installSnapshot({
   esArgs,
   useCached = false,
   resources,
+  configPath,
 }: InstallSnapshotOptions) {
   const { downloadPath } = await downloadSnapshot({
     license,
@@ -90,5 +91,6 @@ export async function installSnapshot({
     log,
     esArgs,
     resources,
+    configPath,
   });
 }

--- a/src/platform/packages/shared/kbn-es/src/install/install_source.ts
+++ b/src/platform/packages/shared/kbn-es/src/install/install_source.ts
@@ -35,6 +35,7 @@ export async function installSource({
   log = defaultLog,
   esArgs,
   resources,
+  configPath,
 }: InstallSourceOptions) {
   log.info('source path: %s', chalk.bold(sourcePath));
   log.info('install path: %s', chalk.bold(installPath));
@@ -62,6 +63,7 @@ export async function installSource({
     log,
     esArgs,
     resources,
+    configPath,
   });
 }
 

--- a/src/platform/packages/shared/kbn-es/src/install/types.ts
+++ b/src/platform/packages/shared/kbn-es/src/install/types.ts
@@ -10,7 +10,12 @@
 import type { ToolingLog } from '@kbn/tooling-log';
 import type { ArtifactLicense } from '../artifact';
 
-export interface InstallSourceOptions {
+interface ConfigPathOption {
+  /** Where to write `config/`, passed to ES as `ES_PATH_CONF`. Defaults to the install dir */
+  configPath?: string;
+}
+
+export interface InstallSourceOptions extends ConfigPathOption {
   sourcePath: string;
   license?: ArtifactLicense;
   password?: string;
@@ -31,12 +36,12 @@ export interface DownloadSnapshotOptions {
   resources?: string[];
 }
 
-export interface InstallSnapshotOptions extends DownloadSnapshotOptions {
+export interface InstallSnapshotOptions extends DownloadSnapshotOptions, ConfigPathOption {
   password?: string;
   esArgs?: string[];
 }
 
-export interface InstallArchiveOptions {
+export interface InstallArchiveOptions extends ConfigPathOption {
   license?: ArtifactLicense;
   password?: string;
   basePath?: string;

--- a/src/platform/packages/shared/kbn-es/src/integration_tests/cluster.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/integration_tests/cluster.test.ts
@@ -186,7 +186,7 @@ describe('#installSource()', () => {
       () =>
         new Promise((resolve) => {
           resolveInstallSource = () => {
-            resolve({ installPath: 'foo', disableEsTmpDir: false });
+            resolve({ installPath: 'foo', disableEsTmpDir: false, configPath: undefined });
           };
         })
     );
@@ -202,7 +202,11 @@ describe('#installSource()', () => {
   });
 
   test('passes through all options+log to installSource()', async () => {
-    installSourceMock.mockResolvedValue({ installPath: 'foo', disableEsTmpDir: false });
+    installSourceMock.mockResolvedValue({
+      installPath: 'foo',
+      disableEsTmpDir: false,
+      configPath: undefined,
+    });
     const options: InstallSourceOptions = {
       sourcePath: 'bar',
       license: 'trial',
@@ -236,7 +240,7 @@ describe('#installSnapshot()', () => {
       () =>
         new Promise((resolve) => {
           resolveInstallSnapshot = () => {
-            resolve({ installPath: 'foo', disableEsTmpDir: false });
+            resolve({ installPath: 'foo', disableEsTmpDir: false, configPath: undefined });
           };
         })
     );
@@ -252,7 +256,11 @@ describe('#installSnapshot()', () => {
   });
 
   test('passes through all options+log to installSnapshot()', async () => {
-    installSnapshotMock.mockResolvedValue({ installPath: 'foo', disableEsTmpDir: false });
+    installSnapshotMock.mockResolvedValue({
+      installPath: 'foo',
+      disableEsTmpDir: false,
+      configPath: undefined,
+    });
     const options: InstallSnapshotOptions = {
       version: '8.10.0',
       license: 'trial',
@@ -287,7 +295,7 @@ describe('#installArchive()', () => {
       () =>
         new Promise((resolve) => {
           resolveInstallArchive = () => {
-            resolve({ installPath: 'foo', disableEsTmpDir: false });
+            resolve({ installPath: 'foo', disableEsTmpDir: false, configPath: undefined });
           };
         })
     );
@@ -303,7 +311,11 @@ describe('#installArchive()', () => {
   });
 
   test('passes through all options+log to installArchive()', async () => {
-    installArchiveMock.mockResolvedValue({ installPath: 'foo', disableEsTmpDir: true });
+    installArchiveMock.mockResolvedValue({
+      installPath: 'foo',
+      disableEsTmpDir: true,
+      configPath: undefined,
+    });
     const options: InstallArchiveOptions = {
       license: 'trial',
       password: 'changeme',

--- a/src/platform/packages/shared/kbn-es/src/paths.ts
+++ b/src/platform/packages/shared/kbn-es/src/paths.ts
@@ -22,7 +22,12 @@ export const BASE_PATH = resolve(tempDir, 'kbn-es');
 export const GRADLE_BIN = maybeUseBat('./gradlew');
 export const ES_BIN = maybeUseBat('bin/elasticsearch');
 export const ES_PLUGIN_BIN = maybeUseBat('bin/elasticsearch-plugin');
-export const ES_CONFIG = 'config/elasticsearch.yml';
+export const ES_CONFIG_DIRNAME = 'config';
+export const ES_CONFIG_FILENAME = 'elasticsearch.yml';
+
+/** Shared immutable install path used by test and CI cache callers */
+export const getEsInstallPath = (basePath: string, version: string) =>
+  resolve(basePath, 'installs', version);
 
 export const ES_KEYSTORE_BIN = maybeUseBat('./bin/elasticsearch-keystore');
 

--- a/src/platform/packages/shared/kbn-es/src/settings.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/settings.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { parseSettings, SettingsFilter } from './settings';
+import { defaultToSingleNodeDiscovery, parseSettings, SettingsFilter } from './settings';
 
 const mockSettings = [
   'abc.def=1',
@@ -62,4 +62,30 @@ test('`parseSettings` parses and returns only non-secure settings with `Settings
     ['xpack.security.authc.realms.oidc.oidc1.rp.client_id', 'client id'],
     ['discovery.type', 'single-node'],
   ]);
+});
+
+describe('defaultToSingleNodeDiscovery', () => {
+  test('prepends single-node discovery when no discovery settings are given', () => {
+    expect(defaultToSingleNodeDiscovery(['abc.def=1'])).toEqual([
+      'discovery.type=single-node',
+      'abc.def=1',
+    ]);
+    expect(defaultToSingleNodeDiscovery()).toEqual(['discovery.type=single-node']);
+    expect(defaultToSingleNodeDiscovery('abc.def=1')).toEqual([
+      'discovery.type=single-node',
+      'abc.def=1',
+    ]);
+  });
+
+  test('leaves esArgs unchanged when discovery is already configured', () => {
+    expect(defaultToSingleNodeDiscovery(['discovery.type=multi-node'])).toEqual([
+      'discovery.type=multi-node',
+    ]);
+    expect(defaultToSingleNodeDiscovery(['discovery.seed_hosts=127.0.0.1:9301'])).toEqual([
+      'discovery.seed_hosts=127.0.0.1:9301',
+    ]);
+    expect(defaultToSingleNodeDiscovery(['cluster.initial_master_nodes=node-01'])).toEqual([
+      'cluster.initial_master_nodes=node-01',
+    ]);
+  });
 });

--- a/src/platform/packages/shared/kbn-es/src/settings.ts
+++ b/src/platform/packages/shared/kbn-es/src/settings.ts
@@ -31,6 +31,20 @@ export enum SettingsFilter {
 }
 
 /**
+ * Defaults `esArgs` to single-node discovery, which skips the multi-second cluster
+ * bootstrap wait, unless the caller configured discovery themselves.
+ */
+export function defaultToSingleNodeDiscovery(esArgs: string | string[] = []): string[] {
+  const args = typeof esArgs === 'string' ? [esArgs] : esArgs;
+  const hasDiscoverySetting = args.some((arg) => {
+    const [settingName] = arg.split('=');
+    return settingName.startsWith('discovery.') || settingName === 'cluster.initial_master_nodes';
+  });
+
+  return hasDiscoverySetting ? args : ['discovery.type=single-node', ...args];
+}
+
+/**
  * Accepts an array of `esSettingName=esSettingValue` strings and parses them into an array of
  * [esSettingName, esSettingValue] tuples optionally filter out secure or non-secure settings.
  * @param rawSettingNameValuePairs Array of strings to parse

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.test.ts
@@ -50,6 +50,9 @@ import {
 import * as waitClusterUtil from './wait_until_cluster_ready';
 import * as waitForSecurityIndexUtil from './wait_for_security_index';
 import * as mockIdpPluginUtil from '@kbn/mock-idp-utils';
+import { createStripAnsiSerializer } from '@kbn/jest-serializers';
+
+expect.addSnapshotSerializer(createStripAnsiSerializer());
 
 /**
  * This is set to 'true' on CI, and it causes some docker behaviours to differ.
@@ -325,8 +328,8 @@ describe('verifyDockerInstalled()', () => {
 
     expect(logWriter.messages).toMatchInlineSnapshot(`
       Array [
-        " [34minfo[39m [1mVerifying Docker is installed.[22m",
-        "   │ [34minfo[39m Docker Version 123",
+        " info Verifying Docker is installed.",
+        "   │ info Docker Version 123",
       ]
     `);
   });
@@ -363,8 +366,8 @@ describe('maybeCreateDockerNetwork()', () => {
 
     expect(logWriter.messages).toMatchInlineSnapshot(`
       Array [
-        " [34minfo[39m [1mChecking status of elastic Docker network.[22m",
-        "   │ [34minfo[39m Created new network.",
+        " info Checking status of elastic Docker network.",
+        "   │ info Created new network.",
       ]
     `);
   });
@@ -378,8 +381,8 @@ describe('maybeCreateDockerNetwork()', () => {
 
     expect(logWriter.messages).toMatchInlineSnapshot(`
       Array [
-        " [34minfo[39m [1mChecking status of elastic Docker network.[22m",
-        "   │ [34minfo[39m Using existing network.",
+        " info Checking status of elastic Docker network.",
+        "   │ info Using existing network.",
       ]
     `);
   });

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
@@ -9,6 +9,9 @@
 
 import { ToolingLog } from '@kbn/tooling-log';
 import { initializeUiamContainers, runUiamContainer, UIAM_CONTAINERS } from './docker_uiam';
+import { createStripAnsiSerializer } from '@kbn/jest-serializers';
+
+expect.addSnapshotSerializer(createStripAnsiSerializer());
 
 jest.mock('timers/promises', () => ({
   setTimeout: jest.fn(() => Promise.resolve()),
@@ -365,10 +368,8 @@ describe(`#runUiamContainer()`, () => {
       .mockResolvedValueOnce({ stdout: `name-${cosmosDbContainer.name}` })
       .mockResolvedValue({ stdout: ` running ` });
 
-    await expect(
-      runUiamContainer(new ToolingLog(), cosmosDbContainer)
-    ).rejects.toMatchInlineSnapshot(
-      `[Error: The "uiam-cosmosdb" container failed to start within the expected time. Last known status: running. Check the logs with [1mdocker logs -f uiam-cosmosdb[22m]`
+    await expect(runUiamContainer(new ToolingLog(), cosmosDbContainer)).rejects.toThrow(
+      'The "uiam-cosmosdb" container failed to start within the expected time. Last known status: running.'
     );
 
     // Skip the first call to `docker run` as we checked it in the previous test.
@@ -381,8 +382,8 @@ describe(`#runUiamContainer()`, () => {
       .mockResolvedValueOnce({ stdout: `name-${uiamContainer.name}` })
       .mockResolvedValue({ stdout: ` running ` });
 
-    await expect(runUiamContainer(new ToolingLog(), uiamContainer)).rejects.toMatchInlineSnapshot(
-      `[Error: The "uiam" container failed to start within the expected time. Last known status: running. Check the logs with [1mdocker logs -f uiam[22m]`
+    await expect(runUiamContainer(new ToolingLog(), uiamContainer)).rejects.toThrow(
+      'The "uiam" container failed to start within the expected time. Last known status: running.'
     );
 
     // Skip the first call to `docker run` as we checked it in the previous test.

--- a/src/platform/packages/shared/kbn-es/src/utils/extract_config_files.test.js
+++ b/src/platform/packages/shared/kbn-es/src/utils/extract_config_files.test.js
@@ -36,7 +36,7 @@ test('returns config with local paths', () => {
 });
 
 test('copies file', () => {
-  extractConfigFiles(['path=/data/foo.yml'], '/es');
+  extractConfigFiles(['path=/data/foo.yml'], '/es/config');
 
   expect(fs.readFileSync.mock.calls[0][0]).toEqual('/data/foo.yml');
   expect(fs.writeFileSync.mock.calls[0][0]).toEqual('/es/config/foo.yml');

--- a/src/platform/packages/shared/kbn-es/src/utils/extract_config_files.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/extract_config_files.ts
@@ -12,13 +12,13 @@ import fs from 'fs';
 import type { ToolingLog } from '@kbn/tooling-log';
 
 /**
- * Copies config references to an absolute path to
- * the provided destination. This is necessary as ES security
- * requires files to be within the installation directory
+ * Copies config references to an absolute path into the given config directory,
+ * rewriting each setting to the bare filename. This is necessary as ES security
+ * requires files to be within the config directory.
  */
 export function extractConfigFiles(
   config: string | string[],
-  dest: string,
+  configDir: string,
   options?: { log: ToolingLog }
 ) {
   const originalConfig = typeof config === 'string' ? [config] : config;
@@ -29,7 +29,7 @@ export function extractConfigFiles(
 
     if (isFile(value)) {
       const filename = path.basename(value);
-      const destPath = path.resolve(dest, 'config', filename);
+      const destPath = path.resolve(configDir, filename);
 
       copyFileSync(value, destPath);
 

--- a/src/platform/packages/shared/kbn-es/src/utils/native_realm.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/native_realm.ts
@@ -19,7 +19,6 @@ export const SYSTEM_INDICES_SUPERUSER =
 export const SYSTEM_INDICES_SUPERUSER_PASSWORD = process.env.TEST_ES_PASS || 'changeme';
 
 interface RetryOpts {
-  attempt?: number;
   maxAttempts?: number;
 }
 
@@ -118,20 +117,21 @@ export class NativeRealm {
   }
 
   private async _autoRetry<T>(opts: RetryOpts, fn: (attempt: number) => Promise<T>): Promise<T> {
-    const { attempt = 1, maxAttempts = 3 } = opts;
+    const { maxAttempts = 15 } = opts;
 
-    try {
-      return await fn(attempt);
-    } catch (error) {
-      if (attempt >= maxAttempts) {
-        throw error;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await fn(attempt);
+      } catch (error) {
+        if (attempt >= maxAttempts) {
+          throw error;
+        }
+
+        if (attempt === 1) {
+          this._log.warning(`assuming ES isn't initialized completely, retrying`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, Math.min(attempt * 100, 500)));
       }
-
-      const sec = 1.5 * attempt;
-      this._log.warning(`assuming ES isn't initialized completely, trying again in ${sec} seconds`);
-      await new Promise((resolve) => setTimeout(resolve, sec * 1000));
-
-      return await this._autoRetry({ ...opts, attempt: attempt + 1 }, fn);
     }
   }
 

--- a/src/platform/packages/shared/kbn-es/src/utils/wait_for_security_index.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/wait_for_security_index.test.ts
@@ -10,6 +10,9 @@
 import { Client } from '@elastic/elasticsearch';
 import { ToolingLog, ToolingLogCollectingWriter } from '@kbn/tooling-log';
 import { waitForSecurityIndex } from './wait_for_security_index';
+import { createStripAnsiSerializer } from '@kbn/jest-serializers';
+
+expect.addSnapshotSerializer(createStripAnsiSerializer());
 
 jest.mock('@elastic/elasticsearch', () => {
   return {
@@ -49,16 +52,15 @@ describe('waitForSecurityIndex', () => {
     expect(invalidateApiKey).toHaveBeenCalledTimes(2);
     expect(logWriter.messages).toMatchInlineSnapshot(`
       Array [
-        " [34minfo[39m waiting for ES cluster to bootstrap the security index",
-        " [33mwarn[39m waiting for ES cluster to bootstrap the security index, attempt 1 failed with: foo",
-        " [32msucc[39m ES security index is ready",
+        " info waiting for ES cluster to bootstrap the security index",
+        " warn waiting for ES cluster to bootstrap the security index, attempt 1 failed with: foo",
+        " succ ES security index is ready",
       ]
     `);
   }, 10000);
 
   test(`rejects when 'readyTimeout' is exceeded`, async () => {
-    invalidateApiKey.mockImplementationOnce(() => Promise.reject(new Error('foo')));
-    invalidateApiKey.mockImplementationOnce(() => Promise.reject(new Error('foo')));
+    invalidateApiKey.mockImplementation(() => Promise.reject(new Error('foo')));
     const client = new Client({});
     await expect(waitForSecurityIndex({ client, log, readyTimeout: 1000 })).rejects.toThrow(
       'ES cluster failed to bootstrap the security index with the 1 second timeout'

--- a/src/platform/packages/shared/kbn-es/src/utils/wait_for_security_index.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/wait_for_security_index.ts
@@ -55,8 +55,8 @@ export async function waitForSecurityIndex({
         `waiting for ES cluster to bootstrap the security index, attempt ${attempt} failed with: ${error?.message}`
       );
 
-      const waitSec = attempt * 1.5;
-      await new Promise((resolve) => setTimeout(resolve, waitSec * 1000));
+      const waitMs = Math.min(attempt * 100, 2000);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
     }
   }
 }

--- a/src/platform/packages/shared/kbn-es/src/utils/wait_until_cluster_ready.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/wait_until_cluster_ready.test.ts
@@ -10,6 +10,9 @@
 import { Client } from '@elastic/elasticsearch';
 import { ToolingLog, ToolingLogCollectingWriter } from '@kbn/tooling-log';
 import { waitUntilClusterReady } from './wait_until_cluster_ready';
+import { createStripAnsiSerializer } from '@kbn/jest-serializers';
+
+expect.addSnapshotSerializer(createStripAnsiSerializer());
 
 jest.mock('@elastic/elasticsearch', () => {
   return {
@@ -49,9 +52,9 @@ describe('waitUntilClusterReady', () => {
     expect(health).toHaveBeenCalledTimes(4);
     expect(logWriter.messages).toMatchInlineSnapshot(`
       Array [
-        " [34minfo[39m waiting for ES cluster to report a green status",
-        " [33mwarn[39m waiting for ES cluster to come online, attempt 1 failed with: foo",
-        " [32msucc[39m ES cluster is ready",
+        " info waiting for ES cluster to report a green status",
+        " warn waiting for ES cluster to come online, attempt 1 failed with: foo",
+        " succ ES cluster is ready",
       ]
     `);
   }, 10000);
@@ -69,9 +72,9 @@ describe('waitUntilClusterReady', () => {
     expect(health).toHaveBeenCalledTimes(3);
     expect(logWriter.messages).toMatchInlineSnapshot(`
       Array [
-        " [34minfo[39m waiting for ES cluster to report a yellow status",
-        " [33mwarn[39m waiting for ES cluster to come online, attempt 1 failed with: foo",
-        " [32msucc[39m ES cluster is ready",
+        " info waiting for ES cluster to report a yellow status",
+        " warn waiting for ES cluster to come online, attempt 1 failed with: foo",
+        " succ ES cluster is ready",
       ]
     `);
   }, 10000);

--- a/src/platform/packages/shared/kbn-es/src/utils/wait_until_cluster_ready.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/wait_until_cluster_ready.ts
@@ -74,8 +74,8 @@ export async function waitUntilClusterReady({
         );
       }
 
-      const waitSec = attempt * 1.5;
-      await new Promise((resolve) => setTimeout(resolve, waitSec * 1000));
+      const waitMs = Math.min(attempt * 100, 2000);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
     }
   }
 }

--- a/src/platform/packages/shared/kbn-test-es-server/src/test_es_cluster.test.ts
+++ b/src/platform/packages/shared/kbn-test-es-server/src/test_es_cluster.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { Cluster } from '@kbn/es';
+import { ToolingLog } from '@kbn/tooling-log';
+import { createTestEsCluster } from './test_es_cluster';
+
+jest.mock('@kbn/es', () => ({
+  Cluster: jest.fn(),
+  getEsInstallPath: (basePath: string, version: string) =>
+    jest.requireActual('path').resolve(basePath, 'installs', version),
+}));
+
+const ClusterMock = Cluster as jest.Mock;
+const installSourceMock = jest.fn();
+const startMock = jest.fn();
+let basePath: string;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'kbn-test-es-server-'));
+  ClusterMock.mockImplementation(() => ({
+    installSource: installSourceMock,
+    start: startMock,
+  }));
+  installSourceMock.mockResolvedValue({
+    installPath: path.resolve(basePath, 'installs', 'source'),
+    disableEsTmpDir: false,
+    configPath: path.resolve(basePath, 'runtime', 'es-test-cluster', 'config'),
+  });
+  startMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  fs.rmSync(basePath, { recursive: true, force: true });
+});
+
+test('source test clusters use an install isolated from the mutable CLI install', async () => {
+  const cluster = createTestEsCluster({
+    basePath,
+    esFrom: 'source',
+    log: new ToolingLog(),
+  });
+
+  await cluster.start();
+
+  expect(installSourceMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      installPath: path.resolve(basePath, 'installs', 'source'),
+    })
+  );
+});

--- a/src/platform/packages/shared/kbn-test-es-server/src/test_es_cluster.ts
+++ b/src/platform/packages/shared/kbn-test-es-server/src/test_es_cluster.ts
@@ -15,7 +15,7 @@ import globby from 'globby';
 import createArchiver from 'archiver';
 import Fs from 'fs';
 import { pipeline } from 'stream/promises';
-import { Cluster } from '@kbn/es';
+import { Cluster, getEsInstallPath } from '@kbn/es';
 import { Client, HttpConnection } from '@elastic/elasticsearch';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { REPO_ROOT } from '@kbn/repo-info';
@@ -238,15 +238,30 @@ export function createTestEsCluster<
   // Use 'trial' license if FIPS mode is enabled, otherwise use the provided license or default to 'basic'
   const testLicense: ArtifactLicense = getFips() === 1 ? 'trial' : license ? license : 'basic';
 
+  // Keeping run state out of the distribution lets every cluster share one install.
+  const runtimePath = Path.resolve(basePath, 'runtime', clusterName);
+
   const config = {
     version: esVersion,
-    installPath: Path.resolve(basePath, clusterName),
+    installPath: getEsInstallPath(basePath, esFrom === 'source' ? 'source' : esVersion),
+    runtimePath,
+    configPath: Path.resolve(runtimePath, 'config'),
     sourcePath: Path.resolve(REPO_ROOT, '../elasticsearch'),
     license: testLicense,
     password,
     basePath,
     esArgs,
     resources: files,
+  };
+
+  const nodeRuntimePaths = (nodeName: string) => {
+    const root = Path.resolve(config.runtimePath, 'nodes', nodeName);
+    return {
+      root,
+      data: Path.resolve(root, 'data'),
+      logs: Path.resolve(root, 'logs'),
+      tmp: Path.resolve(root, 'tmp'),
+    };
   };
 
   return new (class TestCluster {
@@ -274,20 +289,26 @@ export function createTestEsCluster<
     async start() {
       let installPath: string;
       let disableEsTmpDir: boolean;
+      // Stays unset for an absolute `esFrom` path, which uses its own config directory
+      let configPath: string | undefined;
+
+      await del(config.runtimePath, { force: true });
 
       // We only install once using the first node. If the cluster has
       // multiple nodes, they'll all share the same ESinstallation.
       const firstNode = this.nodes[0];
       if (esFrom === 'source') {
-        ({ installPath, disableEsTmpDir } = await firstNode.installSource({
+        ({ installPath, disableEsTmpDir, configPath } = await firstNode.installSource({
           sourcePath: config.sourcePath,
           license: config.license,
           password: config.password,
           basePath: config.basePath,
+          installPath: config.installPath,
           esArgs: config.esArgs,
+          configPath: config.configPath,
         }));
       } else if (esFrom === 'snapshot') {
-        ({ installPath, disableEsTmpDir } = await firstNode.installSnapshot(config));
+        ({ installPath, disableEsTmpDir, configPath } = await firstNode.installSnapshot(config));
       } else if (esFrom === 'docker') {
         await firstNode.runDocker({
           snapshot: true,
@@ -330,7 +351,7 @@ export function createTestEsCluster<
 
       if (secureFiles?.length) {
         const pairs = secureFiles.map((kv) => kv.split('=').map((v) => v.trim()));
-        await firstNode.configureKeystoreWithSecureSettingsFiles(installPath, pairs);
+        await firstNode.configureKeystoreWithSecureSettingsFiles(installPath, pairs, configPath);
       }
 
       // Collect promises so we can run them in parallel
@@ -340,18 +361,22 @@ export function createTestEsCluster<
       for (let i = 0; i < this.nodes.length; i++) {
         const node = nodes[i];
         const nodePort = this.ports[i];
-        const overriddenArgs = [`node.name=${node.name}`, `http.port=${nodePort}`];
+        const runtimePaths = nodeRuntimePaths(node.name);
+        const overriddenArgs = [
+          `node.name=${node.name}`,
+          `http.port=${nodePort}`,
+          `path.data=${runtimePaths.data}`,
+          `path.logs=${runtimePaths.logs}`,
+        ];
+
+        Fs.mkdirSync(runtimePaths.data, { recursive: true });
+        Fs.mkdirSync(runtimePaths.logs, { recursive: true });
+        Fs.mkdirSync(runtimePaths.tmp, { recursive: true });
 
         const archive = node.dataArchive || dataArchive;
         if (archive) {
           extractDirectoryPromises.push(async () => {
-            const nodeDataDirectory = node.dataArchive ? `data-${node.name}` : 'data';
-            overriddenArgs.push(`path.data=${Path.resolve(installPath, nodeDataDirectory)}`);
-            return await this.nodes[i].extractDataDirectory(
-              installPath,
-              archive,
-              nodeDataDirectory
-            );
+            return await this.nodes[i].extractDataDirectory(runtimePaths.data, archive);
           });
         }
 
@@ -360,7 +385,8 @@ export function createTestEsCluster<
           return this.nodes[i].start(installPath, {
             password: config.password,
             esArgs: assignArgs(esArgs, overriddenArgs),
-            esJavaOpts,
+            // The default HeapDumpPath (`data`) resolves against the shared install dir
+            esJavaOpts: `${esJavaOpts ?? ''} -XX:HeapDumpPath=${runtimePaths.root}`.trim(),
             esStdoutLogLevel,
             // If we have multiple nodes, we shouldn't try setting up the native realm
             // right away or wait for ES to be green, the cluster isn't ready. So we only
@@ -370,6 +396,8 @@ export function createTestEsCluster<
             onEarlyExit,
             writeLogsToPath,
             disableEsTmpDir,
+            esTmpDir: runtimePaths.tmp,
+            configPath,
           });
         });
       }
@@ -408,36 +436,49 @@ export function createTestEsCluster<
     }
 
     async captureDebugFiles() {
-      const debugFiles = await globby([`**/hs_err_pid*.log`, `**/replay_pid*.log`, `**/*.hprof`], {
-        cwd: config.installPath,
-        absolute: true,
-      });
+      const uuid = uuidv4();
+      const archiveDirname = `es_debug_${uuid}`;
+      const searchRoots = [
+        { root: config.installPath, dirname: archiveDirname },
+        { root: config.runtimePath, dirname: Path.join(archiveDirname, 'runtime') },
+      ].filter(({ root }) => Fs.existsSync(root));
+
+      const debugFiles = (
+        await Promise.all(
+          searchRoots.map(({ root }) =>
+            globby([`**/hs_err_pid*.log`, `**/replay_pid*.log`, `**/*.hprof`], {
+              cwd: root,
+              absolute: true,
+            })
+          )
+        )
+      ).flat();
 
       if (!debugFiles.length) {
         log.info('[es] no debug files found, assuming es did not write any');
         return;
       }
 
-      const uuid = uuidv4();
       const debugPath = Path.resolve(REPO_ROOT, `data/es_debug_${uuid}.tar.gz`);
       log.error(`[es] debug files found, archiving install to ${debugPath}`);
       const archiver = createArchiver('tar', { gzip: true });
       const promise = pipeline(archiver, Fs.createWriteStream(debugPath));
 
-      const archiveDirname = `es_debug_${uuid}`;
-      for (const name of Fs.readdirSync(config.installPath)) {
-        if (name === 'modules' || name === 'jdk') {
-          // drop these large and unnecessary directories
-          continue;
-        }
+      for (const { root, dirname } of searchRoots) {
+        for (const name of Fs.readdirSync(root)) {
+          if (name === 'modules' || name === 'jdk') {
+            // drop these large and unnecessary directories
+            continue;
+          }
 
-        const src = Path.resolve(config.installPath, name);
-        const dest = Path.join(archiveDirname, name);
-        const stat = Fs.statSync(src);
-        if (stat.isDirectory()) {
-          archiver.directory(src, dest);
-        } else {
-          archiver.file(src, { name: dest });
+          const src = Path.resolve(root, name);
+          const dest = Path.join(dirname, name);
+          const stat = Fs.statSync(src);
+          if (stat.isDirectory()) {
+            archiver.directory(src, dest);
+          } else {
+            archiver.file(src, { name: dest });
+          }
         }
       }
 
@@ -461,7 +502,7 @@ export function createTestEsCluster<
       );
 
       await this.captureDebugFiles();
-      await del(config.installPath, { force: true });
+      await del(config.runtimePath, { force: true });
       log.info('[es] cleanup complete');
       this.handleStopResults(results);
     }


### PR DESCRIPTION
Updates `node scripts/es snapshot` to extract elasticsearch once per build.  Previously every invocation was re-extracting elasticsearch.  

Locally this saves 10 seconds per warm startup.  
In aggregate on CI this should save 3 hours of compute per build, mainly on jest integration and FTR.