### PR TITLE
[9.5] Upgrade svgo to 4.0.2 (#285372)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2221,7 +2221,7 @@
     "stylelint-scss": "4.3.0",
     "superagent": "10.3.0",
     "supertest": "7.2.2",
-    "svgo": "4.0.1",
+    "svgo": "4.0.2",
     "swagger-jsdoc": "6.3.0",
     "swagger-ui-express": "5.0.1",
     "table": "6.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33305,10 +33305,10 @@ svg-tags@^1.0.0:
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
 
-svgo@4.0.1, svgo@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.1.tgz#c82dacd04ee9f1d55cd4e0b7f9a214c86670e3ee"
-  integrity sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==
+svgo@4.0.2, svgo@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.2.tgz#a62246f0a9d671c0314d04f3cc15f78b1bd0667f"
+  integrity sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==
   dependencies:
     commander "^11.1.0"
     css-select "^5.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Upgrade svgo to 4.0.2 (#285372)](https://github.com/elastic/kibana/pull/285372)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2026-08-17T12:32:44Z","message":"Upgrade svgo to 4.0.2 (#285372)\n\n## Summary\n\nUpgrades `svgo` from `4.0.1` to `4.0.2`","sha":"86a073a2eb6288a69aff76628e8ad8cca11f81c5","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.6.0"],"title":"Upgrade svgo to 4.0.2","number":285372,"url":"https://github.com/elastic/kibana/pull/285372","mergeCommit":{"message":"Upgrade svgo to 4.0.2 (#285372)\n\n## Summary\n\nUpgrades `svgo` from `4.0.1` to `4.0.2`","sha":"86a073a2eb6288a69aff76628e8ad8cca11f81c5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/285372","number":285372,"mergeCommit":{"message":"Upgrade svgo to 4.0.2 (#285372)\n\n## Summary\n\nUpgrades `svgo` from `4.0.1` to `4.0.2`","sha":"86a073a2eb6288a69aff76628e8ad8cca11f81c5"}}]}] BACKPORT-->