### PR TITLE
[scout] retry test only on the 1st CI attempt

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/datasources/buildkite.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/datasources/buildkite.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { BuildkiteMetadata } from './buildkite';
+
+describe('buildkite metadata', () => {
+  const originalEnv = process.env;
+
+  // `buildkite` is resolved at import time, so each case needs a fresh module registry.
+  const loadMetadata = async (env: Record<string, string>): Promise<BuildkiteMetadata> => {
+    const nextEnv = { ...originalEnv };
+    // Drop inherited values so the assertions hold when these tests run on Buildkite themselves.
+    delete nextEnv.BUILDKITE;
+    delete nextEnv.BUILDKITE_RETRY_COUNT;
+
+    process.env = { ...nextEnv, ...env };
+    jest.resetModules();
+    return (await import('./buildkite')).buildkite;
+  };
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('reports retry_count 0 on the original run', async () => {
+    const metadata = await loadMetadata({ BUILDKITE: 'true', BUILDKITE_RETRY_COUNT: '0' });
+    expect(metadata.retry_count).toBe(0);
+  });
+
+  it('reports how many times the job was retried', async () => {
+    expect(
+      (await loadMetadata({ BUILDKITE: 'true', BUILDKITE_RETRY_COUNT: '1' })).retry_count
+    ).toBe(1);
+    expect(
+      (await loadMetadata({ BUILDKITE: 'true', BUILDKITE_RETRY_COUNT: '2' })).retry_count
+    ).toBe(2);
+  });
+
+  it('falls back to 0 when BUILDKITE_RETRY_COUNT is missing or malformed', async () => {
+    expect((await loadMetadata({ BUILDKITE: 'true' })).retry_count).toBe(0);
+    expect((await loadMetadata({ BUILDKITE: 'true', BUILDKITE_RETRY_COUNT: '' })).retry_count).toBe(
+      0
+    );
+  });
+
+  it('is not reported outside Buildkite', async () => {
+    const metadata = await loadMetadata({ BUILDKITE_RETRY_COUNT: '1' });
+    expect(metadata.retry_count).toBeUndefined();
+  });
+});

