### PR TITLE
[Alerting v2] Fix missing Create rule icon

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_header.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_header.tsx
@@ -35,7 +35,7 @@ const getRulesListMenu = ({
     label: i18n.translate('xpack.alertingV2.rulesList.createRuleButton', {
       defaultMessage: 'Create rule',
     }),
-    iconType: 'plusInCircle',
+    iconType: 'plusCircle',
     run: onCreateRule,
     testId: 'createRuleButton',
     popoverTestId: 'createRulePopoverPanel',


### PR DESCRIPTION
## Summary

The v2 rules list **Create rule** split button used `iconType: 'plusInCircle'`, which is not a current EUI glyph. `EuiIcon` treats unknown strings as image URLs, so the button showed a broken-image placeholder.

This switches the token to `plusCircle`, matching the Action Policies create button and current EUI icon names.
