### PR TITLE
[1Feedback] Add isEsql property

### DIFF
--- a/packages/kbn-rspack-optimizer/limits.yml
+++ b/packages/kbn-rspack-optimizer/limits.yml
@@ -79,7 +79,7 @@ pageLoadAssetSize:
   expressionTagcloud: 6629
   expressionXY: 566
   features: 1218
-  feedback: 3622
+  feedback: 4484
   fieldFormats: 4136
   fieldsMetadata: 1568
   files: 3957

--- a/src/platform/kbn-ui/feedback/index.ts
+++ b/src/platform/kbn-ui/feedback/index.ts
@@ -15,5 +15,7 @@ export type {
   FeedbackRegistryEntry,
   FeedbackSubmittedData,
   FeedbackQuestion,
+  FeedbackContext,
   FeedbackFormData,
+  AppDetails,
 } from './src/types';

--- a/src/platform/kbn-ui/feedback/packaging/react/index.tsx
+++ b/src/platform/kbn-ui/feedback/packaging/react/index.tsx
@@ -14,7 +14,9 @@ export { FeedbackTriggerButton, FeedbackContainer } from '../../src';
 export type { FeedbackTriggerButtonProps, FeedbackContainerProps } from '../../src';
 export type {
   FeedbackRegistryEntry,
+  FeedbackContext,
   FeedbackSubmittedData,
   FeedbackQuestion,
   FeedbackFormData,
+  AppDetails,
 } from '../../src/types';

--- a/src/platform/kbn-ui/feedback/packaging/react/types.ts
+++ b/src/platform/kbn-ui/feedback/packaging/react/types.ts
@@ -41,6 +41,11 @@ export interface FeedbackQuestion {
   answer: string;
 }
 
+/** Optional app-specific context recorded with the feedback payload. */
+export interface FeedbackContext {
+  isEsql?: boolean;
+}
+
 /** The full feedback payload recorded in telemetry. */
 export interface FeedbackSubmittedData {
   app_id: string;
@@ -51,6 +56,7 @@ export interface FeedbackSubmittedData {
   csat_score?: number;
   questions?: FeedbackQuestion[];
   organization_id?: string;
+  context?: FeedbackContext;
 }
 
 /** The subset of feedback data collected from the form. */
@@ -61,6 +67,7 @@ interface AppDetails {
   title: string;
   id: string;
   url: string;
+  context?: FeedbackContext;
 }
 
 /** Props accepted by the `FeedbackTriggerButton` component. */

--- a/src/platform/kbn-ui/feedback/packaging/react/types.ts
+++ b/src/platform/kbn-ui/feedback/packaging/react/types.ts
@@ -41,10 +41,8 @@ export interface FeedbackQuestion {
   answer: string;
 }
 
-/** Optional app-specific context recorded with the feedback payload. */
-export interface FeedbackContext {
-  isEsql?: boolean;
-}
+/** App-specific context recorded with the feedback payload. */
+export type FeedbackContext = Record<string, string | boolean | number>;
 
 /** The full feedback payload recorded in telemetry. */
 export interface FeedbackSubmittedData {

--- a/src/platform/kbn-ui/feedback/src/components/feedback_container.test.tsx
+++ b/src/platform/kbn-ui/feedback/src/components/feedback_container.test.tsx
@@ -105,6 +105,40 @@ describe('FeedbackContainer', () => {
     });
   });
 
