### PR TITLE
[Alerting v2] Accept TS ES|QL source queries for time-field resolution

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_form/alert_condition_step.test.tsx
@@ -19,6 +19,7 @@ import { AlertConditionStep } from './alert_condition_step';
 import { QueryFieldRules } from './query_field_rules';
 
 jest.mock('@kbn/esql-utils', () => ({
+  ...jest.requireActual('@kbn/esql-utils'),
   getEsqlColumns: jest.fn(async () => []),
 }));
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/extract_from_source_query.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/extract_from_source_query.test.ts
@@ -31,8 +31,8 @@ describe('extractFromSourceQuery', () => {
     );
   });
 
-  it('returns empty string when query has no FROM or TS source command', () => {
-    expect(extractFromSourceQuery('SHOW INFO')).toBe('');
+  it('returns empty string when query has no source command', () => {
+    expect(extractFromSourceQuery('STATS COUNT(*)')).toBe('');
   });
 
   it('extracts FROM with multiple indices', () => {
@@ -51,5 +51,31 @@ describe('extractFromSourceQuery', () => {
         'TS metrics-kubeletstatsreceiver.otel-* | STATS COUNT(*) BY @timestamp | WHERE throttled == true'
       )
     ).toBe('TS metrics-kubeletstatsreceiver.otel-*');
+  });
+
+  it('extracts FROM after a leading comment', () => {
+    expect(extractFromSourceQuery('// a comment\nFROM logs-* | LIMIT 10')).toBe('FROM logs-*');
+  });
+
+  it('extracts FROM after a SET header', () => {
+    expect(extractFromSourceQuery('SET unmapped_fields = "FAIL"; FROM logs-* | LIMIT 10')).toBe(
+      'FROM logs-*'
+    );
+  });
+
+  it('extracts ROW', () => {
+    expect(extractFromSourceQuery('ROW a = 1')).toBe('ROW a = 1');
+  });
+
+  it('extracts SHOW', () => {
+    expect(extractFromSourceQuery('SHOW INFO')).toBe('SHOW INFO');
+  });
+
+  it('extracts PROMQL', () => {
+    expect(
+      extractFromSourceQuery(
+        'PROMQL index=metrics step=1m start=?_tstart end=?_tend (avg(cpu_usage))'
+      )
+    ).toBe('PROMQL index=metrics step=1m start=?_tstart end=?_tend (avg(cpu_usage))');
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/extract_from_source_query.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/extract_from_source_query.test.ts
@@ -31,7 +31,7 @@ describe('extractFromSourceQuery', () => {
     );
   });
 
-  it('returns empty string when query has no FROM', () => {
+  it('returns empty string when query has no FROM or TS source command', () => {
     expect(extractFromSourceQuery('SHOW INFO')).toBe('');
   });
 
@@ -39,5 +39,17 @@ describe('extractFromSourceQuery', () => {
     expect(extractFromSourceQuery('FROM logs-*, metrics-* | LIMIT 10')).toBe(
       'FROM logs-*, metrics-*'
     );
+  });
+
+  it('extracts TS from a simple timeseries query', () => {
+    expect(extractFromSourceQuery('TS metrics-* | LIMIT 10')).toBe('TS metrics-*');
+  });
+
+  it('extracts TS from a STATS pipeline', () => {
+    expect(
+      extractFromSourceQuery(
+        'TS metrics-kubeletstatsreceiver.otel-* | STATS COUNT(*) BY @timestamp | WHERE throttled == true'
+      )
+    ).toBe('TS metrics-kubeletstatsreceiver.otel-*');
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/extract_from_source_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/extract_from_source_query.ts
@@ -8,8 +8,9 @@
 import { Parser } from '@elastic/esql';
 
 /**
- * Returns a FROM-only query (e.g. `FROM logs-*`) extracted from a full ES|QL
- * pipeline. Used for index-level field lookups such as resolving the time field.
+ * Returns the source command (e.g. `FROM logs-*` or `TS metrics-*`) extracted
+ * from a full ES|QL pipeline. Used for index-level field lookups such as
+ * resolving the time field.
  */
 export function extractFromSourceQuery(query: string): string {
   const trimmed = query.trim();
@@ -26,7 +27,7 @@ export function extractFromSourceQuery(query: string): string {
 
     return trimmed.slice(fromCmd.location.min, fromCmd.location.max + 1).trim();
   } catch {
-    const match = trimmed.match(/^\s*(FROM\s+[^|]+)/i);
+    const match = trimmed.match(/^\s*((?:FROM|TS)\s+[^|]+)/i);
     return match ? match[1].trim() : '';
   }
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/extract_from_source_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/extract_from_source_query.ts
@@ -6,11 +6,15 @@
  */
 
 import { Parser } from '@elastic/esql';
+import { getAnySourceCommandFromESQLQuery } from '@kbn/esql-utils';
 
 /**
- * Returns the source command (e.g. `FROM logs-*` or `TS metrics-*`) extracted
- * from a full ES|QL pipeline. Used for index-level field lookups such as
- * resolving the time field.
+ * Returns the source command (e.g. `FROM logs-*`, `TS metrics-*`, `PROMQL …`)
+ * extracted from a full ES|QL pipeline. Used for index-level field lookups
+ * such as resolving the time field.
+ *
+ * Matches any registered source command so FROM, TS, PROMQL, and future
+ * sources stay in sync with the language registry.
  */
 export function extractFromSourceQuery(query: string): string {
   const trimmed = query.trim();
@@ -19,15 +23,19 @@ export function extractFromSourceQuery(query: string): string {
   }
 
   try {
-    const { root } = Parser.parse(trimmed);
-    const fromCmd = root.commands.find((c) => c.name === 'from' || c.name === 'ts');
-    if (!fromCmd) {
+    const sourceCommandName = getAnySourceCommandFromESQLQuery(trimmed);
+    if (!sourceCommandName) {
       return '';
     }
 
-    return trimmed.slice(fromCmd.location.min, fromCmd.location.max + 1).trim();
+    const { root } = Parser.parse(trimmed);
+    const sourceCmd = root.commands.find((c) => c.name.toUpperCase() === sourceCommandName);
+    if (!sourceCmd) {
+      return '';
+    }
+
+    return trimmed.slice(sourceCmd.location.min, sourceCmd.location.max + 1).trim();
   } catch {
-    const match = trimmed.match(/^\s*((?:FROM|TS)\s+[^|]+)/i);
-    return match ? match[1].trim() : '';
+    return '';
   }
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.test.ts
@@ -19,8 +19,7 @@ const standaloneQuery: RuleQuery = {
   breach: { query: 'FROM logs-* | LIMIT 10' },
 };
 
-const PROMQL_QUERY =
-  'PROMQL index=metrics step=1m start=?_tstart end=?_tend (avg(cpu_usage))';
+const PROMQL_QUERY = 'PROMQL index=metrics step=1m start=?_tstart end=?_tend (avg(cpu_usage))';
 
 describe('getTimeFieldResolutionQuery', () => {
   it('returns the base query in alert mode when committed', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.test.ts
@@ -40,7 +40,7 @@ describe('getTimeFieldResolutionQuery', () => {
     expect(getTimeFieldResolutionQuery(composedQuery, true, false)).toBe('');
   });
 
-  it('returns empty when the candidate query has no FROM clause', () => {
+  it('returns empty when the candidate query has no FROM or TS source command', () => {
     expect(
       getTimeFieldResolutionQuery(
         { format: 'composed', base: '', breach: { segment: '| WHERE count > 1' } },
@@ -48,5 +48,22 @@ describe('getTimeFieldResolutionQuery', () => {
         true
       )
     ).toBe('');
+  });
+
+  it('returns a committed TS composed base query in alert mode', () => {
+    const tsQuery: RuleQuery = {
+      format: 'composed',
+      base: 'TS metrics-kubeletstatsreceiver.otel-* | STATS COUNT(*) BY @timestamp',
+      breach: { segment: '| WHERE throttled == true' },
+    };
+    expect(getTimeFieldResolutionQuery(tsQuery, true, true)).toBe(tsQuery.base);
+  });
+
+  it('returns a committed TS standalone query in signal mode', () => {
+    const tsQuery: RuleQuery = {
+      format: 'standalone',
+      breach: { query: 'TS metrics-* | LIMIT 10' },
+    };
+    expect(getTimeFieldResolutionQuery(tsQuery, false, true)).toBe(tsQuery.breach.query);
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.test.ts
@@ -19,6 +19,9 @@ const standaloneQuery: RuleQuery = {
   breach: { query: 'FROM logs-* | LIMIT 10' },
 };
 
+const PROMQL_QUERY =
+  'PROMQL index=metrics step=1m start=?_tstart end=?_tend (avg(cpu_usage))';
+
 describe('getTimeFieldResolutionQuery', () => {
   it('returns the base query in alert mode when committed', () => {
     expect(getTimeFieldResolutionQuery(composedQuery, true, true)).toBe(composedQuery.base);
@@ -40,7 +43,7 @@ describe('getTimeFieldResolutionQuery', () => {
     expect(getTimeFieldResolutionQuery(composedQuery, true, false)).toBe('');
   });
 
-  it('returns empty when the candidate query has no FROM or TS source command', () => {
+  it('returns empty when the candidate query has no source command', () => {
     expect(
       getTimeFieldResolutionQuery(
         { format: 'composed', base: '', breach: { segment: '| WHERE count > 1' } },
@@ -65,5 +68,29 @@ describe('getTimeFieldResolutionQuery', () => {
       breach: { query: 'TS metrics-* | LIMIT 10' },
     };
     expect(getTimeFieldResolutionQuery(tsQuery, false, true)).toBe(tsQuery.breach.query);
+  });
+
+  it('returns a committed PROMQL query', () => {
+    const promqlQuery: RuleQuery = {
+      format: 'standalone',
+      breach: { query: PROMQL_QUERY },
+    };
+    expect(getTimeFieldResolutionQuery(promqlQuery, false, true)).toBe(PROMQL_QUERY);
+  });
+
+  it('returns a committed ROW query', () => {
+    const rowQuery: RuleQuery = {
+      format: 'standalone',
+      breach: { query: 'ROW a = 1' },
+    };
+    expect(getTimeFieldResolutionQuery(rowQuery, true, true)).toBe('ROW a = 1');
+  });
+
+  it('returns a committed query that starts with SET then FROM', () => {
+    const setQuery: RuleQuery = {
+      format: 'standalone',
+      breach: { query: 'SET unmapped_fields = "FAIL"; FROM logs-* | LIMIT 10' },
+    };
+    expect(getTimeFieldResolutionQuery(setQuery, true, true)).toBe(setQuery.breach.query);
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.ts
@@ -8,7 +8,7 @@
 import type { RuleQuery } from '../../form/types';
 import { getBreachQuery } from '../../form/utils/query_helpers';
 
-const FROM_QUERY_PATTERN = /^\s*FROM\s+[a-zA-Z0-9_.*-]/i;
+const SOURCE_QUERY_PATTERN = /^\s*(?:FROM|TS)\s+[a-zA-Z0-9_.*-]/i;
 
 /**
  * Returns the ES|QL query used to resolve index date fields for time-field
@@ -28,5 +28,5 @@ export function getTimeFieldResolutionQuery(
   const fullQuery = getBreachQuery(query);
   // Prefer composed base for alerts; YAML-only standalone alerts only have breach.query.
   const candidate = isAlert ? baseQuery || fullQuery : fullQuery;
-  return FROM_QUERY_PATTERN.test(candidate) && queryCommitted ? candidate : '';
+  return SOURCE_QUERY_PATTERN.test(candidate) && queryCommitted ? candidate : '';
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/get_time_field_resolution_query.ts
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
+import { getAnySourceCommandFromESQLQuery } from '@kbn/esql-utils';
 import type { RuleQuery } from '../../form/types';
 import { getBreachQuery } from '../../form/utils/query_helpers';
-
-const SOURCE_QUERY_PATTERN = /^\s*(?:FROM|TS)\s+[a-zA-Z0-9_.*-]/i;
 
 /**
  * Returns the ES|QL query used to resolve index date fields for time-field
@@ -18,6 +17,10 @@ const SOURCE_QUERY_PATTERN = /^\s*(?:FROM|TS)\s+[a-zA-Z0-9_.*-]/i;
  * Alert + standalone is YAML-only and never authored by the form, but the
  * Query sandbox still opens from YAML mode — those rules have no composed
  * base, so fall back to `breach.query` for field-caps resolution.
+ *
+ * Any registered ES|QL source command (FROM, TS, PROMQL, ROW, SHOW, …) is
+ * eligible; the language registry is the source of truth so new commands do
+ * not need a local allowlist.
  */
 export function getTimeFieldResolutionQuery(
   query: RuleQuery,
@@ -28,5 +31,5 @@ export function getTimeFieldResolutionQuery(
   const fullQuery = getBreachQuery(query);
   // Prefer composed base for alerts; YAML-only standalone alerts only have breach.query.
   const candidate = isAlert ? baseQuery || fullQuery : fullQuery;
-  return SOURCE_QUERY_PATTERN.test(candidate) && queryCommitted ? candidate : '';
+  return queryCommitted && Boolean(getAnySourceCommandFromESQLQuery(candidate)) ? candidate : '';
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_resolve_time_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/use_resolve_time_field.test.tsx
@@ -17,6 +17,7 @@ import { ruleFormKeys } from '../../form/hooks/query_key_factory';
 import { useResolveTimeField } from './use_resolve_time_field';
 
 jest.mock('@kbn/esql-utils', () => ({
+  ...jest.requireActual('@kbn/esql-utils'),
   getESQLTimeField: jest.fn(async () => undefined),
 }));
 


### PR DESCRIPTION
## Summary
- Time-field resolution in the Compose Discover flyout now treats any registered ES|QL source command (`FROM`, `TS`, `PROMQL`, …) as eligible, so timeseries templates can resolve `@timestamp` (and other date fields) instead of failing with an empty field list.
- Source extraction uses `getAnySourceCommandFromESQLQuery` from `@kbn/esql-utils` so new source commands follow the language registry instead of a local `FROM`/`TS` regex.
- Fixes #280931

<img width="1521" height="619" alt="Screenshot 2026-08-17 at 3 59 35 PM" src="https://github.com/user-attachments/assets/07748ac7-d0c0-43a2-b3a2-276163863519" />
<img width="1533" height="661" alt="Screenshot 2026-08-17 at 3 46 35 PM" src="https://github.com/user-attachments/assets/ff2da45e-f996-43b6-8299-56095f7f9f14" />

## Manual testing
**Easiest TS repro**
1. Home → Add sample data → **Sample web logs (TSDB)** (or `POST /api/sample_data/logstsdb`)
2. Head to the rule form and try to create a a rule with
     ```esql
     TS kibana_sample_data_logstsdb
     ```
3. Confirm time-field resolution picks `@timestamp` and the sandbox is not blocked
4. Using data forge or any other data, try to create a FROM query rule and ensure no regressions. 