### PR TITLE
[Synthetics] Fix flaky GettingStarted test caused by stale private location

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/monitor_crud/ui/tests/getting_started.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/monitor_crud/ui/tests/getting_started.spec.ts
@@ -10,9 +10,12 @@ import { expect } from '@kbn/scout-oblt/ui';
 import { test } from '../../../common/ui/fixtures';
 
 test.describe('GettingStarted', { tag: tags.stateful.classic }, () => {
+  let locationLabel: string;
+
   test.beforeAll(async ({ syntheticsServices }) => {
     await syntheticsServices.deleteMonitors();
-    await syntheticsServices.ensurePrivateLocationExists();
+    const location = await syntheticsServices.ensurePrivateLocationExists();
+    locationLabel = location.label;
   });
 
   test.afterAll(async ({ syntheticsServices }) => {
@@ -43,7 +46,7 @@ test.describe('GettingStarted', { tag: tags.stateful.classic }, () => {
     await test.step('create basic monitor', async () => {
       await pageObjects.syntheticsApp.fillFirstMonitorDetails({
         url: 'https://www.elastic.co',
-        location: 'Test private location',
+        location: locationLabel,
       });
       await pageObjects.syntheticsApp.confirmAndSave();
     });


### PR DESCRIPTION
## Summary

Fixes a flaky `GettingStarted` synthetics test that was reported as a comboBox helper issue but is not one.

`getting_started.spec.ts` hardcoded `location: 'Test private location'` when filling the combo box, but `ensurePrivateLocationExists()` returns whichever private location already exists in the cluster, not necessarily one with that exact label. When another test suite leaves behind a differently-named location, the combo box has nothing to match and the selection fails.

## Changes

- `getting_started.spec.ts` now uses the label returned by `ensurePrivateLocationExists()` instead of a hardcoded string, matching the existing pattern already used in `add_monitor.spec.ts` and `detail_flyout.spec.ts`.

An earlier revision of this PR also changed `ensurePrivateLocationExists()` to find-or-create a location by an exact label. That broke `private_locations.spec.ts`, which relies on the fixture reusing whatever location already exists (including its own), and started unconditionally creating an extra one instead. Reverted, this PR is now a single-file, minimal fix.