### PR TITLE
[sigevents][ki] Fix `error_logs` KI feature on union-typed `log.level` streams

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.test.ts
@@ -8,6 +8,7 @@
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { Streams } from '@kbn/streams-schema';
 import { getSampleDocumentsEsql } from '@kbn/ai-tools';
+import { esql } from '@elastic/esql';
 import { errorLogsGenerator } from './error_logs';
 
 jest.mock('@kbn/ai-tools', () => ({
@@ -26,7 +27,7 @@ describe('errorLogsGenerator', () => {
     jest.clearAllMocks();
   });
 
-  it('uses an ES|QL MATCH_PHRASE filter with unmappedFields=NULLIFY', async () => {
+  it('wires the error filter through to the sampling helper', async () => {
     getSampleDocumentsEsqlMock.mockResolvedValueOnce({
       hits: [
         {
@@ -56,17 +57,24 @@ describe('errorLogsGenerator', () => {
         start: 100,
         end: 200,
         sampleSize: 5,
-        unmappedFields: 'NULLIFY',
-        // Composer-built expression; deep-equality matchers fail here so just
-        // assert it is present. The query-string assertion lives in
-        // get_sample_documents.test.ts; this test guarantees the generator
-        // wires the whereCondition through.
         whereCondition: expect.anything(),
       })
     );
     expect(result).toEqual({
       samples: [{ 'log.level': 'error', message: 'exception thrown' }],
     });
+  });
+
+  it('filters with a single QSTR predicate so union-typed log.level stays pushable', async () => {
+    getSampleDocumentsEsqlMock.mockResolvedValueOnce({ hits: [], total: 0 });
+
+    await errorLogsGenerator.generate({ stream, start: 100, end: 200, esClient, logger });
+
+    const { whereCondition } = getSampleDocumentsEsqlMock.mock.calls[0][0];
+    const printed = esql.from('logs-*').where`${whereCondition}`.print('basic');
+    expect(printed).toContain(
+      'QSTR("log.level:error OR message:error OR message:exception OR body.text:error OR body.text:exception")'
+    );
   });
 
   it('keeps only message + minimal context fields, dropping raw-document metadata', async () => {

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.test.ts
@@ -71,6 +71,7 @@ describe('errorLogsGenerator', () => {
     await errorLogsGenerator.generate({ stream, start: 100, end: 200, esClient, logger });
 
     const { whereCondition } = getSampleDocumentsEsqlMock.mock.calls[0][0];
+    if (!whereCondition) throw new Error('expected whereCondition to be defined');
     const printed = esql.from('logs-*').where`${whereCondition}`.print('basic');
     expect(printed).toContain(
       'QSTR("log.level:error OR message:error OR message:exception OR body.text:error OR body.text:exception")'

--- a/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-ai/src/features/computed/error_logs.ts
@@ -17,10 +17,6 @@ const SAMPLE_SIZE = 5;
 const LOG_MESSAGE_FIELDS = ['message', 'body.text'] as const;
 const ERROR_KEYWORDS = ['error', 'exception'] as const;
 
-// Keep only the message + prompt-relevant signal fields; raw docs are otherwise
-// mostly irrelevant metadata. OTel nests under `(resource.)attributes.*`, so
-// match on the prefix-stripped leaf (keeps `resource.attributes.service.name`,
-// drops `resource.attributes.cloud.service.name`).
 const ERROR_LOG_KEEP_FIELDS = new Set<string>([
   '@timestamp',
   ...LOG_MESSAGE_FIELDS,
@@ -37,7 +33,6 @@ const ERROR_LOG_KEEP_FIELDS = new Set<string>([
 
 const OTEL_FIELD_PREFIX = /^(?:resource\.)?attributes\./;
 
-// Keep the original (dotted) key — the name the LLM must reference in ES|QL — not the leaf.
 export const pickErrorLogFields = (fields: Record<string, unknown>): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(fields)) {
@@ -49,28 +44,13 @@ export const pickErrorLogFields = (fields: Record<string, unknown>): Record<stri
   return result;
 };
 
-const columnPath = (field: string) => (field.includes('.') ? field.split('.') : field);
+// QSTR: log.level is union-typed on some streams; ::keyword cast fixes verification but kills OR pushdown. QSTR resolves per-shard, avoiding both.
+const ERROR_QUERY_STRING = [
+  'log.level:error',
+  ...LOG_MESSAGE_FIELDS.flatMap((field) => ERROR_KEYWORDS.map((keyword) => `${field}:${keyword}`)),
+].join(' OR ');
 
-// Equivalent to the pre-ES|QL DSL filter:
-//   { term: { 'log.level': 'error' } }
-//   OR match_phrase: { message: 'error' | 'exception' }
-//   OR match_phrase: { 'body.text': 'error' | 'exception' }
-//
-// Built as a Composer `whereCondition` rather than a `KQL(...)` string because
-// ES 9.3 rejects `WHERE KQL(...) | SAMPLE` at planning time. `MATCH_PHRASE` is
-// the analyzer-aware ES|QL analogue of DSL `match_phrase` and works after
-// `SAMPLE` on both 9.3 and 9.5.
-const ERROR_WHERE_CONDITION = (() => {
-  const logLevelClause = esql.exp`${esql.col(columnPath('log.level'))} == "error"`;
-  const messageClauses = LOG_MESSAGE_FIELDS.flatMap((field) =>
-    ERROR_KEYWORDS.map(
-      (keyword) => esql.exp`MATCH_PHRASE(${esql.col(columnPath(field))}, ${esql.str(keyword)})`
-    )
-  );
-  return [logLevelClause, ...messageClauses].reduce(
-    (acc, current) => esql.exp`${acc} OR ${current}`
-  );
-})();
+const ERROR_WHERE_CONDITION = esql.exp`QSTR(${esql.str(ERROR_QUERY_STRING)})`;
 
 export const errorLogsGenerator: ComputedFeatureGenerator = {
   type: ERROR_LOGS_FEATURE_TYPE,
@@ -82,11 +62,6 @@ Use the \`properties.samples\` array to see actual error log entries.
 This is useful for understanding error patterns, identifying recurring issues, and diagnosing problems in the system.`,
 
   generate: async ({ stream, start, end, esClient }) => {
-    // `unmappedFields: 'NULLIFY'` lets `MATCH_PHRASE` skip clauses whose field
-    // is not mapped on any backing index. Without it, ECS-only streams (no
-    // `body.text`) and OTEL-only streams (no `message`) would fail with
-    // `verification_exception: Unknown column [...]`. DSL `match_phrase`
-    // silently no-matches missing fields, so this preserves baseline parity.
     const { hits } = await getSampleDocumentsEsql({
       esClient,
       index: getStreamSamplingSource(stream),
@@ -94,7 +69,6 @@ This is useful for understanding error patterns, identifying recurring issues, a
       end,
       sampleSize: SAMPLE_SIZE,
       whereCondition: ERROR_WHERE_CONDITION,
-      unmappedFields: 'NULLIFY',
       requestTimeout: DEFAULT_ESQL_QUERY_TIMEOUT_MS,
     });
 


### PR DESCRIPTION
On streams where `log.level` is mapped as `keyword` on some indices and `text` on others, the error logs query fails with a `verification_exception`. The fix (`::keyword` cast) trades that for a worse problem: the cast is non-pushable, and OR-ing it with the `MATCH_PHRASE` clauses collapses Lucene pushdown for the whole disjunction — turning 1.5s queries into ~97s timeouts on large cross-cluster streams (30s budget).

Replaces the mixed predicate with a single `QSTR()` call, which resolves fields per-shard and pushes as one Lucene query. Also drops `unmappedFields: 'NULLIFY'` as QSTR is natively lenient about unmapped fields.

Verified on ~3580 CCS indices, 205M docs: `::keyword OR MATCH_PHRASE` ~97s → `QSTR` ~1.5s.