### PR TITLE
[9.4] Upgrade EUI to v115.0.0-backport.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@elastic/elasticsearch": "9.3.4",
     "@elastic/ems-client": "8.7.0",
     "@elastic/esql": "1.8.0",
-    "@elastic/eui": "115.0.0",
+    "@elastic/eui": "115.0.0-backport.0",
     "@elastic/eui-theme-borealis": "7.0.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/kibana-d3-color": "npm:@elastic/kibana-d3-color@2.0.1",

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
@@ -18,7 +18,7 @@
 @elastic/esql@1.8.0
 @elastic/eui-theme-borealis@7.0.0
 @elastic/eui-theme-common@9.0.0
-@elastic/eui@115.0.0
+@elastic/eui@115.0.0-backport.0
 @elastic/numeral@2.5.1
 @elastic/prismjs-esql@1.1.2
 @emotion/babel-plugin@11.13.5
@@ -494,7 +494,6 @@ util-deprecate@1.0.2
 util@0.12.5
 utility-types@3.11.0
 uuid@14.0.1
-uuid@8.3.2
 value-equal@0.4.0
 vfile-location@3.0.1
 vfile-message@2.0.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,10 +1998,10 @@
     chroma-js "^2.4.2"
     lodash "^4.17.21"
 
-"@elastic/eui@115.0.0":
-  version "115.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-115.0.0.tgz#a946565fc1fa336c1b02834584a879e02bdc2efe"
-  integrity sha512-jbkoTnfF9qYTzLoDsudREIlhLXTpg1vB7uPoytpoZlUkxkxE4773BiUgtcyDzNInZ00KUFlY/NzgI8Wy6IW5eA==
+"@elastic/eui@115.0.0-backport.0":
+  version "115.0.0-backport.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-115.0.0-backport.0.tgz#6510c3ef4c42a1c0de7561535e15d285abd43506"
+  integrity sha512-6tncPpxzWNpYbvPE+SdbtLB+GaEpn7Rtx5wHTAWVt6XIL2HtKb/1CWl6iGRWoe/W7uAiwq0PP2Fj330bvT7omQ==
   dependencies:
     "@elastic/eui-theme-common" "9.0.0"
     "@elastic/prismjs-esql" "^1.1.2"
@@ -2037,7 +2037,7 @@
     unist-util-visit "^2.0.3"
     url-parse "^1.5.10"
     use-sync-external-store "^1.6.0"
-    uuid "^8.3.0"
+    uuid "^14.0.0"
     vfile "^4.2.1"
 
 "@elastic/filesaver@1.1.2":
@@ -34023,7 +34023,7 @@ uuid@^11.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
   integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
-uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
Upgrades EUI to v115.0.0-backport.0, a backport release that updates the `uuid` dependency to v14. No other changes.