### PR TITLE
[One Workflow] Keep the workflow editor editable outside the executions tab

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/hooks/use_workflow_editor_read_only.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/hooks/use_workflow_editor_read_only.test.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { WorkflowDetailDto, WorkflowExecutionDto } from '@kbn/workflows';
+import { ExecutionStatus } from '@kbn/workflows';
+
+import { useWorkflowEditorReadOnly } from './use_workflow_editor_read_only';
+import { createMockStore } from '../entities/workflows/store/__mocks__/store.mock';
+import {
+  setActiveTab,
+  setExecution,
+  setWorkflow,
+} from '../entities/workflows/store/workflow_detail/slice';
+import { getTestProvider } from '../shared/mocks/test_providers';
+
+jest.mock('@kbn/workflows-ui', () => ({
+  ...jest.requireActual('@kbn/workflows-ui'),
+  useWorkflowsCapabilities: jest.fn(),
+}));
+
+const { useWorkflowsCapabilities } = jest.requireMock('@kbn/workflows-ui') as {
+  useWorkflowsCapabilities: jest.Mock;
+};
+
+const EXECUTION_ID = 'execution-1';
+
+const baseWorkflow: WorkflowDetailDto = {
+  id: 'workflow-1',
+  name: 'My workflow',
+  yaml: 'name: committed\n',
+  enabled: true,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  createdBy: 'user-1',
+  lastUpdatedAt: '2026-06-16T00:00:00.000Z',
+  lastUpdatedBy: 'user-1',
+  definition: null,
+  valid: true,
+};
+
+const baseExecution = {
+  spaceId: 'default',
+  id: EXECUTION_ID,
+  status: ExecutionStatus.COMPLETED,
+  isTestRun: true,
+  startedAt: '2026-06-16T00:00:00.000Z',
+  finishedAt: '2026-06-16T00:00:01.000Z',
+  error: null,
+  workflowId: baseWorkflow.id,
+  workflowDefinition: {} as WorkflowExecutionDto['workflowDefinition'],
+  stepExecutions: [],
+  duration: 1000,
+  yaml: 'name: snapshot\n',
+} satisfies WorkflowExecutionDto;
+
+interface RenderParams {
+  /** Search string appended to the editor route, e.g. `?tab=executions&executionId=x`. */
+  search?: string;
+  activeTab?: 'workflow' | 'executions';
+  execution?: WorkflowExecutionDto;
+  workflow?: WorkflowDetailDto;
+}
+
+const renderReadOnlyHook = ({
+  search = '',
+  activeTab = 'workflow',
+  execution,
+  workflow = baseWorkflow,
+}: RenderParams = {}) => {
+  const store = createMockStore();
+  store.dispatch(setWorkflow(workflow));
+  store.dispatch(setActiveTab(activeTab));
+  if (execution) {
+    store.dispatch(setExecution(execution));
+  }
+
+  return renderHook(() => useWorkflowEditorReadOnly(), {
+    wrapper: getTestProvider({ store, initialEntries: [`/workflows/${workflow.id}${search}`] }),
+  });
+};
+
+describe('useWorkflowEditorReadOnly', () => {
+  beforeEach(() => {
+    useWorkflowsCapabilities.mockReturnValue({
+      canCreateWorkflow: true,
+      canUpdateWorkflow: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('is editable on the workflow tab with no execution selected', () => {
+    const { result } = renderReadOnlyHook();
+
+    expect(result.current).toBe(false);
+  });
+
+  it('stays editable when a test execution is running on the workflow tab', () => {
+    // Running a test from the editor puts an executionId in the URL so the execution panel can
+    // follow along, but the editor must remain editable.
+    const { result } = renderReadOnlyHook({
+      search: `?executionId=${EXECUTION_ID}`,
+      activeTab: 'workflow',
+      execution: baseExecution,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('is read-only when an execution is selected on the executions tab', () => {
+    const { result } = renderReadOnlyHook({
+      search: `?tab=executions&executionId=${EXECUTION_ID}`,
+      activeTab: 'executions',
+      execution: baseExecution,
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is read-only on the executions tab before the execution snapshot has loaded', () => {
+    const { result } = renderReadOnlyHook({
+      search: `?tab=executions&executionId=${EXECUTION_ID}`,
+      activeTab: 'executions',
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is read-only on the executions tab with no execution selected', () => {
+    const { result } = renderReadOnlyHook({
+      search: '?tab=executions',
+      activeTab: 'executions',
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is read-only for a managed workflow', () => {
+    const { result } = renderReadOnlyHook({
+      workflow: { ...baseWorkflow, managed: true },
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is read-only when the user cannot create or update workflows', () => {
+    useWorkflowsCapabilities.mockReturnValue({
+      canCreateWorkflow: false,
+      canUpdateWorkflow: false,
+    });
+
+    const { result } = renderReadOnlyHook();
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/hooks/use_workflow_editor_read_only.ts
+++ b/src/platform/plugins/shared/workflows_management/public/hooks/use_workflow_editor_read_only.ts
@@ -11,23 +11,19 @@ import { useSelector } from 'react-redux-v7';
 import { useParams } from 'react-router-dom';
 import { useWorkflowsCapabilities } from '@kbn/workflows-ui';
 import { useWorkflowUrlState } from './use_workflow_url_state';
-import {
-  selectIsEditorExecutionYaml,
-  selectWorkflow,
-} from '../entities/workflows/store/workflow_detail/selectors';
+import { selectWorkflow } from '../entities/workflows/store/workflow_detail/selectors';
 
 export const useWorkflowEditorReadOnly = (): boolean => {
   const { id: workflowId } = useParams<{ id?: string }>();
   const workflow = useSelector(selectWorkflow);
-  const isExecutionYaml = useSelector(selectIsEditorExecutionYaml);
-  const { selectedExecutionId } = useWorkflowUrlState();
+  const { activeTab } = useWorkflowUrlState();
   const { canCreateWorkflow, canUpdateWorkflow } = useWorkflowsCapabilities();
   const canEditWorkflow = workflowId ? canUpdateWorkflow : canCreateWorkflow;
 
-  return (
-    Boolean(selectedExecutionId) ||
-    isExecutionYaml ||
-    workflow?.managed === true ||
-    !canEditWorkflow
-  );
+  // The executions tab shows past execution snapshots, so editing is never meaningful there. The URL
+  // is the source of truth so the editor is read-only right away, before the store catches up.
+  // Running a test from the workflow tab also puts an executionId in the URL, but stays editable.
+  const isExecutionsTab = activeTab === 'executions';
+
+  return isExecutionsTab || workflow?.managed === true || !canEditWorkflow;
 };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
@@ -370,7 +370,7 @@ describe('WorkflowYAMLEditor', () => {
     });
   });
 
-  it('keeps workflow YAML editable on the executions tab without a selection', async () => {
+  it('renders workflow YAML as read-only on the executions tab without a selection', async () => {
     const store = createMockStore();
     store.dispatch(setWorkflow(mockWorkflow));
     store.dispatch(setActiveTab('executions'));
@@ -381,7 +381,7 @@ describe('WorkflowYAMLEditor', () => {
       const textarea = document.querySelector(
         '[data-testid="yaml-textarea"]'
       ) as HTMLTextAreaElement;
-      expect(textarea.readOnly).toBe(false);
+      expect(textarea.readOnly).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #285198

The Workflows YAML editor turned read-only as soon as an `executionId` was present in the URL. Triggering a test run from the Workflow tab writes that param so the execution panel can follow the run, so simply testing a workflow blocked YAML edits, save, save-and-run, the actions menu and the AI assist section, and rendered a "Read only" badge.

Read-only is now driven by the active tab alone:

```ts
const isExecutionsTab = activeTab === 'executions';

return isExecutionsTab || workflow?.managed === true || !canEditWorkflow;
```

The Executions tab shows immutable snapshots of past executions, so editing is never meaningful there. `activeTab` is read from the URL rather than the store so the editor is read-only immediately on navigation, with no flash of editable state while the store catches up.

This also fixes a smaller inconsistency: with `?tab=executions` and no execution selected, the editor rendered the read-only background while still being editable.

### Why `isExecutionYaml` was removed

`selectIsEditorExecutionYaml` is `isExecutionsTab && execution?.yaml`, which is now a strict subset of `activeTab === 'executions'`. Keeping it would only add a dependency on store state that can lag the URL. The selector itself is unchanged and still used by `selectEditorYaml` and `selectEditorComputed` to pick *which* YAML to render.

### Context

The `Boolean(selectedExecutionId)` condition was introduced in #283093, which centralized read-only logic into `useWorkflowEditorReadOnly`. Before that PR read-only was driven only by `isExecutionYaml || isManagedWorkflow`.

## Testing

Added `use_workflow_editor_read_only.test.ts` covering all read-only conditions (7 tests, passing). The regression case is *"stays editable when a test execution is running on the workflow tab"*, which fails against the previous logic.

## Snapshot

Before:
<img width="1917" height="989" alt="Captura de pantalla 2026-08-14 a les 16 06 48" src="https://github.com/user-attachments/assets/f89970ea-dc6b-40b3-8f6a-03b87b6c4694" />

After:
<img width="1917" height="989" alt="Captura de pantalla 2026-08-14 a les 16 05 58" src="https://github.com/user-attachments/assets/671f04a8-6ccd-417b-8a31-c16c8165969e" />


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

Low. The change is confined to a single hook that computes a boolean.

The main behavior change beyond the fix: the editor is now read-only on the Executions tab even when no execution is selected. This is intentional — it makes the read-only styling and the actual read-only state agree, and editing on that tab was never meaningful.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->