### PR TITLE
Add sequence builder — alert condition canvas

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -104,3 +104,23 @@ export type {
 
 export { getRunbookContent, getDashboardId } from './form';
 export type { RunbookArtifactData, DashboardArtifactData } from './form';
+
+export { composeFormToCreateRequest } from './flyout/compose_discover/compose_mappers';
+
+// Sequence builder
+export type { SequenceFormValues, SequenceRule, HopWindow } from './sequence/form_types';
+export {
+  RULE_DRAG_MIME_TYPE,
+  generateStepId,
+  DEFAULT_SEQUENCE_FORM_VALUES,
+  isSequenceValid,
+  totalLookbackSeconds,
+  getCommonGroupingFields,
+  formatLookbackString,
+} from './sequence/form_types';
+export { buildSequenceRuleQueryData } from './sequence/build_esql';
+export { SequenceNode } from './sequence/sequence_node';
+export type { SequenceNodeType } from './sequence/sequence_node';
+export { SequenceEdge, WINDOW_OPTIONS } from './sequence/sequence_edge';
+export type { SequenceEdgeType } from './sequence/sequence_edge';
+export { layoutSequence } from './sequence/layout_sequence';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/build_esql.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/build_esql.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SequenceFormValues, SequenceStep } from './form_types';
+import {
+  formatLookbackString,
+  getCommonGroupingFields,
+  hopWindowToSeconds,
+  totalLookbackSeconds,
+} from './form_types';
+
+const hasSignalRules = (state: SequenceFormValues): boolean =>
+  state.steps.some((s) => s.rules.some((r) => r.kind === 'signal'));
+
+export const RULE_EVENTS_INDEX = '.rule-events';
+const GROUP_HASH_COL = 'group_hash';
+const SEQUENCE_GROUP_COL = 'sequence_group';
+const SEQUENCE_GROUP_VALUE = 'default';
+
+const escapeRuleId = (id: string): string => id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+const isAndStep = (step: SequenceStep): step is SequenceStep & { operator: 'and' } =>
+  step.operator === 'and' && step.rules.length > 1;
+
+const effectiveColName = (stepIdx: number, step: SequenceStep): string =>
+  isAndStep(step) ? `t_${stepIdx}_eff` : `t_${stepIdx}`;
+
+const stepColNames = (stepIdx: number, step: SequenceStep): string[] => {
+  if (isAndStep(step)) {
+    return step.rules.map((_, j) => `t_${stepIdx}_${j}`);
+  }
+  return [`t_${stepIdx}`];
+};
+
+interface RecoveryTrackingPair {
+  stepIdx: number;
+  ruleIdx?: number;
+  ruleId: string;
+  kind: 'alert' | 'signal';
+  stalenessSeconds: number;
+}
+
+const recoveryTrackingColSuffix = (pair: RecoveryTrackingPair): string =>
+  pair.ruleIdx !== undefined ? `${pair.stepIdx}_${pair.ruleIdx}` : `${pair.stepIdx}`;
+
+const resolveRecoveryTrackingPairs = (state: SequenceFormValues): RecoveryTrackingPair[] | null => {
+  const recoveryIndices: number[] =
+    state.recoveryStepIndices && state.recoveryStepIndices.length > 0
+      ? [...state.recoveryStepIndices].sort((a, b) => a - b)
+      : [state.recoveryStepIndex];
+
+  const recoveryPairs: RecoveryTrackingPair[] = [];
+  for (const si of recoveryIndices) {
+    const step = state.steps[si];
+    if (!step || step.rules.length === 0) return null;
+    const hopIdx = si > 0 ? si - 1 : 0;
+    const stalenessSeconds = hopWindowToSeconds(state.hopWindows[hopIdx]);
+
+    if (isAndStep(step)) {
+      for (let j = 0; j < step.rules.length; j++) {
+        recoveryPairs.push({
+          stepIdx: si,
+          ruleIdx: j,
+          ruleId: escapeRuleId(step.rules[j].ruleId),
+          kind: step.rules[j].kind,
+          stalenessSeconds,
+        });
+      }
+    } else {
+      const firstRule = step.rules[0];
+      recoveryPairs.push({
+        stepIdx: si,
+        ruleId: escapeRuleId(firstRule.ruleId),
+        kind: firstRule.kind,
+        stalenessSeconds,
+      });
+    }
+  }
+  return recoveryPairs;
+};
+
+const pairRecoveredExpr = (pair: RecoveryTrackingPair): string => {
+  const suffix = recoveryTrackingColSuffix(pair);
+  if (pair.kind === 'signal') {
+    return `(a_${suffix} IS NULL OR DATE_DIFF("seconds", a_${suffix}, NOW()) > ${pair.stalenessSeconds})`;
+  }
+  return `(r_${suffix} IS NOT NULL AND r_${suffix} == a_${suffix})`;
+};
+
+const recoveryTrackingPredicate = (pairs: RecoveryTrackingPair[]): string => {
+  const byStep = new Map<number, RecoveryTrackingPair[]>();
+  for (const p of pairs) {
+    const group = byStep.get(p.stepIdx) ?? [];
+    group.push(p);
+    byStep.set(p.stepIdx, group);
+  }
+
+  const perStepConditions = [...byStep.values()].map((stepPairs) => {
+    if (stepPairs.length === 1) return pairRecoveredExpr(stepPairs[0]);
+    return `(${stepPairs.map(pairRecoveredExpr).join(' OR ')})`;
+  });
+
+  return perStepConditions.join(' AND ');
+};
+
+export const buildSequenceEsql = (state: SequenceFormValues): string => {
+  if (state.steps.length < 2) return '';
+  if (state.steps.some((s) => s.rules.length === 0)) return '';
+  if (state.hopWindows.length !== state.steps.length - 1) return '';
+
+  const lookback = totalLookbackSeconds(state);
+  if (lookback <= 0) return '';
+
+  const recoveryPairs = resolveRecoveryTrackingPairs(state);
+  if (!recoveryPairs) return '';
+
+  const allRuleIds = state.steps.flatMap((s) => s.rules.map((r) => `"${escapeRuleId(r.ruleId)}"`));
+  const ruleIdList = [...new Set(allRuleIds)].join(', ');
+
+  const isCorrelated = getCommonGroupingFields(state).length > 0;
+
+  const lines: string[] = [];
+
+  lines.push(`FROM ${RULE_EVENTS_INDEX}`);
+  const typeFilter = hasSignalRules(state) ? 'type IN ("alert", "signal")' : 'type == "alert"';
+  lines.push(`| WHERE ${typeFilter} AND rule.id IN (${ruleIdList})`);
+
+  if (!isCorrelated) {
+    lines.push(`| EVAL ${SEQUENCE_GROUP_COL} = "${SEQUENCE_GROUP_VALUE}"`);
+  }
+
+  const statsCols: string[] = [];
+  for (let i = 0; i < state.steps.length; i++) {
+    const step = state.steps[i];
+    if (isAndStep(step)) {
+      for (let j = 0; j < step.rules.length; j++) {
+        const ruleId = escapeRuleId(step.rules[j].ruleId);
+        const typeVal = step.rules[j].kind === 'signal' ? 'signal' : 'alert';
+        statsCols.push(
+          `t_${i}_${j} = VALUES(CASE(rule.id == "${ruleId}" AND type == "${typeVal}" AND status == "breached", @timestamp, NULL))`
+        );
+      }
+    } else {
+      let wrappedCond: string;
+      if (step.rules.length === 1) {
+        const r = step.rules[0];
+        const typeVal = r.kind === 'signal' ? 'signal' : 'alert';
+        wrappedCond = `rule.id == "${escapeRuleId(r.ruleId)}" AND type == "${typeVal}"`;
+      } else {
+        const ruleConds = step.rules.map((r) => {
+          const typeVal = r.kind === 'signal' ? 'signal' : 'alert';
+          return `(rule.id == "${escapeRuleId(r.ruleId)}" AND type == "${typeVal}")`;
+        });
+        wrappedCond = `(${ruleConds.join(' OR ')})`;
+      }
+      statsCols.push(
+        `t_${i} = VALUES(CASE(${wrappedCond} AND status == "breached", @timestamp, NULL))`
+      );
+    }
+  }
+
+  for (const pair of recoveryPairs) {
+    const suffix = recoveryTrackingColSuffix(pair);
+    if (pair.kind !== 'signal') {
+      statsCols.push(
+        `r_${suffix} = MAX(CASE(rule.id == "${pair.ruleId}" AND status == "recovered", @timestamp, NULL))`
+      );
+    }
+    statsCols.push(`a_${suffix} = MAX(CASE(rule.id == "${pair.ruleId}", @timestamp, NULL))`);
+  }
+
+  const byCol = isCorrelated ? GROUP_HASH_COL : SEQUENCE_GROUP_COL;
+  lines.push(`| STATS\n    ${statsCols.join(',\n    ')}\n    BY ${byCol}`);
+
+  for (let i = 0; i < state.steps.length; i++) {
+    for (const col of stepColNames(i, state.steps[i])) {
+      lines.push(`| MV_EXPAND ${col}`);
+    }
+  }
+
+  const notNullConds: string[] = [];
+  for (let i = 0; i < state.steps.length; i++) {
+    for (const col of stepColNames(i, state.steps[i])) {
+      notNullConds.push(`${col} IS NOT NULL`);
+    }
+  }
+  lines.push(`| WHERE ${notNullConds.join(' AND ')}`);
+
+  for (let i = 0; i < state.steps.length; i++) {
+    const step = state.steps[i];
+    if (isAndStep(step)) {
+      const cols = stepColNames(i, step);
+      lines.push(`| EVAL ${effectiveColName(i, step)} = GREATEST(${cols.join(', ')})`);
+    }
+  }
+
+  const hopChecks: string[] = [];
+  for (let i = 1; i < state.steps.length; i++) {
+    const prevEff = effectiveColName(i - 1, state.steps[i - 1]);
+    const currEff = effectiveColName(i, state.steps[i]);
+    const hopSecs = hopWindowToSeconds(state.hopWindows[i - 1]);
+    hopChecks.push(
+      `${currEff} > ${prevEff} AND DATE_DIFF("seconds", ${prevEff}, ${currEff}) <= ${hopSecs}`
+    );
+  }
+  lines.push(`| WHERE ${hopChecks.join(' AND ')}`);
+
+  lines.push(`| WHERE NOT (${recoveryTrackingPredicate(recoveryPairs)})`);
+
+  const lastEff = effectiveColName(state.steps.length - 1, state.steps[state.steps.length - 1]);
+  lines.push(`| STATS sequence_match_count = COUNT(*), first_breach = MIN(${lastEff}) BY ${byCol}`);
+
+  return lines.join('\n');
+};
+
+export const buildSequenceRuleQueryData = (
+  state: SequenceFormValues
+): {
+  breachQuery: string;
+  recoveryQuery: string;
+  groupingFields: string[];
+  lookbackString: string;
+} | null => {
+  const breachQuery = buildSequenceEsql(state);
+  if (!breachQuery) return null;
+
+  const lookback = totalLookbackSeconds(state);
+  const isCorrelated = getCommonGroupingFields(state).length > 0;
+  const groupingFields = isCorrelated ? [GROUP_HASH_COL] : [SEQUENCE_GROUP_COL];
+
+  return {
+    breachQuery,
+    recoveryQuery: '',
+    groupingFields,
+    lookbackString: formatLookbackString(lookback),
+  };
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/form_types.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/form_types.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type HopWindowUnit = 's' | 'm' | 'h' | 'd';
+
+export interface HopWindow {
+  value: number;
+  unit: HopWindowUnit;
+}
+
+export const HOP_WINDOW_UNIT_SECONDS: Record<HopWindowUnit, number> = {
+  s: 1,
+  m: 60,
+  h: 3600,
+  d: 86400,
+};
+
+export const hopWindowToSeconds = (w: HopWindow): number =>
+  w.value * HOP_WINDOW_UNIT_SECONDS[w.unit];
+
+export const secondsToHopWindow = (totalSeconds: number): HopWindow => {
+  if (totalSeconds % 86400 === 0) return { value: totalSeconds / 86400, unit: 'd' };
+  if (totalSeconds % 3600 === 0) return { value: totalSeconds / 3600, unit: 'h' };
+  if (totalSeconds % 60 === 0) return { value: totalSeconds / 60, unit: 'm' };
+  return { value: totalSeconds, unit: 's' };
+};
+
+export const hopWindowToScheduleString = (w: HopWindow): string => `${w.value}${w.unit}`;
+
+export interface SequenceRule {
+  ruleId: string;
+  ruleName: string;
+  groupingFields: string[];
+  kind: 'alert' | 'signal';
+}
+
+export interface SequenceStep {
+  id: string;
+  rules: SequenceRule[];
+  operator: 'and' | 'or';
+}
+
+export interface SequenceFormValues {
+  steps: SequenceStep[];
+  hopWindows: HopWindow[];
+  recoveryStepIndex: number;
+  recoveryStepIndices?: number[];
+}
+
+export const RULE_DRAG_MIME_TYPE = 'application/x-alerting-v2-rule-id';
+
+let idCounter = 0;
+export const generateStepId = (): string => `step_${Date.now()}_${++idCounter}`;
+
+export const DEFAULT_SEQUENCE_FORM_VALUES: SequenceFormValues = {
+  steps: [],
+  hopWindows: [],
+  recoveryStepIndex: 0,
+};
+
+export const isSequenceValid = (state: SequenceFormValues): boolean => {
+  if (state.steps.length < 2) return false;
+  if (state.hopWindows.length !== state.steps.length - 1) return false;
+  if (state.steps.some((s) => s.rules.length === 0)) return false;
+  if (state.hopWindows.some((w) => w.value <= 0)) return false;
+  return true;
+};
+
+export const totalLookbackSeconds = (state: SequenceFormValues): number =>
+  state.hopWindows.reduce((sum, w) => sum + hopWindowToSeconds(w), 0);
+
+export const formatLookbackString = (totalSeconds: number): string =>
+  totalSeconds <= 0 ? '' : hopWindowToScheduleString(secondsToHopWindow(totalSeconds));
+
+export const getCommonGroupingFields = (state: SequenceFormValues): string[] => {
+  const allRules = state.steps.flatMap((s) => s.rules);
+  if (allRules.length === 0) return [];
+
+  const fieldSets = allRules.map((r) => new Set(r.groupingFields));
+  const first = fieldSets[0];
+  if (first.size === 0) return [];
+  const rest = fieldSets.slice(1);
+  return [...first].filter((f) => rest.every((s) => s.has(f)));
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/layout_sequence.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/layout_sequence.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import dagre, { graphlib } from '@dagrejs/dagre';
+import { MarkerType, Position } from '@xyflow/react';
+import { getNodeHeight, type SequenceNodeType } from './sequence_node';
+import type { SequenceEdgeType } from './sequence_edge';
+
+const NODE_WIDTH = 220;
+const COL_GAP = NODE_WIDTH + 130;
+const MAX_STEPS_PER_ROW = 3;
+const DEFAULT_HOP_WINDOW_STRING = '1h';
+
+export interface StageItem {
+  stepId: string;
+  rules: Array<{ ruleId: string; ruleName: string }>;
+  operator: 'and' | 'or';
+}
+
+const buildEdges = (
+  stages: StageItem[],
+  hopWindows: string[],
+  onHopWindowChange: ((hopIndex: number, value: string) => void) | undefined,
+  closeAllTick: number,
+  interactive: boolean
+): SequenceEdgeType[] => {
+  const edges: SequenceEdgeType[] = [];
+  for (let i = 0; i < stages.length - 1; i++) {
+    const source = stages[i].stepId;
+    const target = stages[i + 1].stepId;
+    const wrapsToNextRow =
+      Math.floor(i / MAX_STEPS_PER_ROW) !== Math.floor((i + 1) / MAX_STEPS_PER_ROW);
+    edges.push({
+      id: `${source}->${target}`,
+      source,
+      target,
+      type: 'sequenceHop',
+      markerEnd: { type: MarkerType.ArrowClosed },
+      data: {
+        window: hopWindows[i] ?? DEFAULT_HOP_WINDOW_STRING,
+        onChange: (value: string) => onHopWindowChange?.(i, value),
+        isRowWrap: wrapsToNextRow,
+        closeAllTick,
+        interactive,
+      },
+    });
+  }
+  return edges;
+};
+
+export const layoutSequence = (
+  stages: StageItem[],
+  hopWindows: string[],
+  onRemoveRule?: (stepId: string, ruleId: string) => void,
+  onOperatorChange?: (stepId: string, op: 'and' | 'or') => void,
+  onDropRule?: (
+    stepId: string,
+    payload: { id: string; name: string; groupingFields: string[]; kind: 'alert' | 'signal' }
+  ) => void,
+  onHopWindowChange?: (hopIndex: number, value: string) => void,
+  closeAllTick: number = 0,
+  interactive: boolean = true
+): { nodes: SequenceNodeType[]; edges: SequenceEdgeType[] } => {
+  const edges = buildEdges(stages, hopWindows, onHopWindowChange, closeAllTick, interactive);
+
+  const noop = () => {};
+  const makeNodeData = (stage: StageItem, index: number): SequenceNodeType['data'] => ({
+    stepId: stage.stepId,
+    rules: stage.rules,
+    operator: stage.operator,
+    stageIndex: index,
+    onRemoveRule: onRemoveRule ?? noop,
+    onOperatorChange: onOperatorChange ?? noop,
+    onDropRule: onDropRule ?? noop,
+    interactive,
+  });
+
+  if (stages.length <= MAX_STEPS_PER_ROW) {
+    const dagreGraph = new graphlib.Graph();
+    dagreGraph.setDefaultEdgeLabel(() => ({}));
+    dagreGraph.setGraph({ rankdir: 'LR', nodesep: 40, ranksep: 130 });
+    stages.forEach((s) =>
+      dagreGraph.setNode(s.stepId, {
+        width: NODE_WIDTH,
+        height: getNodeHeight(s.rules.length),
+      })
+    );
+    edges.forEach((e) => dagreGraph.setEdge(e.source, e.target));
+    dagre.layout(dagreGraph);
+
+    const nodes: SequenceNodeType[] = stages.map((stage, index) => {
+      const dn = dagreGraph.node(stage.stepId);
+      const nodeHeight = getNodeHeight(stage.rules.length);
+      return {
+        id: stage.stepId,
+        type: 'sequenceStage' as const,
+        position: { x: dn.x - NODE_WIDTH / 2, y: dn.y - nodeHeight / 2 },
+        width: NODE_WIDTH,
+        height: nodeHeight,
+        style: { width: NODE_WIDTH, height: nodeHeight },
+        targetPosition: Position.Left,
+        sourcePosition: Position.Right,
+        data: makeNodeData(stage, index),
+      };
+    });
+    return { nodes, edges };
+  }
+
+  const ROW_GAP = 130;
+  const totalRows = Math.ceil(stages.length / MAX_STEPS_PER_ROW);
+  const rowMaxHeights: number[] = Array.from({ length: totalRows }, (_, row) => {
+    const start = row * MAX_STEPS_PER_ROW;
+    const end = Math.min(start + MAX_STEPS_PER_ROW, stages.length);
+    let max = 0;
+    for (let i = start; i < end; i++) {
+      max = Math.max(max, getNodeHeight(stages[i].rules.length));
+    }
+    return max;
+  });
+
+  const rowYOffsets: number[] = [0];
+  for (let r = 1; r < totalRows; r++) {
+    rowYOffsets[r] = rowYOffsets[r - 1] + rowMaxHeights[r - 1] + ROW_GAP;
+  }
+
+  const nodes: SequenceNodeType[] = stages.map((stage, index) => {
+    const row = Math.floor(index / MAX_STEPS_PER_ROW);
+    const col = index % MAX_STEPS_PER_ROW;
+    const nodeHeight = getNodeHeight(stage.rules.length);
+    return {
+      id: stage.stepId,
+      type: 'sequenceStage' as const,
+      position: { x: col * COL_GAP, y: rowYOffsets[row] },
+      width: NODE_WIDTH,
+      height: nodeHeight,
+      style: { width: NODE_WIDTH, height: nodeHeight },
+      targetPosition: Position.Left,
+      sourcePosition: Position.Right,
+      data: makeNodeData(stage, index),
+    };
+  });
+
+  return { nodes, edges };
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/sequence_edge.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/sequence_edge.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { EuiBadge, EuiPopover, EuiSelect } from '@elastic/eui';
+import type { Edge, EdgeProps } from '@xyflow/react';
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, getSmoothStepPath } from '@xyflow/react';
+import { i18n } from '@kbn/i18n';
+
+export const WINDOW_OPTIONS = [
+  {
+    value: '5m',
+    text: i18n.translate('xpack.alertingV2.sequenceBuilder.window5m', {
+      defaultMessage: '5 minutes',
+    }),
+  },
+  {
+    value: '15m',
+    text: i18n.translate('xpack.alertingV2.sequenceBuilder.window15m', {
+      defaultMessage: '15 minutes',
+    }),
+  },
+  {
+    value: '1h',
+    text: i18n.translate('xpack.alertingV2.sequenceBuilder.window1h', {
+      defaultMessage: '1 hour',
+    }),
+  },
+  {
+    value: '6h',
+    text: i18n.translate('xpack.alertingV2.sequenceBuilder.window6h', {
+      defaultMessage: '6 hours',
+    }),
+  },
+  {
+    value: '24h',
+    text: i18n.translate('xpack.alertingV2.sequenceBuilder.window24h', {
+      defaultMessage: '24 hours',
+    }),
+  },
+];
+
+const windowLabel = (value: string | undefined) =>
+  WINDOW_OPTIONS.find((o) => o.value === value)?.text ?? value;
+
+export interface SequenceEdgeData extends Record<string, unknown> {
+  window: string;
+  onChange: (value: string) => void;
+  isRowWrap?: boolean;
+  closeAllTick?: number;
+  interactive?: boolean;
+}
+
+export type SequenceEdgeType = Edge<SequenceEdgeData, 'sequenceHop'>;
+
+export const SequenceEdge: React.FC<EdgeProps<SequenceEdgeType>> = ({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+  data,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [data?.closeAllTick]);
+
+  const [edgePath, labelX, labelY] = data?.isRowWrap
+    ? getSmoothStepPath({
+        sourceX,
+        sourceY,
+        sourcePosition,
+        targetX,
+        targetY,
+        targetPosition,
+        borderRadius: 12,
+      })
+    : getBezierPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition });
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+      <EdgeLabelRenderer>
+        <div
+          className="nodrag nopan"
+          style={{
+            position: 'absolute',
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            pointerEvents: 'all',
+          }}
+        >
+          {data?.interactive === false ? (
+            <EuiBadge color="hollow" data-test-subj={`sequenceHopBadge-${id}`}>
+              {i18n.translate('xpack.alertingV2.sequenceBuilder.withinWindow', {
+                defaultMessage: 'within {window}',
+                values: { window: windowLabel(data?.window) },
+              })}
+            </EuiBadge>
+          ) : (
+            <EuiPopover
+              aria-label={i18n.translate('xpack.alertingV2.sequenceBuilder.hopWindowPopover', {
+                defaultMessage: 'Edit hop window',
+              })}
+              button={
+                <EuiBadge
+                  color="hollow"
+                  onClick={() => setIsOpen((open) => !open)}
+                  onClickAriaLabel={i18n.translate(
+                    'xpack.alertingV2.sequenceBuilder.editHopWindow',
+                    {
+                      defaultMessage: 'Edit time window: within {window}',
+                      values: { window: windowLabel(data?.window) },
+                    }
+                  )}
+                  data-test-subj={`sequenceHopBadge-${id}`}
+                >
+                  {i18n.translate('xpack.alertingV2.sequenceBuilder.withinWindow', {
+                    defaultMessage: 'within {window}',
+                    values: { window: windowLabel(data?.window) },
+                  })}
+                </EuiBadge>
+              }
+              isOpen={isOpen}
+              closePopover={() => setIsOpen(false)}
+              panelPaddingSize="s"
+              anchorPosition="upCenter"
+            >
+              <EuiSelect
+                compressed
+                options={WINDOW_OPTIONS}
+                value={data?.window}
+                onChange={(e) => data?.onChange(e.target.value)}
+                aria-label={i18n.translate('xpack.alertingV2.sequenceBuilder.hopWindowSelect', {
+                  defaultMessage: 'Time window between steps',
+                })}
+                data-test-subj={`sequenceHopWindow-${id}`}
+              />
+            </EuiPopover>
+          )}
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/sequence_node.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/sequence/sequence_node.tsx
@@ -1,0 +1,234 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  EuiButtonGroup,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiToolTip,
+  euiShadow,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import type { Node, NodeProps } from '@xyflow/react';
+import { Handle, Position } from '@xyflow/react';
+import { RULE_DRAG_MIME_TYPE } from './form_types';
+
+const RULE_ROW_HEIGHT = 24;
+const OPERATOR_ROW_HEIGHT = 28;
+const NODE_PADDING_Y = 16;
+
+export const getNodeHeight = (rulesCount: number): number => {
+  if (rulesCount <= 1) return 48;
+  return NODE_PADDING_Y + rulesCount * RULE_ROW_HEIGHT + OPERATOR_ROW_HEIGHT;
+};
+
+export interface SequenceNodeData extends Record<string, unknown> {
+  stepId: string;
+  rules: Array<{ ruleId: string; ruleName: string }>;
+  operator: 'and' | 'or';
+  stageIndex: number;
+  onRemoveRule: (stepId: string, ruleId: string) => void;
+  onOperatorChange: (stepId: string, op: 'and' | 'or') => void;
+  onDropRule: (
+    stepId: string,
+    payload: { id: string; name: string; groupingFields: string[]; kind: 'alert' | 'signal' }
+  ) => void;
+  interactive?: boolean;
+}
+
+export type SequenceNodeType = Node<SequenceNodeData, 'sequenceStage'>;
+
+const OPERATOR_OPTIONS = [
+  {
+    id: 'or',
+    label: i18n.translate('xpack.alertingV2.sequenceBuilder.node.operatorOr', {
+      defaultMessage: 'OR',
+    }),
+  },
+  {
+    id: 'and',
+    label: i18n.translate('xpack.alertingV2.sequenceBuilder.node.operatorAnd', {
+      defaultMessage: 'AND',
+    }),
+  },
+];
+
+export const SequenceNode: React.FC<NodeProps<SequenceNodeType>> = ({ data }) => {
+  const euiThemeCtx = useEuiTheme();
+  const { euiTheme } = euiThemeCtx;
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const nodeCss = useMemo(
+    () => css`
+      width: 100%;
+      height: 100%;
+      background-color: ${euiTheme.colors.backgroundBasePlain};
+      border: 1px solid ${isDragOver ? euiTheme.colors.primary : euiTheme.colors.borderBaseFloating};
+      border-radius: 8px;
+      padding: 8px 10px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 2px;
+      ${euiShadow(euiThemeCtx as Parameters<typeof euiShadow>[0], 'xs', { direction: 'down' })}
+      ${isDragOver ? `box-shadow: 0 0 0 2px ${euiTheme.colors.primary}33;` : ''}
+    `,
+    [euiTheme, euiThemeCtx, isDragOver]
+  );
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!data.interactive) return;
+    if (!e.dataTransfer.types.includes(RULE_DRAG_MIME_TYPE)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = () => setIsDragOver(false);
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!data.interactive) return;
+    setIsDragOver(false);
+    const raw = e.dataTransfer.getData(RULE_DRAG_MIME_TYPE);
+    if (!raw) return;
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      const payload = JSON.parse(raw) as {
+        id: string;
+        name: string;
+        groupingFields: string[];
+        kind: 'alert' | 'signal';
+      };
+      data.onDropRule(data.stepId, payload);
+    } catch {
+      /* noop */
+    }
+  };
+
+  const isMultiRule = data.rules.length > 1;
+  const isInteractive = data.interactive !== false;
+
+  return (
+    <EuiFlexGroup css={{ width: '100%', height: '100%' }} gutterSize="none">
+      <Handle
+        type="target"
+        position={Position.Left}
+        style={{ visibility: data.stageIndex === 0 ? 'hidden' : 'visible' }}
+      />
+
+      <EuiFlexItem
+        css={nodeCss}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <div
+              css={{
+                width: '22px',
+                height: '22px',
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '11px',
+                fontWeight: 'bold',
+                color: euiTheme.colors.emptyShade,
+                backgroundColor: euiTheme.colors.primary,
+                flexShrink: 0,
+              }}
+            >
+              {data.stageIndex + 1}
+            </div>
+          </EuiFlexItem>
+
+          <EuiFlexItem css={{ minWidth: 0 }}>
+            {data.rules.map((rule) => (
+              <EuiFlexGroup
+                key={rule.ruleId}
+                alignItems="center"
+                gutterSize="xs"
+                responsive={false}
+              >
+                <EuiFlexItem css={{ minWidth: 0 }}>
+                  <div
+                    css={{
+                      fontSize: '13px',
+                      fontWeight: 600,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      lineHeight: `${RULE_ROW_HEIGHT}px`,
+                    }}
+                    title={rule.ruleName}
+                  >
+                    {rule.ruleName}
+                  </div>
+                </EuiFlexItem>
+                {isInteractive && (
+                  <EuiFlexItem grow={false}>
+                    <EuiToolTip
+                      content={i18n.translate('xpack.alertingV2.sequenceBuilder.node.removeRule', {
+                        defaultMessage: 'Remove {name} from step',
+                        values: { name: rule.ruleName },
+                      })}
+                      disableScreenReaderOutput
+                    >
+                      <EuiButtonIcon
+                        iconType="cross"
+                        size="xs"
+                        color="text"
+                        aria-label={i18n.translate(
+                          'xpack.alertingV2.sequenceBuilder.node.removeRule',
+                          {
+                            defaultMessage: 'Remove {name} from step',
+                            values: { name: rule.ruleName },
+                          }
+                        )}
+                        onClick={() => data.onRemoveRule(data.stepId, rule.ruleId)}
+                      />
+                    </EuiToolTip>
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
+            ))}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        {isMultiRule && (
+          <div css={{ marginTop: '4px' }}>
+            {isInteractive ? (
+              <EuiButtonGroup
+                legend={i18n.translate('xpack.alertingV2.sequenceBuilder.node.operatorLegend', {
+                  defaultMessage: 'Step match condition',
+                })}
+                options={OPERATOR_OPTIONS}
+                idSelected={data.operator}
+                onChange={(id) => data.onOperatorChange(data.stepId, id as 'and' | 'or')}
+                buttonSize="compressed"
+                isFullWidth
+              />
+            ) : (
+              <EuiText size="xs" color="subdued" textAlign="center">
+                {data.operator.toUpperCase()}
+              </EuiText>
+            )}
+          </div>
+        )}
+      </EuiFlexItem>
+
+      <Handle type="source" position={Position.Right} />
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/application/rules_app.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/application/rules_app.tsx
@@ -5,12 +5,24 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { i18n } from '@kbn/i18n';
 import { Route, Routes } from '@kbn/shared-ux-router';
+import { EuiLoadingSpinner } from '@elastic/eui';
 import { RulesListPage } from '../pages/rules_list_page/rules_list_page';
 import { RuleDetailsRoute } from '../routes/rule_details_route';
 import { RequireAlertingPrivilege } from '../components/require_alerting_privilege';
+
+const SequenceBuilderPage = lazy(() =>
+  import('../pages/sequence_builder_page').then((m) => ({ default: m.SequenceBuilderPage }))
+);
+
+const SequenceBuilderFallback = () => (
+  <EuiLoadingSpinner
+    size="xl"
+    style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)' }}
+  />
+);
 
 export const RulesApp = () => {
   return (
@@ -19,6 +31,12 @@ export const RulesApp = () => {
       pageName={i18n.translate('xpack.alertingV2.rulesApp.pageName', { defaultMessage: 'Rules' })}
     >
       <Routes>
+        <Route exact path="/sequence/create">
+          <Suspense fallback={<SequenceBuilderFallback />}>
+            <SequenceBuilderPage />
+          </Suspense>
+        </Route>
+
         <Route exact path="/:ruleId">
           <RuleDetailsRoute />
         </Route>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
@@ -60,6 +60,7 @@ export const AGENT_BUILDER_NEW_CONVERSATION_PATH = '/agents/elastic-ai-agent/con
 export const paths = {
   ruleDetails: (id: string) => `${ALERTING_V2_RULES_BASE_PATH}/${encodeURIComponent(id)}`,
   ruleList: ALERTING_V2_RULES_BASE_PATH,
+  sequenceRuleCreate: `${ALERTING_V2_RULES_BASE_PATH}/sequence/create`,
   actionPolicyCreate: `${ALERTING_V2_ACTION_POLICIES_BASE_PATH}/create`,
   actionPolicyEdit: (id: string) =>
     `${ALERTING_V2_ACTION_POLICIES_BASE_PATH}/edit/${encodeURIComponent(id)}`,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_header.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_header.tsx
@@ -21,15 +21,31 @@ const getRulesListMenu = ({
   onCreateRule,
   onCreateEsqlRule,
   onCreateWithAgent,
+  onBuildSequence,
   createWithAgentDisabled,
   createWithAgentTooltipText,
 }: {
   onCreateRule: () => void;
   onCreateEsqlRule: () => void;
   onCreateWithAgent: () => void;
+  onBuildSequence: () => void;
   createWithAgentDisabled?: boolean;
   createWithAgentTooltipText?: string;
 }): AppHeaderMenu => ({
+  items: [
+    {
+      id: 'buildSequence',
+      label: i18n.translate('xpack.alertingV2.rulesList.buildSequenceButton', {
+        defaultMessage: 'Build a sequence',
+      }),
+      iconType: 'branch',
+      tooltipContent: i18n.translate('xpack.alertingV2.rulesList.buildSequenceTooltip', {
+        defaultMessage: 'Chain rules to detect multi-step alert patterns',
+      }),
+      testId: 'createSequenceRuleButton',
+      run: onBuildSequence,
+    },
+  ],
   primaryActionItem: {
     id: 'createRule',
     label: i18n.translate('xpack.alertingV2.rulesList.createRuleButton', {
@@ -77,6 +93,7 @@ export interface RulesListHeaderProps {
   onCreateRule: () => void;
   onCreateEsqlRule: () => void;
   onCreateWithAgent: () => void;
+  onBuildSequence: () => void;
   createWithAgentDisabled?: boolean;
   createWithAgentTooltipText?: string;
 }
@@ -91,6 +108,7 @@ export const RulesListHeader = ({
   onCreateRule,
   onCreateEsqlRule,
   onCreateWithAgent,
+  onBuildSequence,
   createWithAgentDisabled,
   createWithAgentTooltipText,
 }: RulesListHeaderProps) => {
@@ -104,6 +122,7 @@ export const RulesListHeader = ({
             onCreateRule,
             onCreateEsqlRule,
             onCreateWithAgent,
+            onBuildSequence,
             createWithAgentDisabled,
             createWithAgentTooltipText,
           })
@@ -113,6 +132,7 @@ export const RulesListHeader = ({
       onCreateRule,
       onCreateEsqlRule,
       onCreateWithAgent,
+      onBuildSequence,
       createWithAgentDisabled,
       createWithAgentTooltipText,
     ]

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { EuiEmptyPrompt } from '@elastic/eui';
 import { ContentList, ContentListProvider, ContentListToolbar } from '@kbn/content-list';
-import { useService } from '@kbn/core-di-browser';
+import { CoreStart, useService } from '@kbn/core-di-browser';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useBoolean } from '@kbn/react-hooks';
 import { UserCapabilities } from '../../services/user_capabilities';
-import { RULES_CONTENT_LIST_ID } from '../../constants';
+import { RULES_CONTENT_LIST_ID, paths } from '../../constants';
 import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
 import { useComposeDiscoverFlyout } from '../../hooks/use_compose_discover_flyout';
 import {
@@ -49,6 +49,11 @@ export const RulesListPage = () => {
   const { flyout, openCreateFlyout, openCreateBuilderFlyout, openEditFlyout, openCloneFlyout } =
     useComposeDiscoverFlyout();
   const navigateToAgentBuilder = useNavigateToAgentBuilder();
+  const { navigateToUrl } = useService(CoreStart('application'));
+  const basePath = useService(CoreStart('http')).basePath;
+  const navigateToSequenceBuilder = useCallback(() => {
+    navigateToUrl(basePath.prepend(paths.sequenceRuleCreate));
+  }, [navigateToUrl, basePath]);
   const isRuleManagementABSkillAvailable = useIsRuleManagementABSkillAvailable();
   const abSkillRequirements = useRuleManagementABSkillRequirements();
   // We always render the "Create with agent" entry points; when the skill is unavailable they
@@ -153,6 +158,7 @@ export const RulesListPage = () => {
           onCreateRule={openCreateOptionsFlyout}
           onCreateEsqlRule={openCreateFlyout}
           onCreateWithAgent={navigateToAgentBuilder}
+          onBuildSequence={navigateToSequenceBuilder}
           createWithAgentDisabled={!isRuleManagementABSkillAvailable}
           createWithAgentTooltipText={createWithAgentTooltipText}
         />

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/alert_condition_canvas.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/alert_condition_canvas.tsx
@@ -1,0 +1,414 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { ColorMode } from '@xyflow/react';
+import { Background, Controls, ReactFlow, ReactFlowProvider } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { useQuery } from '@kbn/react-query';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import {
+  SequenceNode,
+  SequenceEdge,
+  layoutSequence,
+  RULE_DRAG_MIME_TYPE,
+  generateStepId,
+  WINDOW_OPTIONS,
+} from '@kbn/alerting-v2-rule-form';
+import type {
+  SequenceFormValues,
+  SequenceNodeType,
+  SequenceEdgeType,
+} from '@kbn/alerting-v2-rule-form';
+import { ALERTING_V2_RULE_API_PATH } from '../../constants';
+import { useCanvasFitView } from './use_canvas_fit_view';
+
+const nodeTypes = { sequenceStage: SequenceNode };
+const edgeTypes = { sequenceHop: SequenceEdge };
+
+interface FetchedRule {
+  id: string;
+  name: string;
+  groupingFields: string[];
+  kind: 'alert' | 'signal';
+}
+
+interface CanvasContentProps {
+  nodes: SequenceNodeType[];
+  edges: SequenceEdgeType[];
+  stepsLength: number;
+  closeAllHopPopovers: () => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  colorMode: ColorMode;
+}
+
+const AlertCanvasContent: React.FC<CanvasContentProps> = ({
+  nodes,
+  edges,
+  stepsLength,
+  closeAllHopPopovers,
+  onDrop,
+  colorMode,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  useCanvasFitView(nodes.length);
+
+  return (
+    <div
+      style={{ height: '100%', position: 'relative' }}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={onDrop}
+      data-test-subj="sequenceBuilderAlertCanvas"
+    >
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView={false}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        onPaneClick={closeAllHopPopovers}
+        onNodeClick={closeAllHopPopovers}
+        onMoveStart={closeAllHopPopovers}
+        proOptions={{ hideAttribution: true }}
+        colorMode={colorMode}
+      >
+        <Controls showInteractive={false} />
+        <Background />
+      </ReactFlow>
+
+      {stepsLength === 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            pointerEvents: 'none',
+            zIndex: euiTheme.levels.header,
+          }}
+        >
+          <EuiText color="subdued" textAlign="center">
+            <FormattedMessage
+              id="xpack.alertingV2.sequenceBuilderPage.emptyCanvas"
+              defaultMessage="Drag rules here to build a sequence"
+            />
+          </EuiText>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const RuleListItem: React.FC<{ rule: FetchedRule }> = ({ rule }) => (
+  <EuiPanel
+    paddingSize="s"
+    hasBorder
+    draggable
+    onDragStart={(e: React.DragEvent<HTMLDivElement>) => {
+      e.dataTransfer.setData(
+        RULE_DRAG_MIME_TYPE,
+        JSON.stringify({
+          id: rule.id,
+          name: rule.name,
+          groupingFields: rule.groupingFields,
+          kind: rule.kind,
+        })
+      );
+      e.dataTransfer.effectAllowed = 'copy';
+    }}
+    css={css`
+      cursor: grab;
+      &:active {
+        cursor: grabbing;
+      }
+    `}
+    data-test-subj={`sequenceBuilderRuleItem-${rule.id}`}
+  >
+    <EuiText size="s" className="eui-textTruncate">
+      {rule.name}
+    </EuiText>
+  </EuiPanel>
+);
+
+export interface AlertConditionCanvasProps {
+  seqValues: SequenceFormValues;
+  setSeqValues: React.Dispatch<React.SetStateAction<SequenceFormValues>>;
+  excludeRuleId?: string;
+}
+
+export const AlertConditionCanvas: React.FC<AlertConditionCanvasProps> = ({
+  seqValues,
+  setSeqValues,
+  excludeRuleId,
+}) => {
+  const { colorMode } = useEuiTheme();
+  const http = useService(CoreStart('http'));
+
+  // TODO: Add pagination or infinite scroll for users with more than 200 rules
+  const { data: rulesData, isLoading: isLoadingRules } = useQuery({
+    queryKey: ['sequence-builder-available-rules'],
+    refetchOnWindowFocus: false,
+    queryFn: () =>
+      http.get<{
+        items: Array<{
+          id: string;
+          kind: 'alert' | 'signal';
+          metadata: { name: string };
+          grouping?: { fields: string[] } | null;
+        }>;
+      }>(ALERTING_V2_RULE_API_PATH, {
+        query: { perPage: 200, sortField: 'name', sortOrder: 'asc' },
+      }),
+  });
+
+  const fetchedRules = useMemo<FetchedRule[]>(
+    () =>
+      (rulesData?.items ?? []).map((r) => ({
+        id: r.id,
+        name: r.metadata.name,
+        groupingFields: r.grouping?.fields ?? [],
+        kind: r.kind,
+      })),
+    [rulesData]
+  );
+
+  const usedRuleIds = useMemo<Set<string>>(
+    () => new Set(seqValues.steps.flatMap((s) => s.rules.map((r) => r.ruleId))),
+    [seqValues.steps]
+  );
+
+  const availableRules = useMemo(
+    () =>
+      fetchedRules.filter(
+        (r) => !usedRuleIds.has(r.id) && (excludeRuleId === undefined || r.id !== excludeRuleId)
+      ),
+    [fetchedRules, usedRuleIds, excludeRuleId]
+  );
+
+  const [closeAllHopPopoversTick, setCloseAllHopPopoversTick] = useState(0);
+  const closeAllHopPopovers = useCallback(() => setCloseAllHopPopoversTick((t) => t + 1), []);
+
+  const removeRule = useCallback(
+    (stepId: string, ruleId: string) => {
+      setSeqValues((prev) => {
+        const nextSteps = prev.steps
+          .map((s) =>
+            s.id === stepId ? { ...s, rules: s.rules.filter((r) => r.ruleId !== ruleId) } : s
+          )
+          .filter((s) => s.rules.length > 0);
+        const hopWindows = prev.hopWindows.slice(0, Math.max(0, nextSteps.length - 1));
+        return {
+          ...prev,
+          steps: nextSteps,
+          hopWindows,
+          recoveryStepIndex: Math.max(0, Math.min(prev.recoveryStepIndex, nextSteps.length - 1)),
+          recoveryStepIndices: undefined,
+        };
+      });
+    },
+    [setSeqValues]
+  );
+
+  const changeStepOperator = useCallback(
+    (stepId: string, operator: 'and' | 'or') => {
+      setSeqValues((prev) => ({
+        ...prev,
+        steps: prev.steps.map((s) => (s.id === stepId ? { ...s, operator } : s)),
+      }));
+    },
+    [setSeqValues]
+  );
+
+  const addRuleToStep = useCallback(
+    (
+      stepId: string,
+      payload: { id: string; name: string; groupingFields: string[]; kind: 'alert' | 'signal' }
+    ) => {
+      setSeqValues((prev) => ({
+        ...prev,
+        steps: prev.steps.map((s) =>
+          s.id === stepId
+            ? {
+                ...s,
+                rules: [
+                  ...s.rules,
+                  {
+                    ruleId: payload.id,
+                    ruleName: payload.name,
+                    groupingFields: payload.groupingFields,
+                    kind: payload.kind,
+                  },
+                ],
+              }
+            : s
+        ),
+      }));
+    },
+    [setSeqValues]
+  );
+
+  const updateHopWindow = useCallback(
+    (hopIndex: number, value: string) => {
+      const option = WINDOW_OPTIONS.find((o) => o.value === value);
+      if (!option) return;
+      const num = parseInt(value.slice(0, -1), 10);
+      const unit = value.slice(-1) as 'm' | 'h' | 'd';
+      if (isNaN(num)) return;
+      setSeqValues((prev) => ({
+        ...prev,
+        hopWindows: prev.hopWindows.map((hw, i) => (i === hopIndex ? { value: num, unit } : hw)),
+      }));
+    },
+    [setSeqValues]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const payload = e.dataTransfer.getData(RULE_DRAG_MIME_TYPE);
+      if (!payload) return;
+      try {
+        const { id, name, groupingFields, kind } = JSON.parse(payload) as {
+          id: string;
+          name: string;
+          groupingFields: string[];
+          kind: 'alert' | 'signal';
+        };
+        setSeqValues((prev) => {
+          if (prev.steps.some((s) => s.rules.some((r) => r.ruleId === id))) return prev;
+          const newStep = {
+            id: generateStepId(),
+            rules: [{ ruleId: id, ruleName: name, groupingFields, kind }],
+            operator: 'or' as const,
+          };
+          const nextSteps = [...prev.steps, newStep];
+          return {
+            ...prev,
+            steps: nextSteps,
+            hopWindows: [...prev.hopWindows, { value: 1, unit: 'h' as const }].slice(
+              0,
+              nextSteps.length - 1
+            ),
+            recoveryStepIndex: nextSteps.length - 1,
+            recoveryStepIndices: undefined,
+          };
+        });
+      } catch {
+        /* noop */
+      }
+    },
+    [setSeqValues]
+  );
+
+  const stages = useMemo(
+    () =>
+      seqValues.steps.map((step) => ({
+        stepId: step.id,
+        rules: step.rules.map((r) => ({ ruleId: r.ruleId, ruleName: r.ruleName ?? r.ruleId })),
+        operator: step.operator,
+      })),
+    [seqValues.steps]
+  );
+
+  const hopWindowStrings = useMemo(
+    () => seqValues.hopWindows.map((h) => `${h.value}${h.unit}`),
+    [seqValues.hopWindows]
+  );
+
+  const { nodes, edges } = useMemo(
+    () =>
+      layoutSequence(
+        stages,
+        hopWindowStrings,
+        removeRule,
+        changeStepOperator,
+        addRuleToStep,
+        updateHopWindow,
+        closeAllHopPopoversTick
+      ),
+    [
+      stages,
+      hopWindowStrings,
+      removeRule,
+      changeStepOperator,
+      addRuleToStep,
+      updateHopWindow,
+      closeAllHopPopoversTick,
+    ]
+  );
+
+  return (
+    <EuiFlexGroup gutterSize="none" style={{ height: '100%', overflow: 'hidden' }}>
+      <EuiFlexItem grow={false} style={{ width: 260, overflow: 'auto', padding: 8 }}>
+        <EuiText size="xs">
+          <strong>
+            <FormattedMessage
+              id="xpack.alertingV2.sequenceBuilderPage.availableRulesTitle"
+              defaultMessage="Available rules"
+            />
+          </strong>
+        </EuiText>
+        <EuiFlexGroup direction="column" gutterSize="xs" style={{ marginTop: 8 }}>
+          {isLoadingRules ? (
+            <EuiFlexGroup justifyContent="center" alignItems="center" style={{ height: '100%' }}>
+              <EuiLoadingSpinner size="m" />
+            </EuiFlexGroup>
+          ) : (
+            <>
+              {availableRules.map((rule) => (
+                <EuiFlexItem key={rule.id} grow={false}>
+                  <RuleListItem rule={rule} />
+                </EuiFlexItem>
+              ))}
+              {availableRules.length === 0 && (
+                <EuiText size="s" color="subdued">
+                  {fetchedRules.length === 0 ? (
+                    <FormattedMessage
+                      id="xpack.alertingV2.sequenceBuilderPage.noRulesFound"
+                      defaultMessage="No rules found"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="xpack.alertingV2.sequenceBuilderPage.allRulesUsed"
+                      defaultMessage="All rules are placed on the canvas"
+                    />
+                  )}
+                </EuiText>
+              )}
+            </>
+          )}
+        </EuiFlexGroup>
+      </EuiFlexItem>
+
+      <EuiFlexItem style={{ minWidth: 0 }}>
+        <ReactFlowProvider>
+          <AlertCanvasContent
+            nodes={nodes}
+            edges={edges}
+            stepsLength={seqValues.steps.length}
+            closeAllHopPopovers={closeAllHopPopovers}
+            onDrop={handleDrop}
+            colorMode={colorMode as ColorMode}
+          />
+        </ReactFlowProvider>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/index.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/index.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import { FormProvider } from 'react-hook-form';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { PluginStart } from '@kbn/core-di';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { LensPublicStart } from '@kbn/lens-plugin/public';
+import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
+import type { DashboardStart } from '@kbn/dashboard-plugin/public';
+import type { CPSPluginStart } from '@kbn/cps/public';
+import { RuleFormProvider } from '@kbn/alerting-v2-rule-form';
+import type { RuleFormServices } from '@kbn/alerting-v2-rule-form';
+import { paths } from '../../constants';
+import { useSequenceBuilderForm, useSequenceBuilderState } from './use_sequence_builder_form';
+import { SequenceBuilderHeader } from './sequence_builder_header';
+import { AlertConditionCanvas } from './alert_condition_canvas';
+
+const useRuleFormServicesBag = (): RuleFormServices => {
+  const http = useService(CoreStart('http'));
+  const notifications = useService(CoreStart('notifications'));
+  const application = useService(CoreStart('application'));
+  const data = useService(PluginStart('data')) as DataPublicPluginStart;
+  const dataViews = useService(PluginStart('dataViews')) as DataViewsPublicPluginStart;
+  const lens = useService(PluginStart('lens')) as LensPublicStart;
+  const uiActions = useService(PluginStart('uiActions')) as UiActionsStart;
+  const dashboard = useService(PluginStart('dashboard'), { optional: true }) as
+    | DashboardStart
+    | undefined;
+  const cps = useService(PluginStart('cps'), { optional: true }) as CPSPluginStart | undefined;
+
+  return useMemo<RuleFormServices>(
+    () => ({ http, data, dataViews, notifications, application, lens, uiActions, dashboard, cps }),
+    [http, data, dataViews, notifications, application, lens, uiActions, dashboard, cps]
+  );
+};
+
+export const SequenceBuilderPage: React.FC = () => {
+  const application = useService(CoreStart('application'));
+  const ruleFormServices = useRuleFormServicesBag();
+
+  const { methods } = useSequenceBuilderForm();
+  const uiState = useSequenceBuilderState();
+
+  const basePath = useService(CoreStart('http')).basePath;
+  const handleCancel = useCallback(() => {
+    application.navigateToUrl(basePath.prepend(paths.ruleList));
+  }, [application, basePath]);
+
+  const rulesListHref = useMemo(() => basePath.prepend(paths.ruleList), [basePath]);
+
+  const handleSave = methods.handleSubmit((formValues) => uiState.save(formValues));
+
+  return (
+    <RuleFormProvider services={ruleFormServices} meta={{ layout: 'flyout' }}>
+      <FormProvider {...methods}>
+        <EuiFlexGroup
+          direction="column"
+          gutterSize="none"
+          style={{ height: '100%', overflow: 'hidden' }}
+        >
+          <EuiFlexItem grow={false}>
+            <SequenceBuilderHeader
+              seqValues={uiState.seqValues}
+              isSaving={uiState.isSaving}
+              rulesListHref={rulesListHref}
+              onSave={handleSave}
+              onCancel={handleCancel}
+            />
+          </EuiFlexItem>
+
+          <EuiFlexItem style={{ minHeight: 0 }}>
+            <AlertConditionCanvas
+              seqValues={uiState.seqValues}
+              setSeqValues={uiState.setSeqValues}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </FormProvider>
+    </RuleFormProvider>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/sequence_builder_header.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/sequence_builder_header.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import { AppHeader } from '@kbn/app-header';
+import type { AppHeaderMenu } from '@kbn/app-header';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { isSequenceValid } from '@kbn/alerting-v2-rule-form';
+import type { FormValues, SequenceFormValues } from '@kbn/alerting-v2-rule-form';
+import { DEFAULT_SEQUENCE_RULE_NAME } from './use_sequence_builder_form';
+
+export interface SequenceBuilderHeaderProps {
+  seqValues: SequenceFormValues;
+  isSaving: boolean;
+  rulesListHref: string;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+export const SequenceBuilderHeader: React.FC<SequenceBuilderHeaderProps> = ({
+  seqValues,
+  isSaving,
+  rulesListHref,
+  onSave,
+  onCancel,
+}) => {
+  const { setValue } = useFormContext<FormValues>();
+  const ruleName = useWatch<FormValues, 'metadata.name'>({ name: 'metadata.name' });
+  const sequenceValid = isSequenceValid(seqValues);
+  const trimmedName = (ruleName ?? '').trim();
+  const canSave =
+    !isSaving &&
+    sequenceValid &&
+    trimmedName.length > 0 &&
+    trimmedName !== DEFAULT_SEQUENCE_RULE_NAME;
+
+  const onTitleSave = useCallback(
+    async (newName: string) => {
+      setValue('metadata.name', newName);
+    },
+    [setValue]
+  );
+
+  const editableTitle = useMemo(
+    () => ({
+      text: ruleName ?? DEFAULT_SEQUENCE_RULE_NAME,
+      onSave: onTitleSave,
+    }),
+    [ruleName, onTitleSave]
+  );
+
+  const saveDisabledReason = useMemo(() => {
+    if (isSaving) return undefined;
+    if (!sequenceValid) {
+      return i18n.translate('xpack.alertingV2.sequenceBuilderPage.saveDisabledSequenceTooltip', {
+        defaultMessage: 'Add at least two steps with rules to save',
+      });
+    }
+    if (!canSave && !isSaving) {
+      return i18n.translate('xpack.alertingV2.sequenceBuilderPage.saveDisabledGenericTooltip', {
+        defaultMessage: 'Enter a valid rule name and fix any validation errors to save',
+      });
+    }
+    return undefined;
+  }, [isSaving, sequenceValid, canSave]);
+
+  const menu = useMemo((): AppHeaderMenu => {
+    return {
+      items: [],
+      primaryActionItem: {
+        id: 'save',
+        label: i18n.translate('xpack.alertingV2.sequenceBuilderPage.saveButton', {
+          defaultMessage: 'Save',
+        }),
+        iconType: 'check',
+        run: onSave,
+        isLoading: isSaving,
+        disableButton: !canSave,
+        tooltipContent: saveDisabledReason,
+        testId: 'sequenceBuilderSave',
+      },
+    };
+  }, [isSaving, canSave, saveDisabledReason, onSave]);
+
+  return (
+    <AppHeader
+      sticky={false}
+      title={editableTitle}
+      spacing="bleed"
+      back={{
+        href: rulesListHref,
+        label: i18n.translate('xpack.alertingV2.sequenceBuilderPage.backToRulesLabel', {
+          defaultMessage: 'Rules',
+        }),
+        onClick: (event) => {
+          event.preventDefault();
+          onCancel();
+        },
+      }}
+      menu={menu}
+      showAddIntegrations={false}
+    />
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/use_canvas_fit_view.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/use_canvas_fit_view.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useReactFlow, useStore } from '@xyflow/react';
+import type { SequenceNodeType, SequenceEdgeType } from '@kbn/alerting-v2-rule-form';
+
+export const useCanvasFitView = (nodesLength: number) => {
+  const { fitView } = useReactFlow<SequenceNodeType, SequenceEdgeType>();
+  const measuredWidth = useStore((s) => s.width);
+  const measuredHeight = useStore((s) => s.height);
+
+  const lastFittedCountRef = useRef(-1);
+  const fitTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    lastFittedCountRef.current = -1;
+    return () => {
+      if (fitTimerRef.current !== undefined) clearTimeout(fitTimerRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (nodesLength === 0 || measuredWidth <= 0 || measuredHeight <= 0) return;
+    if (lastFittedCountRef.current === nodesLength) return;
+
+    const isInitialFit = lastFittedCountRef.current === -1;
+    const targetCount = nodesLength;
+
+    if (fitTimerRef.current !== undefined) clearTimeout(fitTimerRef.current);
+
+    fitTimerRef.current = setTimeout(() => {
+      fitTimerRef.current = undefined;
+      fitView({ padding: 0.4, duration: isInitialFit ? 0 : 200, maxZoom: 1.2 });
+      lastFittedCountRef.current = targetCount;
+    }, 50);
+  }, [measuredWidth, measuredHeight, nodesLength, fitView]);
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/use_sequence_builder_form.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/sequence_builder_page/use_sequence_builder_form.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useQueryClient } from '@kbn/react-query';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import { i18n } from '@kbn/i18n';
+import type { FormValues } from '@kbn/alerting-v2-rule-form';
+import {
+  DEFAULT_SEQUENCE_FORM_VALUES,
+  buildSequenceRuleQueryData,
+  composeFormToCreateRequest,
+} from '@kbn/alerting-v2-rule-form';
+import type { SequenceFormValues } from '@kbn/alerting-v2-rule-form';
+import { RulesApi } from '../../services/rules_api';
+import { ruleKeys } from '../../hooks/query_key_factory';
+import { paths } from '../../constants';
+
+export const DEFAULT_SEQUENCE_RULE_NAME = i18n.translate(
+  'xpack.alertingV2.sequenceBuilder.defaultRuleName',
+  { defaultMessage: 'Untitled sequence rule' }
+);
+
+const getDefaultFormValues = (): FormValues => ({
+  kind: 'alert',
+  metadata: { name: DEFAULT_SEQUENCE_RULE_NAME, enabled: true, description: '', tags: [] },
+  timeField: '@timestamp',
+  schedule: { every: '1m', lookback: '5m' },
+  query: { format: 'standalone', breach: { query: '' }, recovery: { query: '' } },
+  recoveryStrategy: undefined,
+  grouping: undefined,
+  noDataStrategy: 'none',
+  stateTransition: undefined,
+  stateTransitionAlertDelayMode: 'immediate',
+  stateTransitionRecoveryDelayMode: 'immediate',
+  artifacts: [],
+  runbookArtifacts: [],
+  dashboardArtifacts: [],
+});
+
+export type SequenceBuilderStep = 'alert' | 'recovery';
+
+export const useSequenceBuilderForm = () => {
+  const methods = useForm<FormValues>({ mode: 'onBlur', values: getDefaultFormValues() });
+  return { methods, isLoading: false };
+};
+
+export const useSequenceBuilderState = () => {
+  const rulesApi = useService(RulesApi);
+  const { navigateToUrl } = useService(CoreStart('application'));
+  const basePath = useService(CoreStart('http')).basePath;
+  const notifications = useService(CoreStart('notifications'));
+  const queryClient = useQueryClient();
+
+  const [seqValues, setSeqValues] = useState<SequenceFormValues>(DEFAULT_SEQUENCE_FORM_VALUES);
+  const [step, setStep] = useState<SequenceBuilderStep>('alert');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const seqValuesRef = useRef(seqValues);
+  seqValuesRef.current = seqValues;
+
+  const save = useCallback(
+    async (formValues: FormValues) => {
+      setIsSaving(true);
+      try {
+        const queryData = buildSequenceRuleQueryData(seqValuesRef.current);
+        if (!queryData) {
+          throw new Error(
+            i18n.translate('xpack.alertingV2.sequenceBuilder.invalidSequenceError', {
+              defaultMessage: 'Sequence is not valid — add at least two steps.',
+            })
+          );
+        }
+
+        const merged: FormValues = {
+          ...formValues,
+          kind: 'alert',
+          query: {
+            format: 'standalone',
+            breach: { query: queryData.breachQuery },
+            ...(queryData.recoveryQuery ? { recovery: { query: queryData.recoveryQuery } } : {}),
+          },
+          grouping:
+            queryData.groupingFields.length > 0 ? { fields: queryData.groupingFields } : undefined,
+          schedule: {
+            ...formValues.schedule,
+            lookback: queryData.lookbackString,
+          },
+          noDataStrategy: 'none',
+          recoveryStrategy: undefined,
+        };
+
+        const payload = composeFormToCreateRequest(merged, 'sequence');
+        await rulesApi.createRule(payload);
+
+        queryClient.invalidateQueries(ruleKeys.lists());
+        queryClient.invalidateQueries(ruleKeys.tags());
+
+        notifications.toasts.addSuccess(
+          i18n.translate('xpack.alertingV2.sequenceBuilder.saveSuccess', {
+            defaultMessage: 'Sequence rule saved successfully.',
+          })
+        );
+
+        navigateToUrl(basePath.prepend(paths.ruleList));
+      } catch (err) {
+        notifications.toasts.addError(err, {
+          title: i18n.translate('xpack.alertingV2.sequenceBuilder.saveError', {
+            defaultMessage: 'Failed to save sequence rule',
+          }),
+        });
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [rulesApi, navigateToUrl, basePath, notifications, queryClient]
+  );
+
+  return {
+    seqValues,
+    setSeqValues,
+    step,
+    setStep,
+    isSaving,
+    save,
+  };
+};


### PR DESCRIPTION
## Summary

First PR in a series adding the rule sequence builder. This PR adds the alert condition canvas - the core UI for building rule sequences.

**What's included:**
- Alert condition canvas with drag-and-drop rule placement
- Step ordering with configurable hop windows (time between steps)
- AND/OR step operators for combining rules within a step
- Breach query generation
- Save flow creating a new sequence rule
- "Build a sequence" entry point in the rules list header

**What's NOT included (coming in follow-up PRs):**
- PR2: Tests + collapsible panel + full header + last-step recovery
- PR3: Recovery condition UI + multi-step recovery
- PR4: Details panel - rule name, schedule, grouping fields
- PR5: Signal rule support
- PR6: Edit flow - parsing saved queries back into canvas state, Clone flow

## Test plan
- [ ] Navigate to Rules list, click "Build a sequence" from the create dropdown
- [ ] Drag rules onto the canvas to create steps
- [ ] Verify hop windows can be changed between steps
- [ ] Verify AND/OR toggle works within multi-rule steps
- [ ] Save a sequence rule and verify it appears in the rules list

Made with [Cursor](https://cursor.com)