### PR TITLE
[Security] Fix flaky API keys FTR test: use test subject with retry for flyout title

### DIFF
--- a/x-pack/platform/test/functional/page_objects/api_keys_page.ts
+++ b/x-pack/platform/test/functional/page_objects/api_keys_page.ts
@@ -145,8 +145,7 @@ export function ApiKeysPageProvider({ getService }: FtrProviderContext) {
     },
 
     async getFlyoutTitleText() {
-      const header = await find.byClassName('euiFlyoutHeader');
-      return header.getVisibleText();
+      return await testSubjects.getVisibleText('apiKeyFlyoutTitle');
     },
 
     async getFlyoutApiKeyStatus() {


### PR DESCRIPTION
## Summary

- `getFlyoutTitleText()` in the FTR `apiKeys` page object was using `find.byClassName('euiFlyoutHeader')` without any retry, causing it to read the element before the text rendered.
- The Scout migration (#283368) added `data-test-subj="apiKeyFlyoutTitle"` to the flyout `h2` in `api_key_flyout.tsx`, but the FTR page object was not updated.
- After migration, the flyout opens via a route change (`/create`), so the title renders asynchronously — `getVisibleText()` returned `''` intermittently.

**Fix:** Switch to `testSubjects.getVisibleText('apiKeyFlyoutTitle')`.

Fixes: https://github.com/elastic/kibana/issues/283855

## Test plan

- [ ] Confirm the failing test `Serverless Common UI - Platform Security API keys should create and delete API keys correctly` passes consistently after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)