### PR TITLE
Fix load_skill path resolution for default-basePath skills

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/skills/utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/skills/utils.test.ts
@@ -6,6 +6,7 @@
  */
 
 import type { InternalSkillDefinition } from '@kbn/agent-builder-server/skills';
+import { getSkillAbsolutePath } from '../execution/runner/store/volumes/skills/utils';
 import { internalToPublicDefinition, resolveSkill } from './utils';
 
 describe('internalToPublicDefinition', () => {
@@ -191,6 +192,26 @@ describe('resolveSkill', () => {
     it('trims surrounding whitespace', () => {
       const s = skill({ id: 'a', name: 'my-skill' });
       expect(resolveSkill('  my-skill  ', [s])).toEqual({ match: s });
+    });
+  });
+
+  describe('basePath storage shapes', () => {
+    it("resolves a skill with a mount-default basePath ('/skills', no subfolder)", () => {
+      const s = skill({ id: 'a', name: 'Repo Discovery', basePath: '/skills' });
+      const path = getSkillAbsolutePath({ skill: s });
+      expect(resolveSkill(path, [s])).toEqual({ match: s });
+    });
+
+    it("resolves a skill with a bare basePath ('skills/platform')", () => {
+      const s = skill({ id: 'a', name: 'my-skill', basePath: 'skills/platform' });
+      const path = getSkillAbsolutePath({ skill: s });
+      expect(resolveSkill(path, [s])).toEqual({ match: s });
+    });
+
+    it("resolves a skill with an explicit custom basePath (no 'skills' prefix)", () => {
+      const s = skill({ id: 'a', name: 'my-skill', basePath: 'sourcerer' });
+      const path = getSkillAbsolutePath({ skill: s });
+      expect(resolveSkill(path, [s])).toEqual({ match: s });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/skills/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/skills/utils.ts
@@ -78,10 +78,8 @@ export const resolveSkill = (
   const isPath = target.includes('/');
 
   if (isPath) {
-    const lastSlash = target.lastIndexOf('/');
-    const basePath = target.slice(0, lastSlash);
-    const name = target.slice(lastSlash + 1);
-    const match = allSkills.find((s) => s.name === name && s.basePath === basePath);
+    const targetPath = `/${target}${SKILL_FILE_SUFFIX}`;
+    const match = allSkills.find((s) => getSkillAbsolutePath({ skill: s }) === targetPath);
     if (!match) {
       return { error: `Skill not found at path '${input}'.` };
     }


### PR DESCRIPTION
## What
Fixes `resolveSkill` so `load_skill` accepts a skill's full absolute path — the exact form the model is shown in its own system prompt. Skills with a default `basePath` (no explicit `base_path` set at creation) always failed to resolve by path; the fix reuses `getSkillAbsolutePath` (already used for display) instead of hand-deriving and string-comparing a `basePath` from the input.

## How to Verify
1. `node scripts/jest --config x-pack/platform/plugins/shared/agent_builder/jest.config.js server/services/skills/utils.test.ts` — all tests pass, including 3 new cases covering mount-default (`/skills`), bare (`skills/platform`), and explicit custom (`sourcerer`) `basePath` shapes.
2. `node scripts/type_check --project x-pack/platform/plugins/shared/agent_builder/tsconfig.json` — exits 0.
3. Manual trace: input `/skills/Repo Discovery/SKILL.md` against a skill with `basePath: '/skills'`, `name: 'Repo Discovery'` now resolves to `{ match }` instead of `Skill not found at path '...'.`

## Breaking Changes
None.

## Example of issue

<img width="806" height="796" alt="image" src="https://github.com/user-attachments/assets/429f29a3-482a-42cb-bcab-195551842c5d" />

<img width="801" height="365" alt="image" src="https://github.com/user-attachments/assets/80713172-fc33-4f2c-902c-409047021e67" />
