### PR TITLE
Add ignore list to APM, add benign ResizeObserver notification event …

### DIFF
--- a/src/core/packages/root/browser-internal/src/apm_system.test.ts
+++ b/src/core/packages/root/browser-internal/src/apm_system.test.ts
@@ -15,6 +15,7 @@ import { init, apm, type Transaction } from '@elastic/apm-rum';
 import { executionContextServiceMock } from '@kbn/core-execution-context-browser-mocks';
 import type { InternalApplicationStart } from '@kbn/core-application-browser-internal';
 import { ApmSystem } from './apm_system';
+import { RESIZE_OBSERVER_LOOP_ERROR } from './events';
 
 const initMock = init as jest.Mocked<typeof init>;
 const apmMock = apm as DeeplyMockedKeys<typeof apm>;
@@ -42,6 +43,29 @@ describe('ApmSystem', () => {
       const apmSystem = new ApmSystem({ active: true, globalLabels: { alpha: 'one' } });
       await apmSystem.setup();
       expect(apm.addLabels).toHaveBeenCalledWith({ alpha: 'one' });
+    });
+
+    it('filters benign ResizeObserver errors from APM payloads', async () => {
+      const apmSystem = new ApmSystem({ active: true });
+      await apmSystem.setup();
+      const errorFilter = apmMock.addFilter.mock.calls[1][0];
+      const payload = {
+        transactions: [],
+        errors: [
+          {
+            exception: {
+              type: RESIZE_OBSERVER_LOOP_ERROR,
+              message: RESIZE_OBSERVER_LOOP_ERROR,
+            },
+          },
+          { exception: { type: 'Error', message: 'Unexpected error' } },
+        ],
+      };
+
+      expect(errorFilter(payload)).toEqual({
+        transactions: [],
+        errors: [{ exception: { type: 'Error', message: 'Unexpected error' } }],
+      });
     });
 
     describe('manages the page load transaction', () => {

--- a/src/core/packages/root/browser-internal/src/apm_system.ts
+++ b/src/core/packages/root/browser-internal/src/apm_system.ts
@@ -14,6 +14,7 @@ import type { InternalApplicationStart } from '@kbn/core-application-browser-int
 import { ebtSpanFilter } from './filters/ebt_span_filter';
 import { CachedResourceObserver } from './apm_resource_counter';
 import { getPageLoadTransactionName, isAppPath } from './get_page_load_transaction_name';
+import { IGNORED_EVENTS_LIST } from './events';
 
 /** "GET protocol://hostname:port/pathname" */
 const HTTP_REQUEST_TRANSACTION_NAME_REGEX =
@@ -64,6 +65,14 @@ export class ApmSystem {
     });
 
     apm.addFilter(ebtSpanFilter);
+
+    // Ignore specific events
+    apm.addFilter((payload) => {
+      payload.errors = payload.errors.filter(
+        (error) => !IGNORED_EVENTS_LIST.includes(error.exception?.message ?? '')
+      );
+      return payload;
+    });
 
     // Remove the query params from the URLs (page's URL and refererer)
     apm.addFilter((payload) => {

--- a/src/core/packages/root/browser-internal/src/events.ts
+++ b/src/core/packages/root/browser-internal/src/events.ts
@@ -15,3 +15,9 @@ export const LOAD_CORE_CREATED = 'core_created';
 export const LOAD_SETUP_DONE = 'setup_done';
 export const LOAD_START_DONE = 'start_done';
 export const LOAD_FIRST_NAV = 'first_app_nav';
+
+// Chromium reports this benign ResizeObserver condition as an uncaught error.
+export const RESIZE_OBSERVER_LOOP_ERROR =
+  'ResizeObserver loop completed with undelivered notifications.';
+
+export const IGNORED_EVENTS_LIST = [RESIZE_OBSERVER_LOOP_ERROR];


### PR DESCRIPTION
Closes https://github.com/elastic/observability-error-backlog/issues/675

## Summary

This suppresses the `ResizeObserver loop completed with undelivered notifications` error, as reported by APM, by adding the event to an ignore list and configuring the Kibana APM instrumentation setup function to use that ignore list.

## Details

The error reported does not affect customers: it is not noticeable in any way, yet is being logged by Kibana's APM in large numbers, leading to a significant amount of instrumentation noise.

Therefore, lets suppress the error it to make sure it doesn't reach the telemetry clusters.

<!--ONMERGE {"backportTargets":["9.3","9.4","9.5"]} ONMERGE-->