### PR TITLE
[Cases] Fix CAI v1 backfill/sync space-awareness + scheduling bug (security-team#18174)

### DIFF
--- a/x-pack/platform/test/cases_api_integration/common/lib/api/analytics.ts
+++ b/x-pack/platform/test/cases_api_integration/common/lib/api/analytics.ts
@@ -46,23 +46,29 @@ export const runCasesBackfillTask = async (supertest: SuperTest.Agent) => {
     .expect(200);
 };
 
-export const runCAISynchronizationTask = async (supertest: SuperTest.Agent) => {
+export const runCAISynchronizationTask = async (
+  supertest: SuperTest.Agent,
+  spaceId: string = 'default'
+) => {
   await supertest
     .post('/api/analytics_index/synchronization/run_soon')
     .set('kbn-xsrf', 'xxx')
-    .send({ taskId: getSynchronizationTaskId('default', 'securitySolution') })
+    .send({ taskId: getSynchronizationTaskId(spaceId, 'securitySolution') })
     .expect(200);
 };
 
-export const runAttachmentsBackfillTask = async (supertest: SuperTest.Agent) => {
+export const runAttachmentsBackfillTask = async (
+  supertest: SuperTest.Agent,
+  spaceId: string = 'default'
+) => {
   await supertest
     .post('/api/analytics_index/backfill/run_soon')
     .set('kbn-xsrf', 'xxx')
     .send({
-      taskId: getCAIAttachmentsBackfillTaskId('default', 'securitySolution'),
+      taskId: getCAIAttachmentsBackfillTaskId(spaceId, 'securitySolution'),
       sourceIndex: CAI_ATTACHMENTS_SOURCE_INDEX,
-      destIndex: getAttachmentsDestinationIndexName('default', 'securitySolution'),
-      sourceQuery: JSON.stringify(getAttachmentsSourceQuery('default', 'securitySolution')),
+      destIndex: getAttachmentsDestinationIndexName(spaceId, 'securitySolution'),
+      sourceQuery: JSON.stringify(getAttachmentsSourceQuery(spaceId, 'securitySolution')),
     })
     .expect(200);
 };

--- a/x-pack/platform/test/cases_api_integration/common/plugins/cases/server/routes.ts
+++ b/x-pack/platform/test/cases_api_integration/common/plugins/cases/server/routes.ts
@@ -298,15 +298,24 @@ export const registerRoutes = (core: CoreSetup<FixtureStartDeps>, logger: Logger
       try {
         const [_, { taskManager }] = await core.getStartServices();
 
-        return res.ok({
-          body: await taskManager.ensureScheduled({
-            id: taskId,
-            taskType: ANALYTICS_BACKFILL_TASK_TYPE,
-            params: { sourceIndex, destIndex, sourceQuery: JSON.parse(sourceQuery) },
-            runAt: new Date(),
-            state: {},
-          }),
-        });
+        // The backfill task is one-off (no recurring `schedule`), so a task with this id may
+        // already exist from an earlier `ensureScheduled` call (e.g. triggered by index
+        // creation) with a `runAt` in the future. `ensureScheduled` is schedule-if-absent and
+        // silently no-ops in that case, so prefer `runSoon` to force immediate execution and
+        // only fall back to scheduling if the task doesn't exist yet.
+        try {
+          return res.ok({ body: await taskManager.runSoon(taskId) });
+        } catch (runSoonErr) {
+          return res.ok({
+            body: await taskManager.ensureScheduled({
+              id: taskId,
+              taskType: ANALYTICS_BACKFILL_TASK_TYPE,
+              params: { sourceIndex, destIndex, sourceQuery: JSON.parse(sourceQuery) },
+              runAt: new Date(),
+              state: {},
+            }),
+          });
+        }
       } catch (err) {
         logger.error(`Error : ${err}`);
         return res.ok({ body: { id: taskId, error: `${err}` } });

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/backfill.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/backfill.ts
@@ -31,6 +31,7 @@ import {
   updateCase,
   deleteCases,
   deleteAllCaseAnalyticsItems,
+  elasticUserProfileId,
 } from '../../../../../common/lib/api';
 import {
   getPostCaseRequest,
@@ -47,8 +48,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const retry = getService('retry');
   const authSpace1 = getAuthWithSuperUser();
 
-  // FLAKY: https://github.com/elastic/kibana/issues/243870
-  describe.skip('analytics indexes backfill task', () => {
+  describe('analytics indexes backfill task', () => {
     beforeEach(async () => {
       await deleteAllCaseAnalyticsItems(esClient);
       await deleteAllCaseItems(esClient);
@@ -101,9 +101,9 @@ export default ({ getService }: FtrProviderContext): void => {
         200
       );
 
-      await runCasesBackfillTask(supertest);
-
       await retry.tryForTime(300000, async () => {
+        await runCasesBackfillTask(supertest);
+
         const caseAnalytics = await esClient.get({
           index: '.internal.cases.securitysolution-default',
           id: `cases:${caseToBackfill.id}`,
@@ -131,7 +131,7 @@ export default ({ getService }: FtrProviderContext): void => {
           created_by: {
             email: null,
             full_name: null,
-            profile_uid: null,
+            profile_uid: elasticUserProfileId,
             username: 'elastic',
           },
           custom_fields: [
@@ -158,9 +158,17 @@ export default ({ getService }: FtrProviderContext): void => {
       });
     });
 
-    // This test passes locally but fails in the flaky test runner.
-    // Increasing the timeout did not work.
-    it('should backfill the cases attachments index', async () => {
+    // Failing: See https://github.com/elastic/kibana/issues/243870
+    // Root cause is deeper than the space-awareness bug this file's other tests were blocked
+    // on: the source query in cases_analytics/attachments_index/constants.ts still filters on
+    // the legacy `cases-comments` SO type (and its `cases-comments.type` sub-field), but
+    // attachment/comment writes now go exclusively to the unified `cases-attachments` SO type
+    // introduced by the AttachmentV2 migration (#275225), with fields nested under
+    // `cases-attachments.*` and sub-type values renamed (e.g. `alert` -> `security.alert`).
+    // Confirmed directly against a live dev Kibana/ES instance: the query matches zero
+    // documents, so the backfill "succeeds" but reindexes nothing. Needs the source query
+    // updated to the current schema, not another test-side fix.
+    it.skip('should backfill the cases attachments index', async () => {
       const postedCase = await createCase(
         supertest,
         {
@@ -190,9 +198,9 @@ export default ({ getService }: FtrProviderContext): void => {
         auth: authSpace1,
       });
 
-      await runAttachmentsBackfillTask(supertest);
-
       await retry.tryForTime(300000, async () => {
+        await runAttachmentsBackfillTask(supertest, 'space1');
+
         const firstAttachmentAnalytics = await esClient.get({
           index: '.internal.cases-attachments.securitysolution-space1',
           id: `cases-comments:${postedCaseWithAttachments.comments![0].id}`,
@@ -209,7 +217,12 @@ export default ({ getService }: FtrProviderContext): void => {
       });
     });
 
-    it('should backfill the cases comments index', async () => {
+    // Failing: See https://github.com/elastic/kibana/issues/243870
+    // Same root cause as the attachments-index test above: cases_analytics/comments_index/
+    // constants.ts's source query still targets the legacy `cases-comments` SO type, which no
+    // longer receives writes post-AttachmentV2 (unified `cases-attachments` type). Confirmed
+    // against a live dev instance that a newly-created comment has zero matching source docs.
+    it.skip('should backfill the cases comments index', async () => {
       const postedCase = await createCase(
         supertest,
         {
@@ -224,9 +237,10 @@ export default ({ getService }: FtrProviderContext): void => {
         caseId: postedCase.id,
         params: { ...postCommentUserReq, owner: SECURITY_SOLUTION_OWNER },
       });
-      await runCommentsBackfillTask(supertest);
 
       await retry.try(async () => {
+        await runCommentsBackfillTask(supertest);
+
         const commentAnalytics = await esClient.get({
           index: '.internal.cases-comments.securitysolution-default',
           id: `cases-comments:${patchedCase.comments![0].id}`,
@@ -254,6 +268,7 @@ export default ({ getService }: FtrProviderContext): void => {
             email: null,
             full_name: null,
             username: 'elastic',
+            profile_uid: elasticUserProfileId,
           },
           owner: 'securitySolution',
           space_ids: ['default'],

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/synchronization.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/cases/analytics_index/synchronization.ts
@@ -43,8 +43,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const retry = getService('retry');
   const authSpace1 = getAuthWithSuperUser();
 
-  // Failing: See https://github.com/elastic/kibana/issues/227734
-  describe.skip('analytics indexes synchronization task', () => {
+  describe('analytics indexes synchronization task', () => {
     beforeEach(async () => {
       await deleteAllCaseAnalyticsItems(esClient);
       await deleteAllCaseItems(esClient);
@@ -63,8 +62,6 @@ export default ({ getService }: FtrProviderContext): void => {
       await deleteAllCaseItems(esClient);
     });
 
-    // This test passes locally but fails in the flaky test runner.
-    // Increasing the timeout did not work.
     it('should sync the cases index', async () => {
       await createConfiguration(
         supertest,
@@ -100,9 +97,9 @@ export default ({ getService }: FtrProviderContext): void => {
         200
       );
 
-      await runCAISynchronizationTask(supertest);
-
       await retry.tryForTime(300000, async () => {
+        await runCAISynchronizationTask(supertest);
+
         const caseAnalytics = await esClient.get({
           index: '.internal.cases.securitysolution-default',
           id: `cases:${caseToBackfill.id}`,
@@ -157,7 +154,17 @@ export default ({ getService }: FtrProviderContext): void => {
       });
     });
 
-    it('should sync the cases attachments index', async () => {
+    // Failing: See https://github.com/elastic/kibana/issues/227734
+    // Root cause is deeper than the space-awareness bug this file's other tests were blocked
+    // on: the source query in cases_analytics/attachments_index/constants.ts still filters on
+    // the legacy `cases-comments` SO type (and its `cases-comments.type` sub-field), but
+    // attachment/comment writes now go exclusively to the unified `cases-attachments` SO type
+    // introduced by the AttachmentV2 migration (#275225), with fields nested under
+    // `cases-attachments.*` and sub-type values renamed (e.g. `alert` -> `security.alert`).
+    // Confirmed directly against a live dev Kibana/ES instance: the query matches zero
+    // documents, so the sync "succeeds" but reindexes nothing. Needs the source query updated
+    // to the current schema, not another test-side fix.
+    it.skip('should sync the cases attachments index', async () => {
       const postedCase = await createCase(
         supertest,
         {
@@ -187,9 +194,9 @@ export default ({ getService }: FtrProviderContext): void => {
         auth: authSpace1,
       });
 
-      await runCAISynchronizationTask(supertest);
-
       await retry.tryForTime(300000, async () => {
+        await runCAISynchronizationTask(supertest, 'space1');
+
         const firstAttachmentAnalytics = await esClient.get({
           index: '.internal.cases-attachments.securitysolution-space1',
           id: `cases-comments:${postedCaseWithAttachments.comments![0].id}`,
@@ -206,7 +213,12 @@ export default ({ getService }: FtrProviderContext): void => {
       });
     });
 
-    it('should sync the cases comments index', async () => {
+    // Failing: See https://github.com/elastic/kibana/issues/227734
+    // Same root cause as the attachments-index test above: cases_analytics/comments_index/
+    // constants.ts's source query still targets the legacy `cases-comments` SO type, which no
+    // longer receives writes post-AttachmentV2 (unified `cases-attachments` type). Confirmed
+    // against a live dev instance that a newly-created comment has zero matching source docs.
+    it.skip('should sync the cases comments index', async () => {
       const postedCase = await createCase(
         supertest,
         { ...postCaseReq, owner: SECURITY_SOLUTION_OWNER },
@@ -218,9 +230,9 @@ export default ({ getService }: FtrProviderContext): void => {
         params: { ...postCommentUserReq, owner: SECURITY_SOLUTION_OWNER },
       });
 
-      await runCAISynchronizationTask(supertest);
-
       await retry.try(async () => {
+        await runCAISynchronizationTask(supertest);
+
         const commentAnalytics = await esClient.get({
           index: '.internal.cases-comments.securitysolution-default',
           id: `cases-comments:${patchedCase.comments![0].id}`,


### PR DESCRIPTION
## Summary
Second PR in the security-team#18174 series. Fixes and unskips 4 of the 8 tests originally skipped in `backfill.ts` and `synchronization.ts` (the CAI v1 analytics-index backfill/sync suites). The other 4 are re-skipped with a far more accurate root-cause comment than before — investigation turned up a real production bug beyond this PR's scope (tracking issue to follow).

## Motivation
Both files were skipped wholesale as "failing"/"flaky". The originally diagnosed cause (upstream PR #282643, credit to that investigation) was that `runAttachmentsBackfillTask`/`runCAISynchronizationTask` hardcoded `spaceId: 'default'` while the tests assert against `space1`'s index. Fixing just that wasn't enough — digging further surfaced two more bugs layered underneath, and one that's out of scope for this PR entirely.

## Changes
- **Space-awareness**: parameterized `runAttachmentsBackfillTask`/`runCAISynchronizationTask` with `spaceId` (default `'default'`), passed `'space1'` where the test asserts on that space's index.
- **Fixture bug**: the test-only `/api/analytics_index/backfill/run_soon` route called `taskManager.ensureScheduled(...)`, which is schedule-if-absent — a no-op if a one-off task with that ID already exists (which it usually does here, auto-scheduled by index creation). Now tries `taskManager.runSoon()` first, falling back to `ensureScheduled` only if the task doesn't exist yet.
- **Stale assertions**: two `created_by.profile_uid` assertions in `backfill.ts` hardcoded `null` (or omitted the field), disagreeing with `synchronization.ts`'s equivalent tests. Fixed to use the `elasticUserProfileId` constant, matching current user-profile-activation behavior.
- **Hardening**: all four now-passing tests (`cases index`, `activity index` × backfill/sync) retrigger the backfill/sync call on every retry iteration instead of once-then-poll — self-healing against an ES-refresh timing race, matching a pattern the `activity index` test already used successfully.
- **New finding, out of scope here**: `attachments index` and `comments index` tests (4 total) still fail. Root cause: the CAI v1 source queries in `cases_analytics/{attachments_index,comments_index}/constants.ts` filter on the legacy `cases-comments` SO type and its old field/subtype names, but attachment/comment writes now go exclusively to the unified `cases-attachments` type (AttachmentV2 migration, #275225) — confirmed by creating a real case+comment against a live dev instance and inspecting the raw document. Re-skipped with an accurate comment; will be tracked in a follow-up issue.

## Risk & Migration
**Score: 1** — test-only + test-fixture changes; no production code paths touched. The `routes.ts` change only affects the FTR test-plugin fixture, not the real Cases plugin routes.

## Testing
**Manual:** N/A (test-only change)
**Automated:**
- [x] Verified locally: `node scripts/functional_tests --config .../security_and_spaces/config_trial_common.ts --include backfill.ts --include synchronization.ts` — 4 passing (cases index × 2, activity index × 2), 4 correctly skipped (attachments/comments index × 2 each), 0 failing.