+  it('should include context from getAppDetails in the submitted payload', async () => {
+    mockProps.getAppDetails.mockReturnValue({
+      title: 'Analytics - Discover ES|QL',
+      id: 'discover',
+      url: '/app/discover',
+      context: { isEsql: true },
+    });
+
+    renderWithI18n(<FeedbackContainer {...mockProps} />);
+
+    const emailConsentCheckbox = await screen.findByTestId('feedbackEmailConsentCheckbox');
+    await userEvent.click(emailConsentCheckbox);
+
+    const csatButtons = screen.getAllByRole('button', { name: /^\d$/ });
+    await userEvent.click(csatButtons[3]);
+
+    const sendButton = screen.getByTestId('feedbackFooterSendFeedbackButton');
+
+    await waitFor(() => {
+      expect(sendButton).not.toBeDisabled();
+    });
+
+    await userEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(mockProps.sendFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          app_id: 'discover',
+          context: { isEsql: true },
+        })
+      );
+    });
+  });
+
   it('should show success toast and hide container on successful submit', async () => {
     renderWithI18n(<FeedbackContainer {...mockProps} />);
 

--- a/src/platform/kbn-ui/feedback/src/components/feedback_container.tsx
+++ b/src/platform/kbn-ui/feedback/src/components/feedback_container.tsx
@@ -11,7 +11,7 @@ import React, { useEffect, useState } from 'react';
 import { EuiFlexGroup, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import type { FeedbackFormData, FeedbackRegistryEntry } from '../types';
+import type { AppDetails, FeedbackFormData, FeedbackRegistryEntry } from '../types';
 import { FeedbackHeader } from './header';
 import { FeedbackBody } from './body/feedback_body';
 import { FeedbackFooter } from './footer/feedback_footer';
@@ -20,7 +20,7 @@ import { useQuestionsForApp } from '../hooks/use_questions_for_app';
 
 export interface FeedbackContainerProps {
   getQuestions: (appId: string) => Promise<FeedbackRegistryEntry[]>;
-  getAppDetails: () => { title: string; id: string; url: string };
+  getAppDetails: () => AppDetails;
   getCurrentUserEmail: () => Promise<string | undefined>;
   sendFeedback: (data: FeedbackFormData) => Promise<void>;
   showToast: (title: string, type: 'success' | 'error') => void;
@@ -44,7 +44,7 @@ export const FeedbackContainer = ({
   const [isEmailValid, setIsEmailValid] = useState(true);
   const [forceShowEmailError, setForceShowEmailError] = useState(false);
 
-  const { title: appTitle, id: appId, url: appUrl } = getAppDetails();
+  const { title: appTitle, id: appId, url: appUrl, context } = getAppDetails();
 
   const { questions, isLoading, error } = useQuestionsForApp({ getQuestions, appId });
 
@@ -119,6 +119,7 @@ export const FeedbackContainer = ({
           answer: questionAnswers[question.id]?.trim() || 'N/A',
         })),
         url: appUrl,
+        ...(context && { context }),
       };
 
       await sendFeedback(eventData);

--- a/src/platform/kbn-ui/feedback/src/components/feedback_trigger_button.tsx
+++ b/src/platform/kbn-ui/feedback/src/components/feedback_trigger_button.tsx
@@ -11,7 +11,7 @@ import React, { useState, useEffect, lazy, Suspense } from 'react';
 import { EuiHeaderSectionItemButton, EuiIcon, EuiToolTip, EuiModal } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import type { FeedbackFormData, FeedbackRegistryEntry } from '../types';
+import type { AppDetails, FeedbackFormData, FeedbackRegistryEntry } from '../types';
 
 const LazyFeedbackContainer = lazy(() =>
   import('./feedback_container').then((m) => ({ default: m.FeedbackContainer }))
@@ -19,7 +19,7 @@ const LazyFeedbackContainer = lazy(() =>
 
 export interface FeedbackTriggerButtonProps {
   getQuestions: (appId: string) => Promise<FeedbackRegistryEntry[]>;
-  getAppDetails: () => { title: string; id: string; url: string };
+  getAppDetails: () => AppDetails;
   getCurrentUserEmail: () => Promise<string | undefined>;
   sendFeedback: (data: FeedbackFormData) => Promise<void>;
   showToast: (title: string, type: 'success' | 'error') => void;

--- a/src/platform/kbn-ui/feedback/src/types.ts
+++ b/src/platform/kbn-ui/feedback/src/types.ts
@@ -52,6 +52,10 @@ export interface FeedbackQuestion {
   answer: string;
 }
 
+export interface FeedbackContext {
+  isEsql?: boolean;
+}
+
 export interface FeedbackSubmittedData {
   app_id: string;
   solution: string;
@@ -61,6 +65,14 @@ export interface FeedbackSubmittedData {
   csat_score?: number;
   questions?: FeedbackQuestion[];
   organization_id?: string;
+  context?: FeedbackContext;
+}
+
+export interface AppDetails {
+  title: string;
+  id: string;
+  url: string;
+  context?: FeedbackContext;
 }
 
 export type FeedbackFormData = Omit<FeedbackSubmittedData, 'solution' | 'organization_id'>;

--- a/src/platform/kbn-ui/feedback/src/types.ts
+++ b/src/platform/kbn-ui/feedback/src/types.ts
@@ -52,9 +52,8 @@ export interface FeedbackQuestion {
   answer: string;
 }
 
-export interface FeedbackContext {
-  isEsql?: boolean;
-}
+/** App-specific context recorded with the feedback payload. */
+export type FeedbackContext = Record<string, string | boolean | number>;
 
 export interface FeedbackSubmittedData {
   app_id: string;

--- a/src/platform/plugins/shared/discover/kibana.jsonc
+++ b/src/platform/plugins/shared/discover/kibana.jsonc
@@ -52,7 +52,8 @@
       "apmSourcesAccess",
       "fileUpload",
       "cps",
-      "alertingVTwo"
+      "alertingVTwo",
+      "feedback"
     ],
     "requiredBundles": [
       "kibanaUtils",

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -59,6 +59,7 @@ import { addLog } from '../../../../utils/add_log';
 import { DiscoverResizableLayout } from './discover_resizable_layout';
 import { PanelsToggle } from '../../../../components/panels_toggle';
 import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
+import { useRegisterDiscoverEsqlFeedback } from '../../hooks/use_register_discover_esql_feedback';
 import {
   internalStateActions,
   useCurrentDataView,
@@ -118,6 +119,7 @@ export function DiscoverLayout() {
     state.grid,
   ]);
   const isEsqlMode = useIsEsqlMode();
+  useRegisterDiscoverEsqlFeedback();
   const viewMode: VIEW_MODE = useAppStateSelector((state) => {
     const fieldStatsNotAvailable =
       !uiSettings.get(SHOW_FIELD_STATISTICS) && !!dataVisualizerService;

--- a/src/platform/plugins/shared/discover/public/application/main/hooks/use_register_discover_esql_feedback.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/hooks/use_register_discover_esql_feedback.test.ts
@@ -46,7 +46,11 @@ describe('useRegisterDiscoverEsqlFeedback', () => {
 
     const { unmount } = renderHook(() => useRegisterDiscoverEsqlFeedback());
 
-    expect(setContext).toHaveBeenCalledWith(DISCOVER_APP_ID, { isEsql: true });
+    expect(setContext).toHaveBeenCalledWith(
+      DISCOVER_APP_ID,
+      { isEsql: true },
+      { title: 'Analytics - Discover ES|QL' }
+    );
 
     unmount();
 

--- a/src/platform/plugins/shared/discover/public/application/main/hooks/use_register_discover_esql_feedback.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/hooks/use_register_discover_esql_feedback.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { DISCOVER_APP_ID } from '@kbn/deeplinks-analytics';
+import { renderHook } from '@testing-library/react';
+import { useRegisterDiscoverEsqlFeedback } from './use_register_discover_esql_feedback';
+import { useDiscoverServices } from '../../../hooks/use_discover_services';
+import { useIsEsqlMode } from './use_is_esql_mode';
+import { createDiscoverServicesMock } from '../../../__mocks__/services';
+import type { DiscoverServices } from '../../../build_services';
+
+jest.mock('../../../hooks/use_discover_services');
+jest.mock('./use_is_esql_mode');
+
+const mockUseDiscoverServices = useDiscoverServices as jest.MockedFunction<
+  typeof useDiscoverServices
+>;
+const mockUseIsEsqlMode = useIsEsqlMode as jest.MockedFunction<typeof useIsEsqlMode>;
+
+const mockServices = (feedback?: DiscoverServices['feedback']) => {
+  mockUseDiscoverServices.mockReturnValue({
+    ...createDiscoverServicesMock(),
+    feedback,
+  });
+};
+
+describe('useRegisterDiscoverEsqlFeedback', () => {
+  it('does nothing when the feedback plugin is not available', () => {
+    mockServices(undefined);
+    mockUseIsEsqlMode.mockReturnValue(true);
+
+    expect(() => renderHook(() => useRegisterDiscoverEsqlFeedback())).not.toThrow();
+  });
+
+  it('registers ES|QL context and unregisters on unmount', () => {
+    const unregister = jest.fn();
+    const setContext = jest.fn().mockReturnValue(unregister);
+    mockServices({ setContext });
+    mockUseIsEsqlMode.mockReturnValue(true);
+
+    const { unmount } = renderHook(() => useRegisterDiscoverEsqlFeedback());
+
+    expect(setContext).toHaveBeenCalledWith(DISCOVER_APP_ID, { isEsql: true });
+
+    unmount();
+
+    expect(unregister).toHaveBeenCalled();
+  });
+
+  it('clears ES|QL context when Discover is in classic mode', () => {
+    const setContext = jest.fn().mockReturnValue(jest.fn());
+    mockServices({ setContext });
+    mockUseIsEsqlMode.mockReturnValue(false);
+
+    renderHook(() => useRegisterDiscoverEsqlFeedback());
+
+    expect(setContext).toHaveBeenCalledWith(DISCOVER_APP_ID, {});
+  });
+});

--- a/src/platform/plugins/shared/discover/public/application/main/hooks/use_register_discover_esql_feedback.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/hooks/use_register_discover_esql_feedback.ts
@@ -9,8 +9,13 @@
 
 import { useEffect } from 'react';
 import { DISCOVER_APP_ID } from '@kbn/deeplinks-analytics';
+import { i18n } from '@kbn/i18n';
 import { useDiscoverServices } from '../../../hooks/use_discover_services';
 import { useIsEsqlMode } from './use_is_esql_mode';
+
+const DISCOVER_ESQL_FEEDBACK_TITLE = i18n.translate('discover.feedback.esqlAppTitle', {
+  defaultMessage: 'Analytics - Discover ES|QL',
+});
 
 /**
  * Publishes Discover ES|QL mode to 1Feedback when the optional feedback plugin is present.
@@ -20,6 +25,18 @@ export const useRegisterDiscoverEsqlFeedback = () => {
   const isEsqlMode = useIsEsqlMode();
 
   useEffect(() => {
-    return feedback?.setContext(DISCOVER_APP_ID, isEsqlMode ? { isEsql: true } : {});
+    if (!feedback) {
+      return;
+    }
+
+    if (isEsqlMode) {
+      return feedback.setContext(
+        DISCOVER_APP_ID,
+        { isEsql: true },
+        { title: DISCOVER_ESQL_FEEDBACK_TITLE }
+      );
+    }
+
+    return feedback.setContext(DISCOVER_APP_ID, {});
   }, [feedback, isEsqlMode]);
 };

--- a/src/platform/plugins/shared/discover/public/application/main/hooks/use_register_discover_esql_feedback.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/hooks/use_register_discover_esql_feedback.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEffect } from 'react';
+import { DISCOVER_APP_ID } from '@kbn/deeplinks-analytics';
+import { useDiscoverServices } from '../../../hooks/use_discover_services';
+import { useIsEsqlMode } from './use_is_esql_mode';
+
+/**
+ * Publishes Discover ES|QL mode to 1Feedback when the optional feedback plugin is present.
+ */
+export const useRegisterDiscoverEsqlFeedback = () => {
+  const { feedback } = useDiscoverServices();
+  const isEsqlMode = useIsEsqlMode();
+
+  useEffect(() => {
+    return feedback?.setContext(DISCOVER_APP_ID, isEsqlMode ? { isEsql: true } : {});
+  }, [feedback, isEsqlMode]);
+};

--- a/src/platform/plugins/shared/discover/public/build_services.ts
+++ b/src/platform/plugins/shared/discover/public/build_services.ts
@@ -168,6 +168,7 @@ export interface DiscoverServices {
   cps?: CPSPluginStart;
   embeddableEditor: EmbeddableEditorService;
   logger: Logger;
+  feedback?: DiscoverStartPlugins['feedback'];
 }
 
 export const buildServices = ({
@@ -282,5 +283,6 @@ export const buildServices = ({
       core.application
     ),
     logger: context.logger.get(),
+    feedback: plugins.feedback,
   };
 };

--- a/src/platform/plugins/shared/discover/public/types.ts
+++ b/src/platform/plugins/shared/discover/public/types.ts
@@ -185,4 +185,7 @@ export interface DiscoverStartPlugins {
   apmSourcesAccess?: ApmSourceAccessPluginStart;
   fileUpload?: FileUploadPluginStart;
   cps?: CPSPluginStart;
+  feedback?: {
+    setContext: (appId: string, context: Record<string, string | boolean | number>) => () => void;
+  };
 }

--- a/src/platform/plugins/shared/discover/public/types.ts
+++ b/src/platform/plugins/shared/discover/public/types.ts
@@ -186,6 +186,10 @@ export interface DiscoverStartPlugins {
   fileUpload?: FileUploadPluginStart;
   cps?: CPSPluginStart;
   feedback?: {
-    setContext: (appId: string, context: Record<string, string | boolean | number>) => () => void;
+    setContext: (
+      appId: string,
+      context: Record<string, string | boolean | number>,
+      options?: { title?: string }
+    ) => () => void;
   };
 }

--- a/x-pack/platform/plugins/private/feedback/common/index.ts
+++ b/x-pack/platform/plugins/private/feedback/common/index.ts
@@ -5,4 +5,9 @@
  * 2.0.
  */
 
-export type { FeedbackQuestion, FeedbackSubmittedData, FeedbackFormData } from './types';
+export type {
+  FeedbackQuestion,
+  FeedbackContext,
+  FeedbackSubmittedData,
+  FeedbackFormData,
+} from './types';

--- a/x-pack/platform/plugins/private/feedback/common/index.ts
+++ b/x-pack/platform/plugins/private/feedback/common/index.ts
@@ -8,6 +8,8 @@
 export type {
   FeedbackQuestion,
   FeedbackContext,
+  FeedbackContextOptions,
+  SetFeedbackContext,
   FeedbackSubmittedData,
   FeedbackFormData,
 } from './types';

--- a/x-pack/platform/plugins/private/feedback/common/types.ts
+++ b/x-pack/platform/plugins/private/feedback/common/types.ts
@@ -14,6 +14,18 @@ export interface FeedbackQuestion {
 /** App-specific context recorded with the feedback payload. */
 export type FeedbackContext = Record<string, string | boolean | number>;
 
+/** Optional UI overrides applied when collecting feedback for the current app. */
+export interface FeedbackContextOptions {
+  /** Fully replaces the derived app title shown in the feedback form. */
+  title?: string;
+}
+
+export type SetFeedbackContext = (
+  appId: string,
+  context: FeedbackContext,
+  options?: FeedbackContextOptions
+) => () => void;
+
 export interface FeedbackSubmittedData {
   app_id: string;
   solution: string;

--- a/x-pack/platform/plugins/private/feedback/common/types.ts
+++ b/x-pack/platform/plugins/private/feedback/common/types.ts
@@ -11,6 +11,10 @@ export interface FeedbackQuestion {
   answer: string;
 }
 
+export interface FeedbackContext {
+  isEsql?: boolean;
+}
+
 export interface FeedbackSubmittedData {
   app_id: string;
   solution: string;
@@ -20,6 +24,7 @@ export interface FeedbackSubmittedData {
   csat_score?: number;
   questions?: FeedbackQuestion[];
   organization_id?: string;
+  context?: FeedbackContext;
 }
 
 export type FeedbackFormData = Omit<FeedbackSubmittedData, 'solution' | 'organization_id'>;

--- a/x-pack/platform/plugins/private/feedback/common/types.ts
+++ b/x-pack/platform/plugins/private/feedback/common/types.ts
@@ -11,9 +11,8 @@ export interface FeedbackQuestion {
   answer: string;
 }
 
-export interface FeedbackContext {
-  isEsql?: boolean;
-}
+/** App-specific context recorded with the feedback payload. */
+export type FeedbackContext = Record<string, string | boolean | number>;
 
 export interface FeedbackSubmittedData {
   app_id: string;

--- a/x-pack/platform/plugins/private/feedback/moon.yml
+++ b/x-pack/platform/plugins/private/feedback/moon.yml
@@ -28,7 +28,7 @@ dependsOn:
   - '@kbn/core-chrome-feature-flags'
   - '@kbn/react-kibana-mount'
   - '@kbn/i18n'
-  - '@kbn/kibana-utils-plugin'
+  - '@kbn/deeplinks-analytics'
   - '@kbn/core-http-router-server-mocks'
 tags:
   - plugin

--- a/x-pack/platform/plugins/private/feedback/moon.yml
+++ b/x-pack/platform/plugins/private/feedback/moon.yml
@@ -28,7 +28,6 @@ dependsOn:
   - '@kbn/core-chrome-feature-flags'
   - '@kbn/react-kibana-mount'
   - '@kbn/i18n'
-  - '@kbn/deeplinks-analytics'
   - '@kbn/core-http-router-server-mocks'
 tags:
   - plugin

--- a/x-pack/platform/plugins/private/feedback/moon.yml
+++ b/x-pack/platform/plugins/private/feedback/moon.yml
@@ -28,6 +28,7 @@ dependsOn:
   - '@kbn/core-chrome-feature-flags'
   - '@kbn/react-kibana-mount'
   - '@kbn/i18n'
+  - '@kbn/kibana-utils-plugin'
   - '@kbn/core-http-router-server-mocks'
 tags:
   - plugin

--- a/x-pack/platform/plugins/private/feedback/public/plugin.test.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { FeedbackPlugin } from './plugin';
 import { coreMock } from '@kbn/core/public/mocks';
 import { cloudMock } from '@kbn/cloud-plugin/public/mocks';
@@ -16,6 +16,7 @@ describe('Feedback Plugin', () => {
   let coreStartMock: ReturnType<typeof coreMock.createStart>;
   let cloudStartMock: ReturnType<typeof cloudMock.createStart>;
   let isOptedIn$: Subject<boolean>;
+  let currentAppId$: BehaviorSubject<string | undefined>;
   let telemetryStartMock: TelemetryPluginStart;
   let plugin: FeedbackPlugin;
 
@@ -30,6 +31,8 @@ describe('Feedback Plugin', () => {
     coreStartMock = coreMock.createStart();
     cloudStartMock = cloudMock.createStart();
     isOptedIn$ = new Subject<boolean>();
+    currentAppId$ = new BehaviorSubject<string | undefined>(undefined);
+    coreStartMock.application.currentAppId$ = currentAppId$;
     // The plugin only consumes `isOptedIn$`, so a Subject we can emit on is all we need.
     telemetryStartMock = {
       telemetryService: { isOptedIn$ },
@@ -98,5 +101,59 @@ describe('Feedback Plugin', () => {
     isOptedIn$.next(true);
 
     expect(coreStartMock.chrome.next.registerFeedbackHandler).not.toHaveBeenCalled();
+  });
+
+  describe('setContext', () => {
+    const getAppDetailsFromTrigger = () => {
+      const [[{ content }]] = coreStartMock.chrome.navControls.registerRight.mock.calls;
+      return (content as React.ReactElement).props.children.props.getAppDetails as () => {
+        title: string;
+        id: string;
+        url: string;
+        context?: Record<string, string | boolean | number>;
+      };
+    };
+
+    it('no-ops when appId does not match the current app', () => {
+      enableFeedback();
+      const { setContext } = startPlugin();
+      currentAppId$.next('dashboard');
+
+      setContext('discover', { isEsql: true });
+
+      expect(getAppDetailsFromTrigger()().context).toBeUndefined();
+    });
+
+    it('stores context only while appId is the current app', () => {
+      enableFeedback();
+      const { setContext } = startPlugin();
+      currentAppId$.next('discover');
+
+      setContext('discover', { isEsql: true });
+
+      expect(getAppDetailsFromTrigger()().context).toEqual({ isEsql: true });
+    });
+
+    it('clears context when the current app changes', () => {
+      enableFeedback();
+      const { setContext } = startPlugin();
+      currentAppId$.next('discover');
+      setContext('discover', { isEsql: true });
+
+      currentAppId$.next('dashboard');
+
+      expect(getAppDetailsFromTrigger()().context).toBeUndefined();
+    });
+
+    it('clears context on unregister', () => {
+      enableFeedback();
+      const { setContext } = startPlugin();
+      currentAppId$.next('discover');
+      const unregister = setContext('discover', { isEsql: true });
+
+      unregister();
+
+      expect(getAppDetailsFromTrigger()().context).toBeUndefined();
+    });
   });
 });

--- a/x-pack/platform/plugins/private/feedback/public/plugin.test.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.test.tsx
@@ -155,5 +155,20 @@ describe('Feedback Plugin', () => {
 
       expect(getAppDetailsFromTrigger()().context).toBeUndefined();
     });
+
+    it('uses options.title as a full app title override', () => {
+      enableFeedback();
+      const { setContext } = startPlugin();
+      currentAppId$.next('discover');
+
+      setContext('discover', { isEsql: true }, { title: 'Analytics - Discover ES|QL' });
+
+      expect(getAppDetailsFromTrigger()()).toEqual(
+        expect.objectContaining({
+          title: 'Analytics - Discover ES|QL',
+          context: { isEsql: true },
+        })
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/private/feedback/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.tsx
@@ -17,7 +17,7 @@ import { isNextChrome } from '@kbn/core-chrome-feature-flags';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { i18n } from '@kbn/i18n';
 import { firstValueFrom, type Subscription } from 'rxjs';
-import type { FeedbackFormData } from '../common';
+import type { FeedbackContext, FeedbackFormData } from '../common';
 import { getAppDetails } from './src/utils';
 
 interface FeedbackPluginSetupDependencies {
@@ -57,6 +57,7 @@ const feedbackModalCss = css`
 const createFeedbackDeps = (
   core: CoreStart,
   organizationId: string | undefined,
+  getContext: () => FeedbackContext | undefined,
   cloud?: CloudStart,
   spaces?: SpacesPluginStart
 ): FeedbackDeps => {
@@ -70,7 +71,7 @@ const createFeedbackDeps = (
   };
 
   return {
-    getAppDetails: () => getAppDetails(core),
+    getAppDetails: () => getAppDetails(core, getContext()),
     getQuestions: async (appId: string) => {
       const { getFeedbackQuestionsForApp } = await import('@kbn/feedback-registry');
       return getFeedbackQuestionsForApp(appId);
@@ -132,6 +133,10 @@ const openFeedbackModal = (core: CoreStart, deps: FeedbackDeps) => {
 export class FeedbackPlugin implements Plugin {
   private organizationId?: string;
   private telemetryOptInSubscription?: Subscription;
+  private appIdSubscription?: Subscription;
+  private currentAppId?: string;
+  private contextAppId?: string;
+  private context?: FeedbackContext;
 
   public setup(_core: CoreSetup, { cloud }: FeedbackPluginSetupDependencies) {
     this.organizationId = cloud?.organizationId;
@@ -139,11 +144,40 @@ export class FeedbackPlugin implements Plugin {
   }
 
   public start(core: CoreStart, { cloud, telemetry, spaces }: FeedbackPluginStartDependencies) {
+    this.appIdSubscription = core.application.currentAppId$.subscribe((appId) => {
+      if (appId !== this.currentAppId) {
+        this.context = undefined;
+        this.contextAppId = undefined;
+      }
+      this.currentAppId = appId;
+    });
+
+    /**
+     * Stores opaque feedback context for the current app.
+     * No-ops unless `appId` matches `currentAppId`, so one app cannot pollute another.
+     */
+    const setContext = (appId: string, context: FeedbackContext): (() => void) => {
+      if (appId !== this.currentAppId) {
+        return () => {};
+      }
+
+      this.contextAppId = appId;
+      this.context = context;
+      return () => {
+        if (this.contextAppId === appId) {
+          this.context = undefined;
+          this.contextAppId = undefined;
+        }
+      };
+    };
+
+    const getContext = () => (this.contextAppId === this.currentAppId ? this.context : undefined);
+
     if (!core.notifications.feedback.isEnabled()) {
-      return {};
+      return { setContext };
     }
 
-    const deps = createFeedbackDeps(core, this.organizationId, cloud, spaces);
+    const deps = createFeedbackDeps(core, this.organizationId, getContext, cloud, spaces);
     const { isOptedIn$ } = telemetry.telemetryService;
     const checkTelemetryOptIn = () => firstValueFrom(isOptedIn$);
 
@@ -171,11 +205,15 @@ export class FeedbackPlugin implements Plugin {
       ),
     });
 
-    return {};
+    return { setContext };
   }
 
   public stop() {
     this.telemetryOptInSubscription?.unsubscribe();
     this.telemetryOptInSubscription = undefined;
+    this.appIdSubscription?.unsubscribe();
+    this.appIdSubscription = undefined;
+    this.context = undefined;
+    this.contextAppId = undefined;
   }
 }

--- a/x-pack/platform/plugins/private/feedback/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.tsx
@@ -12,7 +12,7 @@ import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
 import type { TelemetryPluginStart } from '@kbn/telemetry-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
-import type { FeedbackRegistryEntry } from '@kbn/ui-feedback';
+import type { AppDetails, FeedbackRegistryEntry } from '@kbn/ui-feedback';
 import { isNextChrome } from '@kbn/core-chrome-feature-flags';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { i18n } from '@kbn/i18n';
@@ -32,7 +32,7 @@ interface FeedbackPluginStartDependencies {
 
 interface FeedbackDeps {
   getQuestions: (appId: string) => Promise<FeedbackRegistryEntry[]>;
-  getAppDetails: () => { title: string; id: string; url: string };
+  getAppDetails: () => AppDetails;
   getCurrentUserEmail: () => Promise<string | undefined>;
   sendFeedback: (data: FeedbackFormData) => Promise<void>;
   showToast: (title: string, color: 'success' | 'error') => void;

--- a/x-pack/platform/plugins/private/feedback/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/plugin.tsx
@@ -17,7 +17,7 @@ import { isNextChrome } from '@kbn/core-chrome-feature-flags';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { i18n } from '@kbn/i18n';
 import { firstValueFrom, type Subscription } from 'rxjs';
-import type { FeedbackContext, FeedbackFormData } from '../common';
+import type { FeedbackContext, FeedbackFormData, SetFeedbackContext } from '../common';
 import { getAppDetails } from './src/utils';
 
 interface FeedbackPluginSetupDependencies {
@@ -58,6 +58,7 @@ const createFeedbackDeps = (
   core: CoreStart,
   organizationId: string | undefined,
   getContext: () => FeedbackContext | undefined,
+  getTitleOverride: () => string | undefined,
   cloud?: CloudStart,
   spaces?: SpacesPluginStart
 ): FeedbackDeps => {
@@ -71,7 +72,7 @@ const createFeedbackDeps = (
   };
 
   return {
-    getAppDetails: () => getAppDetails(core, getContext()),
+    getAppDetails: () => getAppDetails(core, getContext(), getTitleOverride()),
     getQuestions: async (appId: string) => {
       const { getFeedbackQuestionsForApp } = await import('@kbn/feedback-registry');
       return getFeedbackQuestionsForApp(appId);
@@ -137,6 +138,7 @@ export class FeedbackPlugin implements Plugin {
   private currentAppId?: string;
   private contextAppId?: string;
   private context?: FeedbackContext;
+  private titleOverride?: string;
 
   public setup(_core: CoreSetup, { cloud }: FeedbackPluginSetupDependencies) {
     this.organizationId = cloud?.organizationId;
@@ -148,36 +150,49 @@ export class FeedbackPlugin implements Plugin {
       if (appId !== this.currentAppId) {
         this.context = undefined;
         this.contextAppId = undefined;
+        this.titleOverride = undefined;
       }
       this.currentAppId = appId;
     });
 
     /**
      * Stores opaque feedback context for the current app.
+     * `options.title` fully replaces the derived app title in the feedback UI.
      * No-ops unless `appId` matches `currentAppId`, so one app cannot pollute another.
      */
-    const setContext = (appId: string, context: FeedbackContext): (() => void) => {
+    const setContext: SetFeedbackContext = (appId, context, options) => {
       if (appId !== this.currentAppId) {
         return () => {};
       }
 
       this.contextAppId = appId;
       this.context = context;
+      this.titleOverride = options?.title;
       return () => {
         if (this.contextAppId === appId) {
           this.context = undefined;
           this.contextAppId = undefined;
+          this.titleOverride = undefined;
         }
       };
     };
 
     const getContext = () => (this.contextAppId === this.currentAppId ? this.context : undefined);
+    const getTitleOverride = () =>
+      this.contextAppId === this.currentAppId ? this.titleOverride : undefined;
 
     if (!core.notifications.feedback.isEnabled()) {
       return { setContext };
     }
 
-    const deps = createFeedbackDeps(core, this.organizationId, getContext, cloud, spaces);
+    const deps = createFeedbackDeps(
+      core,
+      this.organizationId,
+      getContext,
+      getTitleOverride,
+      cloud,
+      spaces
+    );
     const { isOptedIn$ } = telemetry.telemetryService;
     const checkTelemetryOptIn = () => firstValueFrom(isOptedIn$);
 
@@ -215,5 +230,6 @@ export class FeedbackPlugin implements Plugin {
     this.appIdSubscription = undefined;
     this.context = undefined;
     this.contextAppId = undefined;
+    this.titleOverride = undefined;
   }
 }

--- a/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.test.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.test.tsx
@@ -20,15 +20,30 @@ const createMockNavLink = (
   ...partial,
 });
 
-const setWindowLocation = (pathname: string) => {
+const setWindowLocation = (pathname: string, hash = '') => {
   Object.defineProperty(window, 'location', {
     value: {
       pathname,
       origin: 'http://localhost:5601',
+      href: `http://localhost:5601${pathname}${hash}`,
+      hash,
     },
     writable: true,
   });
 };
+
+const discoverNavLink = (overrides: Partial<ChromeNavLink> = {}): ChromeNavLink =>
+  createMockNavLink({
+    id: 'discover',
+    title: 'Discover',
+    url: '/app/discover',
+    category: {
+      id: 'analytics',
+      label: 'Analytics',
+      order: 1000,
+    },
+    ...overrides,
+  });
 
 describe('getAppDetails', () => {
   beforeEach(() => {
@@ -212,6 +227,93 @@ describe('getAppDetails', () => {
       title: 'SLOs Welcome',
       id: 'slos-welcome',
       url: '/app/slos/welcome',
+    });
+  });
+
+  it('should tag Discover ES|QL mode from dataSource.type', () => {
+    setWindowLocation('/app/discover', "#/?_a=(dataSource:(type:esql),query:(esql:'FROM logs'))");
+    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
+
+    const result = getAppDetails(coreStartMock);
+
+    expect(result).toEqual({
+      title: 'Analytics - Discover ES|QL',
+      id: 'discover',
+      url: '/app/discover',
+      context: { isEsql: true },
+    });
+  });
+
+  it('should tag Discover ES|QL mode from query.esql when dataSource is missing', () => {
+    setWindowLocation('/app/discover', "#/?_a=(query:(esql:'FROM logs'))");
+    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
+
+    const result = getAppDetails(coreStartMock);
+
+    expect(result).toEqual({
+      title: 'Analytics - Discover ES|QL',
+      id: 'discover',
+      url: '/app/discover',
+      context: { isEsql: true },
+    });
+  });
+
+  it('should leave Discover DataView mode unchanged', () => {
+    setWindowLocation(
+      '/app/discover',
+      "#/?_a=(dataSource:(dataViewId:logs,type:dataView),query:(language:kuery,query:''))"
+    );
+    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
+
+    const result = getAppDetails(coreStartMock);
+
+    expect(result).toEqual({
+      title: 'Analytics - Discover',
+      id: 'discover',
+      url: '/app/discover',
+    });
+  });
+
+  it('should leave Discover unchanged when _a is missing or invalid', () => {
+    setWindowLocation('/app/discover', '#/?_a=not-valid-rison');
+    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
+
+    expect(getAppDetails(coreStartMock)).toEqual({
+      title: 'Analytics - Discover',
+      id: 'discover',
+      url: '/app/discover',
+    });
+
+    setWindowLocation('/app/discover');
+
+    expect(getAppDetails(coreStartMock)).toEqual({
+      title: 'Analytics - Discover',
+      id: 'discover',
+      url: '/app/discover',
+    });
+  });
+
+  it('should not tag non-Discover apps that have ES|QL-like _a state', () => {
+    setWindowLocation('/app/dashboard', "#/?_a=(dataSource:(type:esql),query:(esql:'FROM logs'))");
+    coreStartMock.chrome.navLinks.getAll.mockReturnValue([
+      createMockNavLink({
+        id: 'dashboard',
+        title: 'Dashboard',
+        url: '/app/dashboard',
+        category: {
+          id: 'analytics',
+          label: 'Analytics',
+          order: 1000,
+        },
+      }),
+    ]);
+
+    const result = getAppDetails(coreStartMock);
+
+    expect(result).toEqual({
+      title: 'Analytics - Dashboard',
+      id: 'dashboard',
+      url: '/app/dashboard',
     });
   });
 });

--- a/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.test.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.test.tsx
@@ -230,11 +230,11 @@ describe('getAppDetails', () => {
     });
   });
 
-  it('should derive a Discover ES|QL title from context', () => {
+  it('should use titleOverride as a full title replacement', () => {
     setWindowLocation('/app/discover');
     coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
 
-    const result = getAppDetails(coreStartMock, { isEsql: true });
+    const result = getAppDetails(coreStartMock, { isEsql: true }, 'Analytics - Discover ES|QL');
 
     expect(result).toEqual({
       title: 'Analytics - Discover ES|QL',
@@ -255,7 +255,7 @@ describe('getAppDetails', () => {
     });
   });
 
-  it('should not suffix non-Discover titles when context.isEsql is true', () => {
+  it('should keep the derived title when no title override is provided', () => {
     setWindowLocation('/app/dashboard');
     coreStartMock.chrome.navLinks.getAll.mockReturnValue([
       createMockNavLink({
@@ -276,6 +276,18 @@ describe('getAppDetails', () => {
       title: 'Analytics - Dashboard',
       id: 'dashboard',
       url: '/app/dashboard',
+      context: { isEsql: true },
+    });
+  });
+
+  it('should ignore an empty title override', () => {
+    setWindowLocation('/app/discover');
+    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
+
+    expect(getAppDetails(coreStartMock, { isEsql: true }, '')).toEqual({
+      title: 'Analytics - Discover',
+      id: 'discover',
+      url: '/app/discover',
       context: { isEsql: true },
     });
   });

--- a/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.test.tsx
+++ b/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.test.tsx
@@ -230,71 +230,33 @@ describe('getAppDetails', () => {
     });
   });
 
-  it('should tag Discover ES|QL mode from dataSource.type', () => {
-    setWindowLocation('/app/discover', "#/?_a=(dataSource:(type:esql),query:(esql:'FROM logs'))");
-    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
-
-    const result = getAppDetails(coreStartMock);
-
-    expect(result).toEqual({
-      title: 'Analytics - Discover ES|QL',
-      id: 'discover',
-      url: '/app/discover',
-      context: { isEsql: true },
-    });
-  });
-
-  it('should tag Discover ES|QL mode from query.esql when dataSource is missing', () => {
-    setWindowLocation('/app/discover', "#/?_a=(query:(esql:'FROM logs'))");
-    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
-
-    const result = getAppDetails(coreStartMock);
-
-    expect(result).toEqual({
-      title: 'Analytics - Discover ES|QL',
-      id: 'discover',
-      url: '/app/discover',
-      context: { isEsql: true },
-    });
-  });
-
-  it('should leave Discover DataView mode unchanged', () => {
-    setWindowLocation(
-      '/app/discover',
-      "#/?_a=(dataSource:(dataViewId:logs,type:dataView),query:(language:kuery,query:''))"
-    );
-    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
-
-    const result = getAppDetails(coreStartMock);
-
-    expect(result).toEqual({
-      title: 'Analytics - Discover',
-      id: 'discover',
-      url: '/app/discover',
-    });
-  });
-
-  it('should leave Discover unchanged when _a is missing or invalid', () => {
-    setWindowLocation('/app/discover', '#/?_a=not-valid-rison');
-    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
-
-    expect(getAppDetails(coreStartMock)).toEqual({
-      title: 'Analytics - Discover',
-      id: 'discover',
-      url: '/app/discover',
-    });
-
+  it('should derive a Discover ES|QL title from context', () => {
     setWindowLocation('/app/discover');
+    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
 
-    expect(getAppDetails(coreStartMock)).toEqual({
+    const result = getAppDetails(coreStartMock, { isEsql: true });
+
+    expect(result).toEqual({
+      title: 'Analytics - Discover ES|QL',
+      id: 'discover',
+      url: '/app/discover',
+      context: { isEsql: true },
+    });
+  });
+
+  it('should omit empty context from the result', () => {
+    setWindowLocation('/app/discover');
+    coreStartMock.chrome.navLinks.getAll.mockReturnValue([discoverNavLink()]);
+
+    expect(getAppDetails(coreStartMock, {})).toEqual({
       title: 'Analytics - Discover',
       id: 'discover',
       url: '/app/discover',
     });
   });
 
-  it('should not tag non-Discover apps that have ES|QL-like _a state', () => {
-    setWindowLocation('/app/dashboard', "#/?_a=(dataSource:(type:esql),query:(esql:'FROM logs'))");
+  it('should not suffix non-Discover titles when context.isEsql is true', () => {
+    setWindowLocation('/app/dashboard');
     coreStartMock.chrome.navLinks.getAll.mockReturnValue([
       createMockNavLink({
         id: 'dashboard',
@@ -308,12 +270,13 @@ describe('getAppDetails', () => {
       }),
     ]);
 
-    const result = getAppDetails(coreStartMock);
+    const result = getAppDetails(coreStartMock, { isEsql: true });
 
     expect(result).toEqual({
       title: 'Analytics - Dashboard',
       id: 'dashboard',
       url: '/app/dashboard',
+      context: { isEsql: true },
     });
   });
 });

--- a/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.ts
+++ b/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.ts
@@ -6,6 +6,39 @@
  */
 
 import type { CoreStart } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
+import { getStateFromKbnUrl } from '@kbn/kibana-utils-plugin/public';
+
+const DISCOVER_APP_ID = 'discover';
+
+interface DiscoverAppState {
+  dataSource?: {
+    type?: string;
+  };
+  query?: {
+    esql?: unknown;
+  };
+}
+
+const isDiscoverEsqlMode = (): boolean => {
+  try {
+    const appState = getStateFromKbnUrl<DiscoverAppState>('_a');
+
+    if (!appState || typeof appState !== 'object') {
+      return false;
+    }
+
+    if (appState.dataSource?.type === 'esql') {
+      return true;
+    }
+
+    return Boolean(
+      appState.query && typeof appState.query === 'object' && 'esql' in appState.query
+    );
+  } catch {
+    return false;
+  }
+};
 
 /**
  * Apps listed here will not have their category prefix in the satisfaction question.
@@ -69,15 +102,26 @@ export const getAppDetails = (core: CoreStart) => {
   }
 
   let title = match?.title;
+  const id = match?.id;
   const category = match?.category;
 
   if (category && !APPS_WITHOUT_CATEGORY_PREFIX.includes(match?.id)) {
     title = `${category.label} - ${match?.title}`;
   }
 
+  const isEsql = id === DISCOVER_APP_ID && isDiscoverEsqlMode();
+
+  if (isEsql && title) {
+    title = i18n.translate('feedback.getAppDetails.discoverEsqlTitle', {
+      defaultMessage: '{appTitle} ES|QL',
+      values: { appTitle: title },
+    });
+  }
+
   return {
     title: title ?? 'Kibana',
-    id: match?.id ?? 'Kibana',
+    id: id ?? 'Kibana',
     url: currentPath,
+    ...(isEsql && { context: { isEsql: true } }),
   };
 };

--- a/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.ts
+++ b/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.ts
@@ -6,39 +6,8 @@
  */
 
 import type { CoreStart } from '@kbn/core/public';
-import { i18n } from '@kbn/i18n';
-import { getStateFromKbnUrl } from '@kbn/kibana-utils-plugin/public';
-
-const DISCOVER_APP_ID = 'discover';
-
-interface DiscoverAppState {
-  dataSource?: {
-    type?: string;
-  };
-  query?: {
-    esql?: unknown;
-  };
-}
-
-const isDiscoverEsqlMode = (): boolean => {
-  try {
-    const appState = getStateFromKbnUrl<DiscoverAppState>('_a');
-
-    if (!appState || typeof appState !== 'object') {
-      return false;
-    }
-
-    if (appState.dataSource?.type === 'esql') {
-      return true;
-    }
-
-    return Boolean(
-      appState.query && typeof appState.query === 'object' && 'esql' in appState.query
-    );
-  } catch {
-    return false;
-  }
-};
+import { DISCOVER_APP_ID } from '@kbn/deeplinks-analytics';
+import type { FeedbackContext } from '../../../common';
 
 /**
  * Apps listed here will not have their category prefix in the satisfaction question.
@@ -66,11 +35,14 @@ export const APPS_WITHOUT_CATEGORY_PREFIX = [
   'metrics:assetDetails',
 ] as readonly string[];
 
+const hasContextKeys = (context?: FeedbackContext): context is FeedbackContext =>
+  context !== undefined && Object.keys(context).length > 0;
+
 /**
  * Get current app details from browser URL and nav links.
  * Uses the actual browser URL for accurate deep link detection.
  */
-export const getAppDetails = (core: CoreStart) => {
+export const getAppDetails = (core: CoreStart, context?: FeedbackContext) => {
   const currentPath = window.location.pathname;
   const navLinks = core.chrome.navLinks.getAll();
 
@@ -109,19 +81,14 @@ export const getAppDetails = (core: CoreStart) => {
     title = `${category.label} - ${match?.title}`;
   }
 
-  const isEsql = id === DISCOVER_APP_ID && isDiscoverEsqlMode();
-
-  if (isEsql && title) {
-    title = i18n.translate('feedback.getAppDetails.discoverEsqlTitle', {
-      defaultMessage: '{appTitle} ES|QL',
-      values: { appTitle: title },
-    });
+  if (id === DISCOVER_APP_ID && context?.isEsql === true && title) {
+    title = `${title} ES|QL`;
   }
 
   return {
     title: title ?? 'Kibana',
     id: id ?? 'Kibana',
     url: currentPath,
-    ...(isEsql && { context: { isEsql: true } }),
+    ...(hasContextKeys(context) && { context }),
   };
 };

--- a/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.ts
+++ b/x-pack/platform/plugins/private/feedback/public/src/utils/get_app_details.ts
@@ -6,7 +6,6 @@
  */
 
 import type { CoreStart } from '@kbn/core/public';
-import { DISCOVER_APP_ID } from '@kbn/deeplinks-analytics';
 import type { FeedbackContext } from '../../../common';
 
 /**
@@ -42,7 +41,11 @@ const hasContextKeys = (context?: FeedbackContext): context is FeedbackContext =
  * Get current app details from browser URL and nav links.
  * Uses the actual browser URL for accurate deep link detection.
  */
-export const getAppDetails = (core: CoreStart, context?: FeedbackContext) => {
+export const getAppDetails = (
+  core: CoreStart,
+  context?: FeedbackContext,
+  titleOverride?: string
+) => {
   const currentPath = window.location.pathname;
   const navLinks = core.chrome.navLinks.getAll();
 
@@ -81,8 +84,8 @@ export const getAppDetails = (core: CoreStart, context?: FeedbackContext) => {
     title = `${category.label} - ${match?.title}`;
   }
 
-  if (id === DISCOVER_APP_ID && context?.isEsql === true && title) {
-    title = `${title} ES|QL`;
+  if (titleOverride) {
+    title = titleOverride;
   }
 
   return {

--- a/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.test.ts
+++ b/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.test.ts
@@ -88,6 +88,43 @@ describe('registerSendFeedbackRoute', () => {
     });
   });
 
+  it('should include optional context in the analytics event', async () => {
+    registerSendFeedbackRoute(router, mockAnalytics);
+
+    const [, handler] = router.post.mock.calls[0];
+
+    const coreContext = coreMock.createRequestHandlerContext();
+    coreContext.userProfile.getCurrentProfileId.mockResolvedValue(mockUserProfileId);
+
+    const mockContext = {
+      core: Promise.resolve(coreContext),
+    };
+
+    const mockRequest = httpServerMock.createKibanaRequest({
+      body: {
+        app_id: 'discover',
+        solution: 'classic',
+        allow_email_contact: false,
+        url: '/app/discover',
+        context: { isEsql: true },
+      },
+    });
+
+    const mockResponse = httpServerMock.createResponseFactory();
+
+    await handler(mockContext, mockRequest, mockResponse);
+
+    expect(mockAnalytics.reportEvent).toHaveBeenCalledWith(FEEDBACK_SUBMITTED_EVENT_TYPE, {
+      app_id: 'discover',
+      solution: 'classic',
+      allow_email_contact: false,
+      url: '/app/discover',
+      context: { isEsql: true },
+      user_id: 'test-user-id',
+      source: 'kibana',
+    });
+  });
+
   it('reports user_id as undefined when no current profile is resolved', async () => {
     registerSendFeedbackRoute(router, mockAnalytics);
 

--- a/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.test.ts
+++ b/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { registerSendFeedbackRoute } from './send_feedback';
+import { feedbackBodySchema, registerSendFeedbackRoute } from './send_feedback';
 import { httpServerMock, analyticsServiceMock, coreMock } from '@kbn/core/server/mocks';
 import { mockRouter } from '@kbn/core-http-router-server-mocks';
 import { FEEDBACK_SUBMITTED_EVENT_TYPE } from '../src';
@@ -85,6 +85,40 @@ describe('registerSendFeedbackRoute', () => {
 
     expect(mockResponse.ok).toHaveBeenCalledWith({
       body: { success: true },
+    });
+  });
+
+  it('should reject context with too many entries', () => {
+    const oversizedContext = Object.fromEntries(
+      Array.from({ length: 17 }, (_, i) => [`key${i}`, true])
+    );
+
+    expect(() =>
+      feedbackBodySchema.validate({
+        app_id: 'discover',
+        solution: 'classic',
+        allow_email_contact: false,
+        url: '/app/discover',
+        context: oversizedContext,
+      })
+    ).toThrow(/context cannot have more than 16 entries/);
+  });
+
+  it('should accept context within the entry limit', () => {
+    expect(
+      feedbackBodySchema.validate({
+        app_id: 'discover',
+        solution: 'classic',
+        allow_email_contact: false,
+        url: '/app/discover',
+        context: { isEsql: true },
+      })
+    ).toEqual({
+      app_id: 'discover',
+      solution: 'classic',
+      allow_email_contact: false,
+      url: '/app/discover',
+      context: { isEsql: true },
     });
   });
 

--- a/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
+++ b/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
@@ -9,13 +9,15 @@ import { schema } from '@kbn/config-schema';
 import type { IRouter, AnalyticsServiceSetup } from '@kbn/core/server';
 import { FEEDBACK_SUBMITTED_EVENT_TYPE } from '../src';
 
+const MAX_FEEDBACK_CONTEXT_ENTRIES = 16;
+
 const feedbackQuestionSchema = schema.object({
   id: schema.string({ minLength: 1, maxLength: 256 }),
   question: schema.string({ maxLength: 1024 }),
   answer: schema.string({ maxLength: 16384 }),
 });
 
-const feedbackBodySchema = schema.object({
+export const feedbackBodySchema = schema.object({
   app_id: schema.string({ minLength: 1, maxLength: 256 }),
   user_email: schema.maybe(schema.string({ maxLength: 256 })),
   solution: schema.string({ maxLength: 256 }),
@@ -27,7 +29,14 @@ const feedbackBodySchema = schema.object({
   context: schema.maybe(
     schema.recordOf(
       schema.string({ minLength: 1, maxLength: 64 }),
-      schema.oneOf([schema.string({ maxLength: 256 }), schema.boolean(), schema.number()])
+      schema.oneOf([schema.string({ maxLength: 256 }), schema.boolean(), schema.number()]),
+      {
+        validate: (value) => {
+          if (Object.keys(value).length > MAX_FEEDBACK_CONTEXT_ENTRIES) {
+            return `context cannot have more than ${MAX_FEEDBACK_CONTEXT_ENTRIES} entries`;
+          }
+        },
+      }
     )
   ),
 });

--- a/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
+++ b/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
@@ -24,6 +24,11 @@ const feedbackBodySchema = schema.object({
   organization_id: schema.maybe(schema.string({ maxLength: 256 })),
   allow_email_contact: schema.boolean(),
   url: schema.string({ maxLength: 2048 }),
+  context: schema.maybe(
+    schema.object({
+      isEsql: schema.maybe(schema.boolean()),
+    })
+  ),
 });
 
 export function registerSendFeedbackRoute(router: IRouter, analytics: AnalyticsServiceSetup) {

--- a/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
+++ b/x-pack/platform/plugins/private/feedback/server/routes/send_feedback.ts
@@ -25,9 +25,10 @@ const feedbackBodySchema = schema.object({
   allow_email_contact: schema.boolean(),
   url: schema.string({ maxLength: 2048 }),
   context: schema.maybe(
-    schema.object({
-      isEsql: schema.maybe(schema.boolean()),
-    })
+    schema.recordOf(
+      schema.string({ minLength: 1, maxLength: 64 }),
+      schema.oneOf([schema.string({ maxLength: 256 }), schema.boolean(), schema.number()])
+    )
   ),
 });
 

--- a/x-pack/platform/plugins/private/feedback/server/src/telemetry/feedback_events.ts
+++ b/x-pack/platform/plugins/private/feedback/server/src/telemetry/feedback_events.ts
@@ -94,17 +94,9 @@ const feedbackSubmittedEventSchema: RootSchema<FeedbackSubmittedEventData> = {
     },
   },
   context: {
-    properties: {
-      isEsql: {
-        type: 'boolean',
-        _meta: {
-          description: 'Whether Discover was in ES|QL mode when feedback was submitted',
-          optional: true,
-        },
-      },
-    },
+    type: 'pass_through',
     _meta: {
-      description: 'Optional app-specific context for the feedback submission',
+      description: 'App-specific context',
       optional: true,
     },
   },

--- a/x-pack/platform/plugins/private/feedback/server/src/telemetry/feedback_events.ts
+++ b/x-pack/platform/plugins/private/feedback/server/src/telemetry/feedback_events.ts
@@ -93,6 +93,21 @@ const feedbackSubmittedEventSchema: RootSchema<FeedbackSubmittedEventData> = {
       optional: false,
     },
   },
+  context: {
+    properties: {
+      isEsql: {
+        type: 'boolean',
+        _meta: {
+          description: 'Whether Discover was in ES|QL mode when feedback was submitted',
+          optional: true,
+        },
+      },
+    },
+    _meta: {
+      description: 'Optional app-specific context for the feedback submission',
+      optional: true,
+    },
+  },
 };
 
 export const feedbackSubmittedEventType: EventTypeOpts<FeedbackSubmittedEventData> = {

--- a/x-pack/platform/plugins/private/feedback/tsconfig.json
+++ b/x-pack/platform/plugins/private/feedback/tsconfig.json
@@ -20,7 +20,6 @@
     "@kbn/core-chrome-feature-flags",
     "@kbn/react-kibana-mount",
     "@kbn/i18n",
-    "@kbn/deeplinks-analytics",
     "@kbn/core-http-router-server-mocks"
   ],
   "exclude": [

--- a/x-pack/platform/plugins/private/feedback/tsconfig.json
+++ b/x-pack/platform/plugins/private/feedback/tsconfig.json
@@ -20,6 +20,7 @@
     "@kbn/core-chrome-feature-flags",
     "@kbn/react-kibana-mount",
     "@kbn/i18n",
+    "@kbn/kibana-utils-plugin",
     "@kbn/core-http-router-server-mocks"
   ],
   "exclude": [

--- a/x-pack/platform/plugins/private/feedback/tsconfig.json
+++ b/x-pack/platform/plugins/private/feedback/tsconfig.json
@@ -20,7 +20,7 @@
     "@kbn/core-chrome-feature-flags",
     "@kbn/react-kibana-mount",
     "@kbn/i18n",
-    "@kbn/kibana-utils-plugin",
+    "@kbn/deeplinks-analytics",
     "@kbn/core-http-router-server-mocks"
   ],
   "exclude": [


### PR DESCRIPTION
## Summary

This PR adds optional `FeedbackContext` to 1Feedback submissions which is meant to contain app-specific metadata. 

Closes: https://github.com/elastic/kibana/issues/271655


