### PR TITLE
[Dashboard] Fix missing icons

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/copy_to_dashboard_action.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/copy_to_dashboard_action.tsx
@@ -72,7 +72,7 @@ export class CopyToDashboardAction implements Action<EmbeddableApiContext> {
 
   public getIconType({ embeddable }: EmbeddableApiContext) {
     if (!apiIsCompatible(embeddable)) throw new IncompatibleActionError();
-    return 'exit';
+    return 'copy';
   }
 
   public async isCompatible({ embeddable }: EmbeddableApiContext) {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/copy_to_dashboard_action.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/copy_to_dashboard_action.tsx
@@ -72,7 +72,7 @@ export class CopyToDashboardAction implements Action<EmbeddableApiContext> {
 
   public getIconType({ embeddable }: EmbeddableApiContext) {
     if (!apiIsCompatible(embeddable)) throw new IncompatibleActionError();
-    return 'copy';
+    return 'logOut';
   }
 
   public async isCompatible({ embeddable }: EmbeddableApiContext) {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -303,7 +303,7 @@ export const useDashboardMenuItems = ({
 
       switchToViewMode: {
         order: 1,
-        iconType: 'logOut', // use 'logOut' when added to EUI
+        iconType: 'logOut',
         label: topNavStrings.switchToViewMode.label,
         id: 'cancel',
         disableButton: disableTopNav || !lastSavedId || isResetting,

--- a/src/platform/plugins/shared/embeddable/public/ui_actions/show_config_panel_action/show_config_panel_action.ts
+++ b/src/platform/plugins/shared/embeddable/public/ui_actions/show_config_panel_action/show_config_panel_action.ts
@@ -62,7 +62,7 @@ export class ShowConfigPanelAction
 
   public getIconType({ embeddable }: EmbeddableApiContext) {
     if (!isApiCompatible(embeddable)) throw new IncompatibleActionError();
-    return 'glasses';
+    return 'readOnly';
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/285354

## Summary

https://github.com/elastic/kibana/pull/284032 upgraded to EUI v119.0.0, which removed some deprecated icons that had not yet been replaced in Dashboard - this resulted in broken images on some browsers + blank icons on others. This PR fixes that.

**Show Visualization Config Action**

| v9.5 | Main | This PR |
|--------|--------|--------|
| <img width="599" height="400" alt="image" src="https://github.com/user-attachments/assets/90539805-f274-4718-bd66-dbc25d5b90d7" /> | <img width="599" height="400" alt="image" src="https://github.com/user-attachments/assets/a3ac5c6a-78df-4b6d-b163-abf44d0d90b7" /> |  <img width="599" height="400" alt="image" src="https://github.com/user-attachments/assets/dce862a4-eae7-413f-916e-8abe8151ee8f" /> | 

**Copy to Dashboard Action**

| v9.5 | Main | This PR |
|--------|--------|--------|
| <img width="520" height="509" alt="image" src="https://github.com/user-attachments/assets/5b61c6e9-a786-4b89-9174-44c312871d9e" /> | <img width="520" height="509" alt="image" src="https://github.com/user-attachments/assets/8eb8613e-2370-4144-ab9e-c79c226375c1" /> | <img width="520" height="509" alt="image" src="https://github.com/user-attachments/assets/7b771c60-b05a-4cf2-ad21-684b727e6a57" /> |




### Checklist


- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
