### PR TITLE
[Chrome Next] Change switch label font weight

### DIFF
--- a/src/platform/kbn-ui/app-menu/src/components/app_menu_switch.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu_switch.tsx
@@ -37,6 +37,10 @@ export const AppMenuSwitchComponent = ({ switchConfig }: AppMenuSwitchComponentP
     margin-right: ${euiTheme.size.s};
   `;
 
+  const labelCss = css`
+    font-weight: ${euiTheme.font.weight.medium};
+  `;
+
   const handleChange = (e: EuiSwitchEvent) => {
     onChange(e.target.checked);
   };
@@ -48,7 +52,10 @@ export const AppMenuSwitchComponent = ({ switchConfig }: AppMenuSwitchComponentP
     <EuiSwitch
       id={id}
       label={label}
-      labelProps={labelProps}
+      labelProps={{
+        ...labelProps,
+        css: labelCss,
+      }}
       checked={checked}
       onChange={handleChange}
       disabled={disabled}

--- a/src/platform/kbn-ui/app-menu/src/types.ts
+++ b/src/platform/kbn-ui/app-menu/src/types.ts
@@ -315,7 +315,7 @@ export type AppMenuPopoverItem = Omit<
 export interface AppMenuSwitch {
   id: string;
   label: string;
-  labelProps: EuiSwitchProps['labelProps'];
+  labelProps?: Omit<NonNullable<EuiSwitchProps['labelProps']>, 'css'>;
   checked: boolean;
   onChange: (checked: boolean) => void;
   disabled?: boolean;


### PR DESCRIPTION
## Summary

This PR updates the font weight of app menu switch to match the font weight of app menu buttons. It also hardens the public interface for app menu switch by omitting `css` from `labelProps`.

<img width="364" height="62" alt="Screenshot 2026-08-16 at 21 24 00" src="https://github.com/user-attachments/assets/41d962be-bfab-4e93-923c-8d0a4cf89c46" />

Closes: https://github.com/elastic/kibana-team/issues/3926