### PR TITLE
[Synthetics] Safely roll back failed monitor creates

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.test.ts
@@ -9,8 +9,91 @@ import { AddEditMonitorAPI } from './add_monitor_api';
 import { SyntheticsMonitorClient } from '../../../synthetics_service/synthetics_monitor/synthetics_monitor_client';
 import { SyntheticsService } from '../../../synthetics_service/synthetics_service';
 import { syntheticsMonitorAttributes } from '../../../../common/types/saved_objects';
+import { PackagePolicyService } from '../../../synthetics_service/private_location/package_policy_service';
+import { DeleteMonitorAPI } from '../services/delete_monitor_api';
 
 describe('AddNewMonitorsPublicAPI', () => {
+  describe('revertMonitorIfCreated', () => {
+    const buildApi = (get: jest.Mock) =>
+      new AddEditMonitorAPI({
+        server: { logger: { error: jest.fn() } },
+        spaceId: 'default',
+        monitorConfigRepository: { get },
+      } as any);
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('does not delete policies when a conflicting existing monitor owns the id', async () => {
+      const bulkDelete = jest
+        .spyOn(PackagePolicyService.prototype, 'bulkDelete')
+        .mockResolvedValue(undefined);
+      const api = buildApi(jest.fn().mockResolvedValue({ id: 'monitor-1' }));
+
+      await api.revertMonitorIfCreated({
+        newMonitorId: 'monitor-1',
+        packagePolicyIds: ['monitor-1-location-1'],
+        soCreated: false,
+      });
+
+      expect(bulkDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes deterministic orphan policies when no monitor owns the id', async () => {
+      const bulkDelete = jest
+        .spyOn(PackagePolicyService.prototype, 'bulkDelete')
+        .mockResolvedValue(undefined);
+      const api = buildApi(jest.fn().mockResolvedValue(null));
+
+      await api.revertMonitorIfCreated({
+        newMonitorId: 'monitor-1',
+        packagePolicyIds: ['monitor-1-location-1'],
+        soCreated: false,
+      });
+
+      expect(bulkDelete).toHaveBeenCalledWith({
+        policyIdsToDelete: ['monitor-1-location-1'],
+        spaceId: 'default',
+      });
+    });
+
+    it('does not delete policies when the monitor SO was created and revert fails', async () => {
+      const bulkDelete = jest
+        .spyOn(PackagePolicyService.prototype, 'bulkDelete')
+        .mockResolvedValue(undefined);
+      jest.spyOn(DeleteMonitorAPI.prototype, 'execute').mockRejectedValue(new Error('forbidden'));
+      const api = buildApi(jest.fn().mockResolvedValue({ id: 'monitor-1' }));
+
+      await api.revertMonitorIfCreated({
+        newMonitorId: 'monitor-1',
+        packagePolicyIds: ['monitor-1-location-1'],
+        soCreated: true,
+      });
+
+      expect(bulkDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes the monitor and its policies via DeleteMonitorAPI when the monitor SO was created', async () => {
+      const bulkDelete = jest
+        .spyOn(PackagePolicyService.prototype, 'bulkDelete')
+        .mockResolvedValue(undefined);
+      const deleteMonitorExecute = jest
+        .spyOn(DeleteMonitorAPI.prototype, 'execute')
+        .mockResolvedValue(undefined as any);
+      const api = buildApi(jest.fn().mockResolvedValue({ id: 'monitor-1' }));
+
+      await api.revertMonitorIfCreated({
+        newMonitorId: 'monitor-1',
+        packagePolicyIds: ['monitor-1-location-1'],
+        soCreated: true,
+      });
+
+      expect(deleteMonitorExecute).toHaveBeenCalledWith({ monitorIds: ['monitor-1'] });
+      expect(bulkDelete).not.toHaveBeenCalled();
+    });
+  });
+
   it('should normalize schedule', async function () {
     const syntheticsService = new SyntheticsService({
       config: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.ts
@@ -45,6 +45,7 @@ import { formatTelemetryEvent, sendTelemetryEvents } from '../../telemetry/monit
 import { formatKibanaNamespace } from '../../../../common/formatters';
 import { getPrivateLocationsForNamespaces } from '../../../synthetics_service/get_private_locations';
 import { resolveMaintenanceWindowsOrThrow } from '../../../synthetics_service/maintenance_windows/resolve_maintenance_windows';
+import { PackagePolicyService } from '../../../synthetics_service/private_location/package_policy_service';
 
 export type CreateMonitorPayLoad = MonitorFields & {
   url?: string;
@@ -78,11 +79,13 @@ export class AddEditMonitorAPI {
       normalizedMonitor,
       newMonitorId,
     });
+    const monitorPrivateLocations = monitorWithNamespace[ConfigKey.LOCATIONS].filter(
+      (loc) => !loc.isServiceManaged
+    );
+    const packagePolicyIds = monitorPrivateLocations.map((loc) => `${newMonitorId}-${loc.id}`);
+    let soCreated = false;
 
     try {
-      const monitorPrivateLocations = monitorWithNamespace[ConfigKey.LOCATIONS].filter(
-        (loc) => !loc.isServiceManaged
-      );
       const packagePolicySoType = await getPackagePolicySavedObjectType();
       const references = monitorPrivateLocations.map((loc) => ({
         id: `${newMonitorId}-${loc.id}`,
@@ -104,12 +107,22 @@ export class AddEditMonitorAPI {
         spaceId
       );
 
-      const [monitorSavedObjectN, [packagePolicyResult, syncErrors]] = await Promise.all([
+      const [soResult, syncResult] = await Promise.allSettled([
         newMonitorPromise,
         syncErrorsPromise,
       ]);
+      soCreated = soResult.status === 'fulfilled';
 
-      if (packagePolicyResult && (packagePolicyResult?.failed?.length ?? []) > 0) {
+      if (soResult.status === 'rejected') {
+        throw soResult.reason;
+      }
+      if (syncResult.status === 'rejected') {
+        throw syncResult.reason;
+      }
+
+      const [packagePolicyResult, syncErrors] = syncResult.value;
+
+      if ((packagePolicyResult?.failed?.length ?? 0) > 0) {
         // Fleet reports saved object level failures (e.g. a policy id conflict) as plain
         // objects, so they have to be formatted explicitly to stay readable.
         const failed = packagePolicyResult.failed.map(({ error }) =>
@@ -118,7 +131,7 @@ export class AddEditMonitorAPI {
         throw new Error(failed.join(', '));
       }
 
-      monitorSavedObject = monitorSavedObjectN;
+      monitorSavedObject = soResult.value;
 
       sendTelemetryEvents(
         server.logger,
@@ -142,6 +155,8 @@ export class AddEditMonitorAPI {
       e.message = `${e.message}, monitor name: ${monitorWithNamespace[ConfigKey.NAME]}`;
       await this.revertMonitorIfCreated({
         newMonitorId,
+        packagePolicyIds,
+        soCreated,
       });
 
       throw e;
@@ -364,28 +379,58 @@ export class AddEditMonitorAPI {
     return namespace;
   }
 
-  async revertMonitorIfCreated({ newMonitorId }: { newMonitorId: string }) {
-    const { server, monitorConfigRepository } = this.routeContext;
+  async revertMonitorIfCreated({
+    newMonitorId,
+    packagePolicyIds = [],
+    soCreated = true,
+  }: {
+    newMonitorId: string;
+    packagePolicyIds?: string[];
+    soCreated?: boolean;
+  }) {
+    const { server, spaceId, monitorConfigRepository } = this.routeContext;
     try {
-      const encryptedMonitor = await monitorConfigRepository.get(newMonitorId);
+      const encryptedMonitor = soCreated ? await monitorConfigRepository.get(newMonitorId) : null;
       if (encryptedMonitor) {
+        const deleteMonitorAPI = new DeleteMonitorAPI(this.routeContext);
+        await deleteMonitorAPI.execute({ monitorIds: [newMonitorId] });
         await monitorConfigRepository.bulkDelete([
           { id: newMonitorId, type: syntheticsMonitorSavedObjectType },
           { id: newMonitorId, type: legacySyntheticsMonitorTypeSingle },
         ]);
-
-        const deleteMonitorAPI = new DeleteMonitorAPI(this.routeContext);
-        await deleteMonitorAPI.execute({
-          monitorIds: [newMonitorId],
-        });
       }
     } catch (error) {
-      // ignore errors here
       server.logger.error(
-        `Unable to revert monitor with id ${newMonitorId}, Error: ${error.message}`,
+        `Unable to revert monitor saved object with id ${newMonitorId}, Error: ${error.message}`,
         {
           error,
         }
+      );
+    }
+
+    // Saved-monitor policies are owned by DeleteMonitorAPI; orphan cleanup is only for unsaved creates.
+    if (soCreated || packagePolicyIds.length === 0) {
+      return;
+    }
+
+    const ownedByExistingMonitor = Boolean(
+      await monitorConfigRepository.get(newMonitorId).catch(() => null)
+    );
+    if (ownedByExistingMonitor) {
+      return;
+    }
+
+    try {
+      await new PackagePolicyService(server).bulkDelete({
+        policyIdsToDelete: packagePolicyIds,
+        spaceId,
+      });
+    } catch (error) {
+      server.logger.error(
+        `Unable to revert package policies [${packagePolicyIds.join(
+          ', '
+        )}] for monitor with id ${newMonitorId}, Error: ${error.message}`,
+        { error }
       );
     }
   }


### PR DESCRIPTION
## Summary

Safely roll back monitor creates when the monitor saved-object write and Fleet package-policy synchronization complete independently.

- Do not delete a pre-existing monitor after a conflicting create.
- Remove orphaned package policies only when no monitor owns the requested ID.
- Keep `DeleteMonitorAPI` as the cleanup owner when the monitor saved object exists.

Closes #285445

## Testing

- `node scripts/jest x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor/add_monitor_api.test.ts` (started locally; sandbox did not return a final result)
- `git diff --check`
- Prettier