### PR TITLE
[9.5] [Entity Store] Self delete orphaned ES tasks (#281514)

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
@@ -27,6 +27,8 @@ import {
   stopHistorySnapshotTask,
 } from '../../tasks/history_snapshot_task';
 import { scheduleStatusReportTask, stopStatusReportTask } from '../../tasks/status_report_task';
+import { removeEntityMaintainer } from '../../tasks/entity_maintainers';
+import { entityMaintainersRegistry } from '../../tasks/entity_maintainers/entity_maintainers_registry';
 import { stopAndRemoveV1, stopAndRemoveV1SharedTasks } from '../../infra/remove_v1';
 
 jest.mock('./install_assets');
@@ -34,6 +36,14 @@ jest.mock('./euid_stored_scripts');
 jest.mock('../../tasks/extract_entity_task');
 jest.mock('../../tasks/history_snapshot_task');
 jest.mock('../../tasks/status_report_task');
+jest.mock('../../tasks/entity_maintainers', () => ({
+  removeEntityMaintainer: jest.fn(),
+}));
+jest.mock('../../tasks/entity_maintainers/entity_maintainers_registry', () => ({
+  entityMaintainersRegistry: {
+    getAll: jest.fn(),
+  },
+}));
 jest.mock('../../infra/remove_v1');
 
 const mockInstallSharedElasticsearchAssets =
@@ -67,6 +77,12 @@ const mockScheduleStatusReportTask = scheduleStatusReportTask as jest.MockedFunc
 >;
 const mockStopStatusReportTask = stopStatusReportTask as jest.MockedFunction<
   typeof stopStatusReportTask
+>;
+const mockRemoveEntityMaintainer = removeEntityMaintainer as jest.MockedFunction<
+  typeof removeEntityMaintainer
+>;
+const mockEntityMaintainersGetAll = entityMaintainersRegistry.getAll as jest.MockedFunction<
+  typeof entityMaintainersRegistry.getAll
 >;
 const mockStopAndRemoveV1 = stopAndRemoveV1 as jest.MockedFunction<typeof stopAndRemoveV1>;
 const mockStopAndRemoveV1SharedTasks = stopAndRemoveV1SharedTasks as jest.MockedFunction<
@@ -106,6 +122,11 @@ describe('AssetManagerClient', () => {
     mockStopHistorySnapshotTask.mockResolvedValue(undefined);
     mockScheduleStatusReportTask.mockResolvedValue(undefined);
     mockStopStatusReportTask.mockResolvedValue(undefined);
+    mockRemoveEntityMaintainer.mockResolvedValue(undefined);
+    mockEntityMaintainersGetAll.mockReturnValue([
+      { id: 'automated-resolution', interval: '1h', minLicense: 'basic' },
+      { id: 'risk-score', interval: '1h', minLicense: 'platinum' },
+    ]);
     mockStopAndRemoveV1.mockResolvedValue(undefined);
     mockStopAndRemoveV1SharedTasks.mockResolvedValue(undefined);
 
@@ -161,6 +182,26 @@ describe('AssetManagerClient', () => {
     expect(mockEngineDescriptorClient.init).toHaveBeenCalledWith('host');
     expect(mockEngineDescriptorClient.init).toHaveBeenCalledWith('user');
     expect(mockScheduleExtractEntityTask).toHaveBeenCalledTimes(2);
+  });
+
+  it('schedules status and history tasks only after engine descriptors exist', async () => {
+    const order: string[] = [];
+    mockEngineDescriptorClient.init.mockImplementation(async () => {
+      order.push('descriptor');
+    });
+    mockScheduleStatusReportTask.mockImplementation(async () => {
+      order.push('status');
+    });
+    mockScheduleHistorySnapshotTasks.mockImplementation(async () => {
+      order.push('history');
+    });
+
+    await client.init({} as KibanaRequest, ['host', 'user']);
+
+    const lastDescriptor = order.lastIndexOf('descriptor');
+    expect(lastDescriptor).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf('status')).toBeGreaterThan(lastDescriptor);
+    expect(order.indexOf('history')).toBeGreaterThan(lastDescriptor);
   });
 
   it('runs v1 cleanup and stored-script setup as the internal user', async () => {
@@ -289,8 +330,8 @@ describe('AssetManagerClient', () => {
   });
 
   describe('uninstall', () => {
-    // getAll is called twice in uninstall: once via getStatus (before delete) and once
-    // to compute remainingEngines (after delete). Sequence the mock accordingly.
+    // getAll is called twice: once via getStatus (before delete) and once for
+    // remainingEngines (after delete). Sequence the mock accordingly.
     it('keeps shared assets when other engines remain (see: https://github.com/elastic/security-team/issues/18143)', async () => {
       mockEngineDescriptorClient.getAll
         .mockResolvedValueOnce([
@@ -302,13 +343,17 @@ describe('AssetManagerClient', () => {
       const result = await client.uninstall('host');
 
       expect(result).toBe(true);
+      expect(mockStopExtractEntityTask).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'host', namespace })
+      );
       expect(mockEngineDescriptorClient.delete).toHaveBeenCalledWith('host');
       // Shared, per-namespace / cluster assets must survive.
       expect(mockUninstallElasticsearchAssets).not.toHaveBeenCalled();
       expect(mockDeleteEuidStoredScripts).not.toHaveBeenCalled();
       expect(mockGlobalStateClient.delete).not.toHaveBeenCalled();
-      expect(mockStopStatusReportTask).not.toHaveBeenCalled();
       expect(mockStopHistorySnapshotTask).not.toHaveBeenCalled();
+      expect(mockStopStatusReportTask).not.toHaveBeenCalled();
+      expect(mockRemoveEntityMaintainer).not.toHaveBeenCalled();
     });
 
     it('deletes shared assets when the last engine is uninstalled', async () => {
@@ -320,11 +365,18 @@ describe('AssetManagerClient', () => {
 
       expect(result).toBe(true);
       expect(mockEngineDescriptorClient.delete).toHaveBeenCalledWith('host');
-      expect(mockUninstallElasticsearchAssets).toHaveBeenCalledTimes(1);
-      expect(mockDeleteEuidStoredScripts).toHaveBeenCalledTimes(1);
+      expect(mockStopHistorySnapshotTask).toHaveBeenCalledWith(
+        expect.objectContaining({ namespace })
+      );
+      expect(mockStopStatusReportTask).toHaveBeenCalledWith(expect.objectContaining({ namespace }));
+      expect(mockRemoveEntityMaintainer).toHaveBeenCalled();
+      expect(mockUninstallElasticsearchAssets).toHaveBeenCalledWith(
+        expect.objectContaining({ esClient: mockUserEsClient, namespace })
+      );
+      expect(mockDeleteEuidStoredScripts).toHaveBeenCalledWith(
+        expect.objectContaining({ esClient: mockUserEsClient })
+      );
       expect(mockGlobalStateClient.delete).toHaveBeenCalledTimes(1);
-      expect(mockStopStatusReportTask).toHaveBeenCalledTimes(1);
-      expect(mockStopHistorySnapshotTask).toHaveBeenCalledTimes(1);
     });
 
     it('is a no-op when the type is not installed', async () => {
@@ -336,8 +388,34 @@ describe('AssetManagerClient', () => {
 
       expect(result).toBe(false);
       expect(mockEngineDescriptorClient.delete).not.toHaveBeenCalled();
+      expect(mockStopExtractEntityTask).not.toHaveBeenCalled();
       expect(mockUninstallElasticsearchAssets).not.toHaveBeenCalled();
-      expect(mockDeleteEuidStoredScripts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanupNamespace', () => {
+    it('removes namespace tasks, ES assets, EUID scripts, and global state', async () => {
+      await client.cleanupNamespace();
+
+      expect(mockStopHistorySnapshotTask).toHaveBeenCalledWith(
+        expect.objectContaining({ namespace })
+      );
+      expect(mockStopStatusReportTask).toHaveBeenCalledWith(expect.objectContaining({ namespace }));
+      expect(mockRemoveEntityMaintainer).toHaveBeenCalledTimes(2);
+      expect(mockRemoveEntityMaintainer).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'automated-resolution', namespace })
+      );
+      expect(mockRemoveEntityMaintainer).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'risk-score', namespace })
+      );
+      expect(mockUninstallElasticsearchAssets).toHaveBeenCalledWith(
+        expect.objectContaining({ esClient: mockUserEsClient, namespace })
+      );
+      expect(mockDeleteEuidStoredScripts).toHaveBeenCalledWith(
+        expect.objectContaining({ esClient: mockUserEsClient })
+      );
+      expect(mockGlobalStateClient.delete).toHaveBeenCalledTimes(1);
+      expect(mockStopExtractEntityTask).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -27,6 +27,8 @@ import {
   stopHistorySnapshotTask,
 } from '../../tasks/history_snapshot_task';
 import { scheduleStatusReportTask, stopStatusReportTask } from '../../tasks/status_report_task';
+import { removeEntityMaintainer } from '../../tasks/entity_maintainers';
+import { entityMaintainersRegistry } from '../../tasks/entity_maintainers/entity_maintainers_registry';
 import { installSharedElasticsearchAssets, uninstallElasticsearchAssets } from './install_assets';
 import {
   EngineDescriptorTypeName,
@@ -160,10 +162,24 @@ export class AssetManagerClient {
         }),
       ]);
 
-      // Phase 2: Initialize engines and start background tasks.
+      // Phase 2: Initialize engines (and EUID scripts). Descriptors must exist before
+      // namespace-scoped TM schedules are created — those tasks self-delete when they
+      // find zero engines, so scheduling them in parallel with initEntity can tear
+      // down a freshly scheduled status task mid-install.
       await Promise.all([
         ...entityTypes.map((type) => this.initEntity(request, type, logsExtraction)),
 
+        // Stored scripts are managed assets with no granular ES privilege (only `manage`/`all`),
+        // so create them as the internal user rather than forcing the enabling user to hold
+        // broad cluster `manage`.
+        installEuidStoredScripts({
+          esClient: this.internalEsClient,
+          logger: this.logger,
+        }),
+      ]);
+
+      // Phase 3: Schedule namespace-scoped background tasks after descriptors exist.
+      await Promise.all([
         scheduleHistorySnapshotTasks({
           logger: this.logger,
           taskManager: this.taskManager,
@@ -177,14 +193,6 @@ export class AssetManagerClient {
           taskManager: this.taskManager,
           namespace: this.namespace,
           request,
-        }),
-
-        // Stored scripts are managed assets with no granular ES privilege (only `manage`/`all`),
-        // so create them as the internal user rather than forcing the enabling user to hold
-        // broad cluster `manage`.
-        installEuidStoredScripts({
-          esClient: this.internalEsClient,
-          logger: this.logger,
         }),
       ]);
     } catch (error) {
@@ -254,32 +262,8 @@ export class AssetManagerClient {
       // the read/write targets and scripts their extraction queries still depend on.
       const remainingEngines = await this.engineDescriptorClient.getAll();
       if (remainingEngines.length === 0) {
-        this.logger.debug(`Removing shared assets because last engine was uninstalled`);
-        await Promise.all([
-          uninstallElasticsearchAssets({
-            esClient: this.esClient,
-            logger: this.logger.get(type),
-            namespace: this.namespace,
-          }),
-          // Deletion must run as the requesting user: kibana_system holds the raw
-          // `cluster:admin/script/put` action (so managed installs work) but NOT
-          // `cluster:admin/script/delete`, which is only granted by cluster `manage`/`all`.
-          deleteEuidStoredScripts({
-            esClient: this.esClient,
-            logger: this.logger,
-          }),
-          this.globalStateClient.delete(),
-          stopStatusReportTask({
-            taskManager: this.taskManager,
-            logger: this.logger,
-            namespace: this.namespace,
-          }),
-          stopHistorySnapshotTask({
-            taskManager: this.taskManager,
-            logger: this.logger,
-            namespace: this.namespace,
-          }),
-        ]);
+        this.logger.debug(`Cleaning up namespace because last engine was uninstalled`);
+        await this.cleanupNamespace();
       }
 
       this.logger.get(type).debug(`Uninstalled definition: ${type}`);
@@ -292,6 +276,57 @@ export class AssetManagerClient {
       this.logger.get(type).error(`Error uninstalling assets for entity type ${type}`, { error });
       throw error;
     }
+  }
+
+  /**
+   * Tears down namespace-scoped Entity Store resources: Task Manager schedules
+   * (history, status, maintainers), Elasticsearch data-plane assets, EUID stored
+   * scripts, and global state.
+   *
+   * EUID script deletion must use the requesting-user ES client: kibana_system
+   * can put managed scripts but not delete them without cluster manage/all.
+   */
+  public async cleanupNamespace(): Promise<void> {
+    await Promise.all([
+      stopHistorySnapshotTask({
+        taskManager: this.taskManager,
+        logger: this.logger,
+        namespace: this.namespace,
+      }),
+      stopStatusReportTask({
+        taskManager: this.taskManager,
+        logger: this.logger,
+        namespace: this.namespace,
+      }),
+      ...entityMaintainersRegistry.getAll().map(({ id }) =>
+        removeEntityMaintainer({
+          taskManager: this.taskManager,
+          id,
+          namespace: this.namespace,
+          logger: this.logger,
+          analytics: this.analytics,
+        })
+      ),
+    ]);
+
+    // After schedules are gone: remove the ES/SO resources those tasks used so
+    // an in-flight or soon-to-run task cannot hit deleted indices/scripts.
+    await Promise.all([
+      uninstallElasticsearchAssets({
+        esClient: this.esClient,
+        logger: this.logger,
+        namespace: this.namespace,
+      }),
+      deleteEuidStoredScripts({
+        esClient: this.esClient,
+        logger: this.logger,
+      }),
+      this.globalStateClient.delete(),
+    ]);
+
+    this.logger.debug(
+      `Finished cleaning up entity store resources for namespace "${this.namespace}"`
+    );
   }
 
   public async getStatus(withComponents: boolean = false): Promise<GetStatusResult> {

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/history_snapshot_index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/history_snapshot_index.ts
@@ -41,7 +41,8 @@ export const getHistorySnapshotIndexName = (
 
 /**
  * Returns the index pattern matching all history snapshot indices for a namespace.
- * Used for delete and status.
+ * Concrete names are `<base>.<YYYY-MM-DD>-<HH>`.
+ * Used for delete, status, and the history index template.
  */
 export const getHistorySnapshotIndexPattern = (namespace: string): string =>
-  `${getHistorySnapshotBasePattern(namespace)}*`;
+  `${getHistorySnapshotBasePattern(namespace)}.*`;

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.test.ts
@@ -6,8 +6,13 @@
  */
 
 import { loggerMock } from '@kbn/logging-mocks';
+import type { ElasticsearchClient } from '@kbn/core/server';
 import { uninstallElasticsearchAssets } from './install_assets';
 import { getLatestEntitiesIndexName } from '../../../common/domain/entity_index';
+import {
+  getHistorySnapshotIndexName,
+  getHistorySnapshotIndexPattern,
+} from './history_snapshot_index';
 import { getUpdatesEntitiesDataStreamName } from './updates_data_stream';
 import { getMetadataEntitiesDataStreamName } from './metadata_data_stream';
 
@@ -20,6 +25,19 @@ const { deleteIndex, deleteDataStream } = jest.requireMock('../../infra/elastics
 
 describe('uninstallElasticsearchAssets', () => {
   const namespace = 'default';
+  const historyPattern = getHistorySnapshotIndexPattern(namespace);
+  const historyIndexA = getHistorySnapshotIndexName(namespace, new Date('2026-07-29T10:00:00Z'));
+  const historyIndexB = getHistorySnapshotIndexName(namespace, new Date('2026-07-29T11:00:00Z'));
+
+  const createEsClient = (historyIndices: string[] = [historyIndexA, historyIndexB]) => ({
+    indices: {
+      resolveIndex: jest.fn().mockResolvedValue({
+        indices: historyIndices.map((name) => ({ name })),
+        aliases: [],
+        data_streams: [],
+      }),
+    },
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -29,7 +47,7 @@ describe('uninstallElasticsearchAssets', () => {
 
   it('deletes the latest entities index', async () => {
     await uninstallElasticsearchAssets({
-      esClient: {} as never,
+      esClient: createEsClient() as unknown as ElasticsearchClient,
       logger: loggerMock.create(),
       namespace,
     });
@@ -40,9 +58,42 @@ describe('uninstallElasticsearchAssets', () => {
     );
   });
 
+  it('resolves history snapshot wildcards then deletes concrete index names', async () => {
+    const esClient = createEsClient([historyIndexA, historyIndexB]);
+
+    await uninstallElasticsearchAssets({
+      esClient: esClient as unknown as ElasticsearchClient,
+      logger: loggerMock.create(),
+      namespace,
+    });
+
+    expect(esClient.indices.resolveIndex).toHaveBeenCalledWith({
+      name: historyPattern,
+    });
+    // Must not pass the wildcard pattern to delete — ES rejects it when
+    // action.destructive_requires_name=true.
+    expect(deleteIndex).not.toHaveBeenCalledWith(expect.anything(), historyPattern);
+    expect(deleteIndex).toHaveBeenCalledWith(expect.anything(), historyIndexA);
+    expect(deleteIndex).toHaveBeenCalledWith(expect.anything(), historyIndexB);
+  });
+
+  it('skips history index delete when no history indices exist', async () => {
+    await uninstallElasticsearchAssets({
+      esClient: createEsClient([]) as unknown as ElasticsearchClient,
+      logger: loggerMock.create(),
+      namespace,
+    });
+
+    expect(deleteIndex).toHaveBeenCalledTimes(1);
+    expect(deleteIndex).toHaveBeenCalledWith(
+      expect.anything(),
+      getLatestEntitiesIndexName(namespace)
+    );
+  });
+
   it('deletes the updates data stream', async () => {
     await uninstallElasticsearchAssets({
-      esClient: {} as never,
+      esClient: createEsClient() as unknown as ElasticsearchClient,
       logger: loggerMock.create(),
       namespace,
     });
@@ -55,7 +106,7 @@ describe('uninstallElasticsearchAssets', () => {
 
   it('deletes the metadata data stream so Clear Entity Data removes relationship history', async () => {
     await uninstallElasticsearchAssets({
-      esClient: {} as never,
+      esClient: createEsClient() as unknown as ElasticsearchClient,
       logger: loggerMock.create(),
       namespace,
     });
@@ -71,14 +122,14 @@ describe('uninstallElasticsearchAssets', () => {
     );
   });
 
-  it('deletes all three resources in a single uninstall call', async () => {
+  it('deletes all data-plane resources in a single uninstall call', async () => {
     await uninstallElasticsearchAssets({
-      esClient: {} as never,
+      esClient: createEsClient() as unknown as ElasticsearchClient,
       logger: loggerMock.create(),
       namespace,
     });
 
-    expect(deleteIndex).toHaveBeenCalledTimes(1);
+    expect(deleteIndex).toHaveBeenCalledTimes(3);
     expect(deleteDataStream).toHaveBeenCalledTimes(2);
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/install_assets.ts
@@ -27,6 +27,7 @@ import {
   getUpdatesEntityDefinitionComponentTemplate,
 } from './component_templates';
 import { getHistorySnapshotIndexTemplateConfig } from './history_snapshot_index_template';
+import { getHistorySnapshotIndexPattern } from './history_snapshot_index';
 import { getUpdatesEntityIndexTemplateConfig } from './updates_index_template';
 import { getUpdatesEntitiesDataStreamName } from './updates_data_stream';
 import { installLatestIndexIngestPipeline } from './latest_index_ingest_pipeline';
@@ -185,6 +186,11 @@ async function uninstallIndicesAndDataStreams(
       logger.debug(`deleted entity index`);
     })(),
     (async () => {
+      // Resolve wildcards to concrete names first: ES rejects wildcard deletes when
+      // `action.destructive_requires_name=true` (default in Kibana test clusters).
+      await deleteHistorySnapshotIndices(esClient, namespace, logger);
+    })(),
+    (async () => {
       await deleteDataStream(esClient, getUpdatesEntitiesDataStreamName(namespace));
       logger.debug(`deleted entity updates data stream`);
     })(),
@@ -193,4 +199,22 @@ async function uninstallIndicesAndDataStreams(
       logger.debug(`deleted entity metadata data stream`);
     })(),
   ]);
+}
+
+async function deleteHistorySnapshotIndices(
+  esClient: ElasticsearchClient,
+  namespace: string,
+  logger: Logger
+): Promise<void> {
+  const pattern = getHistorySnapshotIndexPattern(namespace);
+  const resolved = await esClient.indices.resolveIndex({ name: pattern });
+
+  const historyIndices = resolved.indices.map((index) => index.name);
+  if (historyIndices.length === 0) {
+    logger.debug(`no history snapshot indices to delete for pattern ${pattern}`);
+    return;
+  }
+
+  await Promise.all(historyIndices.map((index) => deleteIndex(esClient, index)));
+  logger.debug(`deleted entity history snapshot indices: ${historyIndices.join(', ')}`);
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/uninstall.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/uninstall.ts
@@ -51,23 +51,21 @@ export function registerUninstall(router: EntityStorePluginRouter) {
         },
       },
       wrapMiddlewares(async (ctx, req, res) => {
-        const {
-          logger,
-          assetManagerClient: assetManager,
-          entityMaintainersClient,
-        } = await ctx.entityStore;
+        const { logger, assetManagerClient: assetManager } = await ctx.entityStore;
         const { entityTypes } = req.body;
         logger.debug(`uninstalling entities: [${entityTypes.join(', ')}]`);
 
         const { engines } = await assetManager.getStatus();
         const installedTypes = new Set(engines.map((e) => e.type));
-        const toUninstall = entityTypes.filter((type) => installedTypes.has(type));
+        const toUninstall = [...new Set(entityTypes.filter((type) => installedTypes.has(type)))];
 
         await Promise.all(toUninstall.map((type) => assetManager.uninstall(type)));
 
-        const isFullUninstall = toUninstall.length === engines.length;
+        const isFullUninstall = toUninstall.length > 0 && toUninstall.length === engines.length;
         if (isFullUninstall) {
-          await entityMaintainersClient.removeAll();
+          // since engines are removed in parallel, the cleanup inside `assetManager.uninstall` might not have been called
+          // so we call it here to ensure all namespace-scoped resources are cleaned up
+          await assetManager.cleanupNamespace();
         }
 
         return res.ok({ body: { ok: true } });

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/entity_maintainers.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/entity_maintainers.test.ts
@@ -31,6 +31,9 @@ jest.mock('./entity_maintainers_registry', () => ({
     hasId: jest.fn(),
   },
 }));
+jest.mock('../should_delete_orphaned_task', () => ({
+  shouldDeleteOrphanedEntityStoreTask: jest.fn().mockResolvedValue(false),
+}));
 
 const registryMock = jest.requireMock('./entity_maintainers_registry')
   .entityMaintainersRegistry as {

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/entity_maintainers/index.ts
@@ -26,6 +26,7 @@ import { entityMaintainersRegistry } from './entity_maintainers_registry';
 import type { TelemetryReporter } from '../../telemetry/events';
 import { ENTITY_MAINTAINER_EVENT } from '../../telemetry/events';
 import { executeMaintainerRun } from './execution';
+import { shouldDeleteOrphanedEntityStoreTask } from '../should_delete_orphaned_task';
 
 /** Used when `RegisterEntityMaintainerConfig.minLicense` is omitted (minimum Kibana tier). */
 export const DEFAULT_ENTITY_MAINTAINER_MIN_LICENSE: LicenseType = 'basic';
@@ -115,6 +116,21 @@ export function registerEntityMaintainerTask({
             createTaskRunner: ({ taskInstance, abortController, fakeRequest }) => ({
               run: async () => {
                 const status = taskInstance.state;
+                const namespace =
+                  (typeof status?.metadata?.namespace === 'string'
+                    ? status.metadata.namespace
+                    : undefined) ??
+                  (typeof status?.namespace === 'string' ? status.namespace : undefined);
+
+                if (
+                  await shouldDeleteOrphanedEntityStoreTask({
+                    coreStart,
+                    namespace,
+                    logger,
+                  })
+                ) {
+                  return { state: status, shouldDeleteTask: true };
+                }
 
                 if (!fakeRequest) {
                   logger.error(`No fake request found, skipping run`);

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/extract_entity_task.ts
@@ -20,6 +20,7 @@ import type { EntityType } from '../../common/domain/definitions/entity_schema';
 import { createLogsExtractionClient } from './factories';
 import { wrapTaskRun } from '../telemetry/traces';
 import { entityStoreMetrics } from '../monitor/metrics';
+import { shouldDeleteOrphanedEntityStoreTask } from './should_delete_orphaned_task';
 
 function getTaskType(entityType: EntityType): string {
   const config = TasksConfig[EntityStoreTaskType.enum.extractEntity];
@@ -49,6 +50,20 @@ async function runTask({
   const currentState = taskInstance.state;
   const runs = currentState.runs || 0;
   const namespace = currentState.namespace;
+
+  const [coreStart] = await core.getStartServices();
+  if (
+    await shouldDeleteOrphanedEntityStoreTask({
+      coreStart,
+      namespace,
+      logger,
+    })
+  ) {
+    return {
+      state: currentState,
+      shouldDeleteTask: true,
+    };
+  }
 
   if (!fakeRequest) {
     logger.error(`No fake request found, skipping extract entity task`);

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/history_snapshot_task.ts
@@ -20,6 +20,7 @@ import type { EntityStoreCoreSetup } from '../types';
 import { EntityStoreGlobalStateClient } from '../domain/saved_objects';
 import { HistorySnapshotClient } from '../domain/history_snapshot';
 import { wrapTaskRun } from '../telemetry/traces';
+import { shouldDeleteOrphanedEntityStoreTask } from './should_delete_orphaned_task';
 
 const config = TasksConfig[EntityStoreTaskType.enum.historySnapshot];
 
@@ -40,18 +41,32 @@ async function runHistorySnapshotTask({
   fakeRequest,
   core,
   logger,
-}: RunHistorySnapshotTaskParams): Promise<{ state: Record<string, unknown> }> {
+}: RunHistorySnapshotTaskParams): Promise<{
+  state: Record<string, unknown>;
+  shouldDeleteTask?: boolean;
+}> {
   const namespace = taskInstance.state?.namespace as string | undefined;
   if (!namespace) {
     logger.error('History snapshot task missing namespace in state');
     return { state: taskInstance.state };
   }
+
+  const [start] = await core.getStartServices();
+  if (
+    await shouldDeleteOrphanedEntityStoreTask({
+      coreStart: start,
+      namespace,
+      logger,
+    })
+  ) {
+    return { state: taskInstance.state, shouldDeleteTask: true };
+  }
+
   if (!fakeRequest) {
     logger.error('No fake request found, skipping history snapshot task');
     return { state: taskInstance.state };
   }
 
-  const [start] = await core.getStartServices();
   const soClient = start.savedObjects.getScopedClient(fakeRequest);
   const esClient = start.elasticsearch.client.asScoped(fakeRequest).asCurrentUser;
   const taskLogger = logger.get(taskInstance.id);

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/should_delete_orphaned_task.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/should_delete_orphaned_task.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { CoreStart } from '@kbn/core/server';
+import { shouldDeleteOrphanedEntityStoreTask } from './should_delete_orphaned_task';
+import { EngineDescriptorTypeName } from '../domain/saved_objects';
+
+describe('shouldDeleteOrphanedEntityStoreTask', () => {
+  const logger = loggerMock.create();
+  const find = jest.fn();
+  const createInternalRepository = jest.fn(() => ({ find }));
+  const coreStart = {
+    savedObjects: { createInternalRepository },
+  } as unknown as CoreStart;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createInternalRepository.mockReturnValue({ find });
+  });
+
+  it('returns false when namespace is missing', async () => {
+    await expect(
+      shouldDeleteOrphanedEntityStoreTask({
+        coreStart,
+        namespace: undefined,
+        logger,
+      })
+    ).resolves.toBe(false);
+    expect(createInternalRepository).not.toHaveBeenCalled();
+  });
+
+  it('returns true when no engine descriptors exist for the namespace', async () => {
+    find.mockResolvedValue({ saved_objects: [], total: 0 });
+
+    await expect(
+      shouldDeleteOrphanedEntityStoreTask({
+        coreStart,
+        namespace: 'gone-space',
+        logger,
+      })
+    ).resolves.toBe(true);
+
+    expect(createInternalRepository).toHaveBeenCalledWith([EngineDescriptorTypeName]);
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: EngineDescriptorTypeName,
+        namespaces: ['gone-space'],
+      })
+    );
+  });
+
+  it('returns false when at least one engine descriptor exists', async () => {
+    find.mockResolvedValue({
+      saved_objects: [{ attributes: { type: 'user', status: 'started' } }],
+      total: 1,
+    });
+
+    await expect(
+      shouldDeleteOrphanedEntityStoreTask({
+        coreStart,
+        namespace: 'default',
+        logger,
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('returns false on unexpected errors so the task is not deleted', async () => {
+    find.mockRejectedValue(new Error('SO cluster unavailable'));
+
+    await expect(
+      shouldDeleteOrphanedEntityStoreTask({
+        coreStart,
+        namespace: 'default',
+        logger,
+      })
+    ).resolves.toBe(false);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/should_delete_orphaned_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/should_delete_orphaned_task.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart, Logger } from '@kbn/core/server';
+import { EngineDescriptorClient, EngineDescriptorTypeName } from '../domain/saved_objects';
+
+/**
+ * Returns true when Entity Store has no engine descriptors in the namespace
+ * (uninstalled, or space deleted and SOs removed via deleteByNamespace).
+ *
+ * On unexpected errors returns false so transient SO/ES failures do not
+ * self-delete a healthy schedule.
+ */
+export async function shouldDeleteOrphanedEntityStoreTask({
+  coreStart,
+  namespace,
+  logger,
+}: {
+  coreStart: CoreStart;
+  namespace: string | undefined;
+  logger: Logger;
+}): Promise<boolean> {
+  if (!namespace) {
+    return false;
+  }
+
+  try {
+    const soClient = coreStart.savedObjects.createInternalRepository([EngineDescriptorTypeName]);
+    const engines = await new EngineDescriptorClient(soClient, namespace, logger).getAll();
+    if (engines.length === 0) {
+      logger.info(`Entity store is not installed in namespace "${namespace}"`);
+      return true;
+    }
+    return false;
+  } catch (error) {
+    logger.warn(`Could not determine entity store install state for namespace "${namespace}"`, {
+      error,
+    });
+    return false;
+  }
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.test.ts
@@ -23,6 +23,9 @@ import { getLatestEntitiesIndexName } from '../../common/domain/entity_index';
 import type { EntityStoreCoreSetup } from '../types';
 
 jest.mock('./factories');
+jest.mock('./should_delete_orphaned_task', () => ({
+  shouldDeleteOrphanedEntityStoreTask: jest.fn().mockResolvedValue(false),
+}));
 // wrapTaskRun adds a tracing span around the run callback; here it just invokes it.
 jest.mock('../telemetry/traces', () => ({
   wrapTaskRun: jest.fn(({ run }: { run: () => Promise<unknown> }) => run()),
@@ -149,7 +152,19 @@ describe('status report task — usage, resolution state & metadata telemetry', 
     const taskManager = {
       registerTaskDefinitions: jest.fn(),
     } as unknown as TaskManagerSetupContract;
-    const core = { analytics: { reportEvent } } as unknown as EntityStoreCoreSetup;
+    const core = {
+      analytics: { reportEvent },
+      getStartServices: jest.fn().mockResolvedValue([
+        {
+          savedObjects: {
+            createInternalRepository: jest.fn().mockReturnValue({
+              find: jest.fn().mockResolvedValue({ saved_objects: [{ id: 'engine' }], total: 1 }),
+            }),
+          },
+        },
+        {},
+      ]),
+    } as unknown as EntityStoreCoreSetup;
 
     registerStatusReportTask({ taskManager, logger, core });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/status_report_task.ts
@@ -33,6 +33,7 @@ import {
 import { getMetadataEntitiesDataStreamName } from '../domain/asset_manager/metadata_data_stream';
 import { executeEsqlQuery } from '../infra/elasticsearch/esql';
 import { wrapTaskRun } from '../telemetry/traces';
+import { shouldDeleteOrphanedEntityStoreTask } from './should_delete_orphaned_task';
 
 const config = TasksConfig[EntityStoreTaskType.enum.statusReport];
 
@@ -145,6 +146,17 @@ async function runTask({
 
   if (!namespace) {
     throw new Error('Namespace is required for status report task');
+  }
+
+  const [coreStart] = await core.getStartServices();
+  if (
+    await shouldDeleteOrphanedEntityStoreTask({
+      coreStart,
+      namespace,
+      logger,
+    })
+  ) {
+    return { state: { namespace }, shouldDeleteTask: true };
   }
 
   if (!fakeRequest) {

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
@@ -86,6 +86,6 @@ export const HISTORY_INDEX_PATTERN = `${getEntityIndexPattern({
   schemaVersion: ENTITY_SCHEMA_VERSION_V2,
   dataset: ENTITY_HISTORY,
   namespace: 'default',
-})}*`;
+})}.*`;
 
 export const ENTRA_SOURCE_INDEX = 'logs-entityanalytics_entra_id.user-default';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.test.ts
@@ -1204,7 +1204,7 @@ describe('searchEntitiesTool', () => {
 
       // FROM includes both entity index and snapshot index
       expect(query).toContain('entities-latest-default');
-      expect(query).toContain('.entities.v2.history.security_default*');
+      expect(query).toContain('.entities.v2.history.security_default.*');
 
       // Risk score IS NOT NULL and timestamp range filters
       expect(query).toContain('WHERE entity.risk.calculated_score_norm IS NOT NULL');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
- [[Entity Store] Self delete orphaned ES tasks (#281514)](https://github.com/elastic/kibana/pull/281514)

## Conflict resolution

One conflict in `x-pack/solutions/security/plugins/entity_store/server/routes/apis/uninstall.ts`: the 9.5 branch had `entityMaintainersClient` in the destructuring where main (pre-#281514) had `preferencesClient`. Since #281514 removed that client entirely and replaced the full-uninstall cleanup with `assetManager.cleanupNamespace()`, both clients were dropped from the destructuring.

<!--BACKPORT [{"sourcePullRequest":{"number":281514,"url":"https://github.com/elastic/kibana/pull/281514","title":"[Entity Store] Self delete orphaned ES tasks"},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"sourceCommit":{"sha":"2c5764d0635b"}}] BACKPORT-->