### PR TITLE
[selective testing] add config dir to critical paths

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
@@ -68,6 +68,8 @@ export const FTR_CRITICAL_PATHS: readonly string[] = [
   'yarn.lock',
   '.node-version',
   '.nvmrc',
+  'config/**/*.yml',
+  'config/node.options',
 ];
 
 /** Skip FTR when every changed file matches, regardless of owning module. */

--- a/src/platform/packages/private/kbn-scout-info/src/paths.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.ts
@@ -185,6 +185,8 @@ export const CRITICAL_FILES_SCOUT: readonly string[] = [
   'tsconfig.json',
   '.node-version',
   '.nvmrc',
+  'config/**/*.yml',
+  'config/node.options',
   'src/setup_node_env/**/*',
   'packages/kbn-babel-preset/**/*',
   'src/platform/packages/shared/kbn-repo-info/**/*',


### PR DESCRIPTION
## Summary

Adds `config/**/*.yml` and `config/node.options` to `CRITICAL_FILES_SCOUT` and `FTR_CRITICAL_PATHS`.

Files under `config/` belong to no module, so they resolve to `[uncategorized]` and are dropped by `ignoreUncategorizedChanges`. That leaves `affectedModules` empty and a config-only PR currently selects **zero** Playwright configs and runs no Scout tests at all.

That is how [#284524](https://github.com/elastic/kibana/pull/284524) broke `on-merge`: flipping `xpack.ml.ad.enabled` in `config/serverless.es.yml` added 3 ML add-panel actions on serverless-search, which broke the dashboard add-panel canary only on-merge and got the suite skipped [#268101](https://github.com/elastic/kibana/issues/268101).

FTR already runs for these PRs, but only incidentally: `shouldSkipFtrTests` falls through to return `false` because `affectedModules` is empty. Adding the paths makes it intent rather than control flow.

#### Extra Costs are low
`92` commits touched `config/serverless*.yml` in the last 12 months, about **1.8/week**. Only 18 were serverless-config-only diffs; 30 had ≤3 files. The rest already touch product code and so already run a wide scope, so the marginal cost is well below `92` full runs.



<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->