### PR TITLE
[Kbn-UI/React Assembly] Warn when a declarative part is used in the wrong assembly

### DIFF
--- a/src/platform/kbn-ui/react-assembly/RECIPES.md
+++ b/src/platform/kbn-ui/react-assembly/RECIPES.md
@@ -348,7 +348,7 @@ This recipe shows a complete `ActionBar` that renders arbitrary React nodes alon
 
 ### Renderer implementation
 
-Use `assembly.parseChildren()` (not `part.parseChildren()`) to get the full interleaved result. Pass `{ supportsOtherChildren: true }` to suppress the dev-mode warning for unrecognized function components, since this renderer intentionally supports them.
+Use `assembly.parseChildren()` (not `part.parseChildren()`) to get the full interleaved result. Pass `{ supportsOtherChildren: true }` to suppress the dev-mode warning for unrecognized function components, since this renderer intentionally supports them. A child that is a declarative part of a *different* assembly still warns, because such a part is misnested and renders nothing wherever it is placed.
 
 ```tsx
 // action_bar/action_bar.tsx

--- a/src/platform/kbn-ui/react-assembly/src/assembly.test.ts
+++ b/src/platform/kbn-ui/react-assembly/src/assembly.test.ts
@@ -665,6 +665,68 @@ describe('assembly.parseChildren', () => {
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
+
+  describe('parts belonging to another assembly', () => {
+    const ForeignPart = createDeclarativeComponent<{ label?: string }>({
+      assembly: 'OtherAssembly',
+      part: 'row',
+    });
+
+    it('should warn that a part from another assembly renders nothing.', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      asm.parseChildren([
+        createElement(NameCol, { key: '1', label: 'Title' }),
+        createElement(ForeignPart, { key: '2' }),
+      ]);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        `[${assembly}] <OtherAssembly.row> is a "row" part of OtherAssembly and renders ` +
+          `nothing here. Move it inside a OtherAssembly parent.`
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should warn even when `supportsOtherChildren` is `true`.', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      asm.parseChildren([createElement(ForeignPart, { key: '1' })], {
+        supportsOtherChildren: true,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('is a "row" part of OtherAssembly and renders nothing here')
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should still parse the recognized parts around it.', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = asm.parseChildren([
+        createElement(ForeignPart, { key: '1' }),
+        createElement(NameCol, { key: '2', label: 'Title' }),
+      ]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(expect.objectContaining({ type: 'child' }));
+      expect(result[1]).toEqual(expect.objectContaining({ type: 'part', part: 'column' }));
+      warnSpy.mockRestore();
+    });
+
+    it('should not report a part of the assembly being parsed as misplaced.', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      asm.parseChildren([
+        createElement(NameCol, { key: '1', label: 'Title' }),
+        createElement(SpacerPart, { key: '2', size: 'm' }),
+      ]);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+  });
 });
 
 describe('resolveSkeleton', () => {

--- a/src/platform/kbn-ui/react-assembly/src/assembly.ts
+++ b/src/platform/kbn-ui/react-assembly/src/assembly.ts
@@ -12,10 +12,15 @@ import type { FC, ReactNode } from 'react';
 import type { ParsedItem, ParsedPart } from './parsing';
 import { parseDeclarativeChildren } from './parsing';
 import { createDeclarativeComponent, tagDeclarativeComponent } from './factory';
+import { getDeclarativePartTag } from './identification';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Dev-mode warning helper
 // ─────────────────────────────────────────────────────────────────────────────
+
+/** Best-effort component name for warning messages. */
+const describeChild = (type: unknown): string =>
+  (type as { displayName?: string }).displayName || (type as { name?: string }).name || 'Unknown';
 
 /**
  * Dev-mode helper: warns for function component children that are not
@@ -39,15 +44,62 @@ const warnOnPassthroughComponents = (
         isValidElement(item.node) &&
         typeof item.node.type === 'function'
       ) {
-        const name =
-          (item.node.type as unknown as { displayName?: string }).displayName ||
-          item.node.type.name ||
-          'Unknown';
         // eslint-disable-next-line no-console
         console.warn(
-          `[${assemblyName}] <${name}> is not a registered "${scope}" part and may not be rendered.`
+          `[${assemblyName}] <${describeChild(
+            item.node.type
+          )}> is not a registered "${scope}" part and may not be rendered.`
         );
       }
+    }
+  }
+};
+
+/**
+ * Dev-mode helper for the assembly-level parse: classifies each passthrough child.
+ *
+ * A child tagged for a different assembly is a declarative part used at the wrong
+ * nesting level. Because every declarative part renders `null`, such a part is dropped
+ * from the output with no other trace, so it is reported even when the renderer opts
+ * into passthrough children — otherwise the mistake leaves an empty region and no
+ * diagnostic at all.
+ *
+ * @param items - Parsed items from `parseDeclarativeChildren`.
+ * @param assemblyName - The assembly name currently being parsed.
+ * @param supportsOtherChildren - Whether the renderer intentionally renders non-part children.
+ */
+const warnOnUnexpectedChildren = (
+  items: ParsedItem[],
+  assemblyName: string,
+  supportsOtherChildren: boolean
+): void => {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  for (const item of items) {
+    if (item.type !== 'child' || !isValidElement(item.node)) {
+      continue;
+    }
+
+    const misplaced = getDeclarativePartTag(item.node);
+    if (misplaced && misplaced.assembly !== assemblyName) {
+      const { assembly, part } = misplaced;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[${assemblyName}] <${describeChild(item.node.type)}> is a "${part}" part of ` +
+          `${assembly} and renders nothing here. Move it inside a ${assembly} parent.`
+      );
+      continue;
+    }
+
+    if (!supportsOtherChildren && typeof item.node.type === 'function') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[${assemblyName}] <${describeChild(
+          item.node.type
+        )}> is not a registered "${assemblyName}" part and may not be rendered.`
+      );
     }
   }
 };
@@ -254,6 +306,10 @@ export interface AssemblyFactory<TName extends string = string> {
    * registered parts. Pass `{ supportsOtherChildren: true }` to suppress
    * the warning when the renderer intentionally handles non-part children.
    *
+   * A child that is a declarative part of a *different* assembly is always
+   * reported, regardless of `supportsOtherChildren`, because such a part is
+   * misnested and renders nothing.
+   *
    * @param children - React children to parse.
    * @param options - Optional parsing options.
    * @param options.supportsOtherChildren - When `true`, suppresses the
@@ -316,9 +372,7 @@ export const defineAssembly = <const TName extends string>(config: {
     options?: { supportsOtherChildren?: boolean }
   ): ParsedItem[] => {
     const items = parseDeclarativeChildren(children, config.name);
-    if (!options?.supportsOtherChildren) {
-      warnOnPassthroughComponents(items, config.name, config.name);
-    }
+    warnOnUnexpectedChildren(items, config.name, options?.supportsOtherChildren === true);
     return items;
   },
 

--- a/src/platform/kbn-ui/react-assembly/src/identification.ts
+++ b/src/platform/kbn-ui/react-assembly/src/identification.ts
@@ -38,6 +38,40 @@ export const getPartType = (element: unknown, assembly: string): string | undefi
   return typeof value === 'string' ? value : undefined;
 };
 
+/** Matches the static Symbol key written by `tagDeclarativeComponent`: `kbn.<assembly>.part`. */
+const PART_KEY_PATTERN = /^kbn\.(.+)\.part$/;
+
+/**
+ * Gets the assembly and part an element was tagged for, whichever assembly that is.
+ *
+ * {@link getPartType} only answers "does this belong to the assembly I am parsing".
+ * This answers "which assembly does this belong to", which lets a caller tell a part
+ * used at the wrong nesting level apart from ordinary passthrough content. Such a part
+ * renders as `null`, so without this distinction the mistake is invisible.
+ *
+ * @param element - The element to check.
+ * @returns The assembly and part names, or `undefined` for non-declarative elements.
+ */
+export const getDeclarativePartTag = (
+  element: unknown
+): { assembly: string; part: string } | undefined => {
+  if (!isReactLikeElement(element) || !element.type) {
+    return undefined;
+  }
+
+  const { type } = element;
+  for (const key of Object.getOwnPropertySymbols(type)) {
+    const globalKey = Symbol.keyFor(key);
+    const assembly = globalKey ? PART_KEY_PATTERN.exec(globalKey)?.[1] : undefined;
+    const part = assembly === undefined ? undefined : type[key];
+    if (assembly !== undefined && typeof part === 'string') {
+      return { assembly, part };
+    }
+  }
+
+  return undefined;
+};
+
 /**
  * Gets the static preset from a declarative component's Symbol property.
  *


### PR DESCRIPTION
## Summary

Makes `assembly.parseChildren()` report a declarative part that was used at the wrong nesting level.

Every declarative part renders `null` — its only job is to carry attributes up to the assembly root that parses it. That works well until a part ends up under the **wrong parent**: the assembly it was declared for never collects it, it renders nothing, and there is no other trace. The consumer sees an empty region and no diagnostic.

Two things prevented the dev-mode warning from catching this:

1. The only identification helper, `getPartType(element, assembly)`, answers *"does this belong to the assembly I am parsing"*. A misnested part answers `undefined` — indistinguishable from ordinary passthrough content like a `<div>` or a consumer's own component.
2. Renderers that intentionally accept free-form children pass `{ supportsOtherChildren: true }`, which suppressed the passthrough warning wholesale. That is correct for real passthrough content, but it also silenced the one case that is never intentional.

This PR adds the identification needed to tell those apart, then splits the warning so a misnested part is always reported while genuine passthrough content stays quiet when the renderer opted in.

## What changes about the package API

No exported signature changes and no new public exports — `getDeclarativePartTag` is internal to the package. The observable change is the dev-mode warning behavior of `assembly.parseChildren()`.

| Surface | Before | After |
| --- | --- | --- |
| `assembly.parseChildren(children)` | Warns for any function-component child that is not a registered part of this assembly. | Unchanged for ordinary components. A child tagged for a *different* assembly now gets a distinct message naming that assembly and part. |
| `assembly.parseChildren(children, { supportsOtherChildren: true })` | Suppressed **all** passthrough warnings. | Still suppresses warnings for ordinary passthrough content. **No longer suppresses** the misnested-part warning. |
| `part.parseChildren(children)` | Warns for unregistered function-component children. | Unchanged — still routed through `warnOnPassthroughComponents`. |
| `ParsedItem` / `ParsedPart` shape | — | Unchanged. A misnested part still comes back as `{ type: 'child' }`, so existing renderers keep working. |
| `getDeclarativePartTag(element)` *(internal)* | Did not exist. | New helper returning `{ assembly, part }` for any declaratively-tagged element, regardless of which assembly tagged it. |

The only row a consumer could notice is the second: a renderer passing `supportsOtherChildren: true` that is handed a misnested part now logs a warning where it previously logged nothing. That warning is the point of the change — the render output is identical either way.

New message, for a `row` part of `OtherAssembly` placed inside a `ParseTest` root:

```
[ParseTest] <OtherAssembly.row> is a "row" part of OtherAssembly and renders nothing here. Move it inside a OtherAssembly parent.
```

## Why now

`@kbn/flyout-template` (#280911) is the first consumer with two part-bearing assemblies in play at once, which makes this class of mistake reachable: `<FlyoutTemplate.Footer.PrimaryAction>` written inside `<FlyoutTemplate.Body>` is silently dropped. The Body renderer accepts arbitrary children by design, so it is exactly the `supportsOtherChildren: true` case that was previously silent.

That PR motivates this one but carries no code dependency on it, so the two can be reviewed in parallel; this one should merge first.

## Testing

Adds a `describe('parts belonging to another assembly')` block to `assembly.test.ts` covering four behaviors: the warning fires and names the foreign assembly; it fires even with `supportsOtherChildren: true`; surrounding recognized parts still parse into the result; and a part of the assembly *being* parsed is not misreported.

`node scripts/jest src/platform/kbn-ui/react-assembly` — 4 suites, 120 tests passed.

## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials — `RECIPES.md` Recipe 6 now notes that `supportsOtherChildren` does not suppress the misnested-part warning
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing) — n/a, the only added text is a dev-only `console.warn`

## Identify risks

Low, and bounded by two facts that were checked rather than assumed:

- **Production builds are unaffected.** The entire changed branch sits behind `process.env.NODE_ENV !== 'production'`.
- **No existing consumer reaches the changed path.** The two assemblies on `main` outside this package — `ContentListToolbar` and `ContentListTable` — call *part*-level `parseChildren` exclusively (`filter.parseChildren`, `column.parseChildren`, `action.parseChildren`), which this PR leaves untouched. No consumer calls `assembly.parseChildren`, and no consumer passes `supportsOtherChildren` at all today.

Parse results are byte-identical in every case; only console output changes.

The residual risk worth naming: if a renderer ever *deliberately* accepts another assembly's parts as opaque children, it would now warn. No such consumer exists today. If that pattern becomes legitimate, the fix is to add an explicit opt-out option rather than to remove the diagnostic.
