### PR TITLE
Add system DLL enrichment for Windows events

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -2797,6 +2797,16 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     ),
   },
   {
+    key: 'windows.advanced.events.system_dll_enrichment',
+    first_supported_version: '9.6',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.system_dll_enrichment',
+      {
+        defaultMessage: 'Enrich memory events with additional data when they target certain system DLLs. Default: true.',
+      }
+    ),
+  },
+  {
     key: 'mac.advanced.events.script_capture',
     first_supported_version: '9.3',
     documentation: i18n.translate(

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -2802,7 +2802,8 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.system_dll_enrichment',
       {
-        defaultMessage: 'Enrich memory events with additional data when they target certain system DLLs. Default: true.',
+        defaultMessage:
+          'Enrich memory events with additional data when they target certain system DLLs. Default: true.',
       }
     ),
   },


### PR DESCRIPTION
## Summary

This PR introduces a new field in the Windows Advanced policy config for Elastic Defend to provide enrichments to VirtualProtect events when they target the `.text` section of system DLLs in a process.

The feature is to be enabled by default, and this field gives users the ability to disable it by setting the field to `false` if they require.

## Release note

{elastic-defend} Adds advanced policy options for {windows} that lets users disable additional enrichment when the .text section in NTDLL is targeted by VirtualProtect and VirtualProtectEx events.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

