### PR TITLE
[Data Views] Update tests for user data view checks and refine logic …

### DIFF
--- a/src/platform/plugins/shared/data_views/server/has_user_data_view.test.ts
+++ b/src/platform/plugins/shared/data_views/server/has_user_data_view.test.ts
@@ -26,7 +26,7 @@ describe('hasUserDataView', () => {
     expect(await hasUserDataView({ esClient, soClient })).toEqual(false);
   });
 
-  it('returns true when there are data views', async () => {
+  it('returns true when there is an unmanaged data view', async () => {
     soClient.find.mockResolvedValue({
       page: 1,
       per_page: 100,
@@ -41,6 +41,54 @@ describe('hasUserDataView', () => {
         },
       ],
     });
+    expect(await hasUserDataView({ esClient, soClient })).toEqual(true);
+  });
+
+  it('returns false when there are only managed data views', async () => {
+    soClient.find.mockResolvedValue({
+      page: 1,
+      per_page: 100,
+      total: 1,
+      saved_objects: [
+        {
+          id: '1',
+          references: [],
+          type: 'index-pattern',
+          score: 99,
+          managed: true,
+          attributes: { title: 'managed-pattern-*' },
+        },
+      ],
+    });
+
+    expect(await hasUserDataView({ esClient, soClient })).toEqual(false);
+  });
+
+  it('returns true when there is at least one unmanaged data view', async () => {
+    soClient.find.mockResolvedValue({
+      page: 1,
+      per_page: 100,
+      total: 2,
+      saved_objects: [
+        {
+          id: '1',
+          references: [],
+          type: 'index-pattern',
+          score: 99,
+          managed: true,
+          attributes: { title: 'managed-pattern-*' },
+        },
+        {
+          id: '2',
+          references: [],
+          type: 'index-pattern',
+          score: 99,
+          managed: false,
+          attributes: { title: 'my-pattern-*' },
+        },
+      ],
+    });
+
     expect(await hasUserDataView({ esClient, soClient })).toEqual(true);
   });
 

--- a/src/platform/plugins/shared/data_views/server/has_user_data_view.ts
+++ b/src/platform/plugins/shared/data_views/server/has_user_data_view.ts
@@ -32,7 +32,7 @@ export const getDataViews = async ({
 
 /**
  * Checks if user has access to any data view,
- * excluding those that are automatically created by ese (hardcoded)
+ * excluding those that are automatically created
  * @param esClient
  * @param soClient
  * @param dataViews
@@ -47,10 +47,8 @@ export const hasUserDataView = async (
 
   if (dataViews.total === 0) {
     return false;
-  } else {
-    // filter here data views that we know are not created by user during on-boarding for smoother on-boarding experience
-    // currently there is no such data views,
-
-    return true;
   }
+
+  // `managed` is a root-level saved object property, always returned by `find`
+  return dataViews.saved_objects.some((dataView) => dataView.managed !== true);
 };

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/has_data_views.test.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/internal/has_data_views.test.ts
@@ -76,4 +76,47 @@ describe('preview has_data_views route', () => {
       body: { hasDataView: true, hasUserDataView: true },
     });
   });
+
+  it('should send hasDataView: true, hasUserDataView: false when only managed data views exist', async () => {
+    const mockESClientResolveIndexResponse = { indices: [], aliases: [], data_streams: [] };
+    const mockSOClientFindResponse = {
+      page: 1,
+      per_page: 100,
+      total: 1,
+      saved_objects: [
+        {
+          type: 'index-pattern',
+          id: '12345',
+          namespaces: ['default'],
+          managed: true,
+          attributes: { title: 'managed_data_view' },
+        },
+      ],
+    };
+    const mockESClient = {
+      indices: {
+        resolveIndex: jest.fn().mockResolvedValue(mockESClientResolveIndexResponse),
+      },
+    };
+    const mockSOClient = { find: jest.fn().mockResolvedValue(mockSOClientFindResponse) };
+    const mockContext = {
+      core: {
+        elasticsearch: { client: { asCurrentUser: mockESClient } },
+        savedObjects: { client: mockSOClient },
+      },
+    };
+
+    const mockRequest = httpServerMock.createKibanaRequest({
+      body: {},
+      query: {},
+    });
+    const mockResponse = httpServerMock.createResponseFactory();
+
+    await handler(mockContext as unknown as RequestHandlerContext, mockRequest, mockResponse);
+
+    expect(mockResponse.ok).toBeCalled();
+    expect(mockResponse.ok.mock.calls[0][0]).toEqual({
+      body: { hasDataView: true, hasUserDataView: false },
+    });
+  });
 });


### PR DESCRIPTION
…for managed data views

## Summary

This pull request updates the logic for determining whether a user has a "user-created" data view (as opposed to a managed/automatically created one), and adds comprehensive tests for this distinction. The changes ensure that only unmanaged data views are considered "user data views," improving accuracy and onboarding experience.

**Logic update for user data views:**

* Updated `hasUserDataView` in `has_user_data_view.ts` to return `true` only if there is at least one unmanaged data view (i.e., where `managed !== true`), and `false` if all data views are managed.
* Clarified function documentation to specify that managed/automatically created data views are excluded from the check.

**Testing improvements:**

* Enhanced unit tests in `has_user_data_view.test.ts` to cover cases with only managed data views, only unmanaged data views, and mixed scenarios, ensuring correct function behavior. [[1]](diffhunk://#diff-d2b89e5db0791ffec7536ccb620de5237c1c641d283d64ea16bf25ae0e87df97L29-R29) [[2]](diffhunk://#diff-d2b89e5db0791ffec7536ccb620de5237c1c641d283d64ea16bf25ae0e87df97R47-R94)
* Added an integration test in `has_data_views.test.ts` to verify that the API responds with `hasUserDataView: false` when only managed data views exist, even if `hasDataView` is true.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



