### PR TITLE
feat(agent builder): traces ux

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/agent_builder_view_ids.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/agent_builder_view_ids.ts
@@ -33,4 +33,6 @@ export const agentBuilderViewIds = {
   manageMcpClients: 'agent_builder_manage_mcp_clients',
   manageMcpClientCreate: 'agent_builder_manage_mcp_clients_create',
   manageMcpClientEdit: 'agent_builder_manage_mcp_clients_edit',
+  manageTraces: 'agent_builder_manage_traces',
+  manageTraceDetails: 'agent_builder_manage_traces_detail',
 } as const;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/more_actions_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/more_actions_button.tsx
@@ -26,9 +26,12 @@ import { useConversationContext } from '../../../context/conversation/conversati
 import { useConversationId } from '../../../context/conversation/use_conversation_id';
 import { useExperimentalFeatures } from '../../../hooks/use_experimental_features';
 import { useKibana } from '../../../hooks/use_kibana';
+import { useTracingEnabled } from '../../../hooks/use_tracing_enabled';
 import { appPaths } from '../../../utils/app_paths';
 import { useHasConnectorsAllPrivileges } from '../../../hooks/use_has_connectors_all_privileges';
 import { useUiPrivileges } from '../../../hooks/use_ui_privileges';
+import { ConversationTracesFlyout } from '../../traces/conversation_traces_flyout';
+import { labels as sharedLabels } from '../../../utils/i18n';
 
 const fullscreenLabels = {
   actions: i18n.translate('xpack.agentBuilder.conversationActions.actions', {
@@ -75,6 +78,7 @@ interface MoreActionsButtonProps {
 
 export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onCloseSidebar }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isTracesFlyoutOpen, setIsTracesFlyoutOpen] = useState(false);
 
   const agentId = useAgentId();
   const { createAgentBuilderUrl, navigateToAgentBuilderUrl } = useNavigation();
@@ -84,6 +88,7 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onCloseSid
   const isExperimentalEnabled = useExperimentalFeatures();
   const { conversation } = useConversation();
   const conversationRounds = useConversationRounds();
+  const isTracingEnabled = useTracingEnabled();
 
   const {
     services: { application, plugins },
@@ -143,9 +148,31 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onCloseSid
   const showAddToDatasetItem =
     isExperimentalEnabled && plugins.evals?.canAddToDataset && completedRounds.length > 0;
 
+  // Only surface the "View all traces" menu item when tracing is enabled AND at
+  // least one round in this conversation actually has a trace to show — otherwise
+  // the flyout would open with an unhelpful empty state.
+  const hasAnyTrace = useMemo(
+    () =>
+      conversationRounds.some((round) => {
+        const traceId = Array.isArray(round.trace_id) ? round.trace_id[0] : round.trace_id;
+        return Boolean(traceId);
+      }),
+    [conversationRounds]
+  );
+  const showViewAllTracesItem = isTracingEnabled && hasAnyTrace;
+
   const closePopover = () => {
     setIsPopoverOpen(false);
   };
+
+  const openTracesFlyout = useCallback(() => {
+    setIsPopoverOpen(false);
+    setIsTracesFlyoutOpen(true);
+  }, []);
+
+  const closeTracesFlyout = useCallback(() => {
+    setIsTracesFlyoutOpen(false);
+  }, []);
 
   const togglePopover = () => {
     setIsPopoverOpen(!isPopoverOpen);
@@ -190,6 +217,28 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onCloseSid
           })}
         >
           {fullscreenLabels.addToDataset}
+        </EuiContextMenuItem>,
+      ]
+    : [];
+
+  // Reuses the existing VIEW_TRACE EBT action rather than defining a new id — this is
+  // still a "view trace" affordance, just scoped to the whole conversation instead of a
+  // single round. The `conversation_all` detail keeps it distinguishable from the
+  // per-round trace button (which reports `conversation`) in telemetry.
+  const viewAllTracesMenuItem = showViewAllTracesItem
+    ? [
+        <EuiContextMenuItem
+          key="conversationTraces"
+          icon="chartWaterfall"
+          data-test-subj="agentBuilderViewConversationTracesButton"
+          onClick={openTracesFlyout}
+          {...getEbtProps({
+            element: AGENT_BUILDER_UI_EBT.element.pageContent,
+            action: AGENT_BUILDER_UI_EBT.action.conversation.VIEW_TRACE,
+            detail: 'conversation_all',
+          })}
+        >
+          {sharedLabels.traces.conversationTracesMenuItem}
         </EuiContextMenuItem>,
       ]
     : [];
@@ -244,6 +293,7 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onCloseSid
           </EuiContextMenuItem>,
         ]
       : []),
+    ...viewAllTracesMenuItem,
     ...addToDatasetMenuItem,
   ];
 
@@ -280,6 +330,7 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onCloseSid
           </EuiContextMenuItem>,
         ]
       : []),
+    ...viewAllTracesMenuItem,
     ...addToDatasetMenuItem,
   ];
 
@@ -311,6 +362,9 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onCloseSid
       >
         <EuiContextMenuPanel items={menuItems} />
       </EuiPopover>
+      {isTracesFlyoutOpen && (
+        <ConversationTracesFlyout rounds={conversationRounds} onClose={closeTracesFlyout} />
+      )}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/round_trace_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/round_trace_flyout.tsx
@@ -6,12 +6,22 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiFlyoutBody, EuiFlyoutHeader, EuiFlyoutResizable, EuiTitle } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiFlyoutResizable,
+  EuiTitle,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { i18n } from '@kbn/i18n';
 import { createEsTraceFetcher, TraceWaterfall, useTraceSpans } from '@kbn/llm-trace-waterfall';
+import { buildAgentBuilderTracesIndexPattern } from '../../../../../../common/traces';
 import { useKibana } from '../../../../hooks/use_kibana';
