### PR TITLE
[Entity Store] Pass cloneApiKey when scheduling extract entity tasks

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.test.ts
@@ -6,7 +6,9 @@
  */
 
 import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server/task';
-import { getNewSchedule } from './extract_entity_task';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import type { KibanaRequest } from '@kbn/core/server';
+import { getNewSchedule, scheduleExtractEntityTask } from './extract_entity_task';
 
 const createTaskInstance = (schedule?: ConcreteTaskInstance['schedule']): ConcreteTaskInstance =>
   ({
@@ -14,6 +16,29 @@ const createTaskInstance = (schedule?: ConcreteTaskInstance['schedule']): Concre
     taskType: 'entity_store:v2:extract_entity_task:host',
     schedule,
   } as ConcreteTaskInstance);
+
+describe('scheduleExtractEntityTask', () => {
+  it('passes cloneApiKey: true so external Cloud API keys are supported', async () => {
+    const ensureScheduled = jest.fn().mockResolvedValue(undefined);
+    const taskManager = { ensureScheduled } as unknown as TaskManagerStartContract;
+    const request = {} as KibanaRequest;
+    const logger = { error: jest.fn() } as any;
+
+    await scheduleExtractEntityTask({
+      logger,
+      taskManager,
+      type: 'host',
+      namespace: 'default',
+      frequency: '1m',
+      request,
+    });
+
+    expect(ensureScheduled).toHaveBeenCalledWith(
+      expect.objectContaining({ taskType: expect.stringContaining('extract_entity_task') }),
+      expect.objectContaining({ request, cloneApiKey: true })
+    );
+  });
+});
 
 describe('getNewSchedule', () => {
   it('returns a schedule when frequency differs from the current interval', () => {

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.ts
@@ -261,7 +261,7 @@ export async function scheduleExtractEntityTask({
         state: { namespace },
         params: {},
       },
-      { request }
+      { request, cloneApiKey: true }
     );
   } catch (e) {
     logger.error(`Error scheduling extract entity tasks, received ${e.message}`);


### PR DESCRIPTION
## Summary

Part of #282930, scoped to Entity Store.

When an entity-store extract task is scheduled from a request authenticated with a raw external Cloud API key (`essu_...`), Task Manager's default reuse-the-caller's-key path cannot parse the credential (no key id on the wire) and the schedule call throws a TypeError — the same failure mode described in #282930.

With `cloneApiKey: true` the task gets an independent, TM-owned key that is invalidated on task removal. External Cloud API keys are fully supported via the `cloneUiamRequest` path, which grants a fresh internal UIAM key instead of attempting an ES clone.

This aligns Entity Store with Agent Builder (#282965) and `workflows_execution_engine`, which already schedule this way.

### Behavior change

- Extract entity tasks scheduled from API-key-authenticated requests now run on a **cloned, TM-owned key** (privilege snapshot at schedule time) instead of the caller's key. Revoking the caller's key no longer stops the task.
- Session-authenticated requests are unaffected (they already grant fresh keys).

## Testing

- [x] `node scripts/jest x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.test.ts` (4 passing)
- [x] Type check

🤖 Generated with [Claude Code](https://claude.com/claude-code)