### PR TITLE
[ResponseOps][Alerting] Self-heal rule UIAM API keys UIAM no longer knows

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/constants/tags.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/constants/tags.ts
@@ -14,3 +14,4 @@ export const UIAM_LOGS_CREDENTIALS_TAGS = [
   'uiam-api-key-invalid-credentials',
 ];
 export const UIAM_LOGS_USAGE_TAGS = [...UIAM_LOGS_COMMON_TAGS, 'uiam-api-key-missing'];
+export const UIAM_LOGS_REPAIR_TAGS = [...UIAM_LOGS_COMMON_TAGS, 'uiam-api-key-repair'];

--- a/x-pack/platform/plugins/shared/alerting/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin.ts
@@ -808,6 +808,7 @@ export class AlertingPlugin {
       isServerless: this.isServerless,
       apiKeyType: (this.config.rules.apiKeyType as ApiKeyType) ?? ApiKeyType.ES,
       shouldGrantUiam,
+      uiamConvert: core.security.authc.apiKeys.uiam?.convert,
     });
 
     this.eventLogService!.registerSavedObjectProvider(

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/index.ts
@@ -17,4 +17,3 @@ export { evaluatePerAlertSnoozeExpiry } from './evaluate_per_alert_snooze_expiry
 export type { EvaluatePerAlertSnoozeExpiryResult } from './evaluate_per_alert_snooze_expiry';
 export { evaluatePerAlertSnoozeConditions } from './evaluate_per_alert_snooze_conditions';
 export type { EvaluatePerAlertSnoozeConditionsResult } from './evaluate_per_alert_snooze_conditions';
-export { isMissingUiamApiKeyRunError, repairUiamApiKey } from './repair_uiam_api_key';

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/index.ts
@@ -17,3 +17,4 @@ export { evaluatePerAlertSnoozeExpiry } from './evaluate_per_alert_snooze_expiry
 export type { EvaluatePerAlertSnoozeExpiryResult } from './evaluate_per_alert_snooze_expiry';
 export { evaluatePerAlertSnoozeConditions } from './evaluate_per_alert_snooze_conditions';
 export type { EvaluatePerAlertSnoozeConditionsResult } from './evaluate_per_alert_snooze_conditions';
+export { isMissingUiamApiKeyRunError, repairUiamApiKey } from './repair_uiam_api_key';

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.test.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { loggingSystemMock, savedObjectsServiceMock } from '@kbn/core/server/mocks';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
+import { RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
+import { ErrorWithReason } from '../../lib/error_with_reason';
+import { RuleExecutionStatusErrorReasons } from '../../types';
+import type { RawRule } from '../../types';
+import { ApiKeyType, type TaskRunnerContext } from '../types';
+import { isMissingUiamApiKeyRunError, repairUiamApiKey } from './repair_uiam_api_key';
+
+const logger = loggingSystemMock.create().get() as jest.Mocked<Logger>;
+
+const createAuthError = (code: string) =>
+  Object.assign(new Error('security_exception'), {
+    statusCode: 401,
+    body: { error: { type: 'security_exception', caused_by: { authentication_error_code: code } } },
+  });
+
+const MISSING_KEY_ERROR = createAuthError('0x28D520');
+
+const getRawRule = (overrides: Partial<RawRule> = {}): RawRule =>
+  ({
+    name: 'my rule',
+    enabled: true,
+    apiKey: Buffer.from('es-id:es-secret').toString('base64'),
+    uiamApiKey: Buffer.from('stale-id:essu_stale').toString('base64'),
+    apiKeyCreatedByUser: false,
+    ...overrides,
+  } as RawRule);
+
+const setup = ({
+  uiamConvert,
+  apiKeyType = ApiKeyType.UIAM,
+  shouldGrantUiam = true,
+  rawRule = getRawRule(),
+}: {
+  uiamConvert?: jest.Mock;
+  apiKeyType?: ApiKeyType;
+  shouldGrantUiam?: boolean;
+  rawRule?: RawRule;
+} = {}) => {
+  const savedObjects = savedObjectsServiceMock.createStartContract();
+  const unsafeClient = savedObjectsServiceMock.createStartContract().getUnsafeInternalClient();
+  savedObjects.getUnsafeInternalClient = jest.fn().mockReturnValue(unsafeClient);
+
+  const encryptedSavedObjectsClient = encryptedSavedObjectsMock.createClient();
+  encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue({
+    id: 'rule-1',
+    type: RULE_SAVED_OBJECT_TYPE,
+    references: [],
+    version: 'WzQyLDFd',
+    attributes: rawRule,
+  });
+
+  const context = {
+    apiKeyType,
+    shouldGrantUiam,
+    savedObjects,
+    encryptedSavedObjectsClient,
+    spaceIdToNamespace: (spaceId?: string) => (spaceId === 'default' ? undefined : spaceId),
+    uiamConvert:
+      uiamConvert ??
+      jest.fn().mockResolvedValue({
+        results: [{ status: 'success', id: 'fresh-id', key: 'essu_fresh' }],
+      }),
+  } as unknown as TaskRunnerContext;
+
+  return { context, savedObjects, unsafeClient, encryptedSavedObjectsClient };
+};
+
+const callRepair = (context: TaskRunnerContext) =>
+  repairUiamApiKey({ context, logger, ruleId: 'rule-1', spaceId: 'default' });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('isMissingUiamApiKeyRunError()', () => {
+  test('returns true for an Elasticsearch error reporting a UIAM API key UIAM no longer knows', () => {
+    expect(isMissingUiamApiKeyRunError(MISSING_KEY_ERROR)).toBe(true);
+  });
+
+  test('unwraps the alerting framework ErrorWithReason decoration', () => {
+    expect(
+      isMissingUiamApiKeyRunError(
+        new ErrorWithReason(RuleExecutionStatusErrorReasons.Execute, MISSING_KEY_ERROR)
+      )
+    ).toBe(true);
+  });
+
+  test('unwraps a rule type that rethrew with the original error as `cause`', () => {
+    expect(
+      isMissingUiamApiKeyRunError(
+        new ErrorWithReason(
+          RuleExecutionStatusErrorReasons.Execute,
+          new Error('failed to query index', { cause: MISSING_KEY_ERROR })
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('returns false when the key is valid but client authentication was wrong', () => {
+    expect(isMissingUiamApiKeyRunError(createAuthError('0x8560B2'))).toBe(false);
+  });
+
+  test('returns false for the UIAM API key rejections we deliberately do not act on', () => {
+    // APIKEY_REVOKED and APIKEY_EXPIRED: see UIAM_API_KEY_MISSING_CODE for why a re-grant would be
+    // wrong (or futile) for these.
+    expect(isMissingUiamApiKeyRunError(createAuthError('0xD38358'))).toBe(false);
+    expect(isMissingUiamApiKeyRunError(createAuthError('0xE436AE'))).toBe(false);
+  });
+
+  test('returns false for unrelated rule run failures', () => {
+    expect(isMissingUiamApiKeyRunError(new Error('boom'))).toBe(false);
+    expect(
+      isMissingUiamApiKeyRunError(
+        new ErrorWithReason(RuleExecutionStatusErrorReasons.Read, new Error('boom'))
+      )
+    ).toBe(false);
+  });
+
+  test('does not loop on a self-referencing cause chain', () => {
+    const error: Error & { cause?: unknown } = new Error('boom');
+    error.cause = error;
+
+    expect(isMissingUiamApiKeyRunError(error)).toBe(false);
+  });
+});
+
+describe('repairUiamApiKey()', () => {
+  test('converts the Elasticsearch API key and persists the fresh UIAM key on the rule', async () => {
+    const rawRule = getRawRule();
+    const { context, savedObjects, unsafeClient } = setup({ rawRule });
+
+    await repairUiamApiKey({ context, logger, ruleId: 'rule-1', spaceId: 'space-a' });
+
+    expect(context.uiamConvert).toHaveBeenCalledWith([rawRule.apiKey]);
+    expect(savedObjects.getUnsafeInternalClient).toHaveBeenCalledWith({
+      includedHiddenTypes: [RULE_SAVED_OBJECT_TYPE],
+    });
+    expect(unsafeClient.update).toHaveBeenCalledWith(
+      RULE_SAVED_OBJECT_TYPE,
+      'rule-1',
+      { ...rawRule, uiamApiKey: Buffer.from('fresh-id:essu_fresh').toString('base64') },
+      { mergeAttributes: false, version: 'WzQyLDFd', namespace: 'space-a' }
+    );
+  });
+
+  test.each([
+    ['the key was created by the user', { apiKeyCreatedByUser: true }],
+    ['the rule has no UIAM API key', { uiamApiKey: null }],
+    ['there is no Elasticsearch API key to convert', { apiKey: null }],
+  ])('does not re-grant when %s', async (_, overrides) => {
+    const { context, unsafeClient } = setup({ rawRule: getRawRule(overrides) });
+
+    await callRepair(context);
+
+    expect(context.uiamConvert).not.toHaveBeenCalled();
+    expect(unsafeClient.update).not.toHaveBeenCalled();
+  });
+
+  test('does not re-grant when the deployment does not run rules with UIAM API keys', async () => {
+    const esOnly = setup({ apiKeyType: ApiKeyType.ES });
+    await callRepair(esOnly.context);
+    expect(esOnly.context.uiamConvert).not.toHaveBeenCalled();
+
+    const noUiam = setup({ shouldGrantUiam: false });
+    await callRepair(noUiam.context);
+    expect(noUiam.context.uiamConvert).not.toHaveBeenCalled();
+  });
+
+  test('reports failure when the rule can no longer be decrypted', async () => {
+    const { context, encryptedSavedObjectsClient, unsafeClient } = setup();
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockRejectedValue(
+      new Error('Saved object [alert/rule-1] not found')
+    );
+
+    await callRepair(context);
+
+    expect(context.uiamConvert).not.toHaveBeenCalled();
+    expect(unsafeClient.update).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('not found'),
+      expect.anything()
+    );
+  });
+
+  test('does not write anything when the conversion fails', async () => {
+    const { context, unsafeClient } = setup({
+      uiamConvert: jest.fn().mockResolvedValue({
+        results: [{ status: 'failed', code: '0xCEE791', message: 'ES API key not found' }],
+      }),
+    });
+
+    await callRepair(context);
+
+    expect(unsafeClient.update).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('0xCEE791'),
+      expect.anything()
+    );
+  });
+
+  test.each([
+    ['the convert API returns no result', { results: [] }],
+    ['the license does not allow converting keys', null],
+  ])('does not write anything when %s', async (_, convertResponse) => {
+    const { context, unsafeClient } = setup({
+      uiamConvert: jest.fn().mockResolvedValue(convertResponse),
+    });
+
+    await callRepair(context);
+
+    expect(unsafeClient.update).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('reports failure when the conversion throws', async () => {
+    const { context } = setup({ uiamConvert: jest.fn().mockRejectedValue(new Error('UIAM down')) });
+
+    await callRepair(context);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('UIAM down'),
+      expect.anything()
+    );
+  });
+
+  test('reports failure when a concurrent update wins the optimistic concurrency check', async () => {
+    const { context, unsafeClient } = setup();
+    unsafeClient.update = jest.fn().mockRejectedValue(new Error('version conflict'));
+
+    await callRepair(context);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('version conflict'),
+      expect.anything()
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.test.ts
@@ -8,7 +8,8 @@
 import type { Logger } from '@kbn/core/server';
 import { loggingSystemMock, savedObjectsServiceMock } from '@kbn/core/server/mocks';
 import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
-import { RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { API_KEY_PENDING_INVALIDATION_TYPE, RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
 import { ErrorWithReason } from '../../lib/error_with_reason';
 import { RuleExecutionStatusErrorReasons } from '../../types';
 import type { RawRule } from '../../types';
@@ -141,7 +142,7 @@ describe('repairUiamApiKey()', () => {
 
     expect(context.uiamConvert).toHaveBeenCalledWith([rawRule.apiKey]);
     expect(savedObjects.getUnsafeInternalClient).toHaveBeenCalledWith({
-      includedHiddenTypes: [RULE_SAVED_OBJECT_TYPE],
+      includedHiddenTypes: [RULE_SAVED_OBJECT_TYPE, API_KEY_PENDING_INVALIDATION_TYPE],
     });
     expect(unsafeClient.update).toHaveBeenCalledWith(
       RULE_SAVED_OBJECT_TYPE,
@@ -231,15 +232,56 @@ describe('repairUiamApiKey()', () => {
     );
   });
 
-  test('reports failure when a concurrent update wins the optimistic concurrency check', async () => {
+  test.each([
+    [
+      'a concurrent update wins the optimistic concurrency check',
+      SavedObjectsErrorHelpers.createConflictError(RULE_SAVED_OBJECT_TYPE, 'rule-1'),
+    ],
+    [
+      'the rule was deleted while the run was in flight',
+      SavedObjectsErrorHelpers.createGenericNotFoundError(RULE_SAVED_OBJECT_TYPE, 'rule-1'),
+    ],
+  ])('queues the minted key for invalidation when %s', async (_, writeError) => {
     const { context, unsafeClient } = setup();
-    unsafeClient.update = jest.fn().mockRejectedValue(new Error('version conflict'));
+    unsafeClient.update = jest.fn().mockRejectedValue(writeError);
 
     await callRepair(context);
 
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('version conflict'),
+      expect.stringContaining(writeError.message),
       expect.anything()
     );
+    // The write was rejected outright, so the key the convert API minted is referenced by nothing.
+    expect(unsafeClient.bulkCreate).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: API_KEY_PENDING_INVALIDATION_TYPE,
+        attributes: expect.objectContaining({ apiKeyId: 'fresh-id', uiamApiKey: 'essu_fresh' }),
+      }),
+    ]);
+  });
+
+  test('leaves the minted key alone when the write may have committed anyway', async () => {
+    const { context, unsafeClient } = setup();
+    unsafeClient.update = jest.fn().mockRejectedValue(new Error('socket hang up'));
+
+    await callRepair(context);
+
+    // Revoking a key that did persist would break every subsequent run, so an ambiguous failure is
+    // accepted as a bounded leak instead.
+    expect(unsafeClient.bulkCreate).not.toHaveBeenCalled();
+  });
+
+  test('does not queue anything for invalidation when no key was minted', async () => {
+    const { context, unsafeClient } = setup({
+      uiamConvert: jest
+        .fn()
+        .mockRejectedValue(
+          SavedObjectsErrorHelpers.createConflictError(RULE_SAVED_OBJECT_TYPE, 'rule-1')
+        ),
+    });
+
+    await callRepair(context);
+
+    expect(unsafeClient.bulkCreate).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.test.ts
@@ -152,27 +152,67 @@ describe('repairUiamApiKey()', () => {
     );
   });
 
+  // Every skip logs a distinct reason: these lines are how an operator tells which check left a
+  // broken rule alone, so identical messages would make the log useless.
   test.each([
-    ['the key was created by the user', { apiKeyCreatedByUser: true }],
-    ['the rule has no UIAM API key', { uiamApiKey: null }],
-    ['there is no Elasticsearch API key to convert', { apiKey: null }],
-  ])('does not re-grant when %s', async (_, overrides) => {
+    [
+      'the key was created by the user',
+      { apiKeyCreatedByUser: true },
+      'it was created by the user, who manages its lifecycle',
+    ],
+    ['the rule has no UIAM API key', { uiamApiKey: null }, 'the rule does not have one'],
+    [
+      'there is no Elasticsearch API key to convert',
+      { apiKey: null },
+      'the rule has no Elasticsearch API key to convert',
+    ],
+  ])('does not re-grant when %s', async (_, overrides, expectedReason) => {
     const { context, unsafeClient } = setup({ rawRule: getRawRule(overrides) });
 
     await callRepair(context);
 
     expect(context.uiamConvert).not.toHaveBeenCalled();
     expect(unsafeClient.update).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      `Not re-granting the UIAM API key: ${expectedReason}.`,
+      expect.anything()
+    );
   });
 
   test('does not re-grant when the deployment does not run rules with UIAM API keys', async () => {
+    const expectedMessage =
+      'Not re-granting the UIAM API key: this deployment does not run rules with UIAM API keys.';
+
     const esOnly = setup({ apiKeyType: ApiKeyType.ES });
     await callRepair(esOnly.context);
     expect(esOnly.context.uiamConvert).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(expectedMessage, expect.anything());
 
     const noUiam = setup({ shouldGrantUiam: false });
     await callRepair(noUiam.context);
     expect(noUiam.context.uiamConvert).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(expectedMessage, expect.anything());
+  });
+
+  test('logs a different message for every reason it declines to re-grant', async () => {
+    const messages = new Set<string>();
+
+    for (const overrides of [
+      { apiKeyCreatedByUser: true },
+      { uiamApiKey: null },
+      { apiKey: null },
+    ]) {
+      const { context } = setup({ rawRule: getRawRule(overrides) });
+      await callRepair(context);
+    }
+    const { context: esOnly } = setup({ apiKeyType: ApiKeyType.ES });
+    await callRepair(esOnly);
+
+    for (const [message] of logger.debug.mock.calls) {
+      messages.add(String(message));
+    }
+
+    expect(messages.size).toBe(4);
   });
 
   test('reports failure when the rule can no longer be decrypted', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.ts
@@ -93,7 +93,10 @@ export const repairUiamApiKey = async ({
   const { uiamConvert } = context;
 
   if (!context.shouldGrantUiam || context.apiKeyType !== ApiKeyType.UIAM || !uiamConvert) {
-    logger.debug('Not re-granting the UIAM API key for the rule.', { tags: logTags });
+    logger.debug(
+      'Not re-granting the UIAM API key: this deployment does not run rules with UIAM API keys.',
+      { tags: logTags }
+    );
     return;
   }
 
@@ -111,8 +114,28 @@ export const repairUiamApiKey = async ({
     const { rawRule, version } = await getDecryptedRule(context, ruleId, spaceId);
     const { apiKey, uiamApiKey, apiKeyCreatedByUser } = rawRule;
 
-    if (!uiamApiKey || !apiKey || apiKeyCreatedByUser === true) {
-      logger.debug('Not re-granting the UIAM API key for the rule.', { tags: logTags });
+    // Each reason gets its own message: these are the lines an operator reads to understand why a
+    // broken rule was left alone, so "which check skipped it" has to be obvious from the log alone.
+    if (!uiamApiKey) {
+      logger.debug('Not re-granting the UIAM API key: the rule does not have one.', {
+        tags: logTags,
+      });
+      return;
+    }
+
+    if (apiKeyCreatedByUser === true) {
+      logger.debug(
+        'Not re-granting the UIAM API key: it was created by the user, who manages its lifecycle.',
+        { tags: logTags }
+      );
+      return;
+    }
+
+    if (!apiKey) {
+      logger.debug(
+        'Not re-granting the UIAM API key: the rule has no Elasticsearch API key to convert.',
+        { tags: logTags }
+      );
       return;
     }
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.ts
@@ -6,9 +6,11 @@
  */
 
 import type { Logger } from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { UIAM_LOGS_REPAIR_TAGS } from '../../constants';
+import { bulkMarkApiKeysForInvalidation } from '../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
 import { isErrorWithReason } from '../../lib/error_with_reason';
-import { RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
+import { API_KEY_PENDING_INVALIDATION_TYPE, RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
 import type { RawRule } from '../../types';
 import { getDecryptedRule } from '../rule_loader';
 import { ApiKeyType, type TaskRunnerContext } from '../types';
@@ -95,6 +97,13 @@ export const repairUiamApiKey = async ({
     return;
   }
 
+  const savedObjectsClient = context.savedObjects.getUnsafeInternalClient({
+    includedHiddenTypes: [RULE_SAVED_OBJECT_TYPE, API_KEY_PENDING_INVALIDATION_TYPE],
+  });
+  // Set once the convert API has minted a key, so a failed write can tell whether there is a live
+  // UIAM key left over to clean up.
+  let freshUiamApiKey: string | undefined;
+
   try {
     // Re-read the rule rather than reuse what the run loaded: the write below needs the current
     // `version` to lose a concurrency race rather than provoke a spurious one, and re-reading also
@@ -119,31 +128,47 @@ export const repairUiamApiKey = async ({
       return;
     }
 
-    await context.savedObjects
-      .getUnsafeInternalClient({ includedHiddenTypes: [RULE_SAVED_OBJECT_TYPE] })
-      .update<RawRule>(
-        RULE_SAVED_OBJECT_TYPE,
-        ruleId,
-        // A partial update would corrupt the encrypted `apiKey` / `uiamApiKey` attributes, so the
-        // full (decrypted) attribute set is written back and re-encrypted, as the UIAM provisioning
-        // task does. `version` makes the write lose to a concurrent update rather than clobber it.
-        { ...rawRule, uiamApiKey: Buffer.from(`${result.id}:${result.key}`).toString('base64') },
-        {
-          mergeAttributes: false,
-          version,
-          namespace: context.spaceIdToNamespace(spaceId),
-        }
-      );
+    freshUiamApiKey = Buffer.from(`${result.id}:${result.key}`).toString('base64');
+
+    await savedObjectsClient.update<RawRule>(
+      RULE_SAVED_OBJECT_TYPE,
+      ruleId,
+      // A partial update would corrupt the encrypted `apiKey` / `uiamApiKey` attributes, so the
+      // full (decrypted) attribute set is written back and re-encrypted, as the UIAM provisioning
+      // task does. `version` makes the write lose to a concurrent update rather than clobber it.
+      { ...rawRule, uiamApiKey: freshUiamApiKey },
+      {
+        mergeAttributes: false,
+        version,
+        namespace: context.spaceIdToNamespace(spaceId),
+      }
+    );
 
     logger.info(
       'Re-granted the UIAM API key for the rule after it failed to authenticate with the previous one.',
       { tags: logTags }
     );
   } catch (error) {
-    // Includes the 409 from another worker having re-granted the key first, which needs no handling
-    // of its own: that worker's key is live and this rule's next run will use it.
     logger.warn(`Failed to re-grant the UIAM API key for the rule: ${error.message}`, {
       tags: logTags,
     });
+
+    // The convert API had already minted a key, and Elasticsearch rejected the write outright — a
+    // concurrent update won the version check, or the rule is gone — so that key is certainly
+    // referenced by nothing and is queued for invalidation. Any other failure (a timeout, a dropped
+    // connection) may have committed after all, and revoking a key that did persist would break
+    // every subsequent run, so those are left alone as a bounded leak. Same split as the UIAM
+    // provisioning task makes between per-item and whole-call `bulkUpdate` failures.
+    if (
+      freshUiamApiKey &&
+      (SavedObjectsErrorHelpers.isConflictError(error) ||
+        SavedObjectsErrorHelpers.isNotFoundError(error))
+    ) {
+      await bulkMarkApiKeysForInvalidation(
+        { apiKeys: [freshUiamApiKey] },
+        logger,
+        savedObjectsClient
+      );
+    }
   }
 };

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { UIAM_LOGS_REPAIR_TAGS } from '../../constants';
+import { isErrorWithReason } from '../../lib/error_with_reason';
+import { RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
+import type { RawRule } from '../../types';
+import { getDecryptedRule } from '../rule_loader';
+import { ApiKeyType, type TaskRunnerContext } from '../types';
+
+export interface RepairUiamApiKeyParams {
+  context: TaskRunnerContext;
+  logger: Logger;
+  ruleId: string;
+  spaceId: string;
+}
+
+/**
+ * UIAM's `APIKEY_MISSING`, which Elasticsearch surfaces as `authentication_error_code` on the 401 it
+ * returns when UIAM does not know the API key a request presented — the key was deleted, so the only
+ * recovery is a new one.
+ *
+ * The single code is the point: every other API key rejection UIAM reports leaves the key intact or
+ * is not understood well enough to act on. `APIKEY_EXPIRED` (`0xE436AE`) is not known to be
+ * reachable for keys Kibana grants itself, since a converted key inherits the expiration of the
+ * Elasticsearch key behind it; `APIKEY_REVOKED` (`0xD38358`) would mean re-granting over a
+ * deliberate revocation; and `APIKEY_CLIENT_AUTH1`/`2` mean the key is valid but Kibana presented
+ * the wrong client authentication. A bare 401 says nothing about the key at all.
+ */
+const UIAM_API_KEY_MISSING_CODE = '0x28D520';
+
+interface UiamAuthenticationError {
+  statusCode?: number;
+  meta?: { statusCode?: number };
+  body?: {
+    error?: {
+      authentication_error_code?: string;
+      caused_by?: { authentication_error_code?: string };
+    };
+  };
+}
+
+/**
+ * Returns true when a rule run failed because UIAM no longer knows the API key it authenticated
+ * with. Unwraps the alerting framework's error decoration ({@link isErrorWithReason}) and the
+ * standard `cause` chain to reach the Elasticsearch error underneath.
+ */
+export const isMissingUiamApiKeyRunError = (error: unknown): boolean => {
+  // Three levels covers what rule runs actually produce: the raw error, an `ErrorWithReason`
+  // wrapping it, and a rule type that rethrew with the original as `cause`.
+  let current: unknown = error;
+  for (let depth = 0; current && depth < 3; depth++) {
+    const { statusCode, meta, body } = current as UiamAuthenticationError;
+    // Elasticsearch reports the code on the error itself or on the exception it wraps, depending on
+    // which authentication path failed.
+    if (
+      (statusCode ?? meta?.statusCode) === 401 &&
+      (body?.error?.authentication_error_code === UIAM_API_KEY_MISSING_CODE ||
+        body?.error?.caused_by?.authentication_error_code === UIAM_API_KEY_MISSING_CODE)
+    ) {
+      return true;
+    }
+    current = isErrorWithReason(current as Error)
+      ? (current as { error: Error }).error
+      : (current as { cause?: unknown }).cause;
+  }
+
+  return false;
+};
+
+/**
+ * Re-grants a rule's unusable UIAM API key by converting its Elasticsearch API key into a fresh
+ * UIAM one and persisting it on the rule, so the rule's next scheduled run authenticates with a
+ * working credential instead of staying broken until someone re-saves it.
+ *
+ * Does nothing when there is no key to replace, when the key is the user's to rotate, or when the
+ * rule has no Elasticsearch key to convert (UIAM-only rules).
+ */
+export const repairUiamApiKey = async ({
+  context,
+  logger,
+  ruleId,
+  spaceId,
+}: RepairUiamApiKeyParams): Promise<void> => {
+  const logTags = [...UIAM_LOGS_REPAIR_TAGS, ruleId];
+  const { uiamConvert } = context;
+
+  if (!context.shouldGrantUiam || context.apiKeyType !== ApiKeyType.UIAM || !uiamConvert) {
+    logger.debug('Not re-granting the UIAM API key for the rule.', { tags: logTags });
+    return;
+  }
+
+  try {
+    // Re-read the rule rather than reuse what the run loaded: the write below needs the current
+    // `version` to lose a concurrency race rather than provoke a spurious one, and re-reading also
+    // means a rule re-saved mid-run is judged on the credential it holds now.
+    const { rawRule, version } = await getDecryptedRule(context, ruleId, spaceId);
+    const { apiKey, uiamApiKey, apiKeyCreatedByUser } = rawRule;
+
+    if (!uiamApiKey || !apiKey || apiKeyCreatedByUser === true) {
+      logger.debug('Not re-granting the UIAM API key for the rule.', { tags: logTags });
+      return;
+    }
+
+    const result = (await uiamConvert([apiKey]))?.results?.[0];
+
+    if (result?.status !== 'success') {
+      logger.warn(
+        `Failed to re-grant the UIAM API key for the rule: the UIAM convert API did not return a key${
+          result?.status === 'failed' ? ` ([${result.code}] ${result.message})` : ''
+        }.`,
+        { tags: logTags }
+      );
+      return;
+    }
+
+    await context.savedObjects
+      .getUnsafeInternalClient({ includedHiddenTypes: [RULE_SAVED_OBJECT_TYPE] })
+      .update<RawRule>(
+        RULE_SAVED_OBJECT_TYPE,
+        ruleId,
+        // A partial update would corrupt the encrypted `apiKey` / `uiamApiKey` attributes, so the
+        // full (decrypted) attribute set is written back and re-encrypted, as the UIAM provisioning
+        // task does. `version` makes the write lose to a concurrent update rather than clobber it.
+        { ...rawRule, uiamApiKey: Buffer.from(`${result.id}:${result.key}`).toString('base64') },
+        {
+          mergeAttributes: false,
+          version,
+          namespace: context.spaceIdToNamespace(spaceId),
+        }
+      );
+
+    logger.info(
+      'Re-granted the UIAM API key for the rule after it failed to authenticate with the previous one.',
+      { tags: logTags }
+    );
+  } catch (error) {
+    // Includes the 409 from another worker having re-granted the key first, which needs no handling
+    // of its own: that worker's key is live and this rule's next run will use it.
+    logger.warn(`Failed to re-grant the UIAM API key for the rule: ${error.message}`, {
+      tags: logTags,
+    });
+  }
+};

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -78,9 +78,12 @@ import {
   getTaskRunError,
   evaluatePerAlertSnoozeExpiry,
   evaluatePerAlertSnoozeConditions,
-  isMissingUiamApiKeyRunError,
-  repairUiamApiKey,
 } from './lib';
+// Imported directly rather than through `./lib`: that barrel is also the entry point for widely used
+// helpers such as `withAlertingSpan`, so adding a module with heavy dependencies to it changes module
+// initialization order for every importer and closes an import cycle that leaves
+// `DEFAULT_APP_CATEGORIES` undefined in `alert_deletion_client`.
+import { isMissingUiamApiKeyRunError, repairUiamApiKey } from './lib/repair_uiam_api_key';
 import {
   ErrorWithType,
   isOutdatedTaskVersionError,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -78,6 +78,8 @@ import {
   getTaskRunError,
   evaluatePerAlertSnoozeExpiry,
   evaluatePerAlertSnoozeConditions,
+  isMissingUiamApiKeyRunError,
+  repairUiamApiKey,
 } from './lib';
 import {
   ErrorWithType,
@@ -899,6 +901,14 @@ export class TaskRunner<
       runRuleResult = asErr(err);
       schedule = asErr(err);
       shouldDisableTask = err.reason === RuleExecutionStatusErrorReasons.Disabled;
+
+      // The rule's UIAM API key is unusable, so re-grant it now: the rule's next scheduled run then
+      // authenticates with a working credential instead of failing the same way indefinitely.
+      if (isMissingUiamApiKeyRunError(err)) {
+        await withAlertingSpan('alerting:repair-uiam-api-key', () =>
+          repairUiamApiKey({ context: this.context, logger: this.logger, ruleId, spaceId })
+        );
+      }
     }
 
     await withAlertingSpan('alerting:process-run-results-and-update-rule', () =>

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_uiam_api_key_repair.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_uiam_api_key_repair.test.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import sinon from 'sinon';
+import { usageCountersServiceMock } from '@kbn/usage-collection-plugin/server/usage_counters/usage_counters_service.mock';
+import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
+import {
+  loggingSystemMock,
+  savedObjectsRepositoryMock,
+  executionContextServiceMock,
+  savedObjectsServiceMock,
+  elasticsearchServiceMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
+import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import { actionsMock, actionsClientMock } from '@kbn/actions-plugin/server/mocks';
+import { eventLoggerMock } from '@kbn/event-log-plugin/server/event_logger.mock';
+import type { IEventLogger } from '@kbn/event-log-plugin/server';
+import { dataPluginMock } from '@kbn/data-plugin/server/mocks';
+import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
+import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
+import type { SharePluginStart } from '@kbn/share-plugin/server';
+import { eventLogClientMock } from '@kbn/event-log-plugin/server/mocks';
+import type { Rule } from '../types';
+import { DEFAULT_FLAPPING_SETTINGS, DEFAULT_QUERY_DELAY_SETTINGS } from '../types';
+import { TaskRunner } from './task_runner';
+import { alertsMock } from '../mocks';
+import { ruleTypeRegistryMock } from '../rule_type_registry.mock';
+import { inMemoryMetricsMock } from '../monitoring/in_memory_metrics.mock';
+import { getAlertFromRaw } from '../rules_client/lib/get_alert_from_raw';
+import { AlertingEventLogger } from '../lib/alerting_event_logger/alerting_event_logger';
+import { alertingEventLoggerMock } from '../lib/alerting_event_logger/alerting_event_logger.mock';
+import { mockTaskInstance, ruleType, mockedRuleTypeSavedObject, mockedRawRuleSO } from './fixtures';
+import { alertsServiceMock } from '../alerts_service/alerts_service.mock';
+import { ConnectorAdapterRegistry } from '../connector_adapters/connector_adapter_registry';
+import { RULE_SAVED_OBJECT_TYPE } from '../saved_objects';
+import type { TaskRunnerContext } from './types';
+import { ApiKeyType } from './types';
+import { backfillClientMock } from '../backfill_client/backfill_client.mock';
+import { rulesSettingsServiceMock } from '../rules_settings/rules_settings_service.mock';
+import { maintenanceWindowsServiceMock } from './maintenance_windows/maintenance_windows_service.mock';
+
+const RULE_EXECUTION_UUID = '5f6aa57d-3e22-484e-bae8-cbed868f4d28';
+jest.mock('uuid', () => ({ v4: () => RULE_EXECUTION_UUID }));
+jest.mock('../lib/wrap_scoped_cluster_client', () => ({
+  createWrappedScopedClusterClientFactory: jest.fn(),
+}));
+jest.mock('../lib/alerting_event_logger/alerting_event_logger');
+jest.mock('../rules_client/lib/get_alert_from_raw');
+
+const mockGetAlertFromRaw = getAlertFromRaw as jest.MockedFunction<typeof getAlertFromRaw>;
+
+const STALE_UIAM_API_KEY = Buffer.from('stale-id:essu_stale').toString('base64');
+const FRESH_UIAM_API_KEY = Buffer.from('fresh-id:essu_fresh').toString('base64');
+
+/**
+ * The 401 Elasticsearch returns when UIAM rejects the API key a rule run authenticated with,
+ * carrying UIAM's own `APIKEY_MISSING` code.
+ */
+const missingUiamApiKeyError = () =>
+  Object.assign(new Error('security_exception'), {
+    statusCode: 401,
+    body: {
+      error: {
+        type: 'security_exception',
+        reason: 'failed to authenticate cloud api key',
+        caused_by: { authentication_error_code: '0x28D520' },
+      },
+    },
+  });
+
+let fakeTimer: sinon.SinonFakeTimers;
+
+const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+const alertingEventLogger = alertingEventLoggerMock.create();
+const logger: ReturnType<typeof loggingSystemMock.createLogger> = loggingSystemMock.createLogger();
+const dataViewsMock = {
+  dataViewsServiceFactory: jest.fn().mockResolvedValue(dataViewPluginMocks.createStartContract()),
+  getScriptedFieldsEnabled: jest.fn().mockReturnValue(true),
+} as DataViewsServerPluginStart;
+
+describe('Task Runner UIAM API key repair', () => {
+  let mockedTaskInstance: ConcreteTaskInstance;
+
+  beforeAll(() => {
+    fakeTimer = sinon.useFakeTimers(new Date('2026-08-14T12:00:00.000Z'));
+    mockedTaskInstance = mockTaskInstance();
+  });
+
+  afterAll(() => fakeTimer.restore());
+
+  const encryptedSavedObjectsClient = encryptedSavedObjectsMock.createClient();
+  const services = alertsMock.createRuleExecutorServices();
+  const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
+  const ruleTypeRegistry = ruleTypeRegistryMock.create();
+  const savedObjectsService = savedObjectsServiceMock.createInternalStartContract();
+  const elasticsearchService = elasticsearchServiceMock.createInternalStart();
+  const inMemoryMetrics = inMemoryMetricsMock.create();
+  const rulesSettingsService = rulesSettingsServiceMock.create();
+  const maintenanceWindowsService = maintenanceWindowsServiceMock.create();
+  const actionsClient = actionsClientMock.create();
+  const unsafeSavedObjectsClient = savedObjectsServiceMock
+    .createStartContract()
+    .getUnsafeInternalClient();
+
+  const uiamConvert = jest.fn();
+
+  const context: jest.Mocked<TaskRunnerContext> & {
+    actionsPlugin: jest.Mocked<ActionsPluginStart>;
+    eventLogger: jest.Mocked<IEventLogger>;
+    executionContext: ReturnType<typeof executionContextServiceMock.createInternalStartContract>;
+  } = {
+    actionsConfigMap: { default: { max: 1000 } },
+    actionsPlugin: actionsMock.createStart(),
+    alertsService: alertsServiceMock.create(),
+    backfillClient: backfillClientMock.create(),
+    cancelAlertsOnRuleTimeout: true,
+    connectorAdapterRegistry: new ConnectorAdapterRegistry(),
+    data: dataPluginMock.createStartContract(),
+    dataViews: dataViewsMock,
+    elasticsearch: elasticsearchService,
+    encryptedSavedObjectsClient,
+    eventLogger: eventLoggerMock.create(),
+    executionContext: executionContextServiceMock.createInternalStartContract(),
+    kibanaBaseUrl: 'https://localhost:5601',
+    logger,
+    maintenanceWindowsService,
+    maxAlerts: 1000,
+    ruleTypeRegistry,
+    rulesSettingsService,
+    savedObjects: savedObjectsService,
+    share: {} as SharePluginStart,
+    spaceIdToNamespace: jest.fn().mockReturnValue(undefined),
+    uiSettings: uiSettingsServiceMock.createStartContract(),
+    usageCounter: mockUsageCounter,
+    isServerless: true,
+    getEventLogClient: jest.fn().mockReturnValue(eventLogClientMock.create()),
+    apiKeyType: ApiKeyType.UIAM,
+    shouldGrantUiam: true,
+    uiamConvert,
+  };
+
+  const uiamRuleSO = {
+    ...mockedRawRuleSO,
+    attributes: {
+      ...mockedRawRuleSO.attributes,
+      uiamApiKey: STALE_UIAM_API_KEY,
+      apiKeyCreatedByUser: false,
+    },
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest
+      .requireMock('../lib/wrap_scoped_cluster_client')
+      .createWrappedScopedClusterClientFactory.mockReturnValue({
+        client: () => services.scopedClusterClient,
+        getMetrics: () => ({ numSearches: 0, esSearchDurationMs: 0, totalSearchDurationMs: 0 }),
+      });
+    savedObjectsService.getScopedClient.mockReturnValue(services.savedObjectsClient);
+    savedObjectsService.getUnsafeInternalClient = jest
+      .fn()
+      .mockReturnValue(unsafeSavedObjectsClient);
+    elasticsearchService.client.asScoped.mockReturnValue(services.scopedClusterClient);
+    context.actionsPlugin.getActionsClientWithRequest.mockResolvedValue(actionsClient);
+    context.executionContext.withContext.mockImplementation((ctx, fn) => fn());
+    ruleTypeRegistry.get.mockReturnValue(ruleType);
+    rulesSettingsService.getSettings.mockResolvedValue({
+      flappingSettings: DEFAULT_FLAPPING_SETTINGS,
+      queryDelaySettings: DEFAULT_QUERY_DELAY_SETTINGS,
+    });
+    mockGetAlertFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    maintenanceWindowsService.getMaintenanceWindows.mockReturnValue({
+      maintenanceWindows: [],
+      maintenanceWindowsWithoutScopedQueryIds: [],
+    });
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(uiamRuleSO);
+    alertingEventLogger.getStartAndDuration.mockImplementation(() => ({ start: new Date() }));
+    (AlertingEventLogger as jest.Mock).mockImplementation(() => alertingEventLogger);
+    logger.get.mockImplementation(() => logger);
+    uiamConvert.mockResolvedValue({
+      results: [{ status: 'success', id: 'fresh-id', key: 'essu_fresh' }],
+    });
+    internalSavedObjectsRepository.update.mockResolvedValue({
+      id: '1',
+      type: RULE_SAVED_OBJECT_TYPE,
+      attributes: {},
+      references: [],
+    });
+  });
+
+  const createTaskRunner = () =>
+    new TaskRunner({
+      ruleType,
+      taskInstance: mockedTaskInstance,
+      context,
+      inMemoryMetrics,
+      internalSavedObjectsRepository,
+      executionUuid: RULE_EXECUTION_UUID,
+    });
+
+  test('re-grants the UIAM API key when a run fails to authenticate with it', async () => {
+    ruleType.executor.mockRejectedValue(missingUiamApiKeyError());
+
+    const runResult = await createTaskRunner().run();
+
+    expect(uiamConvert).toHaveBeenCalledWith([uiamRuleSO.attributes.apiKey]);
+    expect(unsafeSavedObjectsClient.update).toHaveBeenCalledWith(
+      RULE_SAVED_OBJECT_TYPE,
+      '1',
+      expect.objectContaining({ uiamApiKey: FRESH_UIAM_API_KEY }),
+      expect.objectContaining({ mergeAttributes: false, version: uiamRuleSO.version })
+    );
+    // The re-grant does not disturb the run's own reporting: the rule keeps its schedule and the
+    // failure is still surfaced, it just authenticates with a working key from the next run on.
+    expect(runResult.schedule).toEqual({ interval: '10s' });
+    expect(runResult.taskRunError).toBeDefined();
+    expect(alertingEventLogger.done).toHaveBeenCalledWith(
+      expect.objectContaining({ status: expect.objectContaining({ status: 'error' }) })
+    );
+  });
+
+  test('leaves the key alone when the run failed for an unrelated reason', async () => {
+    ruleType.executor.mockRejectedValue(new Error('rule executor failed'));
+
+    const runResult = await createTaskRunner().run();
+
+    expect(uiamConvert).not.toHaveBeenCalled();
+    expect(unsafeSavedObjectsClient.update).not.toHaveBeenCalled();
+    expect(runResult.schedule).toEqual({ interval: '10s' });
+  });
+
+  test('still reports the run normally when the key could not be re-granted', async () => {
+    ruleType.executor.mockRejectedValue(missingUiamApiKeyError());
+    uiamConvert.mockResolvedValue({
+      results: [{ status: 'failed', code: '0xCEE791', message: 'ES API key not found' }],
+    });
+
+    const runResult = await createTaskRunner().run();
+
+    expect(unsafeSavedObjectsClient.update).not.toHaveBeenCalled();
+    expect(runResult.schedule).toEqual({ interval: '10s' });
+    expect(runResult.taskRunError).toBeDefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/types.ts
@@ -14,6 +14,7 @@ import type {
   UiSettingsServiceStart,
 } from '@kbn/core/server';
 import type { ConcreteTaskInstance, DecoratedError } from '@kbn/task-manager-plugin/server';
+import type { ConvertUiamAPIKeysResponse } from '@kbn/core-security-server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { AuditServiceSetup } from '@kbn/security-plugin-types-server';
 import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
@@ -223,6 +224,11 @@ export interface TaskRunnerContext {
   getEventLogClient: (request: KibanaRequest) => IEventLogClient;
   isServerless: boolean;
   shouldGrantUiam?: boolean;
+  /**
+   * Converts Elasticsearch API keys into UIAM ones. Used to re-grant a rule's UIAM API key when a
+   * run fails because UIAM no longer knows the stored key. Absent when UIAM is not configured.
+   */
+  uiamConvert?: (keys: string[]) => Promise<ConvertUiamAPIKeysResponse | null>;
 }
 
 export interface AsyncSearchClient<T extends AsyncSearchParams> {


### PR DESCRIPTION
## Summary

Refs elastic/response-ops-team#704 (private)

A UIAM API key stored on a rule can stop working after it was granted. The rule run then fails to authenticate and, with no recovery path, the rule stays broken until someone re-saves it.

When a run fails, the task runner now checks whether Elasticsearch reported UIAM's `APIKEY_MISSING` code. If so, it converts the rule's Elasticsearch API key into a fresh UIAM one and writes it to the rule saved object. The rule's next scheduled run then authenticates with a working credential.

The failed run itself is reported exactly as before — same schedule, same error surfaced. The re-grant is a side effect on the failure path only.

### Why a single error code

Detection is deliberately one code rather than "any UIAM auth failure":

| UIAM code | Meaning | Re-grant | Why |
|---|---|---|---|
| `0x28D520` | `APIKEY_MISSING` | ✅ | UIAM does not know the key at all, so a new one is the only recovery |
| `0xE436AE` | `APIKEY_EXPIRED` | ❌ | A converted key inherits the expiration of the ES key behind it, so this is not known to be reachable for keys Kibana grants itself. If it is reached, the ES key has expired too and converting it again would fail anyway |
| `0xD38358` | `APIKEY_REVOKED` | ❌ | Nothing is known to revoke a key Kibana granted, so a re-grant could undo a deliberate revocation |
| `0x8560B2` / `0x1D8502` | `APIKEY_CLIENT_AUTH1`/`2` | ❌ | The key is valid; Kibana presented the wrong client authentication. Structural, unrelated to key validity |
| anything else, incl. a bare 401 | — | ❌ | Says nothing about whether the key still works |

Codes are from UIAM's [`ErrorCode.java`](https://github.com/elastic/uiam/blob/main/modules/domain/src/main/java/co/elastic/cloud/uiam/domain/errors/ErrorCode.java); Elasticsearch surfaces them as `authentication_error_code` on the 401 ([`UniversalIamClient.java`](https://github.com/elastic/elasticsearch-serverless/blob/main/modules/serverless-security/src/main/java/co/elastic/elasticsearch/serverless/security/cloud/uiam/UniversalIamClient.java)), which is the same mechanism `isTokenExpiredError` already relies on in the security plugin.

A re-grant is also skipped when `apiKeyCreatedByUser: true` (the key is the user's to rotate) and when the rule has no ES key to convert (UIAM-only rules have nothing to feed the convert API).

### Notes for reviewers

- The write uses the full decrypted attribute set with `mergeAttributes: false`, matching `buildRuleUpdatesForUiam` in the UIAM provisioning task. A partial update would corrupt the encrypted `apiKey` / `uiamApiKey` attributes, and `partiallyUpdateRuleWithEs` explicitly excludes them.
- The rule is re-read inside the helper rather than reusing what the run loaded, so the `version` used for optimistic concurrency control is current and the guards see the credential the rule holds now.
- Recovery lands on the rule's next scheduled run. There is deliberately no immediate retry: it would let a run re-trigger itself, which then needs persisted task state to bound, and one interval is already far better than staying broken indefinitely.

### Out of scope (follow-ups)

- **Task Manager tasks.** Same problem for `userScope`-carrying tasks. Smaller change there, since TM's existing `attempts`/`getRetryDate` backoff already retries failed single-run tasks.
- **Provisioning-task backstop** (Approach 2 in the issue). Worth noting for whoever picks it up: stripping `uiamApiKey` to null is *not* sufficient on its own — `getExcludeRulesFilter` excludes any rule with a `COMPLETED` provisioning-status doc, which every provisioned rule has, so the backstop must also reset that doc.
- **Detection coverage.** The re-grant triggers on errors that propagate to the task runner (unwrapping `ErrorWithReason` and the `cause` chain). A rule type that catches its own 401 and rethrows without a `cause` won't be detected; the backstop above is what covers that tail.

## Release note

None — internal serverless resiliency fix, no user-facing behavior change.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- **A re-grant could race a concurrent rule update.** Mitigated by passing the saved object `version`, so the write loses to a concurrent update rather than clobbering it; a 409 is logged and the rule recovers on its next run using the winner's key.
- **Widening the error allowlist later could fight deliberate revocations.** Mitigated by documenting the reasoning for each excluded code on the constant itself, plus unit tests asserting the excluded codes do *not* trigger a re-grant.
- **Low severity overall:** the re-grant only runs on an already-failed run, on serverless deployments configured for UIAM API keys, and every failure inside it is caught and logged without affecting how the run is reported.
