### PR TITLE
[8.19] chore(deps): Upgraded @faker-js/faker to 10.5.0 (#284970)

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@emotion/serialize": "1.3.3",
     "@emotion/server": "11.11.0",
     "@emotion/styled": "11.14.1",
-    "@faker-js/faker": "8.3.1",
+    "@faker-js/faker": "10.5.0",
     "@formatjs/icu-messageformat-parser": "2.11.1",
     "@formatjs/intl": "2.10.2",
     "@formatjs/intl-utils": "3.8.4",

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/helpers/unstructured_logs.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/helpers/unstructured_logs.ts
@@ -75,19 +75,19 @@ export const unstructuredLogMessageGenerators = {
   userAuthentication: (f: Faker) =>
     f.helpers.arrayElements(
       [
-        `User ${f.internet.userName()} (id ${f.string.uuid()}) ${f.helpers.arrayElement([
+        `User ${f.internet.username()} (id ${f.string.uuid()}) ${f.helpers.arrayElement([
           'logged in',
           'logged out',
         ])} at ${f.date.recent().toISOString()} from ${f.internet.ip()}:${f.internet.port()}`,
-        `Created new user ${f.internet.userName()} (id ${f.string.uuid()})`,
-        `Disabled user ${f.internet.userName()} (id ${f.string.uuid()}) due to level ${f.number.int(
+        `Created new user ${f.internet.username()} (id ${f.string.uuid()})`,
+        `Disabled user ${f.internet.username()} (id ${f.string.uuid()}) due to level ${f.number.int(
           { max: 10 }
         )} ${f.helpers.arrayElement([
           'suspicious activity',
           'security concerns',
           'policy violation',
         ])}`,
-        `Login ${f.internet.userName()} (id ${f.string.uuid()}) incorrect ${f.number.int({
+        `Login ${f.internet.username()} (id ${f.string.uuid()}) incorrect ${f.number.int({
           max: 100,
         })} times from ${f.internet.ipv6()}.`,
       ],

--- a/src/platform/packages/shared/kbn-test/jest-preset.js
+++ b/src/platform/packages/shared/kbn-test/jest-preset.js
@@ -121,7 +121,7 @@ module.exports = {
   transformIgnorePatterns: [
     // ignore all node_modules except monaco-editor, monaco-yaml which requires babel transforms to handle dynamic import()
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
-    '[/\\\\]node_modules(?![\\/\\\\](byte-size|monaco-editor|monaco-yaml|monaco-languageserver-types|monaco-marker-data-provider|monaco-worker-manager|vscode-languageserver-types|d3-interpolate|d3-color|langchain|langsmith|@cfworker|gpt-tokenizer|flat|@langchain|eventsource-parser|fast-check|@fast-check/jest|@assemblyscript|quickselect|rbush|zod/v4|vega-interpreter|vega-util|vega-tooltip|@modelcontextprotocol|pkce-challenge|ansi-styles|uuid))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](byte-size|monaco-editor|monaco-yaml|monaco-languageserver-types|monaco-marker-data-provider|monaco-worker-manager|vscode-languageserver-types|d3-interpolate|d3-color|langchain|langsmith|@cfworker|gpt-tokenizer|flat|@langchain|eventsource-parser|fast-check|@fast-check/jest|@assemblyscript|quickselect|rbush|zod/v4|vega-interpreter|vega-util|vega-tooltip|@modelcontextprotocol|pkce-challenge|ansi-styles|uuid|@faker-js))[/\\\\].+\\.js$',
     'packages/kbn-pm/dist/index.js',
     '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain|zod/v4))/dist/[/\\\\].+\\.js$',
     '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain|zod/v4))/dist/util/[/\\\\].+\\.js$',

--- a/x-pack/platform/packages/shared/kbn-data-forge/src/data_sources/fake_stack/admin_console/lib/login_cache.ts
+++ b/x-pack/platform/packages/shared/kbn-data-forge/src/data_sources/fake_stack/admin_console/lib/login_cache.ts
@@ -31,7 +31,7 @@ export function isLoggedIn(user: User) {
 export function createUser(): User {
   const firstName = faker.person.firstName();
   const lastName = faker.person.lastName();
-  const userName = faker.internet.userName({ firstName, lastName });
+  const userName = faker.internet.username({ firstName, lastName });
   return {
     id: userName,
     name: `${firstName} ${lastName}`,

--- a/x-pack/platform/plugins/shared/lens/public/lens_ui_telemetry/color_telemetry_helpers.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_ui_telemetry/color_telemetry_helpers.test.ts
@@ -30,7 +30,7 @@ const exampleAssignment = (
         }
       : {
           type: 'colorCode',
-          colorCode: faker.internet.color(),
+          colorCode: faker.color.rgb({ format: 'hex' }),
         };
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,10 +2537,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@faker-js/faker@8.3.1":
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.3.1.tgz#7753df0cb88d7649becf984a96dd1bd0a26f43e3"
-  integrity sha512-FdgpFxY6V6rLZE9mmIBb9hM0xpfvQOSNOLnzolzKwsE1DH+gC7lEKV1p1IbR0lAYyvYd5a4u3qWJzowUkw1bIw==
+"@faker-js/faker@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-10.5.0.tgz#d2f6a8c7f08d087ac5f077d6babd0821edf24c03"
+  integrity sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==
 
 "@floating-ui/core@^1.7.1":
   version "1.7.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(deps): Upgraded @faker-js/faker to 10.5.0 (#284970)](https://github.com/elastic/kibana/pull/284970)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Shostak","email":"165678770+elena-shostak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-14T09:19:30Z","message":"chore(deps): Upgraded @faker-js/faker to 10.5.0 (#284970)\n\n## Summary\n\nUpgraded `@faker-js/faker` to 10.5.0","sha":"33a53c6d8455d336b2bc31948a8326a443cda5c7","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.6.0","Team:streams-ui","Team:obs-signals-traces"],"title":"chore(deps): Upgraded @faker-js/faker to 10.5.0","number":284970,"url":"https://github.com/elastic/kibana/pull/284970","mergeCommit":{"message":"chore(deps): Upgraded @faker-js/faker to 10.5.0 (#284970)\n\n## Summary\n\nUpgraded `@faker-js/faker` to 10.5.0","sha":"33a53c6d8455d336b2bc31948a8326a443cda5c7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284970","number":284970,"mergeCommit":{"message":"chore(deps): Upgraded @faker-js/faker to 10.5.0 (#284970)\n\n## Summary\n\nUpgraded `@faker-js/faker` to 10.5.0","sha":"33a53c6d8455d336b2bc31948a8326a443cda5c7"}}]}] BACKPORT-->