### PR TITLE
Upgrade svgo to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2251,7 +2251,7 @@
     "stylelint-scss": "4.3.0",
     "superagent": "10.3.0",
     "supertest": "7.2.2",
-    "svgo": "4.0.1",
+    "svgo": "4.0.2",
     "table": "6.9.0",
     "tar-fs": "3.1.3",
     "terser-webpack-plugin": "5.3.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32416,10 +32416,10 @@ svg-tags@^1.0.0:
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
 
-svgo@4.0.1, svgo@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.1.tgz#c82dacd04ee9f1d55cd4e0b7f9a214c86670e3ee"
-  integrity sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==
+svgo@4.0.2, svgo@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.2.tgz#a62246f0a9d671c0314d04f3cc15f78b1bd0667f"
+  integrity sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==
   dependencies:
     commander "^11.1.0"
     css-select "^5.1.0"


### PR DESCRIPTION
## Summary

Upgrades `svgo` from `4.0.1` to `4.0.2`

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->