--- a/src/platform/packages/private/kbn-scout-reporting/src/datasources/buildkite.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/datasources/buildkite.ts
@@ -14,6 +14,7 @@ export interface BuildkiteMetadata {
   branch?: string;
   commit?: string;
   job_id?: string;
+  retry_count?: number;
   message?: string;
   build: {
     id?: string;
@@ -46,6 +47,11 @@ export interface BuildkiteMetadata {
   };
 }
 
+const parseRetryCount = (value: string | undefined): number => {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
 /**
  * Buildkite information extracted from environment variables
  *
@@ -57,6 +63,7 @@ export const buildkite: BuildkiteMetadata =
         branch: process.env.BUILDKITE_BRANCH,
         commit: process.env.BUILDKITE_COMMIT,
         job_id: process.env.BUILDKITE_JOB_ID,
+        retry_count: parseRetryCount(process.env.BUILDKITE_RETRY_COUNT),
         build: {
           id: process.env.BUILDKITE_BUILD_ID,
           number: process.env.BUILDKITE_BUILD_NUMBER,

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
@@ -18,7 +18,7 @@ import {
 
 export const buildkiteMappings: ClusterPutComponentTemplateRequest = {
   name: 'scout-test-event.mappings.buildkite',
-  version: 3,
+  version: 4,
   template: {
     mappings: {
       properties: {

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
@@ -18,6 +18,9 @@ export const buildkiteProperties: Record<PropertyName, MappingProperty> = {
   job_id: {
     type: 'wildcard',
   },
+  retry_count: {
+    type: 'integer',
+  },
   build: {
     type: 'object',
     properties: {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.test.ts
@@ -39,25 +39,28 @@ describe('createPlaywrightConfig', () => {
 
   const originalCI = process.env.CI;
   const originalRetries = process.env.SCOUT_TEST_RETRIES;
+  const originalBuildkiteRetryCount = process.env.BUILDKITE_RETRY_COUNT;
+
+  const restoreEnvVar = (name: string, value: string | undefined) => {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.TEST_RUN_ID;
     delete process.env.CI;
     delete process.env.SCOUT_TEST_RETRIES;
+    delete process.env.BUILDKITE_RETRY_COUNT;
   });
 
   afterAll(() => {
-    if (originalCI === undefined) {
-      delete process.env.CI;
-    } else {
-      process.env.CI = originalCI;
-    }
-    if (originalRetries === undefined) {
-      delete process.env.SCOUT_TEST_RETRIES;
-    } else {
-      process.env.SCOUT_TEST_RETRIES = originalRetries;
-    }
+    restoreEnvVar('CI', originalCI);
+    restoreEnvVar('SCOUT_TEST_RETRIES', originalRetries);
+    restoreEnvVar('BUILDKITE_RETRY_COUNT', originalBuildkiteRetryCount);
   });
 
   it('should return a valid default Playwright configuration', () => {
@@ -208,10 +211,48 @@ describe('createPlaywrightConfig', () => {
       expect(config.retries).toBe(0);
     });
 
-    it('is 1 on CI', () => {
+    it('is 1 on the first CI attempt of a step', () => {
       process.env.CI = 'true';
       const config = createPlaywrightConfig({ testDir: './my_tests' });
       expect(config.retries).toBe(1);
+    });
+
+    it('is 1 when BUILDKITE_RETRY_COUNT reports the first attempt', () => {
+      process.env.CI = 'true';
+      process.env.BUILDKITE_RETRY_COUNT = '0';
+      const config = createPlaywrightConfig({ testDir: './my_tests' });
+      expect(config.retries).toBe(1);
+    });
+
+    it('is 0 when the Buildkite step is retried', () => {
+      process.env.CI = 'true';
+      process.env.BUILDKITE_RETRY_COUNT = '1';
+      const config = createPlaywrightConfig({ testDir: './my_tests' });
+      expect(config.retries).toBe(0);
+    });
+
+    it('is 1 on CI when BUILDKITE_RETRY_COUNT is not a number', () => {
+      process.env.CI = 'true';
+      process.env.BUILDKITE_RETRY_COUNT = '';
+      const config = createPlaywrightConfig({ testDir: './my_tests' });
+      expect(config.retries).toBe(1);
+    });
+
+    it('SCOUT_TEST_RETRIES wins over the step attempt count in both directions', () => {
+      process.env.CI = 'true';
+
+      // flaky runner: stays at 0 even on the first attempt
+      process.env.SCOUT_TEST_RETRIES = '0';
+      process.env.BUILDKITE_RETRY_COUNT = '0';
+      expect(createPlaywrightConfig({ testDir: './my_tests' }).retries).toBe(0);
+
+      // flaky runner: stays at 0 when its step is retried
+      process.env.BUILDKITE_RETRY_COUNT = '2';
+      expect(createPlaywrightConfig({ testDir: './my_tests' }).retries).toBe(0);
+
+      // an explicit opt-in still applies on a retried step
+      process.env.SCOUT_TEST_RETRIES = '1';
+      expect(createPlaywrightConfig({ testDir: './my_tests' }).retries).toBe(1);
     });
 
     it('SCOUT_TEST_RETRIES=0 overrides CI=true — the flaky-runner guard', () => {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
@@ -21,15 +21,21 @@ import { VALID_CONFIG_MARKER } from '../types';
 
 const DEFAULT_CI_RETRIES = 1;
 
+const isBuildkiteStepRetry = (): boolean => {
+  const retryCount = Number.parseInt(process.env.BUILDKITE_RETRY_COUNT ?? '', 10);
+  return Number.isFinite(retryCount) && retryCount > 0;
+};
+
 /**
- * Number of Playwright retries: 1 on CI, 0 locally. `SCOUT_TEST_RETRIES` overrides both —
+ * Number of Playwright retries: 1 on a step's first CI attempt, 0 locally and on step retries
+ * (which already re-run only the previously failed specs). `SCOUT_TEST_RETRIES` overrides both —
  * e.g. the flaky-test runner sets it to 0.
  */
 const resolveRetries = (): number => {
   const override = process.env.SCOUT_TEST_RETRIES;
 
   if (override === undefined) {
-    return process.env.CI ? DEFAULT_CI_RETRIES : 0;
+    return process.env.CI && !isBuildkiteStepRetry() ? DEFAULT_CI_RETRIES : 0;
   }
 
   const parsed = Number.parseInt(override, 10);


### PR DESCRIPTION
## Summary

Changing internal Playwright retry of failed tests:

Situation | Playwright retries
-- | --
Local run | 0
CI: 1st attempt of a lane | 1
CI: Retried lane (BUILDKITE_RETRY_COUNT ≥ 1) | 0
SCOUT_TEST_RETRIES set (e.g. flaky runner) | whatever it says





<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->