### PR TITLE
Add managed bulk output permissions

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/output.ts
@@ -45,6 +45,11 @@ export const ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID = 'es-managed-bulk-agentless-o
 export const SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID =
   'es-managed-bulk-agentless-output-internal';
 
+export const AGENTLESS_MANAGED_BULK_OUTPUT_IDS: ReadonlySet<string> = new Set([
+  ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+]);
+
 // Output ID for the private endpoint (PrivateLink) in serverless.
 // Injected by project-controller/kibana-controller when PrivateLink is enabled.
 export const SERVERLESS_PRIVATE_OUTPUT_ID = 'es-private-output';

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -9,6 +9,10 @@ import omit from 'lodash/omit';
 
 import type { AgentPolicy, Output, DownloadSource, PackageInfo } from '../../types';
 import {
+  ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+} from '../../../common/constants';
+import {
   createAppContextStartContractMock,
   createMessageSigningServiceMock,
   createSavedObjectClientMock,
@@ -119,6 +123,30 @@ jest.mock('../output', () => {
       type: 'elasticsearch',
       hosts: ['http://127.0.0.1:9201'],
       write_to_logs_streams: true,
+    },
+    // ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID — literal required inside jest.mock factory
+    'es-managed-bulk-agentless-output': {
+      id: 'es-managed-bulk-agentless-output',
+      is_default: false,
+      is_default_monitoring: false,
+      name: 'Bulk output for managed integrations',
+      // @ts-ignore
+      type: 'elasticsearch',
+      hosts: ['https://managed-otlp.example.invalid:443/_es'],
+      is_internal: true,
+      is_preconfigured: true,
+    },
+    // SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID — literal required inside jest.mock factory
+    'es-managed-bulk-agentless-output-internal': {
+      id: 'es-managed-bulk-agentless-output-internal',
+      is_default: false,
+      is_default_monitoring: false,
+      name: 'Bulk output for managed integrations (serverless)',
+      // @ts-ignore
+      type: 'elasticsearch',
+      hosts: ['https://managed-otlp-internal.example.invalid:443/_es'],
+      is_internal: true,
+      is_preconfigured: true,
     },
   };
   return {
@@ -1666,6 +1694,97 @@ describe('getFullAgentPolicy', () => {
         },
       },
     });
