### PR TITLE
[One Workflow] Add Scout API coverage for the queue concurrency strategy

### DIFF
--- a/src/platform/plugins/shared/workflows_management/test/scout/api/tests/workflow_execution/concurrency_control.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout/api/tests/workflow_execution/concurrency_control.spec.ts
@@ -59,7 +59,11 @@ spaceTest.describe(
       await apiServices.workflowsApi.deleteAll();
     });
 
-    async function runConcurrencyWorkflow(workflowsApi: WorkflowsApiService, workflowId: string) {
+    async function runConcurrencyWorkflow(
+      workflowsApi: WorkflowsApiService,
+      workflowId: string,
+      { waitTimeout = 20_000 }: { waitTimeout?: number } = {}
+    ) {
       const events = [
         { env: 'dev', problem: 'issue-1' },
         { env: 'prod', problem: 'issue-2' },
@@ -85,6 +89,7 @@ spaceTest.describe(
           workflowsApi
             .waitForTermination({
               workflowExecutionId: scheduledExecution.workflowExecutionId,
+              timeout: waitTimeout,
             })
             .then((execution) => ({
               execution,
@@ -168,6 +173,53 @@ spaceTest.describe(
           expect(completedExecution).toHaveLength(1);
           expect(completedExecution.at(0)?.status).toBe(ExecutionStatus.COMPLETED);
           expect(completedExecution.at(0)?.stepExecutions).toHaveLength(4);
+        });
+      }
+    );
+
+    spaceTest(
+      'queue strategy queues new executions and runs them sequentially until all complete',
+      async ({ apiServices }) => {
+        // Scout's default test timeout is 60s. Queue serialises 3 ~10s runs for
+        // the same key (~30s) plus ~6s of inter-run delays, so 120s leaves CI headroom.
+        spaceTest.setTimeout(120_000);
+
+        const createdWorkflow = await apiServices.workflowsApi.create(
+          getConcurrencyWorkflowYaml('queue')
+        );
+
+        // The queue strategy serialises executions per concurrency key. With 3 queued
+        // dev/issue-1 runs each taking ~10s, the last one finishes at ~30s. We use a
+        // 60s timeout so waitForTermination does not expire prematurely.
+        const groupedExecutionsByConcurrencyKey = await runConcurrencyWorkflow(
+          apiServices.workflowsApi,
+          createdWorkflow.id,
+          { waitTimeout: 60_000 }
+        );
+
+        Object.entries(groupedExecutionsByConcurrencyKey).forEach(([, executions]) => {
+          expect(executions.length).toBeGreaterThan(0);
+
+          // All executions must complete — none are skipped or cancelled
+          executions.forEach((execution) => {
+            expect(execution?.status).toBe(ExecutionStatus.COMPLETED);
+            expect(execution?.stepExecutions).toHaveLength(4);
+          });
+
+          // Executions must be strictly sequential: no two runs for the same
+          // concurrency key may overlap in time. Sort by startedAt and verify
+          // that each run began only after the previous one finished.
+          const sortedByStart = [...executions].sort(
+            (a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()
+          );
+
+          for (let i = 1; i < sortedByStart.length; i++) {
+            const prev = sortedByStart[i - 1];
+            const curr = sortedByStart[i];
+            expect(new Date(curr.startedAt).getTime()).toBeGreaterThanOrEqual(
+              new Date(prev.finishedAt).getTime()
+            );
+          }
         });
       }
     );

--- a/src/platform/plugins/shared/workflows_management/test/scout/common/apis/workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout/common/apis/workflows.ts
@@ -259,14 +259,16 @@ export class WorkflowsApiService {
 
   async waitForTermination({
     workflowExecutionId,
+    timeout = 20_000,
   }: {
     workflowExecutionId: string;
+    timeout?: number;
   }): Promise<WorkflowExecutionDto | undefined> {
     return waitForConditionOrThrow({
       action: () => this.getExecution(workflowExecutionId),
       condition: (execution) => !!execution && isTerminalStatus(execution.status ?? ''),
       interval: 1000,
-      timeout: 20_000,
+      timeout,
       errorMessage: `Execution with id ${workflowExecutionId} did not reach a terminal status`,
     });
   }


### PR DESCRIPTION
## Summary

- Adds a Scout API test for the `queue` concurrency strategy: executions that share a concurrency key complete sequentially with no overlap, and none are skipped or cancelled.
- Makes `waitForTermination` timeout configurable so the queue case can wait long enough for serialised ~10s runs (60s vs the 20s default used by drop / cancel-in-progress).
- Raises the Playwright timeout for this test to 120s so it does not hit Scout's 60s default.

## Test plan

- [ ] Scout API: `node scripts/scout.js run-tests --arch stateful --domain classic --testFiles src/platform/plugins/shared/workflows_management/test/scout/api/tests/workflow_execution/concurrency_control.spec.ts`
- [ ] Confirm existing `cancel-in-progress` and `drop` cases still pass with the default 20s wait timeout.