### PR TITLE
[inference] Terminate chat completion streams on cancellation and cap their duration

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/util/event_source_stream_into_observable.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/event_source_stream_into_observable.test.ts
@@ -7,6 +7,7 @@
 
 import { Readable } from 'node:stream';
 import { toArray, firstValueFrom } from 'rxjs';
+import { isInferenceRequestError } from '@kbn/inference-common';
 import { eventSourceStreamIntoObservable } from './event_source_stream_into_observable';
 
 describe('eventSourceStreamIntoObservable', () => {
@@ -50,5 +51,85 @@ describe('eventSourceStreamIntoObservable', () => {
     const results = await firstValueFrom(eventSourceStreamIntoObservable(stream).pipe(toArray()));
 
     expect(results).toEqual(['42', '9000', '51']);
+  });
+
+  it('destroys the underlying stream when the subscriber unsubscribes', () => {
+    const stream = new Readable({ read: () => {} });
+
+    const subscription = eventSourceStreamIntoObservable(stream).subscribe();
+    expect(stream.destroyed).toBe(false);
+
+    subscription.unsubscribe();
+    expect(stream.destroyed).toBe(true);
+  });
+
+  it('destroys the stream and errors the subscriber when maxDurationMs is exceeded', async () => {
+    jest.useFakeTimers();
+    try {
+      const stream = new Readable({ read: () => {} });
+
+      const error$ = new Promise<unknown>((resolve) => {
+        eventSourceStreamIntoObservable(stream, { maxDurationMs: 1_000 }).subscribe({
+          error: resolve,
+        });
+      });
+
+      jest.advanceTimersByTime(1_001);
+
+      const error = await error$;
+      expect(stream.destroyed).toBe(true);
+      // pin the error type: requestError is not retried by the default retry
+      // filter, while a providerError with this status would be
+      expect(isInferenceRequestError(error)).toBe(true);
+      expect(error).toEqual(
+        expect.objectContaining({
+          message: expect.stringContaining('maximum allowed duration'),
+          meta: expect.objectContaining({ status: 408 }),
+        })
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('completes normally when the stream ends before maxDurationMs', async () => {
+    const messages = [JSON.stringify({ foo: 'bar' }), '42'];
+    const stream = Readable.from(messages.map((message) => `data: ${message}\n\n`));
+
+    const results = await firstValueFrom(
+      eventSourceStreamIntoObservable(stream, { maxDurationMs: 5_000 }).pipe(toArray())
+    );
+
+    expect(results).toEqual(messages);
+  });
+
+  it('propagates errors emitted by the stream itself', async () => {
+    const stream = new Readable({ read: () => {} });
+
+    const error$ = new Promise<unknown>((resolve) => {
+      eventSourceStreamIntoObservable(stream).subscribe({ error: resolve });
+    });
+
+    stream.destroy(new Error('boom'));
+
+    const error = await error$;
+    expect(error).toEqual(expect.objectContaining({ message: 'boom' }));
+  });
+
+  it('clears the cap timer once the stream completes', async () => {
+    jest.useFakeTimers();
+    try {
+      const stream = Readable.from([`data: 42\n\n`]);
+
+      const results$ = firstValueFrom(
+        eventSourceStreamIntoObservable(stream, { maxDurationMs: 5_000 }).pipe(toArray())
+      );
+      await jest.advanceTimersByTimeAsync(1);
+
+      expect(await results$).toEqual(['42']);
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/x-pack/platform/plugins/shared/inference/server/util/event_source_stream_into_observable.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/event_source_stream_into_observable.ts
@@ -8,14 +8,31 @@
 import type { Readable } from 'node:stream';
 import { createParser } from 'eventsource-parser';
 import { Observable } from 'rxjs';
+import { createInferenceRequestError } from '@kbn/inference-common';
 
-export function eventSourceStreamIntoObservable(readable: Readable) {
+/** Caps hung inference streams at 10 minutes so Kibana terminates them with a typed error. */
+const MAX_STREAM_DURATION_MS = 10 * 60 * 1000;
+
+export function eventSourceStreamIntoObservable(
+  readable: Readable,
+  { maxDurationMs = MAX_STREAM_DURATION_MS }: { maxDurationMs?: number } = {}
+) {
   return new Observable<string>((subscriber) => {
     const parser = createParser({
       onEvent: (event) => {
         subscriber.next(event.data);
       },
     });
+
+    let tornDown = false;
+    const maxDurationTimer = setTimeout(() => {
+      readable.destroy(
+        createInferenceRequestError(
+          `Inference stream exceeded the maximum allowed duration of ${maxDurationMs}ms`,
+          408
+        )
+      );
+    }, maxDurationMs);
 
     async function processStream() {
       for await (const chunk of readable) {
@@ -28,8 +45,18 @@ export function eventSourceStreamIntoObservable(readable: Readable) {
         subscriber.complete();
       },
       (error) => {
-        subscriber.error(error);
+        // a teardown-initiated destroy rejects the iteration with a premature
+        // close error that must not surface after unsubscription
+        if (!tornDown) {
+          subscriber.error(error);
+        }
       }
     );
+
+    return () => {
+      tornDown = true;
+      clearTimeout(maxDurationTimer);
+      readable.destroy();
+    };
   });
 }


### PR DESCRIPTION
## Summary

The observable wrapping chat completion SSE streams had no teardown, so an aborted request could leave the underlying stream being consumed until the provider closed it. Adds a teardown that destroys the stream on unsubscribe, and a 10-minute cap (matching the OpenAI SDK's default request timeout) that fails the request with a 408 inference error.

Closes https://github.com/elastic/chat-program/issues/22

See screenshot for how the error will look (I hardcoded the limit to 60s locally to test).
<img width="1359" height="750" alt="image" src="https://github.com/user-attachments/assets/b04ec34b-6394-4d2e-87dc-9142205b606f" />



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->