+  });
+
+  it('should emit only the apm applications block for the ECH managed bulk output', async () => {
+    const bulkOutput = {
+      id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+      is_default: false,
+      is_default_monitoring: false,
+      name: 'Bulk output for managed integrations',
+      type: 'elasticsearch' as const,
+      hosts: ['https://managed-otlp.example.invalid:443/_es'],
+    };
+    mockedFetchRelatedSavedObjects.mockResolvedValue({
+      outputs: [bulkOutput],
+      proxies: [],
+      dataOutput: bulkOutput,
+      monitoringOutput: bulkOutput,
+      downloadSource: {
+        id: 'default-download-source-id',
+        is_default: true,
+        name: 'Default host',
+        host: 'http://default-registry.co',
+      },
+      downloadSourceProxy: undefined,
+      fleetServerHost: {
+        name: 'default Fleet Server',
+        id: '93f74c0-e876-11ea-b7d3-8b2acec6f75c',
+        is_default: true,
+        host_urls: ['http://fleetserver:8220'],
+        is_preconfigured: false,
+      },
+    });
+    mockAgentPolicy({ data_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID });
+
+    const agentPolicy = await getFullAgentPolicy(createSavedObjectClientMock(), 'agent-policy');
+
+    expect(agentPolicy?.output_permissions).toEqual({
+      [ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID]: {
+        _managed_bulk_apm: {
+          applications: [{ application: 'apm', privileges: ['event:write'], resources: ['*'] }],
+        },
+      },
+    });
+    expect(
+      agentPolicy?.output_permissions?.[ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID]?._managed_bulk_apm
+    ).not.toHaveProperty('indices');
+  });
+
+  it('should emit only the apm applications block for the serverless managed bulk output', async () => {
+    const bulkOutput = {
+      id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+      is_default: false,
+      is_default_monitoring: false,
+      name: 'Bulk output for managed integrations (serverless)',
+      type: 'elasticsearch' as const,
+      hosts: ['https://managed-otlp-internal.example.invalid:443/_es'],
+    };
+    mockedFetchRelatedSavedObjects.mockResolvedValue({
+      outputs: [bulkOutput],
+      proxies: [],
+      dataOutput: bulkOutput,
+      monitoringOutput: bulkOutput,
+      downloadSource: {
+        id: 'default-download-source-id',
+        is_default: true,
+        name: 'Default host',
+        host: 'http://default-registry.co',
+      },
+      downloadSourceProxy: undefined,
+      fleetServerHost: {
+        name: 'default Fleet Server',
+        id: '93f74c0-e876-11ea-b7d3-8b2acec6f75c',
+        is_default: true,
+        host_urls: ['http://fleetserver:8220'],
+        is_preconfigured: false,
+      },
+    });
+    mockAgentPolicy({ data_output_id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID });
+
+    const agentPolicy = await getFullAgentPolicy(createSavedObjectClientMock(), 'agent-policy');
+
+    expect(agentPolicy?.output_permissions).toEqual({
+      [SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID]: {
+        _managed_bulk_apm: {
+          applications: [{ application: 'apm', privileges: ['event:write'], resources: ['*'] }],
+        },
+      },
+    });
+    expect(
+      agentPolicy?.output_permissions?.[SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID]
+        ?._managed_bulk_apm
+    ).not.toHaveProperty('indices');
   });
 
   it('should return a policy with advanced settings', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -124,7 +124,6 @@ jest.mock('../output', () => {
       hosts: ['http://127.0.0.1:9201'],
       write_to_logs_streams: true,
     },
-    // ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID — literal required inside jest.mock factory
     'es-managed-bulk-agentless-output': {
       id: 'es-managed-bulk-agentless-output',
       is_default: false,
@@ -136,7 +135,6 @@ jest.mock('../output', () => {
       is_internal: true,
       is_preconfigured: true,
     },
-    // SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID — literal required inside jest.mock factory
     'es-managed-bulk-agentless-output-internal': {
       id: 'es-managed-bulk-agentless-output-internal',
       is_default: false,
@@ -1697,9 +1695,6 @@ describe('getFullAgentPolicy', () => {
   });
 
   it('should emit only the apm applications block for the ECH managed bulk output', async () => {
-    // Stub cloud so isManagedBulkEnabled() + getManagedBulkEndpoint() resolve the ECH endpoint.
-    // The persisted host has an explicit port (normalizeHostsForAgents adds :443); the matcher
-    // compares on hostname only, so 'managed-otlp.example.invalid/_es' matches ':443/_es'. ✓
     jest.spyOn(appContextService, 'getCloud').mockReturnValue({
       managedOtlp: { url: 'https://managed-otlp.example.invalid' },
     } as any);
@@ -1757,9 +1752,6 @@ describe('getFullAgentPolicy', () => {
   });
 
   it('should emit only the apm applications block for the serverless managed bulk output, matched via the config-injected endpoint', async () => {
-    // Stub config so the serverless bulk output (injected via xpack.fleet.outputs by
-    // project-controller) appears in getPreconfiguredOutputFromConfig and its hostname is
-    // added to the matcher's set. No cloud stub needed — the serverless path is config-only.
     jest.spyOn(appContextService, 'getConfig').mockReturnValue({
       agents: { enabled: true, elasticsearch: {} },
       enabled: true,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -1737,7 +1737,10 @@ describe('getFullAgentPolicy', () => {
         is_preconfigured: false,
       },
     });
-    mockAgentPolicy({ data_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID });
+    mockAgentPolicy({
+      supports_agentless: true,
+      data_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+    });
 
     const agentPolicy = await getFullAgentPolicy(createSavedObjectClientMock(), 'agent-policy');
 
@@ -1801,7 +1804,10 @@ describe('getFullAgentPolicy', () => {
         is_preconfigured: false,
       },
     });
-    mockAgentPolicy({ data_output_id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID });
+    mockAgentPolicy({
+      supports_agentless: true,
+      data_output_id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+    });
 
     const agentPolicy = await getFullAgentPolicy(createSavedObjectClientMock(), 'agent-policy');
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -1697,6 +1697,18 @@ describe('getFullAgentPolicy', () => {
   });
 
   it('should emit only the apm applications block for the ECH managed bulk output', async () => {
+    // Stub cloud so isManagedBulkEnabled() + getManagedBulkEndpoint() resolve the ECH endpoint.
+    // The persisted host has an explicit port (normalizeHostsForAgents adds :443); the matcher
+    // compares on hostname only, so 'managed-otlp.example.invalid/_es' matches ':443/_es'. ✓
+    jest.spyOn(appContextService, 'getCloud').mockReturnValue({
+      managedOtlp: { url: 'https://managed-otlp.example.invalid' },
+    } as any);
+    jest.spyOn(appContextService, 'getConfig').mockReturnValue({
+      agents: { enabled: true, elasticsearch: {} },
+      enabled: true,
+      agentless: { managedBulk: { enabled: true } },
+    } as any);
+
     const bulkOutput = {
       id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
       is_default: false,
@@ -1741,7 +1753,26 @@ describe('getFullAgentPolicy', () => {
     ).not.toHaveProperty('indices');
   });
 
-  it('should emit only the apm applications block for the serverless managed bulk output', async () => {
+  it('should emit only the apm applications block for the serverless managed bulk output, matched via the config-injected endpoint', async () => {
+    // Stub config so the serverless bulk output (injected via xpack.fleet.outputs by
+    // project-controller) appears in getPreconfiguredOutputFromConfig and its hostname is
+    // added to the matcher's set. No cloud stub needed — the serverless path is config-only.
+    jest.spyOn(appContextService, 'getConfig').mockReturnValue({
+      agents: { enabled: true, elasticsearch: {} },
+      enabled: true,
+      outputs: [
+        {
+          id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+          name: 'Bulk output for managed integrations (serverless)',
+          type: 'elasticsearch' as const,
+          hosts: ['https://managed-otlp-internal.example.invalid:443/_es'],
+          is_default: false,
+          is_default_monitoring: false,
+          is_preconfigured: true,
+        },
+      ],
+    } as any);
+
     const bulkOutput = {
       id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
       is_default: false,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -42,9 +42,8 @@ import {
   OTEL_COLLECTOR_INPUT_TYPE,
   outputType,
   PACKAGE_POLICY_DEFAULT_INDEX_PRIVILEGES,
-  ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
-  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
 } from '../../../common/constants';
+import { createManagedBulkOutputMatcher } from '../preconfiguration/outputs';
 import { getSettingsValuesForAgentPolicy } from '../form_settings';
 import { getPackageInfo } from '../epm/packages';
 import { pkgToPkgKey, splitPkgKey } from '../epm/registry';
@@ -344,6 +343,8 @@ export async function getFullAgentPolicy(
     cluster: DEFAULT_CLUSTER_PERMISSIONS,
   };
 
+  const isManagedBulkOutput = createManagedBulkOutputMatcher(appContextService.getConfig());
+
   // Only add permissions if output.type is "elasticsearch"
   fullAgentPolicy.output_permissions = Object.keys(fullAgentPolicy.outputs).reduce<
     NonNullable<FullAgentPolicy['output_permissions']>
@@ -353,10 +354,9 @@ export async function getFullAgentPolicy(
       output &&
       (output.type === outputType.Elasticsearch || output.type === outputType.RemoteElasticsearch)
     ) {
-      if (
-        outputId === ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID ||
-        outputId === SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID
-      ) {
+      const originalOutput = outputs.find((o) => getOutputIdForAgentPolicy(o) === outputId);
+
+      if (originalOutput && isManagedBulkOutput(originalOutput)) {
         outputPermissions[outputId] = {
           _managed_bulk_apm: {
             applications: [
@@ -380,7 +380,6 @@ export async function getFullAgentPolicy(
       }
 
       // Add logs-* permissions for outputs with write_to_streams enabled
-      const originalOutput = outputs.find((o) => getOutputIdForAgentPolicy(o) === outputId);
       if (originalOutput?.write_to_logs_streams) {
         const streamsPermissions = {
           _write_to_logs_streams: {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -356,7 +356,7 @@ export async function getFullAgentPolicy(
     ) {
       const originalOutput = outputs.find((o) => getOutputIdForAgentPolicy(o) === outputId);
 
-      if (originalOutput && isManagedBulkOutput(originalOutput)) {
+      if (agentPolicy.supports_agentless && originalOutput && isManagedBulkOutput(originalOutput)) {
         outputPermissions[outputId] = {
           _managed_bulk_apm: {
             applications: [

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -9,6 +9,7 @@ import type { SavedObjectsClientContract } from '@kbn/core/server';
 import { parse } from 'yaml';
 import deepMerge from 'deepmerge';
 import { set } from '@kbn/safer-lodash-set';
+import { PrivilegeType } from '@kbn/apm-types';
 
 import {
   getDefaultPresetForEsOutput,
@@ -34,12 +35,15 @@ import type {
   PackageInfo,
 } from '../../../common/types';
 import { agentPolicyService } from '../agent_policy';
+
 import {
   dataTypes,
   kafkaCompressionType,
   OTEL_COLLECTOR_INPUT_TYPE,
   outputType,
   PACKAGE_POLICY_DEFAULT_INDEX_PRIVILEGES,
+  ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
 } from '../../../common/constants';
 import { getSettingsValuesForAgentPolicy } from '../form_settings';
 import { getPackageInfo } from '../epm/packages';
@@ -349,6 +353,20 @@ export async function getFullAgentPolicy(
       output &&
       (output.type === outputType.Elasticsearch || output.type === outputType.RemoteElasticsearch)
     ) {
+      if (
+        outputId === ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID ||
+        outputId === SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID
+      ) {
+        outputPermissions[outputId] = {
+          _managed_bulk_apm: {
+            applications: [
+              { application: 'apm', privileges: [PrivilegeType.EVENT], resources: ['*'] },
+            ],
+          },
+        };
+        return outputPermissions;
+      }
+
       const permissions: FullAgentPolicyOutputPermissions = {};
       if (outputId === getOutputIdForAgentPolicy(monitoringOutput)) {
         Object.assign(permissions, monitoringPermissions);

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/output_helpers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/output_helpers.test.ts
@@ -262,10 +262,12 @@ describe('validateOutputForPolicy managed bulk guard', () => {
   it('should reject a non-agentless policy setting data_output_id to the ECH managed bulk output', async () => {
     mockHasLicence(true);
     await expect(
-      validateOutputForPolicy(savedObjectsClientMock.create(), {
-        data_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
-        monitoring_output_id: null,
-      })
+      validateOutputForPolicy(
+        savedObjectsClientMock.create(),
+        { data_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID, monitoring_output_id: null },
+        {},
+        BEATS_OUTPUT_TYPES
+      )
     ).rejects.toThrow(
       `Output "${ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID}" can only be used with an agentless agent policy.`
     );
@@ -274,10 +276,12 @@ describe('validateOutputForPolicy managed bulk guard', () => {
   it('should reject a non-agentless policy setting monitoring_output_id to the serverless managed bulk output', async () => {
     mockHasLicence(true);
     await expect(
-      validateOutputForPolicy(savedObjectsClientMock.create(), {
-        data_output_id: null,
-        monitoring_output_id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
-      })
+      validateOutputForPolicy(
+        savedObjectsClientMock.create(),
+        { data_output_id: null, monitoring_output_id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID },
+        {},
+        BEATS_OUTPUT_TYPES
+      )
     ).rejects.toThrow(
       `Output "${SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID}" can only be used with an agentless agent policy.`
     );
@@ -285,11 +289,16 @@ describe('validateOutputForPolicy managed bulk guard', () => {
 
   it('should allow an agentless policy to use the managed bulk output via newData', async () => {
     mockHasLicence(true);
-    await validateOutputForPolicy(savedObjectsClientMock.create(), {
-      supports_agentless: true,
-      data_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
-      monitoring_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
-    });
+    await validateOutputForPolicy(
+      savedObjectsClientMock.create(),
+      {
+        supports_agentless: true,
+        data_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+        monitoring_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+      },
+      {},
+      BEATS_OUTPUT_TYPES
+    );
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/output_helpers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/output_helpers.test.ts
@@ -9,7 +9,11 @@ import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 
 import { securityMock } from '@kbn/security-plugin/server/mocks';
 
-import { BEATS_OUTPUT_TYPES } from '../../../common/constants';
+import {
+  BEATS_OUTPUT_TYPES,
+  ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+} from '../../../common/constants';
 import { appContextService } from '..';
 import { outputService } from '../output';
 
@@ -250,6 +254,41 @@ describe('validateOutputForPolicy', () => {
         { data_output_id: 'newdataoutput', monitoring_output_id: 'test1' },
         ['logstash', 'elasticsearch']
       );
+    });
+  });
+});
+
+describe('validateOutputForPolicy managed bulk guard', () => {
+  it('should reject a non-agentless policy setting data_output_id to the ECH managed bulk output', async () => {
+    mockHasLicence(true);
+    await expect(
+      validateOutputForPolicy(savedObjectsClientMock.create(), {
+        data_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+        monitoring_output_id: null,
+      })
+    ).rejects.toThrow(
+      `Output "${ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID}" can only be used with an agentless agent policy.`
+    );
+  });
+
+  it('should reject a non-agentless policy setting monitoring_output_id to the serverless managed bulk output', async () => {
+    mockHasLicence(true);
+    await expect(
+      validateOutputForPolicy(savedObjectsClientMock.create(), {
+        data_output_id: null,
+        monitoring_output_id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+      })
+    ).rejects.toThrow(
+      `Output "${SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID}" can only be used with an agentless agent policy.`
+    );
+  });
+
+  it('should allow an agentless policy to use the managed bulk output via newData', async () => {
+    mockHasLicence(true);
+    await validateOutputForPolicy(savedObjectsClientMock.create(), {
+      supports_agentless: true,
+      data_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+      monitoring_output_id: ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/outputs_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/outputs_helpers.ts
@@ -57,14 +57,6 @@ export async function validateOutputForPolicy(
 ) {
   const data = { ...existingData, ...newData };
 
-  if (
-    Object.keys(existingData).length !== 0 &&
-    newData.data_output_id === existingData.data_output_id &&
-    newData.monitoring_output_id === existingData.monitoring_output_id
-  ) {
-    return;
-  }
-
   if (!data.supports_agentless) {
     const managedBulkOutputId = [data.data_output_id, data.monitoring_output_id].find(
       (outputId) => outputId && AGENTLESS_MANAGED_BULK_OUTPUT_IDS.has(outputId)
@@ -74,6 +66,14 @@ export async function validateOutputForPolicy(
         `Output "${managedBulkOutputId}" can only be used with an agentless agent policy.`
       );
     }
+  }
+
+  if (
+    Object.keys(existingData).length !== 0 &&
+    newData.data_output_id === existingData.data_output_id &&
+    newData.monitoring_output_id === existingData.monitoring_output_id
+  ) {
+    return;
   }
 
   const dataOutput = await getDataOutputForAgentPolicy(soClient, data).catch((err) => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/outputs_helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/outputs_helpers.ts
@@ -13,7 +13,10 @@ import {
 } from '../../../common/services/output_helpers';
 
 import type { AgentPolicySOAttributes, AgentPolicy, PackagePolicy } from '../../types';
-import { LICENCE_FOR_PER_POLICY_OUTPUT } from '../../../common/constants';
+import {
+  LICENCE_FOR_PER_POLICY_OUTPUT,
+  AGENTLESS_MANAGED_BULK_OUTPUT_IDS,
+} from '../../../common/constants';
 import { policyHasFleetServer, policyHasSyntheticsIntegration } from '../../../common/services';
 import { appContextService } from '..';
 import { outputService } from '../output';
@@ -52,6 +55,8 @@ export async function validateOutputForPolicy(
   existingData: Partial<AgentPolicySOAttributes> = {},
   allowedOutputTypeForPolicy: string[]
 ) {
+  const data = { ...existingData, ...newData };
+
   if (
     Object.keys(existingData).length !== 0 &&
     newData.data_output_id === existingData.data_output_id &&
@@ -60,7 +65,16 @@ export async function validateOutputForPolicy(
     return;
   }
 
-  const data = { ...existingData, ...newData };
+  if (!data.supports_agentless) {
+    const managedBulkOutputId = [data.data_output_id, data.monitoring_output_id].find(
+      (outputId) => outputId && AGENTLESS_MANAGED_BULK_OUTPUT_IDS.has(outputId)
+    );
+    if (managedBulkOutputId) {
+      throw new OutputInvalidError(
+        `Output "${managedBulkOutputId}" can only be used with an agentless agent policy.`
+      );
+    }
+  }
 
   const dataOutput = await getDataOutputForAgentPolicy(soClient, data).catch((err) => {
     if (err instanceof OutputNotFoundError) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.test.ts
@@ -1631,8 +1631,6 @@ describe('createManagedBulkOutputMatcher', () => {
   });
 
   it('matches the ECH bulk output on hostname, ignoring the port added by normalizeHostsForAgents', () => {
-    // getManagedBulkEndpoint yields '…/_es' without a port; normalizeHostsForAgents adds :443
-    // before persisting, so the saved host is '…:443/_es'. Hostname comparison dissolves that.
     (appContextService.getCloud as jest.Mock).mockReturnValue({
       managedOtlp: { url: 'https://managed-otlp.example.invalid' },
     });

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.test.ts
@@ -13,11 +13,16 @@ import type { Output } from '../../types';
 import * as agentPolicy from '../agent_policy';
 import { outputService } from '../output';
 
-import { SERVERLESS_DEFAULT_OUTPUT_ID, SERVERLESS_PRIVATE_OUTPUT_ID } from '../../constants';
+import {
+  SERVERLESS_DEFAULT_OUTPUT_ID,
+  SERVERLESS_PRIVATE_OUTPUT_ID,
+  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+} from '../../constants';
 
 import {
   createOrUpdatePreconfiguredOutputs,
   cleanPreconfiguredOutputs,
+  createManagedBulkOutputMatcher,
   getPreconfiguredOutputFromConfig,
   hashSecret,
 } from './outputs';
@@ -1613,5 +1618,146 @@ describe('Outputs preconfiguration', () => {
         );
       });
     });
+  });
+});
+
+describe('createManagedBulkOutputMatcher', () => {
+  beforeEach(() => {
+    (appContextService.getCloud as jest.Mock).mockReturnValue(null);
+    (appContextService.getConfig as jest.Mock).mockReturnValue({
+      agents: { enabled: true, elasticsearch: {} },
+      enabled: true,
+    });
+  });
+
+  it('matches the ECH bulk output on hostname, ignoring the port added by normalizeHostsForAgents', () => {
+    // getManagedBulkEndpoint yields '…/_es' without a port; normalizeHostsForAgents adds :443
+    // before persisting, so the saved host is '…:443/_es'. Hostname comparison dissolves that.
+    (appContextService.getCloud as jest.Mock).mockReturnValue({
+      managedOtlp: { url: 'https://managed-otlp.example.invalid' },
+    });
+    (appContextService.getConfig as jest.Mock).mockReturnValue({
+      agents: { enabled: true, elasticsearch: {} },
+      enabled: true,
+      agentless: { managedBulk: { enabled: true } },
+    });
+
+    const isManagedBulk = createManagedBulkOutputMatcher(appContextService.getConfig());
+
+    expect(
+      isManagedBulk({
+        type: 'elasticsearch',
+        hosts: ['https://managed-otlp.example.invalid:443/_es'],
+      })
+    ).toBe(true);
+  });
+
+  it('matches the serverless bulk output via the config-injected endpoint, with no cloud stub needed', () => {
+    (appContextService.getConfig as jest.Mock).mockReturnValue({
+      agents: { enabled: true, elasticsearch: {} },
+      enabled: true,
+      outputs: [
+        {
+          id: SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+          type: 'elasticsearch',
+          hosts: ['https://managed-otlp-internal.example.invalid:443/_es'],
+          is_default: false,
+          is_default_monitoring: false,
+          is_preconfigured: true,
+        },
+      ],
+    });
+
+    const isManagedBulk = createManagedBulkOutputMatcher(appContextService.getConfig());
+
+    expect(
+      isManagedBulk({
+        type: 'elasticsearch',
+        hosts: ['https://managed-otlp-internal.example.invalid:443/_es'],
+      })
+    ).toBe(true);
+  });
+
+  it('does not match a non-elasticsearch output type, even when the host matches', () => {
+    (appContextService.getCloud as jest.Mock).mockReturnValue({
+      managedOtlp: { url: 'https://managed-otlp.example.invalid' },
+    });
+    (appContextService.getConfig as jest.Mock).mockReturnValue({
+      agents: { enabled: true, elasticsearch: {} },
+      enabled: true,
+      agentless: { managedBulk: { enabled: true } },
+    });
+
+    const isManagedBulk = createManagedBulkOutputMatcher(appContextService.getConfig());
+
+    expect(
+      isManagedBulk({
+        type: 'remote_elasticsearch',
+        hosts: ['https://managed-otlp.example.invalid:443/_es'],
+      })
+    ).toBe(false);
+  });
+
+  it('does not match a direct-ES output on a different host', () => {
+    (appContextService.getCloud as jest.Mock).mockReturnValue({
+      managedOtlp: { url: 'https://managed-otlp.example.invalid' },
+    });
+    (appContextService.getConfig as jest.Mock).mockReturnValue({
+      agents: { enabled: true, elasticsearch: {} },
+      enabled: true,
+      agentless: { managedBulk: { enabled: true } },
+    });
+
+    const isManagedBulk = createManagedBulkOutputMatcher(appContextService.getConfig());
+
+    expect(
+      isManagedBulk({ type: 'elasticsearch', hosts: ['https://es.example.invalid:9200'] })
+    ).toBe(false);
+  });
+
+  it('does not match when the output has no hosts', () => {
+    (appContextService.getCloud as jest.Mock).mockReturnValue({
+      managedOtlp: { url: 'https://managed-otlp.example.invalid' },
+    });
+    (appContextService.getConfig as jest.Mock).mockReturnValue({
+      agents: { enabled: true, elasticsearch: {} },
+      enabled: true,
+      agentless: { managedBulk: { enabled: true } },
+    });
+
+    const isManagedBulk = createManagedBulkOutputMatcher(appContextService.getConfig());
+
+    expect(isManagedBulk({ type: 'elasticsearch', hosts: undefined })).toBe(false);
+  });
+
+  it('returns false for all outputs and does not throw when config is undefined', () => {
+    const isManagedBulk = createManagedBulkOutputMatcher(undefined);
+
+    expect(
+      isManagedBulk({
+        type: 'elasticsearch',
+        hosts: ['https://managed-otlp.example.invalid:443/_es'],
+      })
+    ).toBe(false);
+  });
+
+  it('returns false and does not throw when cloud.managed_otlp.url is a malformed non-URL string', () => {
+    (appContextService.getCloud as jest.Mock).mockReturnValue({
+      managedOtlp: { url: 'not-a-url' },
+    });
+    (appContextService.getConfig as jest.Mock).mockReturnValue({
+      agents: { enabled: true, elasticsearch: {} },
+      enabled: true,
+      agentless: { managedBulk: { enabled: true } },
+    });
+
+    const isManagedBulk = createManagedBulkOutputMatcher(appContextService.getConfig());
+
+    expect(() =>
+      isManagedBulk({ type: 'elasticsearch', hosts: ['https://something.example.invalid'] })
+    ).not.toThrow();
+    expect(
+      isManagedBulk({ type: 'elasticsearch', hosts: ['https://something.example.invalid'] })
+    ).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
@@ -31,11 +31,10 @@ import {
   DEFAULT_OUTPUT,
   ECH_AGENTLESS_OUTPUT_ID,
   ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
-  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
   SERVERLESS_DEFAULT_OUTPUT_ID,
   SERVERLESS_PRIVATE_OUTPUT_ID,
 } from '../../constants';
-import { outputType } from '../../../common/constants';
+import { AGENTLESS_MANAGED_BULK_OUTPUT_IDS, outputType } from '../../../common/constants';
 import { outputService } from '../output';
 import { agentPolicyService } from '../agent_policy';
 import { appContextService } from '../app_context';
@@ -144,11 +143,6 @@ export function getPreconfiguredOutputFromConfig(config?: FleetConfigType) {
   });
 }
 
-const MANAGED_BULK_OUTPUT_IDS: ReadonlySet<string> = new Set([
-  ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
-  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
-]);
-
 /**
  * Builds a predicate matching outputs that route through HOTel's managed `_bulk` gateway,
  * comparing on hostname only so host normalization (explicit ports, trailing slashes) can't
@@ -157,7 +151,7 @@ const MANAGED_BULK_OUTPUT_IDS: ReadonlySet<string> = new Set([
 export const createManagedBulkOutputMatcher = (config?: FleetConfigType) => {
   const managedBulkHostnames = new Set(
     (config ? getPreconfiguredOutputFromConfig(config) : [])
-      .filter(({ id }) => MANAGED_BULK_OUTPUT_IDS.has(id))
+      .filter(({ id }) => AGENTLESS_MANAGED_BULK_OUTPUT_IDS.has(id))
       .flatMap(({ hosts }) => hosts ?? [])
       .flatMap((host) => {
         try {

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
@@ -31,9 +31,11 @@ import {
   DEFAULT_OUTPUT,
   ECH_AGENTLESS_OUTPUT_ID,
   ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
   SERVERLESS_DEFAULT_OUTPUT_ID,
   SERVERLESS_PRIVATE_OUTPUT_ID,
 } from '../../constants';
+import { outputType } from '../../../common/constants';
 import { outputService } from '../output';
 import { agentPolicyService } from '../agent_policy';
 import { appContextService } from '../app_context';
@@ -141,6 +143,43 @@ export function getPreconfiguredOutputFromConfig(config?: FleetConfigType) {
     return { ...output, allow_edit: merged };
   });
 }
+
+const MANAGED_BULK_OUTPUT_IDS: ReadonlySet<string> = new Set([
+  ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+  SERVERLESS_AGENTLESS_MANAGED_BULK_OUTPUT_ID,
+]);
+
+/**
+ * Builds a predicate matching outputs that route through HOTel's managed `_bulk` gateway,
+ * comparing on hostname only so host normalization (explicit ports, trailing slashes) can't
+ * cause a miss. Interim until ingest-dev#8489 replaces this with Streams-scoped ingest API keys.
+ */
+export const createManagedBulkOutputMatcher = (config?: FleetConfigType) => {
+  const managedBulkHostnames = new Set(
+    (config ? getPreconfiguredOutputFromConfig(config) : [])
+      .filter(({ id }) => MANAGED_BULK_OUTPUT_IDS.has(id))
+      .flatMap(({ hosts }) => hosts ?? [])
+      .flatMap((host) => {
+        try {
+          return [new URL(host).hostname];
+        } catch {
+          // cloud.managed_otlp.url is only schema.string(); never throw on the full-policy path
+          return [];
+        }
+      })
+  );
+
+  return ({ type, hosts }: Pick<Output, 'type' | 'hosts'>) =>
+    type === outputType.Elasticsearch &&
+    (hosts?.some((host) => {
+      try {
+        return managedBulkHostnames.has(new URL(host).hostname);
+      } catch {
+        return false;
+      }
+    }) ??
+      false);
+};
 
 export async function ensurePreconfiguredOutputs(
   soClient: SavedObjectsClientContract,

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
@@ -144,18 +144,16 @@ export function getPreconfiguredOutputFromConfig(config?: FleetConfigType) {
 }
 
 /**
- * Builds a predicate matching outputs that route through HOTel's managed `_bulk` gateway,
- * comparing on hostname only so host normalization (explicit ports, trailing slashes) can't
- * cause a miss. Interim until ingest-dev#8489 replaces this with Streams-scoped ingest API keys.
+ * Builds a predicate matching outputs that route through HOTel's managed `_bulk` gateway.
  */
 export const createManagedBulkOutputMatcher = (config?: FleetConfigType) => {
-  const managedBulkHostnames = new Set(
+  const managedBulkUrls = new Set(
     (config ? getPreconfiguredOutputFromConfig(config) : [])
       .filter(({ id }) => AGENTLESS_MANAGED_BULK_OUTPUT_IDS.has(id))
       .flatMap(({ hosts }) => hosts ?? [])
       .flatMap((host) => {
         try {
-          return [new URL(host).hostname];
+          return [normalizeHostsForAgents(host)];
         } catch {
           // cloud.managed_otlp.url is only schema.string(); never throw on the full-policy path
           return [];
@@ -165,14 +163,7 @@ export const createManagedBulkOutputMatcher = (config?: FleetConfigType) => {
 
   return ({ type, hosts }: Pick<Output, 'type' | 'hosts'>) =>
     type === outputType.Elasticsearch &&
-    (hosts?.some((host) => {
-      try {
-        return managedBulkHostnames.has(new URL(host).hostname);
-      } catch {
-        return false;
-      }
-    }) ??
-      false);
+    (hosts?.some((host) => managedBulkUrls.has(host)) ?? false);
 };
 
 export async function ensurePreconfiguredOutputs(

--- a/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/preconfiguration/outputs.ts
@@ -144,7 +144,7 @@ export function getPreconfiguredOutputFromConfig(config?: FleetConfigType) {
 }
 
 /**
- * Builds a predicate matching outputs that route through HOTel's managed `_bulk` gateway.
+ * Builds a predicate matching outputs that route through the managed `_bulk` endpoint.
  */
 export const createManagedBulkOutputMatcher = (config?: FleetConfigType) => {
   const managedBulkUrls = new Set(

--- a/x-pack/platform/plugins/shared/fleet/server/types/so_attributes.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/so_attributes.ts
@@ -83,6 +83,7 @@ export interface AgentPolicySOAttributes {
   agents?: number;
   overrides?: any | null;
   global_data_tags?: Array<{ name: string; value: string | number }>;
+  supports_agentless?: boolean | null;
   agentless?: AgentlessAgentPolicyConfig;
   version?: string;
   has_agent_version_conditions?: boolean;

--- a/x-pack/platform/test/fleet_api_integration/apis/managed_inputs/managed_bulk_output.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/managed_inputs/managed_bulk_output.ts
@@ -98,6 +98,43 @@ export default function (providerContext: FtrProviderContext) {
       expect(agentPolicy.item.monitoring_output_id).to.be(ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID);
     });
 
+    it('should emit only the apm applications block in output_permissions for a managed bulk policy', async () => {
+      const id = uuidv4();
+
+      const policy = await apiClient.createAgentlessPolicy({
+        id,
+        package: {
+          name: 'test_agentless',
+          version: '1.0.0',
+        },
+        name: `test_agentless-bulk-permissions-${Date.now()}`,
+        description: 'test agentless managed bulk permissions',
+        namespace: 'default',
+        inputs: {
+          'sample-httpjson': {
+            enabled: true,
+            vars: {
+              api_key: 'TEST_VALUE_API_KEY',
+            },
+            streams: {},
+          },
+        },
+      });
+
+      const { body: fullPolicy } = await supertest
+        .get(`/api/fleet/agent_policies/${policy.item.id}/full`)
+        .expect(200);
+
+      const outputPerms = fullPolicy.item.output_permissions;
+      const bulkPerms = outputPerms?.[ECH_AGENTLESS_MANAGED_BULK_OUTPUT_ID];
+
+      expect(bulkPerms).to.be.ok();
+      expect(bulkPerms._managed_bulk_apm).to.eql({
+        applications: [{ application: 'apm', privileges: ['event:write'], resources: ['*'] }],
+      });
+      expect(bulkPerms._managed_bulk_apm).not.to.have.key('indices');
+    });
+
     it('should keep an OTel agentless policy on the direct-ES output', async () => {
       const id = uuidv4();
 


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/ingest-dev/issues/8997
Depends on: https://github.com/elastic/elasticsearch/pull/155890

- Adds `output_permissions` declaration for agentless policies using managed bulk
   - Requests APM event:write
- Add guarding do not allow agentless managed bulk outputs on non-agentless policies

## Testing

- Go to the cloud deployment of this test PR that enables the feature: https://github.com/elastic/kibana/pull/285715
- Observe the logging data generated from the `Elastic Managed Hello World` integration
- Verify the expected output is on the agentless policy with:
```
GET kbn:/api/fleet/agent_policies/<policy-id>/full
```
     
- Should see `elasticsearch` output `es-managed-bulk-agentless-output-internal` with host like `https://<project-id>.ingest.<provider-region>.elastic.cloud:443/_es`
- Output permissions 

```
{
      "es-managed-bulk-agentless-output-internal": {
        "_managed_bulk_apm": {
          "applications": [
            {
              "application": "apm",
              "privileges": [
                "event:write"
              ],
              "resources": [
                "*"
              ]
            }
          ]
        }
      }
    },
```

- Log data in the data_stream.dataset `agentless_hello_world.generic`


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



