### PR TITLE
[ResponseOps][Task Manager] Slim claim msearch and skip candidate API key decrypt

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/README.md
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/README.md
@@ -17,7 +17,5 @@ The idea is to get more tasks than we have workers for with a search,
 and then validate that they are still valid (not been claimed) with an
 mget, since they may be stale.
 
-There are lots of interesting potential things we can do here, like maybe
-skipping polling completely for a round (think single Kibana, and the earlier
-poll got 2 * workers tasks out).  But we'll probably start with the bare
-minimum to get it working.
+The claim `msearch` omits `state` and `params` and does not decrypt API keys.
+Those fields are loaded only for the tasks we actually claim, via `bulkGet`.

--- a/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_claimers/strategy_mget.ts
@@ -7,7 +7,8 @@
 
 // Basic operation of this task claimer:
 // - search for candidate tasks to run, more than we actually can run
-// - initial search returns a slimmer task document for I/O efficiency (no params or state)
+// - initial search returns a slimmer task document (no params or state) and
+//   does not decrypt API keys; bulkGet after claim loads the full docs
 // - for each task found, do an mget to get the current seq_no and primary_term
 // - if the mget result doesn't match the search result, the task is stale
 // - from the non-stale search results, return as many as we can run based on available

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -722,6 +722,7 @@ describe('TaskStore', () => {
       const { args } = await testMsearch([{}], []);
       expect(args).toMatchObject({
         index: 'tasky',
+        _source_excludes: ['task.state', 'task.params'],
         searches: [
           {},
           {
@@ -771,7 +772,7 @@ describe('TaskStore', () => {
       });
     });
 
-    test('should return tasks with decrypted API keys', async () => {
+    test('returns slim hits without decrypting API keys', async () => {
       const { result } = await testMsearch(
         [{}],
         [
@@ -788,6 +789,7 @@ describe('TaskStore', () => {
         ]
       );
 
+      expect(esoClient.createPointInTimeFinderDecryptedAsInternalUser).not.toHaveBeenCalled();
       expect(result.docs[0]).toEqual({
         ...mockTask,
         retryAt: new Date(mockTask.retryAt),
@@ -796,11 +798,11 @@ describe('TaskStore', () => {
         startedAt: new Date(mockTask.startedAt),
         state: {},
         params: {},
-        apiKey: 'decryptedApiKey',
+        apiKey: 'encryptedKey',
       });
     });
 
-    test('returns all API keys when first getApiKeys search misses a key, but finds after refresh', async () => {
+    test('search() returns all API keys when first getApiKeys search misses a key, but finds after refresh', async () => {
       const logger = mockLogger();
       const mockSerializer = savedObjectsServiceMock.createSerializer();
       mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
@@ -869,31 +871,22 @@ describe('TaskStore', () => {
         });
       refreshStore.registerEncryptedSavedObjectsClient(esoClient);
 
-      mockEsClient.msearch.mockResponse({
-        took: 0,
-        responses: [
-          {
-            hits: {
-              hits: [
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
-                },
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
-                },
-              ],
+      mockEsClient.search.mockResponse({
+        hits: {
+          hits: [
+            {
+              _index: '.kibana_task_manager_8.16.0_001',
+              _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
             },
-            took: 0,
-            _shards: { failed: 0, successful: 1, total: 1 },
-            timed_out: false,
-            status: 200,
-          },
-        ],
-      });
+            {
+              _index: '.kibana_task_manager_8.16.0_001',
+              _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
+            },
+          ],
+        },
+      } as estypes.SearchResponse);
 
-      const result = await refreshStore.msearch([{}]);
+      const result = await refreshStore.search({});
 
       expect(result.docs).toHaveLength(2);
       expect(result.docs[0].apiKey).toBe('decryptedKey1');
@@ -906,7 +899,7 @@ describe('TaskStore', () => {
       expect(logger.error).not.toHaveBeenCalled();
     });
 
-    test('returns partial API keys when first getApiKeys search misses a key, and second search after refresh still does not find it', async () => {
+    test('search() returns partial API keys when first getApiKeys search misses a key, and second search after refresh still does not find it', async () => {
       const mockSerializer = savedObjectsServiceMock.createSerializer();
       mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
       mockSerializer.rawToSavedObject = jest
@@ -966,31 +959,22 @@ describe('TaskStore', () => {
         });
       refreshStore.registerEncryptedSavedObjectsClient(esoClient);
 
-      mockEsClient.msearch.mockResponse({
-        took: 0,
-        responses: [
-          {
-            hits: {
-              hits: [
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
-                },
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
-                },
-              ],
+      mockEsClient.search.mockResponse({
+        hits: {
+          hits: [
+            {
+              _index: '.kibana_task_manager_8.16.0_001',
+              _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
             },
-            took: 0,
-            _shards: { failed: 0, successful: 1, total: 1 },
-            timed_out: false,
-            status: 200,
-          },
-        ],
-      });
+            {
+              _index: '.kibana_task_manager_8.16.0_001',
+              _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
+            },
+          ],
+        },
+      } as estypes.SearchResponse);
 
-      const result = await refreshStore.msearch([{}]);
+      const result = await refreshStore.search({});
 
       expect(result.docs).toHaveLength(2);
       expect(result.docs[0].apiKey).toBe('decryptedKey1');
@@ -1004,7 +988,7 @@ describe('TaskStore', () => {
       );
     });
 
-    test('returns partial API keys when refresh fails', async () => {
+    test('search() returns partial API keys when refresh fails', async () => {
       const mockSerializer = savedObjectsServiceMock.createSerializer();
       mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
       mockSerializer.rawToSavedObject = jest
@@ -1064,31 +1048,22 @@ describe('TaskStore', () => {
         });
       refreshStore.registerEncryptedSavedObjectsClient(esoClient);
 
-      mockEsClient.msearch.mockResponse({
-        took: 0,
-        responses: [
-          {
-            hits: {
-              hits: [
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
-                },
-                {
-                  _index: '.kibana_task_manager_8.16.0_001',
-                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
-                },
-              ],
+      mockEsClient.search.mockResponse({
+        hits: {
+          hits: [
+            {
+              _index: '.kibana_task_manager_8.16.0_001',
+              _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
             },
-            took: 0,
-            _shards: { failed: 0, successful: 1, total: 1 },
-            timed_out: false,
-            status: 200,
-          },
-        ],
-      });
+            {
+              _index: '.kibana_task_manager_8.16.0_001',
+              _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
+            },
+          ],
+        },
+      } as estypes.SearchResponse);
 
-      const result = await refreshStore.msearch([{}]);
+      const result = await refreshStore.search({});
 
       expect(result.docs).toHaveLength(2);
       expect(result.docs[0].apiKey).toBe('decryptedKey1');

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -91,6 +91,9 @@ export interface StoreOpts {
   apiKeyStrategy: ApiKeyStrategy;
 }
 
+/** Omitted from claim-time search hits; runners load them via bulkGet after claim. */
+export const TASK_SEARCH_SOURCE_EXCLUDES = ['task.state', 'task.params'];
+
 export interface SearchOpts {
   search_after?: Array<number | string>;
   size?: number;
@@ -1080,6 +1083,7 @@ export class TaskStore {
       {
         index: this.index,
         ignore_unavailable: true,
+        _source_excludes: TASK_SEARCH_SOURCE_EXCLUDES,
         searches,
       },
       { retryOnTimeout: false }
@@ -1102,11 +1106,8 @@ export class TaskStore {
       allTasks = allTasks.concat(this.filterTasks(tasks));
     }
 
-    const allSortedTasks = claimSort(this.definitions, allTasks);
-    const tasksWithDecryptedApiKeys = await this.bulkGetAndMergeTasksWithDecryptedApiKey(
-      allSortedTasks
-    );
-    return { docs: tasksWithDecryptedApiKeys, versionMap };
+    // Claim does not need state/params/keys; post-claim bulkGet loads those.
+    return { docs: claimSort(this.definitions, allTasks), versionMap };
   }
 
   public async search(opts: SearchOpts = {}, limitResponse: boolean = false): Promise<FetchResult> {
@@ -1128,7 +1129,7 @@ export class TaskStore {
           ignore_unavailable: true,
           ...opts,
           query,
-          ...(limitResponse ? { _source_excludes: ['task.state', 'task.params'] } : {}),
+          ...(limitResponse ? { _source_excludes: TASK_SEARCH_SOURCE_EXCLUDES } : {}),
         },
         { retryOnTimeout: false }
       );


### PR DESCRIPTION
## 🎯 Summary

Claim polling was fetching and decrypting leftover candidates we never run.

- Claim `msearch` omits `task.state` / `task.params` (same excludes as `search(limitResponse)`).
- Leftover hits no longer go through the ESO PIT decrypt.
- Tasks we actually claim still get decrypted keys from the post-claim `bulkGet`.

This shrinks claim-search payloads and drops an ESO round-trip on every poll that finds keyed tasks. It does **not** raise capacity / tpm.

## 🔍 Why

The mget claimer was already documented as returning slim hits. `_msearch` still fetched full `_source` and ran `createPointInTimeFinderDecryptedAsInternalUser` over **every** hit, before we knew which tasks would run.

Claim selection only needs id, version, type, cost, schedule, and timestamps. Runners load `state` / `params` / keys after claim.

Encrypted `apiKey` can still appear on leftover hits; we skip decrypting it until `bulkGet`.

## 📉 Before / after (1000 claimed tasks)

Claimer `msearch` size is `capacity × 4` (`SIZE_MULTIPLIER_FOR_TASK_FETCH`). For **1000 Tiny keyed tasks claimed in one poll**, that is **4000 candidate hits** → **1000 claimed**, **~3000 leftover**.

Each ESO decrypt is a PIT finder: **open + paged `find` (1000/page) + close**. `decryptAttributes` then runs in-process on every hit. Claimed tasks were decrypted **twice** before (candidate finder + post-claim `bulkGet`).

| | Before | After |
| --- | ---: | ---: |
| Candidate ESO PIT (`msearch` hits) | open + 4 searches + close | — |
| Claimed ESO PIT (`bulkGet`) | open + 1 search + close | same |
| ES requests for decrypt | 9 | 3 |
| Key decrypts | 5000 (4000 candidates + 1000 claimed again) | 1000 |

**Per such poll:** **6 ES requests** and **4000 decrypts** saved. Version `mget`, claim `bulkUpdate`, and claimed `bulkGet` are unchanged.

If the candidate finder missed keys, we also used to `indices.refresh` and run a **second** PIT over leftover ids. That retry now only runs for the 1000 claimed docs.

No-op when leftover hits have no `apiKey` / `uiamApiKey` — the finder was already skipped.

## 🧪 Test plan

- [x] `task_store.test.ts` and `strategy_mget.test.ts` (jest)
- [ ] User-scoped alerting task still runs (decrypt happens on `bulkGet` after claim)
- [ ] On a cluster with many keyed tasks, `claimDuration` should drop and leftover hits should not open an ESO PIT during claim search