+import { useSpaceId } from '../../../../hooks/use_space_id';
+import { DebugTraceButton } from '../../../traces/debug_trace_button';
 
 const title = i18n.translate('xpack.agentBuilder.round.traceFlyout.title', {
   defaultMessage: 'Trace',
@@ -24,9 +34,22 @@ interface RoundTraceFlyoutProps {
 
 export const RoundTraceFlyout: React.FC<RoundTraceFlyoutProps> = ({ traceId, onClose }) => {
   const { services } = useKibana();
-  const { data } = services.plugins;
-  const fetchTrace = useMemo(() => createEsTraceFetcher(data.search.search), [data.search.search]);
-  const traceSpansResult = useTraceSpans(traceId, { fetchTrace });
+  const { data, spaces } = services.plugins;
+  // Space-scoped index prevents spans from other spaces from leaking into the flyout —
+  // aligns the fetcher with `useTraceExists` (previously this used the default `traces-*`).
+  const spaceId = useSpaceId(spaces);
+  const tracesIndex = useMemo(
+    () => (spaceId ? buildAgentBuilderTracesIndexPattern(spaceId) : undefined),
+    [spaceId]
+  );
+  const fetchTrace = useMemo(
+    () =>
+      tracesIndex
+        ? createEsTraceFetcher(data.search.search, { index: tracesIndex })
+        : createEsTraceFetcher(data.search.search),
+    [data.search.search, tracesIndex]
+  );
+  const traceSpansResult = useTraceSpans(traceId, { fetchTrace, index: tracesIndex });
 
   return (
     <EuiFlyoutResizable
@@ -48,11 +71,18 @@ export const RoundTraceFlyout: React.FC<RoundTraceFlyoutProps> = ({ traceId, onC
       `}
     >
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="s">
-          <h2 id="agentBuilderRoundTraceFlyoutTitle" style={{ wordBreak: 'break-all' }}>
-            {title}: {traceId}
-          </h2>
-        </EuiTitle>
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="s">
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h2 id="agentBuilderRoundTraceFlyoutTitle" style={{ wordBreak: 'break-all' }}>
+                {title}: {traceId}
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <DebugTraceButton traceId={traceId} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <div style={{ height: '100%', padding: 16 }}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/build_span_tree.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/build_span_tree.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TraceSpan } from '@kbn/llm-trace-waterfall';
+import { buildSpanTree, flattenSpanTree } from './build_span_tree';
+
+const span = (overrides: Partial<TraceSpan> & Pick<TraceSpan, 'span_id'>): TraceSpan => ({
+  trace_id: 'trace-1',
+  name: overrides.name ?? overrides.span_id,
+  start_time: '2026-08-13T00:00:00.000Z',
+  duration_ms: 10,
+  ...overrides,
+});
+
+describe('buildSpanTree', () => {
+  it('nests children under their parent by parent_span_id', () => {
+    const spans: TraceSpan[] = [
+      span({ span_id: 'root' }),
+      span({ span_id: 'tool', parent_span_id: 'root' }),
+      span({ span_id: 'load_skill', parent_span_id: 'tool' }),
+    ];
+
+    const roots = buildSpanTree(spans);
+
+    expect(roots).toHaveLength(1);
+    expect(roots[0].span_id).toBe('root');
+    expect(roots[0].children.map((c) => c.span_id)).toEqual(['tool']);
+    expect(roots[0].children[0].children.map((c) => c.span_id)).toEqual(['load_skill']);
+  });
+
+  it('assigns depth correctly starting at 0 for roots', () => {
+    const spans: TraceSpan[] = [
+      span({ span_id: 'root' }),
+      span({ span_id: 'child', parent_span_id: 'root' }),
+      span({ span_id: 'grandchild', parent_span_id: 'child' }),
+    ];
+
+    const roots = buildSpanTree(spans);
+    const flat = flattenSpanTree(roots);
+
+    expect(flat.map((s) => [s.span_id, s.depth])).toEqual([
+      ['root', 0],
+      ['child', 1],
+      ['grandchild', 2],
+    ]);
+  });
+
+  it('sorts siblings by start_time and falls back to span_id for ties', () => {
+    const spans: TraceSpan[] = [
+      span({ span_id: 'root' }),
+      span({
+        span_id: 'b',
+        parent_span_id: 'root',
+        start_time: '2026-08-13T00:00:00.010Z',
+      }),
+      span({
+        span_id: 'a',
+        parent_span_id: 'root',
+        start_time: '2026-08-13T00:00:00.000Z',
+      }),
+      span({
+        span_id: 'c',
+        parent_span_id: 'root',
+        start_time: '2026-08-13T00:00:00.000Z',
+      }),
+    ];
+
+    const roots = buildSpanTree(spans);
+
+    expect(roots[0].children.map((c) => c.span_id)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('treats spans with missing parents as roots (out-of-shard parents)', () => {
+    const spans: TraceSpan[] = [
+      span({ span_id: 'orphan', parent_span_id: 'missing' }),
+      span({ span_id: 'root' }),
+    ];
+
+    const roots = buildSpanTree(spans);
+
+    expect(roots.map((r) => r.span_id).sort()).toEqual(['orphan', 'root']);
+  });
+
+  it('handles the empty input gracefully', () => {
+    expect(buildSpanTree([])).toEqual([]);
+    expect(flattenSpanTree([])).toEqual([]);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/build_span_tree.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/build_span_tree.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SpanNode, TraceSpan } from '@kbn/llm-trace-waterfall';
+
+/**
+ * Build a deterministic parent-child span tree from a flat list of `TraceSpan`s.
+ *
+ * The result is used by the "Tree" view of the trace viewer page as a lighter-weight
+ * alternative to the waterfall (parent-child structure is explicit, no timing math).
+ *
+ * Ordering is deterministic:
+ * - siblings are sorted by `start_time` ascending, then by `span_id` as a tie-breaker
+ *   so identical timestamps still produce a stable order across renders.
+ * - a span whose `parent_span_id` is absent, empty, or points to a span not present
+ *   in the input is treated as a root (spans can arrive out-of-order or with parents
+ *   in a different trace shard).
+ */
+export const buildSpanTree = (spans: TraceSpan[]): SpanNode[] => {
+  const nodes = new Map<string, SpanNode>();
+  for (const span of spans) {
+    nodes.set(span.span_id, { ...span, children: [], depth: 0 });
+  }
+
+  const roots: SpanNode[] = [];
+  for (const node of nodes.values()) {
+    const parentId = node.parent_span_id;
+    const parent = parentId ? nodes.get(parentId) : undefined;
+    if (parent && parent !== node) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  const sortSiblings = (a: SpanNode, b: SpanNode) => {
+    const at = new Date(a.start_time).getTime();
+    const bt = new Date(b.start_time).getTime();
+    if (at !== bt) return at - bt;
+    return a.span_id < b.span_id ? -1 : a.span_id > b.span_id ? 1 : 0;
+  };
+
+  const assignDepth = (node: SpanNode, depth: number) => {
+    node.depth = depth;
+    node.children.sort(sortSiblings);
+    for (const child of node.children) assignDepth(child, depth + 1);
+  };
+
+  roots.sort(sortSiblings);
+  for (const root of roots) assignDepth(root, 0);
+
+  return roots;
+};
+
+/** Flatten a span tree into a depth-first ordered list for list rendering. */
+export const flattenSpanTree = (roots: SpanNode[]): SpanNode[] => {
+  const out: SpanNode[] = [];
+  const walk = (nodes: SpanNode[]) => {
+    for (const node of nodes) {
+      out.push(node);
+      walk(node.children);
+    }
+  };
+  walk(roots);
+  return out;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/conversation_traces_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/conversation_traces_flyout.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { type PropsWithChildren } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { of } from 'rxjs';
+import type { ConversationRound } from '@kbn/agent-builder-common';
+import { ConversationTracesFlyout } from './conversation_traces_flyout';
+
+const mockSearch = jest.fn(() =>
+  of({ rawResponse: { hits: { hits: [] } } } as unknown as { rawResponse: unknown })
+);
+
+jest.mock('../../hooks/use_kibana', () => ({
+  useKibana: () => ({
+    services: {
+      plugins: {
+        data: { search: { search: mockSearch } },
+        spaces: {},
+      },
+    },
+  }),
+}));
+
+jest.mock('../../hooks/use_space_id', () => ({
+  useSpaceId: () => 'default',
+}));
+
+jest.mock('../../hooks/use_navigation', () => ({
+  useNavigation: () => ({ navigateToAgentBuilderUrl: jest.fn() }),
+}));
+
+// The detail header renders <DebugTraceButton>, which reads these settings-backed hooks;
+// enable both so the button (and its trace fetch) render in the detail view.
+jest.mock('../../hooks/use_tracing_enabled', () => ({
+  useTracingEnabled: () => true,
+}));
+
+jest.mock('../../hooks/use_experimental_features', () => ({
+  useExperimentalFeatures: () => true,
+}));
+
+const makeRound = (overrides: Partial<ConversationRound>): ConversationRound =>
+  ({
+    id: overrides.id ?? 'round-id',
+    status: 'completed',
+    input: { message: overrides.input?.message ?? 'Hello' },
+    steps: [],
+    time_to_last_token: 0,
+    model_usage: { connector_id: 'c', llm_calls: 0 },
+    ...overrides,
+  } as ConversationRound);
+
+const wrap = ({ children }: PropsWithChildren) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <IntlProvider locale="en">
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </IntlProvider>
+  );
+};
+
+describe('ConversationTracesFlyout', () => {
+  beforeEach(() => {
+    mockSearch.mockClear();
+  });
+
+  it('lists only rounds that produced a trace_id, preserving turn numbering', () => {
+    const rounds = [
+      makeRound({ id: 'r1', trace_id: 'trace-1', input: { message: 'first message' } }),
+      makeRound({ id: 'r2', input: { message: 'no trace here' } }),
+      makeRound({ id: 'r3', trace_id: ['trace-3-a'], input: { message: 'third message' } }),
+    ];
+
+    render(<ConversationTracesFlyout rounds={rounds} onClose={jest.fn()} />, { wrapper: wrap });
+
+    const items = screen.getAllByTestId('agentBuilderConversationTracesListItem');
+    expect(items).toHaveLength(2);
+    // Turn 1 for round-1, Turn 3 for round-3 (round-2 skipped, but numbering keeps original index).
+    expect(screen.getByText(/Turn 1:/)).toBeInTheDocument();
+    expect(screen.getByText(/Turn 3:/)).toBeInTheDocument();
+    expect(screen.getByText('trace-1')).toBeInTheDocument();
+    expect(screen.getByText('trace-3-a')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when no round has a trace', () => {
+    const rounds = [makeRound({ id: 'r1', input: { message: 'no trace' } })];
+    render(<ConversationTracesFlyout rounds={rounds} onClose={jest.fn()} />, { wrapper: wrap });
+    expect(screen.getByTestId('agentBuilderConversationTracesEmpty')).toBeInTheDocument();
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('switches into detail view when a row is clicked and fires the trace fetch', () => {
+    const rounds = [
+      makeRound({ id: 'r1', trace_id: 'trace-1', input: { message: 'first message' } }),
+    ];
+
+    render(<ConversationTracesFlyout rounds={rounds} onClose={jest.fn()} />, { wrapper: wrap });
+
+    fireEvent.click(screen.getByTestId('agentBuilderConversationTracesListItem'));
+
+    expect(screen.getByTestId('agentBuilderConversationTracesBackButton')).toBeInTheDocument();
+    // Waterfall triggers a search with the space-scoped index and correct trace_id term.
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          index: 'traces-agent_builder.otel-default',
+          body: expect.objectContaining({
+            query: { term: { trace_id: 'trace-1' } },
+          }),
+        }),
+      })
+    );
+
+    fireEvent.click(screen.getByTestId('agentBuilderConversationTracesBackButton'));
+    expect(
+      screen.queryByTestId('agentBuilderConversationTracesBackButton')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/conversation_traces_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/conversation_traces_flyout.tsx
@@ -1,0 +1,252 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  EuiButtonEmpty,
+  EuiCode,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiFlyoutResizable,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { euiThemeVars } from '@kbn/ui-theme';
+import type { ConversationRound } from '@kbn/agent-builder-common';
+import { createEsTraceFetcher, TraceWaterfall, useTraceSpans } from '@kbn/llm-trace-waterfall';
+import { buildAgentBuilderTracesIndexPattern } from '../../../../common/traces';
+import { useKibana } from '../../hooks/use_kibana';
+import { useSpaceId } from '../../hooks/use_space_id';
+import { labels } from '../../utils/i18n';
+import { DebugTraceButton } from './debug_trace_button';
+
+/**
+ * A conversation round paired with the round's normalised trace id. The backend
+ * types `trace_id` as `string | string[]` (multi-trace rounds are reserved for
+ * the future), so we always pick the first id — matching how `RoundResponseActions`
+ * treats the field today.
+ */
+interface RoundTraceEntry {
+  roundIndex: number;
+  round: ConversationRound;
+  traceId: string;
+}
+
+interface ConversationTracesFlyoutProps {
+  rounds: readonly ConversationRound[];
+  onClose: () => void;
+}
+
+const flyoutCss = css`
+  z-index: ${euiThemeVars.euiZFlyout + 4};
+  .euiFlyoutBody__overflowContent {
+    height: 100%;
+    padding: 0;
+  }
+  .euiFlyoutBody__overflow {
+    overflow: hidden;
+  }
+`;
+
+const previewOfMessage = (message: string | undefined, empty: string): string => {
+  const trimmed = (message ?? '').trim();
+  if (!trimmed) return empty;
+  return trimmed.length > 80 ? `${trimmed.slice(0, 77).trimEnd()}…` : trimmed;
+};
+
+/**
+ * Flyout that lists every round of the current conversation that produced a trace
+ * and lets the user drill into any one of them without leaving the conversation.
+ *
+ * Two internal views:
+ *   1. `list` (default): one row per round with a trace, showing the user prompt
+ *      preview and the trace ID.
+ *   2. `detail`: full-height `TraceWaterfall` for the selected trace, with a
+ *      "Back to traces" affordance and a `DebugTraceButton`.
+ *
+ * Deliberately renders inside a single flyout (rather than opening a nested
+ * `RoundTraceFlyout` on top) because stacking flyouts is fiddly in EUI and the
+ * list view is only useful long enough for the user to pick a row.
+ */
+export const ConversationTracesFlyout: React.FC<ConversationTracesFlyoutProps> = ({
+  rounds,
+  onClose,
+}) => {
+  const { services } = useKibana();
+  const { data, spaces } = services.plugins;
+  const spaceId = useSpaceId(spaces);
+
+  const entries = useMemo<RoundTraceEntry[]>(
+    () =>
+      rounds.flatMap((round, roundIndex) => {
+        const raw = round.trace_id;
+        const traceId = Array.isArray(raw) ? raw[0] : raw;
+        if (!traceId) return [];
+        return [{ round, roundIndex, traceId }];
+      }),
+    [rounds]
+  );
+
+  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
+  const selectedEntry = useMemo(
+    () => entries.find((entry) => entry.traceId === selectedTraceId) ?? null,
+    [entries, selectedTraceId]
+  );
+
+  const tracesIndex = useMemo(
+    () => (spaceId ? buildAgentBuilderTracesIndexPattern(spaceId) : undefined),
+    [spaceId]
+  );
+  // `useTraceSpans` is only active while a trace is selected — we do not want a
+  // list of 10 traces to fire 10 background searches on open.
+  const fetchTrace = useMemo(
+    () =>
+      tracesIndex
+        ? createEsTraceFetcher(data.search.search, { index: tracesIndex })
+        : createEsTraceFetcher(data.search.search),
+    [data.search.search, tracesIndex]
+  );
+  const spanResult = useTraceSpans(selectedTraceId, {
+    fetchTrace,
+    index: tracesIndex,
+    enabled: selectedTraceId !== null,
+  });
+
+  const handleBack = useCallback(() => setSelectedTraceId(null), []);
+
+  const renderHeader = () => {
+    if (selectedEntry) {
+      return (
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              iconType="arrowLeft"
+              onClick={handleBack}
+              flush="left"
+              data-test-subj="agentBuilderConversationTracesBackButton"
+            >
+              {labels.traces.backToList}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h2 style={{ wordBreak: 'break-all' }}>
+                {labels.traces.roundTraceHeading(selectedEntry.roundIndex + 1)}
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <DebugTraceButton traceId={selectedEntry.traceId} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    }
+
+    return (
+      <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="s">
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h2>{labels.traces.conversationTracesTitle}</h2>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            {labels.traces.tracesCount(entries.length)}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  };
+
+  const renderBody = () => {
+    if (selectedEntry) {
+      return (
+        <div style={{ height: '100%', padding: 16 }}>
+          <TraceWaterfall
+            spans={spanResult.spans}
+            traceId={selectedEntry.traceId}
+            durationMs={spanResult.durationMs}
+            isLoading={spanResult.isLoading}
+            error={spanResult.error}
+          />
+        </div>
+      );
+    }
+
+    if (!entries.length) {
+      return (
+        <div style={{ padding: 16 }}>
+          <EuiEmptyPrompt
+            iconType="help"
+            title={<h3>{labels.traces.noConversationTracesTitle}</h3>}
+            body={<p>{labels.traces.noConversationTracesMessage}</p>}
+            data-test-subj="agentBuilderConversationTracesEmpty"
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div style={{ padding: 16 }} data-test-subj="agentBuilderConversationTracesList">
+        <EuiFlexGroup direction="column" gutterSize="s">
+          {entries.map((entry) => {
+            const preview = previewOfMessage(
+              entry.round.input?.message,
+              labels.traces.emptyMessagePreview
+            );
+            return (
+              <EuiFlexItem grow={false} key={entry.traceId}>
+                <EuiPanel
+                  hasBorder
+                  hasShadow={false}
+                  paddingSize="s"
+                  onClick={() => setSelectedTraceId(entry.traceId)}
+                  data-test-subj="agentBuilderConversationTracesListItem"
+                  aria-label={entry.traceId}
+                >
+                  <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={false}>
+                    <EuiFlexItem>
+                      <EuiText size="s">
+                        <strong>{labels.traces.turnLabel(entry.roundIndex + 1)}</strong> {preview}
+                      </EuiText>
+                      <EuiSpacer size="xs" />
+                      <EuiText size="xs" color="subdued">
+                        <EuiCode transparentBackground>{entry.traceId}</EuiCode>
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiPanel>
+              </EuiFlexItem>
+            );
+          })}
+        </EuiFlexGroup>
+      </div>
+    );
+  };
+
+  return (
+    <EuiFlyoutResizable
+      onClose={onClose}
+      aria-labelledby="agentBuilderConversationTracesFlyoutTitle"
+      size={620}
+      minWidth={400}
+      maxWidth={1200}
+      ownFocus={false}
+      css={flyoutCss}
+      data-test-subj="agentBuilderConversationTracesFlyout"
+    >
+      <EuiFlyoutHeader hasBorder>{renderHeader()}</EuiFlyoutHeader>
+      <EuiFlyoutBody>{renderBody()}</EuiFlyoutBody>
+    </EuiFlyoutResizable>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/debug_trace_button.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/debug_trace_button.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import { useNavigation } from '../../hooks/use_navigation';
+import { useTracingEnabled } from '../../hooks/use_tracing_enabled';
+import { useExperimentalFeatures } from '../../hooks/use_experimental_features';
+import { appPaths } from '../../utils/app_paths';
+import { buildDebugTracePrompt, DebugTraceButton } from './debug_trace_button';
+
+jest.mock('../../hooks/use_navigation', () => ({
+  useNavigation: jest.fn(),
+}));
+
+jest.mock('../../hooks/use_tracing_enabled', () => ({
+  useTracingEnabled: jest.fn(),
+}));
+
+jest.mock('../../hooks/use_experimental_features', () => ({
+  useExperimentalFeatures: jest.fn(),
+}));
+
+const mockUseNavigation = jest.mocked(useNavigation);
+const mockUseTracingEnabled = jest.mocked(useTracingEnabled);
+const mockUseExperimentalFeatures = jest.mocked(useExperimentalFeatures);
+
+const renderButton = (traceId: string) =>
+  render(
+    <IntlProvider locale="en">
+      <DebugTraceButton traceId={traceId} />
+    </IntlProvider>
+  );
+
+describe('DebugTraceButton', () => {
+  let navigateToAgentBuilderUrl: jest.Mock;
+
+  beforeEach(() => {
+    navigateToAgentBuilderUrl = jest.fn();
+    mockUseNavigation.mockReturnValue({
+      navigateToAgentBuilderUrl,
+    } as unknown as ReturnType<typeof useNavigation>);
+    mockUseTracingEnabled.mockReturnValue(true);
+    mockUseExperimentalFeatures.mockReturnValue(true);
+  });
+
+  it('navigates to a new conversation with the default Elastic AI Agent', () => {
+    renderButton('abc-123');
+    fireEvent.click(screen.getByTestId('agentBuilderDebugTraceButton'));
+
+    expect(navigateToAgentBuilderUrl).toHaveBeenCalledTimes(1);
+    const [path, params, state] = navigateToAgentBuilderUrl.mock.calls[0];
+    expect(path).toBe(appPaths.agent.conversations.new({ agentId: agentBuilderDefaultAgentId }));
+    expect(params).toBeUndefined();
+    expect(state).toEqual({
+      initialMessage: buildDebugTracePrompt('abc-123'),
+      autoSendInitialMessage: false,
+    });
+  });
+
+  it('embeds the trace ID in the debug prompt', () => {
+    const prompt = buildDebugTracePrompt('trace-xyz');
+    expect(prompt).toContain('trace-xyz');
+    expect(prompt).toContain('agent-builder-traces');
+  });
+
+  it('renders nothing when tracing is disabled', () => {
+    mockUseTracingEnabled.mockReturnValue(false);
+    renderButton('abc-123');
+    expect(screen.queryByTestId('agentBuilderDebugTraceButton')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when experimental features are disabled', () => {
+    mockUseExperimentalFeatures.mockReturnValue(false);
+    renderButton('abc-123');
+    expect(screen.queryByTestId('agentBuilderDebugTraceButton')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/debug_trace_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/debug_trace_button.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import { EuiButton, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import { useExperimentalFeatures } from '../../hooks/use_experimental_features';
+import { useNavigation } from '../../hooks/use_navigation';
+import { useTracingEnabled } from '../../hooks/use_tracing_enabled';
+import { appPaths } from '../../utils/app_paths';
+import { labels } from '../../utils/i18n';
+
+interface DebugTraceButtonProps {
+  traceId: string;
+  size?: 's' | 'm';
+  fill?: boolean;
+}
+
+/**
+ * Builds the prompt that hands a trace to the Elastic AI Agent.
+ *
+ * Kept as a plain function so a unit test can assert the exact wording without
+ * mounting React. The prompt is deliberately explicit about using the built-in
+ * `agent-builder-traces` skill because that is what makes span retrieval work
+ * without further user input.
+ */
+export const buildDebugTracePrompt = (traceId: string): string =>
+  i18n.translate('xpack.agentBuilder.traces.debugPrompt', {
+    defaultMessage:
+      'Debug Agent Builder trace `{traceId}`. Use the agent-builder-traces skill to fetch all spans for this trace, then identify which span failed or looped and explain the likely root cause. Reference specific span names (e.g. execute_tool, chat, invoke_agent) in your answer.',
+    values: { traceId },
+  });
+
+/**
+ * "Debug trace with agent" action. Starts a new conversation with the default
+ * Elastic AI Agent (`elastic-ai-agent`) and prefills the composer with a
+ * trace-debugging prompt via the existing `initialMessage` router state plumbing
+ * (see `use_initial_message.ts`).
+ *
+ * We pass `autoSendInitialMessage: false` on purpose — the prompt lands in the
+ * editor so the user can review or tweak the wording before sending, rather than
+ * kicking off an LLM call the moment they click the button.
+ *
+ * The button only renders when tracing AND experimental features are enabled: the
+ * default agent is only granted the `agent-builder-traces` skill under those same
+ * conditions, so hiding it elsewhere avoids handing the user an agent that cannot
+ * actually fetch spans. (The client has no dedicated `skills` flag, so the umbrella
+ * experimental-features setting is the proxy for it.)
+ */
+export const DebugTraceButton: React.FC<DebugTraceButtonProps> = ({
+  traceId,
+  size = 's',
+  fill = false,
+}) => {
+  const { navigateToAgentBuilderUrl } = useNavigation();
+  const isTracingEnabled = useTracingEnabled();
+  const isExperimentalEnabled = useExperimentalFeatures();
+
+  const handleClick = useCallback(() => {
+    navigateToAgentBuilderUrl(
+      appPaths.agent.conversations.new({ agentId: agentBuilderDefaultAgentId }),
+      undefined,
+      {
+        initialMessage: buildDebugTracePrompt(traceId),
+        autoSendInitialMessage: false,
+      }
+    );
+  }, [navigateToAgentBuilderUrl, traceId]);
+
+  if (!isTracingEnabled || !isExperimentalEnabled) {
+    return null;
+  }
+
+  return (
+    <EuiToolTip content={labels.traces.debugWithAgentTooltip}>
+      <EuiButton
+        size={size}
+        iconType="sparkles"
+        onClick={handleClick}
+        fill={fill}
+        data-test-subj="agentBuilderDebugTraceButton"
+      >
+        {labels.traces.debugWithAgentButton}
+      </EuiButton>
+    </EuiToolTip>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/recent_traces_list.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/recent_traces_list.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { appPaths } from '../../utils/app_paths';
+import { RecentTracesList } from './recent_traces_list';
+import type { RecentTrace } from './use_recent_traces';
+
+const mockNavigate = jest.fn();
+const mockCreateUrl = jest.fn((path: string) => `/app/agent_builder${path}`);
+
+jest.mock('../../hooks/use_navigation', () => ({
+  useNavigation: () => ({
+    navigateToAgentBuilderUrl: mockNavigate,
+    createAgentBuilderUrl: mockCreateUrl,
+  }),
+}));
+
+const trace = (overrides: Partial<RecentTrace> & Pick<RecentTrace, 'traceId'>): RecentTrace => ({
+  timestamp: '2026-08-13T00:00:00.000Z',
+  rootSpanName: 'invoke_agent elastic-ai-agent',
+  durationMs: 1500,
+  ...overrides,
+});
+
+const renderList = (props: React.ComponentProps<typeof RecentTracesList>) =>
+  render(
+    <IntlProvider locale="en">
+      <RecentTracesList {...props} />
+    </IntlProvider>
+  );
+
+describe('RecentTracesList', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockCreateUrl.mockClear();
+  });
+
+  it('renders a row per trace and formats duration', () => {
+    renderList({
+      isLoading: false,
+      error: null,
+      traces: [
+        trace({ traceId: 'trace-1', durationMs: 1500 }),
+        trace({ traceId: 'trace-2', durationMs: 800 }),
+      ],
+    });
+
+    expect(screen.getByText('trace-1')).toBeInTheDocument();
+    expect(screen.getByText('trace-2')).toBeInTheDocument();
+    // 1500ms -> seconds, 800ms -> milliseconds.
+    expect(screen.getByText('1.50s')).toBeInTheDocument();
+    expect(screen.getByText('800ms')).toBeInTheDocument();
+  });
+
+  it('links each trace to its detail route and navigates on plain click', () => {
+    renderList({
+      isLoading: false,
+      error: null,
+      traces: [trace({ traceId: 'trace-1' })],
+    });
+
+    const link = screen.getByTestId('agentBuilderRecentTraceLink');
+    expect(link).toHaveAttribute(
+      'href',
+      `/app/agent_builder${appPaths.manage.traceDetails({ traceId: 'trace-1' })}`
+    );
+
+    fireEvent.click(link);
+    expect(mockNavigate).toHaveBeenCalledWith(appPaths.manage.traceDetails({ traceId: 'trace-1' }));
+  });
+
+  it('renders an error callout when loading fails', () => {
+    renderList({ isLoading: false, error: new Error('index missing'), traces: [] });
+    expect(screen.getByText('index missing')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no traces', () => {
+    renderList({ isLoading: false, error: null, traces: [] });
+    expect(screen.getByTestId('agentBuilderRecentTracesEmpty')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/recent_traces_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/recent_traces_list.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBasicTable,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiCode,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  type EuiBasicTableColumn,
+} from '@elastic/eui';
+import { FormattedRelative } from '@kbn/i18n-react';
+import { useNavigation } from '../../hooks/use_navigation';
+import { appPaths } from '../../utils/app_paths';
+import { labels } from '../../utils/i18n';
+import type { RecentTrace } from './use_recent_traces';
+
+interface RecentTracesListProps {
+  traces: RecentTrace[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const formatDuration = (ms: number): string => {
+  if (ms <= 0) return '-';
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${ms.toFixed(0)}ms`;
+};
+
+/**
+ * Renders the "recent traces" table on the trace viewer landing page. Each row
+ * navigates to `/manage/traces/:traceId`; the trace ID column uses `EuiButtonEmpty`
+ * so keyboard users get a proper focusable link target.
+ *
+ * Empty / error / loading states are shown inline so the table always occupies
+ * the same slot on the page.
+ */
+export const RecentTracesList: React.FC<RecentTracesListProps> = ({ traces, isLoading, error }) => {
+  const { createAgentBuilderUrl, navigateToAgentBuilderUrl } = useNavigation();
+
+  if (error) {
+    return (
+      <EuiCallOut
+        color="danger"
+        iconType="error"
+        title={labels.traces.recentTracesLoadErrorTitle}
+        announceOnMount
+      >
+        <p>{error.message}</p>
+      </EuiCallOut>
+    );
+  }
+
+  if (!isLoading && !traces.length) {
+    return (
+      <EuiEmptyPrompt
+        iconType="clock"
+        title={<h3>{labels.traces.recentTracesEmptyTitle}</h3>}
+        body={<p>{labels.traces.recentTracesEmptyMessage}</p>}
+        data-test-subj="agentBuilderRecentTracesEmpty"
+      />
+    );
+  }
+
+  const columns: Array<EuiBasicTableColumn<RecentTrace>> = [
+    {
+      field: 'timestamp',
+      name: labels.traces.recentTracesColumnStartedAt,
+      width: '180px',
+      render: (value: string) =>
+        value ? (
+          <EuiText size="s">
+            <FormattedRelative value={value} />
+          </EuiText>
+        ) : (
+          <EuiText size="s" color="subdued">
+            —
+          </EuiText>
+        ),
+    },
+    {
+      field: 'rootSpanName',
+      name: labels.traces.recentTracesColumnRootSpan,
+      render: (name: string) => <EuiText size="s">{name}</EuiText>,
+    },
+    {
+      field: 'traceId',
+      name: labels.traces.recentTracesColumnTraceId,
+      width: '360px',
+      render: (traceId: string) => (
+        <EuiButtonEmpty
+          size="s"
+          flush="left"
+          href={createAgentBuilderUrl(appPaths.manage.traceDetails({ traceId }))}
+          onClick={(event: React.MouseEvent) => {
+            // Support cmd/ctrl+click for "open in new tab" — fall through to the href.
+            if (event.metaKey || event.ctrlKey || event.shiftKey) return;
+            event.preventDefault();
+            navigateToAgentBuilderUrl(appPaths.manage.traceDetails({ traceId }));
+          }}
+          data-test-subj="agentBuilderRecentTraceLink"
+        >
+          <EuiCode transparentBackground>{traceId}</EuiCode>
+        </EuiButtonEmpty>
+      ),
+    },
+    {
+      name: labels.traces.recentTracesColumnActions,
+      width: '80px',
+      align: 'right',
+      render: (item: RecentTrace) => (
+        <EuiFlexGroup
+          gutterSize="xs"
+          alignItems="center"
+          responsive={false}
+          justifyContent="flexEnd"
+        >
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color="subdued">
+              {formatDuration(item.durationMs)}
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+    },
+  ];
+
+  return (
+    <EuiBasicTable
+      columns={columns}
+      items={traces}
+      loading={isLoading}
+      tableCaption={labels.traces.recentTracesTitle}
+      rowProps={(item) => ({ 'data-test-subj': `agentBuilderRecentTracesRow-${item.traceId}` })}
+      data-test-subj="agentBuilderRecentTracesTable"
+    />
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/span_tree_view.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/span_tree_view.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import type { TraceSpan } from '@kbn/llm-trace-waterfall';
+import { SpanTreeView } from './span_tree_view';
+
+// Render a lightweight stand-in for the package's SpanDetail so we can assert selection
+// without pulling in the full waterfall detail panel.
+jest.mock('@kbn/llm-trace-waterfall', () => ({
+  SpanDetail: ({ span }: { span: { name: string } }) => (
+    <div data-test-subj="mockSpanDetail">{span.name}</div>
+  ),
+}));
+
+const span = (overrides: Partial<TraceSpan> & Pick<TraceSpan, 'span_id'>): TraceSpan => ({
+  trace_id: 'trace-1',
+  name: overrides.span_id,
+  start_time: '2026-08-13T00:00:00.000Z',
+  duration_ms: 10,
+  ...overrides,
+});
+
+const renderView = (props: React.ComponentProps<typeof SpanTreeView>) =>
+  render(
+    <IntlProvider locale="en">
+      <SpanTreeView {...props} />
+    </IntlProvider>
+  );
+
+describe('SpanTreeView', () => {
+  it('renders a row per span and a span count', () => {
+    renderView({
+      spans: [
+        span({ span_id: 'root', name: 'invoke_agent' }),
+        span({ span_id: 'child', name: 'execute_tool', parent_span_id: 'root' }),
+      ],
+    });
+
+    expect(screen.getAllByTestId('agentBuilderSpanTreeRow')).toHaveLength(2);
+    expect(screen.getByText('2 spans')).toBeInTheDocument();
+  });
+
+  it('opens the SpanDetail panel for the clicked span', () => {
+    renderView({
+      spans: [
+        span({ span_id: 'root', name: 'invoke_agent' }),
+        span({ span_id: 'child', name: 'execute_tool', parent_span_id: 'root' }),
+      ],
+    });
+
+    // Nothing selected yet -> placeholder message, no detail panel.
+    expect(screen.getByText('Select a span to see its details.')).toBeInTheDocument();
+    expect(screen.queryByTestId('mockSpanDetail')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('execute_tool'));
+
+    const detail = screen.getByTestId('mockSpanDetail');
+    expect(detail).toHaveTextContent('execute_tool');
+  });
+
+  it('flags spans with an error status', () => {
+    renderView({
+      spans: [span({ span_id: 'boom', name: 'execute_tool', status: 'STATUS_CODE_ERROR' })],
+    });
+
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    renderView({ spans: [], error: new Error('kaboom') });
+    expect(screen.getByText('kaboom')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no spans', () => {
+    renderView({ spans: [] });
+    expect(screen.getByTestId('agentBuilderSpanTreeEmpty')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/span_tree_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/span_tree_view.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  EuiBadge,
+  EuiCallOut,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiText,
+  useEuiFontSize,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { SpanDetail, type SpanNode, type TraceSpan } from '@kbn/llm-trace-waterfall';
+import { labels } from '../../utils/i18n';
+import { buildSpanTree, flattenSpanTree } from './build_span_tree';
+
+interface SpanTreeViewProps {
+  spans: TraceSpan[];
+  isLoading?: boolean;
+  error?: Error | null;
+}
+
+/**
+ * "Tree" view of a trace: a deterministic parent-child list of spans with a side panel
+ * that renders `SpanDetail` for the currently selected span. This is the lighter-weight
+ * counterpart to the waterfall — no timing math, just the span hierarchy plus status.
+ */
+export const SpanTreeView: React.FC<SpanTreeViewProps> = ({
+  spans,
+  isLoading = false,
+  error = null,
+}) => {
+  const flatSpans = useMemo(() => flattenSpanTree(buildSpanTree(spans)), [spans]);
+  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
+
+  const selectedSpan = useMemo(
+    () => flatSpans.find((s) => s.span_id === selectedSpanId) ?? null,
+    [flatSpans, selectedSpanId]
+  );
+
+  if (isLoading) {
+    return (
+      <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: 200 }}>
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner size="xl" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  if (error) {
+    return <EuiCallOut title={error.message} color="danger" iconType="error" announceOnMount />;
+  }
+
+  if (!spans.length) {
+    return (
+      <EuiEmptyPrompt
+        iconType="help"
+        title={<h3>{labels.traces.emptyStateTitle}</h3>}
+        body={<p>{labels.traces.emptyStateMessage}</p>}
+        data-test-subj="agentBuilderSpanTreeEmpty"
+      />
+    );
+  }
+
+  const listStyle = css`
+    height: 100%;
+    overflow-y: auto;
+  `;
+
+  return (
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="s"
+      style={{ height: '100%' }}
+      data-test-subj="agentBuilderSpanTreeView"
+    >
+      <EuiFlexItem grow={false}>
+        <EuiText size="xs" color="subdued">
+          {`${flatSpans.length} spans`}
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem style={{ minHeight: 0 }}>
+        <EuiFlexGroup direction="row" gutterSize="s" style={{ height: '100%' }}>
+          <EuiFlexItem>
+            <div css={listStyle} data-test-subj="agentBuilderSpanTreeList">
+              {flatSpans.map((node) => (
+                <SpanTreeRow
+                  key={node.span_id}
+                  node={node}
+                  isSelected={node.span_id === selectedSpanId}
+                  onSelect={() =>
+                    setSelectedSpanId((prev) => (prev === node.span_id ? null : node.span_id))
+                  }
+                />
+              ))}
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            {selectedSpan ? (
+              <div style={{ height: '100%', overflowY: 'auto' }}>
+                <SpanDetail span={selectedSpan} onClose={() => setSelectedSpanId(null)} useTabs />
+              </div>
+            ) : (
+              <EuiPanel hasBorder color="subdued" paddingSize="m">
+                <EuiText size="s" color="subdued">
+                  {labels.traces.treeEmptyPanelMessage}
+                </EuiText>
+              </EuiPanel>
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+interface SpanTreeRowProps {
+  node: SpanNode;
+  isSelected: boolean;
+  onSelect: () => void;
+}
+
+const isErrorStatus = (status?: string): boolean => {
+  if (!status) return false;
+  const normalized = status.toUpperCase();
+  return normalized === 'ERROR' || normalized === 'STATUS_CODE_ERROR';
+};
+
+const SpanTreeRow: React.FC<SpanTreeRowProps> = ({ node, isSelected, onSelect }) => {
+  const { euiTheme } = useEuiTheme();
+  const fontSizeXs = useEuiFontSize('xs');
+  const hasError = isErrorStatus(node.status);
+  const indentStep = parseInt(euiTheme.size.base, 10);
+  const rowStyle = css`
+    ${fontSizeXs}
+    display: flex;
+    align-items: center;
+    gap: ${euiTheme.size.s};
+    padding: ${euiTheme.size.xs} ${euiTheme.size.s};
+    padding-inline-start: ${node.depth * indentStep + parseInt(euiTheme.size.s, 10)}px;
+    border-inline-start: ${euiTheme.border.width.thick} solid
+      ${hasError ? euiTheme.colors.danger : 'transparent'};
+    background: ${isSelected ? euiTheme.colors.backgroundBaseInteractiveSelect : 'transparent'};
+    cursor: pointer;
+    font-family: ${euiTheme.font.familyCode};
+    &:hover {
+      background: ${isSelected
+        ? euiTheme.colors.backgroundBaseInteractiveSelect
+        : euiTheme.colors.backgroundBaseInteractiveHover};
+    }
+  `;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      css={rowStyle}
+      data-test-subj="agentBuilderSpanTreeRow"
+      aria-pressed={isSelected}
+    >
+      <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {node.name}
+      </span>
+      <span style={{ color: euiTheme.colors.subduedText, whiteSpace: 'nowrap' }}>
+        {`${(node.duration_ms ?? 0).toFixed(1)}ms`}
+      </span>
+      {hasError && <EuiBadge color="danger">{labels.traces.spanStatusError}</EuiBadge>}
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/trace_viewer.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/trace_viewer.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { useTraceSpans } from '@kbn/llm-trace-waterfall';
+import { appPaths } from '../../utils/app_paths';
+import { useTracingEnabled } from '../../hooks/use_tracing_enabled';
+import { useTraceExists } from '../../hooks/use_trace_exists';
+import { TraceViewer } from './trace_viewer';
+
+const mockNavigate = jest.fn();
+
+jest.mock('../../hooks/use_kibana', () => ({
+  useKibana: () => ({
+    services: { plugins: { data: { search: { search: jest.fn() } }, spaces: {} } },
+  }),
+}));
+jest.mock('../../hooks/use_navigation', () => ({
+  useNavigation: () => ({
+    navigateToAgentBuilderUrl: mockNavigate,
+    createAgentBuilderUrl: (path: string) => `/app/agent_builder${path}`,
+  }),
+}));
+jest.mock('../../hooks/use_space_id', () => ({ useSpaceId: () => 'default' }));
+jest.mock('../../hooks/use_tracing_enabled', () => ({ useTracingEnabled: jest.fn() }));
+jest.mock('../../hooks/use_trace_exists', () => ({ useTraceExists: jest.fn() }));
+jest.mock('@kbn/llm-trace-waterfall', () => ({
+  TraceWaterfall: () => <div data-test-subj="mockWaterfall" />,
+  useTraceSpans: jest.fn(),
+  createEsTraceFetcher: jest.fn(() => jest.fn()),
+}));
+jest.mock('./span_tree_view', () => ({
+  SpanTreeView: () => <div data-test-subj="mockSpanTree" />,
+}));
+jest.mock('./debug_trace_button', () => ({ DebugTraceButton: () => <div /> }));
+jest.mock('./recent_traces_list', () => ({
+  RecentTracesList: () => <div data-test-subj="mockRecentList" />,
+}));
+jest.mock('./use_recent_traces', () => ({
+  useRecentTraces: () => ({ traces: [], isLoading: false, error: null }),
+}));
+
+const mockUseTracingEnabled = jest.mocked(useTracingEnabled);
+const mockUseTraceExists = jest.mocked(useTraceExists);
+const mockUseTraceSpans = jest.mocked(useTraceSpans);
+
+const renderViewer = (traceId?: string) =>
+  render(
+    <IntlProvider locale="en">
+      <TraceViewer traceId={traceId} />
+    </IntlProvider>
+  );
+
+describe('TraceViewer', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockUseTracingEnabled.mockReturnValue(true);
+    mockUseTraceExists.mockReturnValue({ exists: true, isLoading: false });
+    mockUseTraceSpans.mockReturnValue({ spans: [], durationMs: 0, isLoading: false, error: null });
+  });
+
+  it('warns when tracing is disabled', () => {
+    mockUseTracingEnabled.mockReturnValue(false);
+    renderViewer();
+    expect(screen.getByTestId('agentBuilderTracingDisabledCallout')).toBeInTheDocument();
+  });
+
+  it('navigates to the trace detail route when the search form is submitted', () => {
+    renderViewer();
+    fireEvent.change(screen.getByTestId('agentBuilderTraceIdInput'), {
+      target: { value: '  abc-123  ' },
+    });
+    fireEvent.click(screen.getByTestId('agentBuilderTraceIdSubmit'));
+    expect(mockNavigate).toHaveBeenCalledWith(appPaths.manage.traceDetails({ traceId: 'abc-123' }));
+  });
+
+  it('shows the waterfall by default and switches to the tree view on toggle', () => {
+    mockUseTraceSpans.mockReturnValue({
+      spans: [
+        {
+          span_id: 's1',
+          trace_id: 't1',
+          name: 'invoke_agent',
+          start_time: '2026-08-13T00:00:00.000Z',
+          duration_ms: 5,
+        },
+      ],
+      durationMs: 5,
+      isLoading: false,
+      error: null,
+    });
+
+    renderViewer('t1');
+
+    expect(screen.getByTestId('mockWaterfall')).toBeInTheDocument();
+    expect(screen.queryByTestId('mockSpanTree')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('agentBuilderTraceViewToggleTree'));
+
+    expect(screen.getByTestId('mockSpanTree')).toBeInTheDocument();
+    expect(screen.queryByTestId('mockWaterfall')).not.toBeInTheDocument();
+  });
+
+  it('shows a not-found state for a trace ID with no spans that does not exist', () => {
+    mockUseTraceExists.mockReturnValue({ exists: false, isLoading: false });
+    renderViewer('missing-trace');
+
+    expect(screen.getByTestId('agentBuilderTraceNotFound')).toBeInTheDocument();
+    expect(screen.getByText('Trace not found')).toBeInTheDocument();
+    expect(screen.queryByTestId('mockWaterfall')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/trace_viewer.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/trace_viewer.tsx
@@ -1,0 +1,315 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonGroup,
+  EuiButtonIcon,
+  EuiCallOut,
+  EuiCode,
+  EuiCopy,
+  EuiEmptyPrompt,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiForm,
+  EuiFormRow,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  EuiToolTip,
+} from '@elastic/eui';
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+import { createEsTraceFetcher, TraceWaterfall, useTraceSpans } from '@kbn/llm-trace-waterfall';
+import { buildAgentBuilderTracesIndexPattern } from '../../../../common/traces';
+import { useKibana } from '../../hooks/use_kibana';
+import { useNavigation } from '../../hooks/use_navigation';
+import { useSpaceId } from '../../hooks/use_space_id';
+import { useTraceExists } from '../../hooks/use_trace_exists';
+import { useTracingEnabled } from '../../hooks/use_tracing_enabled';
+import { appPaths } from '../../utils/app_paths';
+import { labels } from '../../utils/i18n';
+import { DebugTraceButton } from './debug_trace_button';
+import { RecentTracesList } from './recent_traces_list';
+import { SpanTreeView } from './span_tree_view';
+import { useRecentTraces } from './use_recent_traces';
+
+type ViewMode = 'waterfall' | 'tree';
+
+interface TraceViewerProps {
+  traceId?: string;
+}
+
+/**
+ * Standalone trace viewer page.
+ *
+ * - When a `traceId` is provided (via `/manage/traces/:traceId`), fetches its spans
+ *   from the space-scoped Agent Builder traces data stream and renders them either
+ *   as a waterfall (via `@kbn/llm-trace-waterfall`) or as a deterministic span tree.
+ * - When no `traceId` is provided, shows a list of the 10 most recent traces in the
+ *   space. A compact "search by trace ID" field remains available for deep-linking
+ *   into a specific trace.
+ */
+export const TraceViewer: React.FC<TraceViewerProps> = ({ traceId }) => {
+  const { services } = useKibana();
+  const { data, spaces } = services.plugins;
+  const { navigateToAgentBuilderUrl, createAgentBuilderUrl } = useNavigation();
+  const spaceId = useSpaceId(spaces);
+  const isTracingEnabled = useTracingEnabled();
+
+  const [inputValue, setInputValue] = useState('');
+  const [viewMode, setViewMode] = useState<ViewMode>('waterfall');
+
+  const tracesIndex = useMemo(
+    () => (spaceId ? buildAgentBuilderTracesIndexPattern(spaceId) : undefined),
+    [spaceId]
+  );
+
+  const fetchTrace = useMemo(
+    () =>
+      tracesIndex
+        ? createEsTraceFetcher(data.search.search, { index: tracesIndex })
+        : createEsTraceFetcher(data.search.search),
+    [data.search.search, tracesIndex]
+  );
+
+  const { spans, durationMs, isLoading, error } = useTraceSpans(traceId ?? null, {
+    fetchTrace,
+    index: tracesIndex,
+    enabled: Boolean(traceId) && isTracingEnabled,
+  });
+
+  // Lets the empty state distinguish a genuine "not found / wrong space" trace from the
+  // rare "exists but has no spans" case, rather than showing one ambiguous message.
+  const { exists: traceExists } = useTraceExists(traceId ?? null, {
+    enabled: Boolean(traceId) && isTracingEnabled,
+  });
+
+  // Only fetch the recent-traces table on the landing view; we do not want an
+  // extra query firing whenever the user is deep-linked into a specific trace.
+  const recentTraces = useRecentTraces({
+    search: data.search.search,
+    index: tracesIndex,
+    enabled: !traceId && isTracingEnabled,
+  });
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault();
+      const value = inputValue.trim();
+      if (!value) return;
+      navigateToAgentBuilderUrl(appPaths.manage.traceDetails({ traceId: value }));
+    },
+    [inputValue, navigateToAgentBuilderUrl]
+  );
+
+  // A settled, span-less result: the trace ID resolved but returned nothing. `useTraceExists`
+  // tells us whether that's a genuine "not found" (nothing in the index) vs. a rare empty trace.
+  const showNotFound = Boolean(traceId) && !isLoading && !error && spans.length === 0;
+
+  const renderTraceHeader = (id: string) => (
+    <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          iconType="chevronSingleLeft"
+          flush="left"
+          href={createAgentBuilderUrl(appPaths.manage.traces)}
+          onClick={(event: React.MouseEvent) => {
+            if (event.metaKey || event.ctrlKey || event.shiftKey) return;
+            event.preventDefault();
+            navigateToAgentBuilderUrl(appPaths.manage.traces);
+          }}
+          data-test-subj="agentBuilderTraceBackButton"
+        >
+          {labels.traces.backToTraces}
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s" color="subdued">
+              {labels.traces.traceIdLabel}
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiCode transparentBackground>{id}</EuiCode>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiCopy textToCopy={id}>
+              {(copy) => (
+                <EuiToolTip content={labels.traces.copyTraceIdAriaLabel} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    iconType="copy"
+                    color="text"
+                    onClick={copy}
+                    aria-label={labels.traces.copyTraceIdAriaLabel}
+                    data-test-subj="agentBuilderTraceIdCopyButton"
+                  />
+                </EuiToolTip>
+              )}
+            </EuiCopy>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  const renderDetailBody = (id: string) => (
+    <EuiFlexGroup direction="column" gutterSize="m" style={{ height: '100%', minHeight: 480 }}>
+      <EuiFlexItem grow={false}>{renderTraceHeader(id)}</EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButtonGroup
+              legend={labels.traces.viewToggleLegend}
+              idSelected={viewMode}
+              onChange={(nextId) => setViewMode(nextId as ViewMode)}
+              options={[
+                {
+                  id: 'waterfall',
+                  label: labels.traces.waterfallViewLabel,
+                  iconType: 'chartWaterfall',
+                  'data-test-subj': 'agentBuilderTraceViewToggleWaterfall',
+                },
+                {
+                  id: 'tree',
+                  label: labels.traces.treeViewLabel,
+                  iconType: 'nested',
+                  'data-test-subj': 'agentBuilderTraceViewToggleTree',
+                },
+              ]}
+              buttonSize="compressed"
+              isDisabled={showNotFound}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <DebugTraceButton traceId={id} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem style={{ minHeight: 0 }}>
+        <EuiPanel hasBorder paddingSize="m" style={{ height: '100%' }}>
+          {showNotFound ? (
+            <EuiEmptyPrompt
+              iconType={traceExists ? 'help' : 'magnify'}
+              title={
+                <h3>
+                  {traceExists ? labels.traces.emptyStateTitle : labels.traces.traceNotFoundTitle}
+                </h3>
+              }
+              body={
+                <p>
+                  {traceExists
+                    ? labels.traces.emptyStateMessage
+                    : labels.traces.traceNotFoundMessage}
+                </p>
+              }
+              data-test-subj="agentBuilderTraceNotFound"
+            />
+          ) : viewMode === 'waterfall' ? (
+            <TraceWaterfall
+              spans={spans}
+              traceId={id}
+              durationMs={durationMs}
+              isLoading={isLoading}
+              error={error}
+              layout="horizontal"
+            />
+          ) : (
+            <SpanTreeView spans={spans} isLoading={isLoading} error={error} />
+          )}
+        </EuiPanel>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  const renderLandingBody = () => (
+    <EuiFlexGroup direction="column" gutterSize="m">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h3>{labels.traces.recentTracesTitle}</h3>
+        </EuiTitle>
+        <EuiSpacer size="xs" />
+        <EuiText size="xs" color="subdued">
+          {labels.traces.recentTracesDescription}
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <RecentTracesList
+          traces={recentTraces.traces}
+          isLoading={recentTraces.isLoading}
+          error={recentTraces.error}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  return (
+    <KibanaPageTemplate data-test-subj="agentBuilderTracesPage" restrictWidth={false}>
+      <KibanaPageTemplate.Header
+        pageTitle={labels.traces.libraryTitle}
+        description={labels.traces.pageDescription}
+      />
+      <KibanaPageTemplate.Section grow>
+        {!isTracingEnabled && (
+          <>
+            <EuiCallOut
+              color="warning"
+              iconType="warning"
+              announceOnMount
+              title={labels.traces.tracingDisabledTitle}
+              data-test-subj="agentBuilderTracingDisabledCallout"
+            >
+              <p>{labels.traces.tracingDisabledMessage}</p>
+            </EuiCallOut>
+            <EuiSpacer size="m" />
+          </>
+        )}
+
+        {traceId ? (
+          renderDetailBody(traceId)
+        ) : (
+          <>
+            <EuiForm component="form" onSubmit={handleSubmit}>
+              <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
+                <EuiFlexItem>
+                  <EuiFormRow label={labels.traces.searchByIdLabel} fullWidth>
+                    <EuiFieldText
+                      fullWidth
+                      value={inputValue}
+                      placeholder={labels.traces.traceIdPlaceholder}
+                      onChange={(e) => setInputValue(e.target.value)}
+                      data-test-subj="agentBuilderTraceIdInput"
+                      compressed
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    type="submit"
+                    iconType="magnify"
+                    isDisabled={!inputValue.trim()}
+                    data-test-subj="agentBuilderTraceIdSubmit"
+                  >
+                    {labels.traces.viewTraceButton}
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiForm>
+
+            <EuiSpacer size="l" />
+
+            {renderLandingBody()}
+          </>
+        )}
+      </KibanaPageTemplate.Section>
+    </KibanaPageTemplate>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/use_recent_traces.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/use_recent_traces.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { of } from 'rxjs';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { useRecentTraces } from './use_recent_traces';
+
+// The real `search` type is `Observable<IKibanaSearchResponse<any>>`; our test doubles
+// resolve with a narrower shape, so cast through `unknown` to keep the hook's public
+// type check happy without leaking `any` into the test bodies.
+type SearchFn = DataPublicPluginStart['search']['search'];
+const asSearch = (fn: unknown): SearchFn => fn as SearchFn;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, Wrapper };
+};
+
+describe('useRecentTraces', () => {
+  it('does not fetch when the index is not resolved yet', () => {
+    const search = jest.fn();
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useRecentTraces({ search: asSearch(search), index: undefined }),
+      {
+        wrapper: Wrapper,
+      }
+    );
+
+    expect(search).not.toHaveBeenCalled();
+    expect(result.current.traces).toEqual([]);
+  });
+
+  it('maps a collapsed inner-hits response into RecentTrace rows', async () => {
+    const search = jest.fn(() =>
+      of({
+        rawResponse: {
+          hits: {
+            hits: [
+              {
+                _source: {
+                  trace_id: 'trace-1',
+                  '@timestamp': '2026-08-13T00:00:10Z',
+                  name: 'chat gpt-5',
+                  duration: 200_000_000,
+                },
+                inner_hits: {
+                  root: {
+                    hits: {
+                      hits: [
+                        {
+                          _source: {
+                            name: 'invoke_agent elastic-ai-agent',
+                            '@timestamp': '2026-08-13T00:00:00Z',
+                            duration: 1_500_000_000,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                _source: {
+                  trace_id: 'trace-2',
+                  '@timestamp': '2026-08-12T00:00:00Z',
+                  name: 'execute_tool load_skill',
+                  duration: 800_000_000,
+                },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(
+      () =>
+        useRecentTraces({
+          search: asSearch(search),
+          index: 'traces-agent_builder.otel-default',
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          index: 'traces-agent_builder.otel-default',
+          body: expect.objectContaining({
+            size: 10,
+            sort: [{ '@timestamp': { order: 'desc' } }],
+            collapse: expect.objectContaining({ field: 'trace_id' }),
+          }),
+        }),
+      })
+    );
+
+    // First row prefers the earliest-inner-hit (i.e. the root span) for name/timestamp/duration.
+    expect(result.current.traces).toEqual([
+      {
+        traceId: 'trace-1',
+        timestamp: '2026-08-13T00:00:00Z',
+        rootSpanName: 'invoke_agent elastic-ai-agent',
+        durationMs: 1500,
+      },
+      // Second row falls back to the outer hit when inner_hits is absent.
+      {
+        traceId: 'trace-2',
+        timestamp: '2026-08-12T00:00:00Z',
+        rootSpanName: 'execute_tool load_skill',
+        durationMs: 800,
+      },
+    ]);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/use_recent_traces.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/traces/use_recent_traces.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import { useQuery } from '@kbn/react-query';
+import { lastValueFrom } from 'rxjs';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+
+/**
+ * A single row rendered by the "recent traces" table on the standalone trace
+ * viewer page. One row = one distinct trace, represented by whichever span for
+ * that trace is most recent (see `useRecentTraces` for why we use collapse).
+ */
+export interface RecentTrace {
+  traceId: string;
+  timestamp: string;
+  rootSpanName: string;
+  durationMs: number;
+}
+
+const NANOSECONDS_PER_MILLISECOND = 1_000_000;
+const DEFAULT_LIMIT = 10;
+const STALE_TIME_MS = 15_000;
+
+interface RecentTracesSearchResponse {
+  rawResponse?: {
+    hits?: {
+      hits?: Array<{
+        _source?: {
+          trace_id?: string;
+          '@timestamp'?: string;
+          name?: string;
+          duration?: number;
+          parent_span_id?: string;
+          inner_hits?: unknown;
+        };
+        fields?: Record<string, unknown>;
+        inner_hits?: {
+          root?: {
+            hits?: {
+              hits?: Array<{
+                _source?: {
+                  name?: string;
+                  '@timestamp'?: string;
+                  duration?: number;
+                };
+              }>;
+            };
+          };
+        };
+      }>;
+    };
+  };
+}
+
+interface UseRecentTracesArgs {
+  search: DataPublicPluginStart['search']['search'];
+  index?: string;
+  limit?: number;
+  enabled?: boolean;
+}
+
+/**
+ * Fetch the N most recent traces in the given index by collapsing on `trace_id`.
+ *
+ * Collapse sorted by `@timestamp` desc returns the most recent span per trace
+ * (Elasticsearch's field collapsing feature is the cheapest way to get "top N
+ * distinct trace_ids" without an aggregation). We also request an `inner_hits`
+ * whose `sort` is ascending, so the first inner hit is the *earliest* span of
+ * that trace — this gives us the trace's start time and, in the common case,
+ * the root span's name (e.g. `invoke_agent elastic-ai-agent`) for the label.
+ *
+ * `parent_span_id` is not required to be indexed as a keyword; we rely purely
+ * on time ordering, which works even when the root span is dropped from the
+ * shard for some reason.
+ */
+export const useRecentTraces = ({
+  search,
+  index,
+  limit = DEFAULT_LIMIT,
+  enabled = true,
+}: UseRecentTracesArgs): {
+  traces: RecentTrace[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+} => {
+  const fetchRecentTraces = useCallback(async (): Promise<RecentTrace[]> => {
+    if (!index) return [];
+    const response = (await lastValueFrom(
+      search({
+        params: {
+          index,
+          body: {
+            size: limit,
+            sort: [{ '@timestamp': { order: 'desc' } }],
+            collapse: {
+              field: 'trace_id',
+              inner_hits: {
+                name: 'root',
+                size: 1,
+                sort: [{ '@timestamp': { order: 'asc' } }],
+                _source: ['name', '@timestamp', 'duration'],
+              },
+            },
+            _source: ['trace_id', '@timestamp', 'name', 'duration'],
+          },
+        },
+      })
+    )) as RecentTracesSearchResponse;
+
+    const hits = response.rawResponse?.hits?.hits ?? [];
+    return hits.flatMap((hit) => {
+      const traceId = hit._source?.trace_id;
+      if (!traceId) return [];
+      const earliest = hit.inner_hits?.root?.hits?.hits?.[0]?._source;
+      return [
+        {
+          traceId,
+          timestamp: earliest?.['@timestamp'] ?? hit._source?.['@timestamp'] ?? '',
+          rootSpanName: earliest?.name ?? hit._source?.name ?? '-',
+          durationMs:
+            (earliest?.duration ?? hit._source?.duration ?? 0) / NANOSECONDS_PER_MILLISECOND,
+        },
+      ];
+    });
+  }, [index, limit, search]);
+
+  const query = useQuery<RecentTrace[], Error>({
+    queryKey: ['agent-builder', 'recent-traces', index, limit],
+    enabled: enabled && Boolean(index),
+    staleTime: STALE_TIME_MS,
+    queryFn: fetchRecentTraces,
+  });
+
+  return {
+    traces: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error ?? null,
+    refetch: query.refetch,
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/pages/traces.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/pages/traces.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { TraceViewer } from '../components/traces/trace_viewer';
+import { useBreadcrumb } from '../hooks/use_breadcrumbs';
+import { appPaths } from '../utils/app_paths';
+import { labels } from '../utils/i18n';
+
+export const AgentBuilderTracesPage = () => {
+  const { traceId } = useParams<{ traceId?: string }>();
+
+  useBreadcrumb(
+    traceId
+      ? [
+          { text: labels.traces.libraryTitle, path: appPaths.manage.traces },
+          { text: traceId, path: appPaths.manage.traceDetails({ traceId }) },
+        ]
+      : [{ text: labels.traces.libraryTitle, path: appPaths.manage.traces }]
+  );
+
+  return <TraceViewer traceId={traceId} />;
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -31,6 +31,7 @@ import { AgentBuilderPluginDetailsPage } from './pages/plugin_details';
 import { AgentBuilderMcpClientsPage } from './pages/mcp_clients';
 import { AgentBuilderMcpClientCreatePage } from './pages/mcp_client_create';
 import { AgentBuilderMcpClientEditPage } from './pages/mcp_client_edit';
+import { AgentBuilderTracesPage } from './pages/traces';
 import { agentBuilderViewIds } from './agent_builder_view_ids';
 import { appPaths } from './utils/app_paths';
 
@@ -78,6 +79,9 @@ const navLabels = {
   }),
   agents: i18n.translate('xpack.agentBuilder.routeConfig.agents', {
     defaultMessage: 'Agents',
+  }),
+  traces: i18n.translate('xpack.agentBuilder.routeConfig.traces', {
+    defaultMessage: 'Traces',
   }),
 };
 
@@ -242,6 +246,23 @@ export const manageRoutes: RouteDefinition[] = [
     viewId: agentBuilderViewIds.manageToolDetails,
     sidebarView: 'manage',
     element: <AgentBuilderToolDetailsPage />,
+  },
+  // Trace viewer: `traces/:traceId` (details) must precede the parameter-less list
+  // route so react-router matches the more specific path first.
+  {
+    path: '/manage/traces/:traceId',
+    viewId: agentBuilderViewIds.manageTraceDetails,
+    sidebarView: 'manage',
+    isExperimental: true,
+    element: <AgentBuilderTracesPage />,
+  },
+  {
+    path: '/manage/traces',
+    viewId: agentBuilderViewIds.manageTraces,
+    sidebarView: 'manage',
+    isExperimental: true,
+    navLabel: navLabels.traces,
+    element: <AgentBuilderTracesPage />,
   },
 ];
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
@@ -41,6 +41,10 @@ export const appPaths = {
     mcpClients: '/manage/tools/mcp_clients',
     mcpClientCreate: '/manage/tools/mcp_clients/new',
     mcpClientEdit: ({ clientId }: { clientId: string }) => `/manage/tools/mcp_clients/${clientId}`,
+    // Trace viewer routes are keyed off a `traceId` param so a trace can be pulled up by URL alone.
+    // `traces` (no id) is the searchable landing page; `traceDetails` renders the waterfall/tree.
+    traces: '/manage/traces',
+    traceDetails: ({ traceId }: { traceId: string }) => `/manage/traces/${traceId}`,
   },
 
   // Legacy paths - redirect to new structure via LegacyConversationRedirect

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
@@ -2936,4 +2936,161 @@ export const labels = {
       defaultMessage: 'Yes, abort',
     }),
   },
+  traces: {
+    libraryTitle: i18n.translate('xpack.agentBuilder.traces.libraryTitle', {
+      defaultMessage: 'Traces',
+    }),
+    pageDescription: i18n.translate('xpack.agentBuilder.traces.pageDescription', {
+      defaultMessage:
+        'Inspect a conversation trace as a timeline or a structured span tree. Paste a trace ID from a conversation round to get started.',
+    }),
+    traceIdLabel: i18n.translate('xpack.agentBuilder.traces.traceIdLabel', {
+      defaultMessage: 'Trace ID',
+    }),
+    traceIdPlaceholder: i18n.translate('xpack.agentBuilder.traces.traceIdPlaceholder', {
+      defaultMessage: 'Paste a trace ID',
+    }),
+    viewTraceButton: i18n.translate('xpack.agentBuilder.traces.viewTraceButton', {
+      defaultMessage: 'View trace',
+    }),
+    viewToggleLegend: i18n.translate('xpack.agentBuilder.traces.viewToggleLegend', {
+      defaultMessage: 'Trace view',
+    }),
+    waterfallViewLabel: i18n.translate('xpack.agentBuilder.traces.waterfallViewLabel', {
+      defaultMessage: 'Waterfall',
+    }),
+    treeViewLabel: i18n.translate('xpack.agentBuilder.traces.treeViewLabel', {
+      defaultMessage: 'Tree',
+    }),
+    debugWithAgentButton: i18n.translate('xpack.agentBuilder.traces.debugWithAgentButton', {
+      defaultMessage: 'Debug with agent',
+    }),
+    debugWithAgentTooltip: i18n.translate('xpack.agentBuilder.traces.debugWithAgentTooltip', {
+      defaultMessage:
+        'Open a new conversation with the Elastic AI Agent, pre-filled with a debug prompt for this trace. You can review or edit the prompt before sending.',
+    }),
+    tracingDisabledTitle: i18n.translate('xpack.agentBuilder.traces.tracingDisabledTitle', {
+      defaultMessage: 'Agent Builder tracing is disabled',
+    }),
+    tracingDisabledMessage: i18n.translate('xpack.agentBuilder.traces.tracingDisabledMessage', {
+      defaultMessage:
+        'Enable the "agentBuilder:tracing:enabled" advanced setting to record and view traces for conversations.',
+    }),
+    emptyStateTitle: i18n.translate('xpack.agentBuilder.traces.emptyStateTitle', {
+      defaultMessage: 'Enter a trace ID',
+    }),
+    emptyStateMessage: i18n.translate('xpack.agentBuilder.traces.emptyStateMessage', {
+      defaultMessage:
+        'Trace IDs are shown on individual conversation rounds. Paste one above to visualise its spans.',
+    }),
+    treeEmptyPanelMessage: i18n.translate('xpack.agentBuilder.traces.treeEmptyPanelMessage', {
+      defaultMessage: 'Select a span to see its details.',
+    }),
+    spanStatusError: i18n.translate('xpack.agentBuilder.traces.spanStatusError', {
+      defaultMessage: 'Error',
+    }),
+    conversationTracesTitle: i18n.translate('xpack.agentBuilder.traces.conversationTracesTitle', {
+      defaultMessage: 'Traces for this conversation',
+    }),
+    conversationTracesMenuItem: i18n.translate(
+      'xpack.agentBuilder.traces.conversationTracesMenuItem',
+      {
+        defaultMessage: 'View all traces',
+      }
+    ),
+    noConversationTracesTitle: i18n.translate(
+      'xpack.agentBuilder.traces.noConversationTracesTitle',
+      {
+        defaultMessage: 'No traces yet',
+      }
+    ),
+    noConversationTracesMessage: i18n.translate(
+      'xpack.agentBuilder.traces.noConversationTracesMessage',
+      {
+        defaultMessage:
+          'This conversation has no rounds with traces. Send a message with tracing enabled to record one.',
+      }
+    ),
+    backToList: i18n.translate('xpack.agentBuilder.traces.backToList', {
+      defaultMessage: 'Back to traces',
+    }),
+    emptyMessagePreview: i18n.translate('xpack.agentBuilder.traces.emptyMessagePreview', {
+      defaultMessage: '(no message)',
+    }),
+    tracesCount: (count: number) =>
+      i18n.translate('xpack.agentBuilder.traces.tracesCount', {
+        defaultMessage: '{count, plural, one {# trace} other {# traces}}',
+        values: { count },
+      }),
+    turnLabel: (turn: number) =>
+      i18n.translate('xpack.agentBuilder.traces.turnLabel', {
+        defaultMessage: 'Turn {turn}:',
+        values: { turn },
+      }),
+    roundTraceHeading: (turn: number) =>
+      i18n.translate('xpack.agentBuilder.traces.roundTraceHeading', {
+        defaultMessage: 'Turn {turn} trace',
+        values: { turn },
+      }),
+    recentTracesTitle: i18n.translate('xpack.agentBuilder.traces.recentTracesTitle', {
+      defaultMessage: 'Recent traces',
+    }),
+    recentTracesDescription: i18n.translate('xpack.agentBuilder.traces.recentTracesDescription', {
+      defaultMessage:
+        'The 10 most recent traces recorded in this space. Select a trace to open its waterfall.',
+    }),
+    recentTracesEmptyTitle: i18n.translate('xpack.agentBuilder.traces.recentTracesEmptyTitle', {
+      defaultMessage: 'No recent traces',
+    }),
+    recentTracesEmptyMessage: i18n.translate('xpack.agentBuilder.traces.recentTracesEmptyMessage', {
+      defaultMessage:
+        'No traces have been recorded in this space yet. Send a conversation with tracing enabled to see traces here.',
+    }),
+    recentTracesLoadErrorTitle: i18n.translate(
+      'xpack.agentBuilder.traces.recentTracesLoadErrorTitle',
+      {
+        defaultMessage: 'Unable to load recent traces',
+      }
+    ),
+    recentTracesColumnTraceId: i18n.translate(
+      'xpack.agentBuilder.traces.recentTracesColumnTraceId',
+      {
+        defaultMessage: 'Trace ID',
+      }
+    ),
+    recentTracesColumnStartedAt: i18n.translate(
+      'xpack.agentBuilder.traces.recentTracesColumnStartedAt',
+      {
+        defaultMessage: 'Started',
+      }
+    ),
+    recentTracesColumnRootSpan: i18n.translate(
+      'xpack.agentBuilder.traces.recentTracesColumnRootSpan',
+      {
+        defaultMessage: 'Root span',
+      }
+    ),
+    recentTracesColumnActions: i18n.translate(
+      'xpack.agentBuilder.traces.recentTracesColumnActions',
+      {
+        defaultMessage: 'Actions',
+      }
+    ),
+    searchByIdLabel: i18n.translate('xpack.agentBuilder.traces.searchByIdLabel', {
+      defaultMessage: 'Or search by trace ID',
+    }),
+    backToTraces: i18n.translate('xpack.agentBuilder.traces.backToTraces', {
+      defaultMessage: 'Back to traces',
+    }),
+    copyTraceIdAriaLabel: i18n.translate('xpack.agentBuilder.traces.copyTraceIdAriaLabel', {
+      defaultMessage: 'Copy trace ID',
+    }),
+    traceNotFoundTitle: i18n.translate('xpack.agentBuilder.traces.traceNotFoundTitle', {
+      defaultMessage: 'Trace not found',
+    }),
+    traceNotFoundMessage: i18n.translate('xpack.agentBuilder.traces.traceNotFoundMessage', {
+      defaultMessage:
+        'No spans were found for this trace ID in the current space. It may not have been ingested yet, or it may belong to a different space.',
+    }),
+  },
 };


### PR DESCRIPTION


## Summary

Agent Builder records a trace for each conversation round. Until now, there was no
way to look at a trace in the UI. To find a failed or looped step, you had to read
raw trace data by hand.

This PR adds a trace viewer. It shows the spans of a trace as a waterfall timeline or
as a simple span tree. You can also hand a trace to the default Elastic AI Agent for
a first-pass diagnosis.

This was not a requested feature. It comes from the pain of trace debugging.

## What this adds

- A Traces page at `/manage/traces`. The landing view lists the 10 most recent traces
  in the space. A search field opens a trace by ID.
- A trace detail view with two modes: a **Waterfall** timeline and a **Tree** span
  list. The tree shows parent-child links (for example `execute_tool` → `load_skill`)
  and marks error spans.
- A **View all traces** action in the conversation "…" menu. It opens a flyout with
  one row per round that has a trace.
- A **Debug with agent** button. It opens a new conversation with the Elastic AI Agent
  and pre-fills a debug prompt for the trace. The button does not send the prompt
  automatically, so you can edit it first.

## Rollout and gating

The Traces page and its nav item are behind the `agentBuilder:experimentalFeatures`
flag. The **Debug with agent** button shows only when both tracing and the
experimental flag are on. The default agent gets the `agent-builder-traces` skill
under those same conditions, so the button never opens an agent that cannot read spans.

## Bug fix included

The per-round trace flyout now uses the space-scoped traces index. Before, it used the
default `traces-*` pattern, which can show spans from other spaces.

## How to test

1. Turn on the `agentBuilder:experimentalFeatures` advanced setting.
2. Make sure that the `agentBuilder:tracing:enabled` setting is on (on by default).
3. Open an agent conversation. Send a message. This records a trace.
4. Go to **Manage → Traces**. The recent traces list shows the new trace.
5. Select the trace. The waterfall opens.
6. Select **Tree**. The span list opens with a detail panel.
7. Select **Debug with agent**. A new conversation opens with a pre-filled prompt.
8. Turn off the experimental flag. The Traces nav item and the button are gone.


## Screenshots


