### PR TITLE
[Security Solution] Support event-type scoping for process-descendant event filters

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/artifacts/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/artifacts/constants.ts
@@ -21,6 +21,33 @@ export const FILTER_PROCESS_DESCENDANTS_TAG = 'filter_process_descendants';
 /** The tag name for process descendants in trusted apps */
 export const TRUSTED_PROCESS_DESCENDANTS_TAG = 'trust_process_descendants';
 
+/**
+ * The tag prefix that narrows a process descendants event filter down to a set of event
+ * categories, e.g. `descendant_event_scope:file,library`. Only meaningful together with
+ * `FILTER_PROCESS_DESCENDANTS_TAG`. When absent, events of every category produced by the
+ * descendants are filtered (the original, all-or-nothing behaviour).
+ */
+export const DESCENDANT_EVENT_SCOPE_TAG_PREFIX = 'descendant_event_scope:';
+
+/**
+ * The event categories a process descendants event filter can be scoped to.
+ *
+ * NOTE: the order of this array is the canonical order used when emitting the scope into an
+ * artifact, so that the very same scope always produces the very same artifact hash.
+ */
+export const DESCENDANT_EVENT_SCOPE_CATEGORIES = Object.freeze([
+  'api',
+  'dns',
+  'file',
+  'library',
+  'network',
+  'process',
+  'registry',
+  'security',
+] as const);
+
+export type DescendantEventScopeCategory = (typeof DESCENDANT_EVENT_SCOPE_CATEGORIES)[number];
+
 /** The tag prefix that tracks the space(s) that is considered the "owner" of the artifact.  */
 export const OWNER_SPACE_ID_TAG_PREFIX = 'ownerSpaceId:';
 

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/artifacts/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/artifacts/index.ts
@@ -11,12 +11,22 @@ export {
   getPolicyIdsFromArtifact,
   getEffectedPolicySelectionByTags,
   getArtifactTagsByPolicySelection,
+  buildDescendantEventScopeEntry,
+  buildDescendantEventScopeTag,
+  getDescendantEventScope,
+  getDescendantEventScopeValues,
+  isDescendantEventScopeCategory,
+  isDescendantEventScopeTag,
 } from './utils';
 
 export {
   BY_POLICY_ARTIFACT_TAG_PREFIX,
   GLOBAL_ARTIFACT_TAG,
   ADVANCED_MODE_TAG,
+  DESCENDANT_EVENT_SCOPE_CATEGORIES,
+  DESCENDANT_EVENT_SCOPE_TAG_PREFIX,
   FILTER_PROCESS_DESCENDANTS_TAG,
   TRUSTED_PROCESS_DESCENDANTS_TAG,
 } from './constants';
