### PR TITLE
[Agent Builder] Restore legacy workflow inputs in tool schemas

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_types/workflow/generate_schema.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_types/workflow/generate_schema.test.ts
@@ -96,6 +96,42 @@ describe('generateSchema', () => {
     expect(jsonSchema.properties?.query).not.toHaveProperty('enum');
   });
 
+  it('maps legacy root-level inputs to workflow tool parameters', () => {
+    const workflow = buildWorkflow({
+      definition: {
+        name: 'Test',
+        version: '1',
+        enabled: true,
+        steps: [],
+        triggers: [{ type: 'manual' }],
+        inputs: [
+          {
+            name: 'query',
+            type: 'string' as const,
+            required: true,
+            description: 'Search query',
+          },
+          {
+            name: 'limit',
+            type: 'number' as const,
+            required: false,
+          },
+        ],
+      } as WorkflowDetailDto['definition'],
+    });
+
+    const schema = generateSchema({ workflow });
+    const jsonSchema = z.toJSONSchema(schema, { io: 'input', unrepresentable: 'any' });
+
+    expect(jsonSchema.properties?.query).toMatchObject({
+      type: 'string',
+      description: 'Search query',
+    });
+    expect(jsonSchema.properties?.limit).toMatchObject({ type: 'number' });
+    expect(jsonSchema.required).toContain('query');
+    expect(jsonSchema.required).not.toContain('limit');
+  });
+
   it('maps JSON Schema object inputs with string enum to the same enum list', () => {
     const workflow = buildWorkflow({
       definition: {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_types/workflow/generate_schema.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_types/workflow/generate_schema.ts
@@ -7,7 +7,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { WorkflowDetailDto } from '@kbn/workflows/types/v1';
-import { normalizeInputsToJsonSchema } from '@kbn/workflows/spec/lib/input_conversion';
+import { extractNormalizedInputsFromYaml } from '@kbn/workflows/spec/lib/field_conversion';
 import type { JSONSchema7 } from 'json-schema';
 
 // Simple JSON Schema to Zod converter for basic types
@@ -59,14 +59,9 @@ export const generateSchema = ({ workflow }: { workflow: WorkflowDetailDto }): z
     return z.object({});
   }
 
-  const manualTrigger = workflow.definition.triggers?.find((trigger) => trigger.type === 'manual');
-
-  if (!manualTrigger) {
-    return z.object({});
-  }
-
-  // Normalize inputs to the new JSON Schema format (handles backward compatibility)
-  const normalizedInputs = normalizeInputsToJsonSchema(manualTrigger.inputs);
+  const normalizedInputs = extractNormalizedInputsFromYaml(workflow.definition, workflow.yaml) as
+    | JSONSchema7
+    | undefined;
 
   if (!normalizedInputs?.properties) {
     return z.object({});


### PR DESCRIPTION
## TL;DR
Restores legacy root-level inputs in Agent Builder/MCP workflow tool schemas, with regression coverage.

Tested with focused Jest plus local API and MCP invocation.

Closes #269992. Supersedes #275499 (CLA blocked).

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->