### PR TITLE
[streams][scout] fix flaky discover integration test

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/integrations/ui/tests/discover_integration_classic.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/integrations/ui/tests/discover_integration_classic.spec.ts
@@ -38,10 +38,10 @@ test.describe(
     }) => {
       await browserAuth.loginAsAdmin();
 
-      // Navigate to Discover and wait for the page to be ready
+      // Discover opens on the space's default data view, which is not guaranteed to hold
+      // this stream's data, so nothing can be asserted until 'All logs' is selected.
       await pageObjects.discover.goto({ queryMode: 'classic' });
       await pageObjects.discover.waitUntilSearchingHasFinished();
-      await pageObjects.discover.waitForHistogramRendered();
 
       await pageObjects.discover.selectDataView('All logs');
       await pageObjects.discover.waitUntilSearchingHasFinished();
@@ -81,10 +81,10 @@ test.describe(
     }) => {
       await browserAuth.loginAsAdmin();
 
-      // Navigate to Discover and wait for the page to be ready
+      // Discover opens on the space's default data view, which is not guaranteed to hold
+      // this stream's data, so nothing can be asserted until 'All logs' is selected.
       await pageObjects.discover.goto({ queryMode: 'classic' });
       await pageObjects.discover.waitUntilSearchingHasFinished();
-      await pageObjects.discover.waitForHistogramRendered();
 
       await pageObjects.discover.selectDataView('All logs');
       await pageObjects.discover.waitUntilSearchingHasFinished();


### PR DESCRIPTION
## Summary

Flaky test fix:

<img width="705" height="146" alt="Screenshot 2026-08-14 at 16 28 04" src="https://github.com/user-attachments/assets/502d171b-1a2b-42cd-8ac0-beed2a8eb90f" />


Fix is to remove two `waitForHistogramRendered()` calls from `discover_integration_classic.spec.ts` (one per test) that ran before `selectDataView('All logs')`.

They asserted that whatever data view `Discover` happened to open on **had chartable data**, then the next line replaced that data view. When `defaultIndex` resolved to Fleet's empty `metrics-*`, the histogram never renders, so the wait could only time out.

I re-run 3 configs to simulate CI Scout Lane and confirm fix.