+
+export type { DescendantEventScopeCategory } from './constants';

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/artifacts/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/artifacts/utils.test.ts
@@ -9,10 +9,15 @@ import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-t
 import type { PolicyData } from '../../types';
 import {
   BY_POLICY_ARTIFACT_TAG_PREFIX,
+  DESCENDANT_EVENT_SCOPE_TAG_PREFIX,
   FILTER_PROCESS_DESCENDANTS_TAG,
   GLOBAL_ARTIFACT_TAG,
 } from './constants';
 import {
+  buildDescendantEventScopeEntry,
+  buildDescendantEventScopeTag,
+  getDescendantEventScope,
+  isDescendantEventScopeTag,
   buildSpaceOwnerIdTag,
   createExceptionListItemForCreate,
   getArtifactOwnerSpaceIds,
@@ -238,6 +243,64 @@ describe('Endpoint artifact utilities', () => {
       setArtifactOwnerSpaceId(item, 'abc');
 
       expect(item).toEqual({ tags: [buildSpaceOwnerIdTag('abc')] });
+    });
+  });
+
+  describe('when using `buildDescendantEventScopeTag()`', () => {
+    it('should return an artifact tag', () => {
+      expect(buildDescendantEventScopeTag(['file'])).toEqual(
+        `${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}file`
+      );
+    });
+
+    it('should keep the event categories in a canonical order', () => {
+      expect(buildDescendantEventScopeTag(['network', 'file'])).toEqual(
+        buildDescendantEventScopeTag(['file', 'network'])
+      );
+    });
+
+    it('should skip unknown event categories', () => {
+      expect(buildDescendantEventScopeTag(['file', 'not-a-category'])).toEqual(
+        `${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}file`
+      );
+    });
+  });
+
+  describe('when using `isDescendantEventScopeTag()`', () => {
+    it.each`
+      name                     | tag                                           | expectedResult
+      ${'an event scope tag'}  | ${`${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}file`} | ${true}
+      ${'an empty scope tag'}  | ${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}          | ${true}
+      ${'the descendants tag'} | ${FILTER_PROCESS_DESCENDANTS_TAG}             | ${false}
+      ${'an unrelated tag'}    | ${'policy:all'}                               | ${false}
+    `('should return $expectedResult when tag is $name', ({ tag, expectedResult }) => {
+      expect(isDescendantEventScopeTag(tag)).toBe(expectedResult);
+    });
+  });
+
+  describe('when using `getDescendantEventScope()`', () => {
+    it.each`
+      name                                         | tags                                                                                                    | expectedResult
+      ${'empty array if no tags'}                  | ${{}}                                                                                                   | ${[]}
+      ${'empty array if no event scope tag'}       | ${{ tags: [FILTER_PROCESS_DESCENDANTS_TAG] }}                                                           | ${[]}
+      ${'empty array if no known category'}        | ${{ tags: [`${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}not-a-category`] }}                                     | ${[]}
+      ${'the event categories in tag'}             | ${{ tags: [`${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}file,library`] }}                                       | ${['file', 'library']}
+      ${'the event categories in canonical order'} | ${{ tags: [`${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}library, file`] }}                                      | ${['file', 'library']}
+      ${'the event categories of all tags'}        | ${{ tags: [`${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}library`, `${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}file`] }} | ${['file', 'library']}
+      ${'the known event categories only'}         | ${{ tags: [`${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}file,not-a-category`] }}                                | ${['file']}
+    `('should return $name', ({ tags, expectedResult }) => {
+      expect(getDescendantEventScope(tags)).toEqual(expectedResult);
+    });
+  });
+
+  describe('when using `buildDescendantEventScopeEntry()`', () => {
+    it('should return an exception item entry matching any of the event categories', () => {
+      expect(buildDescendantEventScopeEntry(['file', 'library'])).toEqual({
+        field: 'event.category',
+        operator: 'included',
+        type: 'match_any',
+        value: ['file', 'library'],
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/artifacts/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/artifacts/utils.ts
@@ -8,16 +8,21 @@
 import type {
   ExceptionListItemSchema,
   CreateExceptionListItemSchema,
+  EntryMatchAny,
 } from '@kbn/securitysolution-io-ts-list-types';
 import { v4 as uuidv4 } from 'uuid';
 import type { EffectedPolicySelection } from '../../../../public/management/components/effected_policy_select';
 import type { PolicyData } from '../../types';
+import type { DescendantEventScopeCategory } from './constants';
 import {
   BY_POLICY_ARTIFACT_TAG_PREFIX,
+  DESCENDANT_EVENT_SCOPE_CATEGORIES,
+  DESCENDANT_EVENT_SCOPE_TAG_PREFIX,
   FILTER_PROCESS_DESCENDANTS_TAG,
   GLOBAL_ARTIFACT_TAG,
   OWNER_SPACE_ID_TAG_PREFIX,
   ADVANCED_MODE_TAG,
+  PROCESS_DESCENDANT_EXTRA_ENTRY,
   TRUSTED_PROCESS_DESCENDANTS_TAG,
 } from './constants';
 
@@ -142,6 +147,81 @@ export const isFilterProcessDescendantsTag: TagFilter = (tag) =>
 /** Checks if the given tag is for filtering process descendants in trusted apps */
 export const isTrustedProcessDescendantsTag: TagFilter = (tag) =>
   tag === TRUSTED_PROCESS_DESCENDANTS_TAG;
+
+/** Checks if the given tag scopes a process descendants event filter to a set of event categories */
+export const isDescendantEventScopeTag: TagFilter = (tag) =>
+  tag.startsWith(DESCENDANT_EVENT_SCOPE_TAG_PREFIX);
+
+/** Checks if the given value is an event category a descendants event filter can be scoped to */
+export const isDescendantEventScopeCategory = (
+  value: string
+): value is DescendantEventScopeCategory =>
+  (DESCENDANT_EVENT_SCOPE_CATEGORIES as readonly string[]).includes(value);
+
+/**
+ * Builds the tag that stores the event categories a process descendants event filter applies to.
+ * Categories are stored in a canonical order so that the same selection always produces the same tag.
+ */
+export const buildDescendantEventScopeTag = (categories: readonly string[]): string => {
+  const canonicalCategories = DESCENDANT_EVENT_SCOPE_CATEGORIES.filter((category) =>
+    categories.includes(category)
+  );
+
+  return `${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}${canonicalCategories.join(',')}`;
+};
+
+/**
+ * Returns the raw, comma separated values found on the artifact's event scope tag(s), without
+ * checking them against the list of known event categories. Mostly useful for validation - use
+ * {@link getDescendantEventScope} to get the categories that are actually applied.
+ */
+export const getDescendantEventScopeValues = (
+  item: Partial<Pick<ExceptionListItemSchema, 'tags'>>
+): string[] => {
+  const values = new Set<string>();
+
+  for (const tag of item.tags ?? []) {
+    if (!isDescendantEventScopeTag(tag)) {
+      continue;
+    }
+
+    for (const value of tag.substring(DESCENDANT_EVENT_SCOPE_TAG_PREFIX.length).split(',')) {
+      const trimmedValue = value.trim();
+
+      if (trimmedValue !== '') {
+        values.add(trimmedValue);
+      }
+    }
+  }
+
+  return [...values];
+};
+
+/**
+ * Returns the event categories a process descendants artifact is scoped to, deduplicated and in a
+ * canonical order. An empty array means "every event category", which is the default behaviour.
+ */
+export const getDescendantEventScope = (
+  item: Partial<Pick<ExceptionListItemSchema, 'tags'>>
+): DescendantEventScopeCategory[] => {
+  const values = new Set(getDescendantEventScopeValues(item));
+
+  return DESCENDANT_EVENT_SCOPE_CATEGORIES.filter((category) => values.has(category));
+};
+
+/**
+ * Builds the exception item entry that narrows a process descendants artifact down to the given
+ * event categories. It is meant to be AND'ed with (i.e. emitted as a sibling of) the
+ * `descendent_of` condition, so that only these event categories get filtered out of the tree.
+ */
+export const buildDescendantEventScopeEntry = (
+  categories: readonly DescendantEventScopeCategory[]
+): EntryMatchAny => ({
+  field: PROCESS_DESCENDANT_EXTRA_ENTRY.field,
+  operator: 'included',
+  type: 'match_any',
+  value: [...categories],
+});
 
 export const createExceptionListItemForCreate = (listId: string): CreateExceptionListItemSchema => {
   return {

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -117,6 +117,13 @@ export const allowedExperimentalValues = Object.freeze({
   filterProcessDescendantsForTrustedAppsEnabled: false,
 
   /**
+   * Allows "filter process descendants" Event Filters to only apply to a subset of the event
+   * categories produced by the process tree (e.g. filter out `file` and `library` events of the
+   * descendants, but keep their `process` and `network` events).
+   */
+  scopedProcessDescendantEventFiltersEnabled: false,
+
+  /**
    * Disables Security's Entity Store engine routes. The Entity Store feature is available by default, but
    * can be disabled if necessary in a given environment.
    */

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/artifacts/lists.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/artifacts/lists.test.ts
@@ -16,13 +16,19 @@ import {
   getFilteredEndpointExceptionListRaw,
   convertExceptionsToEndpointFormat,
 } from './lists';
-import type { TranslatedEntry, TranslatedExceptionListItem } from '../../schemas/artifacts';
+import type {
+  TranslatedEntry,
+  TranslatedExceptionListItem,
+  WrappedTranslatedExceptionList,
+} from '../../schemas/artifacts';
 import { ArtifactConstants } from './common';
 import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
 import {
+  DESCENDANT_EVENT_SCOPE_TAG_PREFIX,
   FILTER_PROCESS_DESCENDANTS_TAG,
   TRUSTED_PROCESS_DESCENDANTS_TAG,
 } from '../../../../common/endpoint/service/artifacts/constants';
+import { buildDescendantEventScopeTag } from '../../../../common/endpoint/service/artifacts/utils';
 import type { ExperimentalFeatures } from '../../../../common';
 import { allowedExperimentalValues } from '../../../../common';
 
@@ -676,6 +682,166 @@ describe('artifacts lists', () => {
         const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
 
         expect(translated).toEqual({ entries: [expectedEndpointExceptions] });
+      });
+
+      describe('with an event scope tag', () => {
+        let enabledScopedProcessDescendantEventFilters: ExperimentalFeatures;
+
+        const inputEntry: EntriesArray = [
+          {
+            field: 'process.executable.text',
+            operator: 'included',
+            type: 'match',
+            value: 'C:\\Windows\\System32\\ping.exe',
+          },
+        ];
+
+        const descendantOfEntry: TranslatedEntry = {
+          operator: 'included',
+          type: 'descendent_of',
+          value: {
+            entries: [
+              {
+                type: 'simple',
+                entries: [
+                  {
+                    field: 'process.executable',
+                    operator: 'included',
+                    type: 'exact_caseless',
+                    value: 'C:\\Windows\\System32\\ping.exe',
+                  },
+                  {
+                    field: 'event.category',
+                    operator: 'included',
+                    type: 'exact_cased',
+                    value: 'process',
+                  },
+                ],
+              },
+            ],
+          },
+        };
+
+        const translateWithTags = async (
+          tags: string[],
+          features: ExperimentalFeatures
+        ): Promise<WrappedTranslatedExceptionList> => {
+          const exceptionMock = getFoundExceptionListItemSchemaMock();
+          exceptionMock.data[0].tags.push(...tags);
+          exceptionMock.data[0].list_id = ENDPOINT_ARTIFACT_LISTS.eventFilters.id;
+          exceptionMock.data[0].entries = inputEntry;
+          mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(exceptionMock);
+
+          const resp = await getFilteredEndpointExceptionListRaw({
+            elClient: mockExceptionClient,
+            filter: TEST_FILTER,
+            listId: ENDPOINT_ARTIFACT_LISTS.endpointExceptions.id,
+          });
+
+          return convertExceptionsToEndpointFormat(resp, 'v1', features);
+        };
+
+        beforeEach(() => {
+          enabledScopedProcessDescendantEventFilters = {
+            ...defaultFeatures,
+            scopedProcessDescendantEventFiltersEnabled: true,
+          };
+        });
+
+        it('should emit the scoped event categories as a sibling of `descendent_of`', async () => {
+          const expectedEndpointExceptions: TranslatedExceptionListItem = {
+            type: 'simple',
+            entries: [
+              {
+                field: 'event.category',
+                operator: 'included',
+                type: 'exact_cased_any',
+                value: ['file', 'library'],
+              },
+              descendantOfEntry,
+            ],
+          };
+
+          const translated = await translateWithTags(
+            [FILTER_PROCESS_DESCENDANTS_TAG, buildDescendantEventScopeTag(['file', 'library'])],
+            enabledScopedProcessDescendantEventFilters
+          );
+
+          expect(translated).toEqual({ entries: [expectedEndpointExceptions] });
+        });
+
+        it('should emit the scoped event categories in a stable order', async () => {
+          const translated = await translateWithTags(
+            [FILTER_PROCESS_DESCENDANTS_TAG, `${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}library, file`],
+            enabledScopedProcessDescendantEventFilters
+          );
+
+          expect(translated).toEqual({
+            entries: [
+              {
+                type: 'simple',
+                entries: [
+                  {
+                    field: 'event.category',
+                    operator: 'included',
+                    type: 'exact_cased_any',
+                    value: ['file', 'library'],
+                  },
+                  descendantOfEntry,
+                ],
+              },
+            ],
+          });
+        });
+
+        it('when the feature flag is disabled, it should filter all event categories', async () => {
+          const expectedEndpointExceptions: TranslatedExceptionListItem = {
+            type: 'simple',
+            entries: [descendantOfEntry],
+          };
+
+          const translated = await translateWithTags(
+            [FILTER_PROCESS_DESCENDANTS_TAG, buildDescendantEventScopeTag(['file', 'library'])],
+            defaultFeatures
+          );
+
+          expect(translated).toEqual({ entries: [expectedEndpointExceptions] });
+        });
+
+        it('when no event category is known, it should filter all event categories', async () => {
+          const expectedEndpointExceptions: TranslatedExceptionListItem = {
+            type: 'simple',
+            entries: [descendantOfEntry],
+          };
+
+          const translated = await translateWithTags(
+            [FILTER_PROCESS_DESCENDANTS_TAG, `${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}not-a-category`],
+            enabledScopedProcessDescendantEventFilters
+          );
+
+          expect(translated).toEqual({ entries: [expectedEndpointExceptions] });
+        });
+
+        it('when the item is not in process descendants mode, it should not be scoped', async () => {
+          const expectedEndpointExceptions: TranslatedExceptionListItem = {
+            type: 'simple',
+            entries: [
+              {
+                field: 'process.executable',
+                operator: 'included',
+                type: 'exact_caseless',
+                value: 'C:\\Windows\\System32\\ping.exe',
+              },
+            ],
+          };
+
+          const translated = await translateWithTags(
+            [buildDescendantEventScopeTag(['file'])],
+            enabledScopedProcessDescendantEventFilters
+          );
+
+          expect(translated).toEqual({ entries: [expectedEndpointExceptions] });
+        });
       });
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/artifacts/lists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/artifacts/lists.ts
@@ -22,10 +22,15 @@ import {
   TRUSTED_PROCESS_DESCENDANTS_TAG,
 } from '../../../../common/endpoint/service/artifacts/constants';
 import type { ExperimentalFeatures } from '../../../../common';
-import { isProcessDescendantsEnabled } from '../../../../common/endpoint/service/artifacts/utils';
+import {
+  buildDescendantEventScopeEntry,
+  getDescendantEventScope,
+  isProcessDescendantsEnabled,
+} from '../../../../common/endpoint/service/artifacts/utils';
 import type {
   InternalArtifactCompleteSchema,
   TranslatedEntry,
+  TranslatedEntryDescendantOf,
   TranslatedPerformantEntries,
   TranslatedEntryMatcher,
   TranslatedEntryMatchWildcard,
@@ -191,7 +196,11 @@ export function translateToEndpointExceptions(
         entry.list_id === ENDPOINT_ARTIFACT_LISTS.eventFilters.id &&
         isProcessDescendantsEnabled(entry)
       ) {
-        const translatedItem = translateProcessDescendantEventFilter(schemaVersion, entry);
+        const translatedItem = translateProcessDescendantEventFilter(
+          schemaVersion,
+          entry,
+          experimentalFeatures
+        );
         storeUniqueItem(translatedItem);
       } else if (
         experimentalFeatures.filterProcessDescendantsForTrustedAppsEnabled &&
@@ -214,24 +223,49 @@ export function translateToEndpointExceptions(
 
 function translateProcessDescendantEventFilter(
   schemaVersion: string,
-  entry: ExceptionListItemSchema
+  entry: ExceptionListItemSchema,
+  experimentalFeatures: ExperimentalFeatures
 ): TranslatedExceptionListItem {
+  // The user provided conditions describe the *ancestor* process, so they are translated together
+  // with the `event.category is process` condition and nested inside `descendent_of`.
   const translatedEntries: TranslatedEntriesOfProcessDescendants = translateItem(schemaVersion, {
     ...entry,
     entries: [...entry.entries, PROCESS_DESCENDANT_EXTRA_ENTRY],
   }) as TranslatedEntriesOfProcessDescendants;
 
+  const descendantOfEntry: TranslatedEntryDescendantOf = {
+    operator: 'included',
+    type: 'descendent_of',
+    value: {
+      entries: [translatedEntries],
+    },
+  };
+
+  const eventScope = experimentalFeatures.scopedProcessDescendantEventFiltersEnabled
+    ? getDescendantEventScope(entry)
+    : [];
+
+  // No (valid) scope means every event category of the descendants is filtered out, which is the
+  // default and only behaviour of process descendants event filters prior to the event scope tag.
+  if (eventScope.length === 0) {
+    return {
+      type: entry.type,
+      entries: [descendantOfEntry],
+    };
+  }
+
+  // Conditions of a `simple` entry are AND'ed together by the endpoint, so emitting the event
+  // category condition as a *sibling* of `descendent_of` filters out only those categories from
+  // the matched process tree. Events of every other category (and all events of the matched
+  // process itself) remain visible.
+  const translatedEventScope: TranslatedEntriesOfProcessDescendants = translateItem(schemaVersion, {
+    ...entry,
+    entries: [buildDescendantEventScopeEntry(eventScope)],
+  }) as TranslatedEntriesOfProcessDescendants;
+
   return {
     type: entry.type,
-    entries: [
-      {
-        operator: 'included',
-        type: 'descendent_of',
-        value: {
-          entries: [translatedEntries],
-        },
-      },
-    ],
+    entries: [...translatedEventScope.entries, descendantOfEntry],
   };
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
@@ -14,6 +14,17 @@ import type {
   UpdateExceptionListItemOptions,
 } from '@kbn/lists-plugin/server';
 
+import {
+  DESCENDANT_EVENT_SCOPE_CATEGORIES,
+  DESCENDANT_EVENT_SCOPE_TAG_PREFIX,
+  FILTER_PROCESS_DESCENDANTS_TAG,
+} from '../../../../common/endpoint/service/artifacts/constants';
+import {
+  getDescendantEventScopeValues,
+  isDescendantEventScopeCategory,
+  isDescendantEventScopeTag,
+  isProcessDescendantsEnabled,
+} from '../../../../common/endpoint/service/artifacts/utils';
 import type { ExceptionItemLikeOptions } from '../types';
 
 import { BaseValidator } from './base_validator';
@@ -97,8 +108,53 @@ export class EventFilterValidator extends BaseValidator {
 
     try {
       EventFilterDataSchema.validate(item);
+      this.validateDescendantEventScope(item);
     } catch (error) {
       throw new EndpointArtifactExceptionValidationError(error.message);
+    }
+  }
+
+  /**
+   * Validates the (optional) tag that scopes a process descendants event filter down to a set of
+   * event categories. Items without that tag keep filtering every event category of the tree.
+   */
+  private validateDescendantEventScope(item: ExceptionItemLikeOptions): void {
+    const tags = item.tags ?? [];
+
+    if (!tags.some(isDescendantEventScopeTag)) {
+      return;
+    }
+
+    if (!this.endpointAppContext.experimentalFeatures.scopedProcessDescendantEventFiltersEnabled) {
+      throw new Error('Scoped process descendants event filtering feature is not enabled');
+    }
+
+    if (!isProcessDescendantsEnabled({ tags })) {
+      throw new Error(
+        `The \`${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}\` tag is only allowed together with the \`${FILTER_PROCESS_DESCENDANTS_TAG}\` tag`
+      );
+    }
+
+    const eventScopeValues = getDescendantEventScopeValues({ tags });
+
+    if (eventScopeValues.length === 0) {
+      throw new Error(
+        `The \`${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}\` tag must list at least one event category. Remove the tag to filter all event categories of the process descendants.`
+      );
+    }
+
+    const invalidCategories = eventScopeValues.filter(
+      (value) => !isDescendantEventScopeCategory(value)
+    );
+
+    if (invalidCategories.length > 0) {
+      throw new Error(
+        `Invalid event category [${invalidCategories.join(
+          ', '
+        )}] in the \`${DESCENDANT_EVENT_SCOPE_TAG_PREFIX}\` tag. Allowed values are: ${DESCENDANT_EVENT_SCOPE_CATEGORIES.join(
+          ', '
+        )}`
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Adds an optional **event-type scope** to "Filter process descendants" event filters, so a filter can drop a *subset* of the event categories produced by a process tree instead of everything.

### Problem

Descendants-mode event filters are all-or-nothing per tree today: `translateProcessDescendantEventFilter()` nests **all** user conditions (plus the auto-added `event.category is process` condition, which anchors the tree selector on the ancestor's process event) inside `descendent_of.value`, so the emitted outer entry contains only the `descendent_of` condition. Nothing constrains *which descendant events* are dropped, so all of them are.

That is a real blocker for ingest-reduction work. Noisy trees (RMM/automation agents spawning script interpreters) generate enormous DLL-load and temp-file churn, but blanket-filtering the tree would blind detection to abuse of that same channel — RMM script execution is a top attacker vector. What is needed is: "from all descendants of `<automation agent>.exe`, drop `file` and `library` events, but keep `process` and `network` events."

Sizing from the engagement that motivated this (a real customer, ~12.4k endpoints): one such tree is the #1 event producer fleet-wide at **3.26B events / 14 days**, and is present on **92% of hosts**. Scoped filtering removes that churn at zero process/network visibility cost. There is no clean workaround on Elastic Cloud: endpoints consume Kibana-generated signed artifacts, and this translation layer is exactly what forces the all-or-nothing shape — hand-crafting exception items through the API cannot produce the scoped form. The practical interim (`event.category: (file OR library) AND process.parent.executable: <root>`) only covers direct children.

### The engine already supports the scoped shape

`descendent_of` is a condition **type** inside a normal `"simple"` entry and is AND'ed with the entry's other conditions (endpoint: `Libraries/EqlLib/Lib/FilterLibCompat.cpp:810-828,905-917`). An entry combining `event.category: file` with a `descendent_of` condition drops only file events from the descendants; there is an existing endpoint fixture for exactly this shape (`Libraries/FilterLib/Tests/filter_data/test-descendent-of-3/exceptionlist.json`) and end-to-end coverage in `Python/endpoint/test/test_event_filtering.py:574-708`. **The endpoint needs no changes** — this is a Kibana translation change only. Root-process events stay visible by construction.

### The change (server-side)

* **Storage**: a second tag, `descendant_event_scope:file,library`, next to the existing `filter_process_descendants` tag. No exception-list schema change, no migration, invisible to older Kibanas. (Storing the scope as a regular `event.category` entry was rejected: today's validators/UX treat every entry as a tree selector, and partitioning by field name is implicit magic.)
* **Translation** (`server/endpoint/lib/artifacts/lists.ts`): when the scope tag is present, emit the `event.category` condition as a **sibling** of `descendent_of` — i.e. exactly today's output plus one extra condition:
  ```json
  {
    "type": "simple",
    "entries": [
      { "field": "event.category", "operator": "included", "type": "exact_cased_any", "value": ["file", "library"] },
      { "operator": "included", "type": "descendent_of", "value": { "entries": [ /* ancestor conditions, as today */ ] } }
    ]
  }
  ```
  Items without the tag (and every existing item) translate byte-for-byte as before. Categories are emitted in a canonical order so the same scope always yields the same artifact hash.
* **Constants/helpers** (`common/endpoint/service/artifacts`): `DESCENDANT_EVENT_SCOPE_TAG_PREFIX`, `DESCENDANT_EVENT_SCOPE_CATEGORIES`, and tag build/parse helpers.
* **Validation** (`EventFilterValidator`): accepts the tag; rejects unknown categories, an empty scope, the tag without `filter_process_descendants`, and the tag while the feature flag is off.
* **Feature flag**: `scopedProcessDescendantEventFiltersEnabled`, default off, following the existing `filterProcessDescendantsForTrustedAppsEnabled` pattern.

### Tests

Unit tests next to `lists.ts` covering the scoped, unscoped, feature-flag-off, unknown-category, and non-descendants-mode translations, plus tests for the new tag helpers.

> ⚠️ **Not executed locally** — running them needs a full `yarn kbn bootstrap`, which was out of scope for this draft. Please treat the test results as unverified until CI runs.

### Not done in this PR

* **UI** — the "Applies to event types" multi-select in the event filter form (File / Library / Network / Registry / DNS / Security / API / Process, default: all), and the artifact card summary line for the scoped variant (the card currently renders `PROCESS_DESCENDANT_EXTRA_ENTRY_TEXT`, which is misleading for scoped items). Until that lands, the scope tag can only be set through the API. Suggested copy: *"Events of the selected types from all descendants are filtered. The matched process itself, and unselected event types, remain visible."*
* **Minimum endpoint version gating** — the combined shape is engine-supported, but we should confirm which endpoint release first shipped `descendent_of` evaluation with sibling conditions and decide whether `schemaVersion` gating is needed for policies with older agents.
* **Validator unit tests** — per the note in `event_filter_validator.test.ts`, API-level coverage belongs in `security_solution_api_integration/test_suites/edr_workflows`.
* **EAF case** mirroring the Kibana-emitted scoped artifact, if the team wants cross-repo end-to-end proof (existing coverage: `test_event_filtering.py:574-708`).

### Pre-existing caveats worth documenting (not new)

Events lacking `process.pid`/`entity_id` never match descendant conditions, and a newly added filter does not retroactively tag already-running trees — it applies as processes restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
