### PR TITLE
[9.5] Bump yarn in configs to 1.22.22 (#282547)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,4 +2,4 @@
 idiomatic_version_file_enable_tools = ["node"]
 
 [tools]
-yarn = "1.22.21"
+yarn = "1.22.22"

--- a/package.json
+++ b/package.json
@@ -2252,5 +2252,5 @@
     "yaml-language-server": "1.23.0",
     "yarn-deduplicate": "6.0.2"
   },
-  "packageManager": "yarn@1.22.21"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Bump yarn in configs to 1.22.22 (#282547)](https://github.com/elastic/kibana/pull/282547)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-08-05T12:02:25Z","message":"Bump yarn in configs to 1.22.22 (#282547)\n\n## Summary\nyarn 1.22.21 writes a lock file inconsistent with 1.22.22, bumping for\nconsistency.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b89bd740ff7bd4a1e6324ba31c51fa904c4e4151","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport missing","backport:all-open","v9.6.0"],"title":"Bump yarn in configs to 1.22.22","number":282547,"url":"https://github.com/elastic/kibana/pull/282547","mergeCommit":{"message":"Bump yarn in configs to 1.22.22 (#282547)\n\n## Summary\nyarn 1.22.21 writes a lock file inconsistent with 1.22.22, bumping for\nconsistency.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b89bd740ff7bd4a1e6324ba31c51fa904c4e4151"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282547","number":282547,"mergeCommit":{"message":"Bump yarn in configs to 1.22.22 (#282547)\n\n## Summary\nyarn 1.22.21 writes a lock file inconsistent with 1.22.22, bumping for\nconsistency.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b89bd740ff7bd4a1e6324ba31c51fa904c4e4151"}}]}] BACKPORT-->