### PR TITLE
[dashboard] fix add-panel-flyout test

### DIFF
--- a/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_add_panel_flyout.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_add_panel_flyout.spec.ts
@@ -12,45 +12,29 @@ import { spaceTest, tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
 import { DASHBOARD_DEFAULT_INDEX_TITLE, DASHBOARD_SAVED_SEARCH_ARCHIVE } from '../constants';
 
-const getExpected = (config: ScoutTestConfig) => {
-  if (config.projectType === 'es') {
-    return {
-      groups: [
-        'visualizationsGroup',
-        'controlsGroup',
-        'annotation-and-navigationGroup',
-        'logs-aiopsGroup',
-        'mlGroup',
-        'legacyGroup',
-      ],
-      count: 18,
-    };
-  }
+const SERVERLESS_GROUPS = [
+  'visualizationsGroup',
+  'controlsGroup',
+  'annotation-and-navigationGroup',
+  'logs-aiopsGroup',
+  'mlGroup',
+  'legacyGroup',
+];
 
-  if (config.projectType === 'security') {
+/**
+ * Serverless search and security both set `xpack.ml.ad.enabled: true`, so the three
+ * anomaly detection actions are compatible and both project types expect the same count.
+ */
+const getExpected = (config: ScoutTestConfig) => {
+  if (config.projectType === 'es' || config.projectType === 'security') {
     return {
-      groups: [
-        'visualizationsGroup',
-        'controlsGroup',
-        'annotation-and-navigationGroup',
-        'logs-aiopsGroup',
-        'mlGroup',
-        'legacyGroup',
-      ],
+      groups: SERVERLESS_GROUPS,
       count: 21,
     };
   }
 
   return {
-    groups: [
-      'visualizationsGroup',
-      'controlsGroup',
-      'annotation-and-navigationGroup',
-      'logs-aiopsGroup',
-      'mlGroup',
-      'observabilityGroup',
-      'legacyGroup',
-    ],
+    groups: [...SERVERLESS_GROUPS, 'observabilityGroup'],
     count: 28,
   };
 };
@@ -61,8 +45,7 @@ const getExpected = (config: ScoutTestConfig) => {
  * This test exists to ensures additions to menu
  * notify our team and can be reviewed by design.
  */
-// Failing: See https://github.com/elastic/kibana/issues/268101
-spaceTest.describe.skip(
+spaceTest.describe(
   'Dashboard add panel flyout',
   {
     tag: [
@@ -73,13 +56,7 @@ spaceTest.describe.skip(
     ],
   },
   () => {
-    let expectedCount: number;
-    let expectedGroups: string[];
-
-    spaceTest.beforeAll(async ({ scoutSpace, config }) => {
-      const expected = getExpected(config);
-      expectedCount = expected.count;
-      expectedGroups = expected.groups;
+    spaceTest.beforeAll(async ({ scoutSpace }) => {
       await scoutSpace.savedObjects.cleanStandardList();
       await scoutSpace.savedObjects.load(DASHBOARD_SAVED_SEARCH_ARCHIVE);
       await scoutSpace.uiSettings.setDefaultIndex(DASHBOARD_DEFAULT_INDEX_TITLE);
@@ -94,7 +71,9 @@ spaceTest.describe.skip(
       await scoutSpace.savedObjects.cleanStandardList();
     });
 
-    spaceTest('renders add panel flyout', async ({ pageObjects, log }) => {
+    spaceTest('renders add panel flyout', async ({ pageObjects, config, log }) => {
+      const expected = getExpected(config);
+
       await spaceTest.step('open new dashboard and add panel flyout', async () => {
         await pageObjects.dashboard.openNewDashboard();
         await pageObjects.dashboard.openAddPanelFlyout();
@@ -102,13 +81,18 @@ spaceTest.describe.skip(
 
       await spaceTest.step('verify panel groups', async () => {
         const groups = await pageObjects.dashboard.getAddPanelFlyoutGroups();
-        expect(groups).toStrictEqual(expectedGroups);
+        // `mlGroup` and `logs-aiopsGroup` both declare order 0, so their relative
+        // position is tie-broken by registration order and is not a contract.
+        expect([...groups].sort()).toStrictEqual([...expected.groups].sort());
       });
 
       await spaceTest.step('verify total panel count', async () => {
         const addPanelActions = await pageObjects.dashboard.getAddPanelFlyoutActions();
         log.info(`Add panel actions: ${addPanelActions.join(',')}`);
-        expect(addPanelActions).toHaveLength(expectedCount);
+        expect(
+          addPanelActions,
+          `add panel actions (${addPanelActions.length}): ${addPanelActions.join(', ')}`
+        ).toHaveLength(expected.count);
       });
     });
   }


### PR DESCRIPTION
## Summary

The dashboard "Add panel" menu has a test that counts the items in it. If anyone adds a new panel type, this test fails (few times in the past)

Serverless Search used to hide `Anomaly Detection`, so its menu had `18` items while Security had `21`. Last week a PR turned `Anomaly Detection` back on for Serverless Search. That added `3` items to the menu, the count became `21`, and the test started failing and got skipped.

Nothing was actually broken: the menu changed on purpose and the test's number was just out of date.

Fix:

- Sets Search and Security to the same expected number (21), since they now have the same features enabled, and turns the test back on.
- Compares the menu groups ignoring their order. Two groups share the same sort priority, so their order can flip between runs — that caused a separate flaky failure back in May.
- Makes the error message list every menu item by name. Before it only said "expected 18, got 21" and cut the list short, so you couldn't tell what had been added.