### PR TITLE
[Alerting V2] Recover immediately when no data strategy is recover

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_strategy_select.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_strategy_select.test.tsx
@@ -22,7 +22,9 @@ describe('NoDataStrategySelect', () => {
 
   it('displays the correct text for each strategy value', () => {
     const { rerender } = render(<NoDataStrategySelect value="recover" onChange={jest.fn()} />);
-    expect(screen.getByTestId('ruleV2NoDataStrategySelect')).toHaveTextContent('Recover');
+    expect(screen.getByTestId('ruleV2NoDataStrategySelect')).toHaveTextContent(
+      'Recover immediately'
+    );
 
     rerender(<NoDataStrategySelect value="none" onChange={jest.fn()} />);
     expect(screen.getByTestId('ruleV2NoDataStrategySelect')).toHaveTextContent('Do nothing');
@@ -43,7 +45,7 @@ describe('NoDataStrategySelect', () => {
     render(<NoDataStrategySelect value="last_known_status" onChange={onChange} />);
 
     await user.click(screen.getByTestId('ruleV2NoDataStrategySelect'));
-    await user.click(screen.getByText('Recover'));
+    await user.click(screen.getByText('Recover immediately'));
 
     expect(onChange).toHaveBeenCalledWith('recover');
   });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_strategy_select.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_strategy_select.tsx
@@ -39,14 +39,14 @@ const LAST_KNOWN_STATUS_DESCRIPTION = i18n.translate(
 
 const RECOVER_TITLE = i18n.translate(
   'xpack.alertingV2.ruleForm.noDataStrategyField.recover.title',
-  { defaultMessage: 'Recover' }
+  { defaultMessage: 'Recover immediately' }
 );
 
 const RECOVER_DESCRIPTION = i18n.translate(
   'xpack.alertingV2.ruleForm.noDataStrategyField.recover.description',
   {
     defaultMessage:
-      'Automatically transition active alerts to recovered status when no new data is received.',
+      'Resolve the alert episode on the first no-data run, regardless of any configured recovery delay.',
   }
 );
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_strategy_select.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/no_data_strategy_select.tsx
@@ -45,8 +45,7 @@ const RECOVER_TITLE = i18n.translate(
 const RECOVER_DESCRIPTION = i18n.translate(
   'xpack.alertingV2.ruleForm.noDataStrategyField.recover.description',
   {
-    defaultMessage:
-      'Resolve the alert episode on the first no-data run, regardless of any configured recovery delay.',
+    defaultMessage: 'Resolve the alert episode on the first no-data run.',
   }
 );
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -142,7 +142,11 @@ export const noDataStrategySchema = z.union([
     .describe(
       'Emits a `no_data` alert event when no_data query returns no rows for the group. "emit" is not currently accepted by the create/update API.'
     ),
-  z.literal('recover').describe('Forces recovery when no data is present.'),
+  z
+    .literal('recover')
+    .describe(
+      'Resolves the alert episode to inactive on the first no-data run, regardless of any configured recovery delay.'
+    ),
   z.literal('none').describe('No-data situations are ignored (default).'),
 ]);
 export const noDataStrategy = {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -142,11 +142,7 @@ export const noDataStrategySchema = z.union([
     .describe(
       'Emits a `no_data` alert event when no_data query returns no rows for the group. "emit" is not currently accepted by the create/update API.'
     ),
-  z
-    .literal('recover')
-    .describe(
-      'Resolves the alert episode to inactive on the first no-data run, regardless of any configured recovery delay.'
-    ),
+  z.literal('recover').describe('Resolves the alert episode to inactive on the first no-data run.'),
   z.literal('none').describe('No-data situations are ignored (default).'),
 ]);
 export const noDataStrategy = {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.test.ts
@@ -289,7 +289,7 @@ describe('rule template create-rule schema coupling', () => {
                 },
                 Object {
                   "const": "recover",
-                  "description": "Forces recovery when no data is present.",
+                  "description": "Resolves the alert episode to inactive on the first no-data run, regardless of any configured recovery delay.",
                   "type": "string",
                 },
                 Object {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.test.ts
@@ -289,7 +289,7 @@ describe('rule template create-rule schema coupling', () => {
                 },
                 Object {
                   "const": "recover",
-                  "description": "Resolves the alert episode to inactive on the first no-data run, regardless of any configured recovery delay.",
+                  "description": "Resolves the alert episode to inactive on the first no-data run.",
                   "type": "string",
                 },
                 Object {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_conditions.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_conditions.test.tsx
@@ -252,9 +252,11 @@ describe('RuleConditions', () => {
     );
   });
 
-  it('renders "Recover" for recover strategy', () => {
+  it('renders "Recover immediately" for recover strategy', () => {
     renderConditions({ ...alertRule, no_data_strategy: 'recover' });
-    expect(screen.getByTestId('alertingV2RuleDetailsNoDataStrategy')).toHaveTextContent('Recover');
+    expect(screen.getByTestId('alertingV2RuleDetailsNoDataStrategy')).toHaveTextContent(
+      'Recover immediately'
+    );
   });
 
   it('renders "Do nothing" for none strategy', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/utils.ts
@@ -132,7 +132,7 @@ const NO_DATA_STRATEGY_LABELS: Record<NoDataStrategy, string> = {
     defaultMessage: 'Use no data status',
   }),
   recover: i18n.translate('xpack.alertingV2.ruleDetails.noDataStrategy.recover', {
-    defaultMessage: 'Recover',
+    defaultMessage: 'Recover immediately',
   }),
   none: i18n.translate('xpack.alertingV2.ruleDetails.noDataStrategy.none', {
     defaultMessage: 'Do nothing',

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
@@ -142,7 +142,7 @@ exports[`schema_to_skill_docs generateNoDataStrategyDoc matches the reviewed ski
 |---|---|
 | \`last_known_status\` | Holds the last known episode status when no data is present. |
 | \`emit\` | Emits a \`no_data\` alert event when no_data query returns no rows for the group. \\"emit\\" is not currently accepted by the create/update API. |
-| \`recover\` | Forces recovery when no data is present. |
+| \`recover\` | Resolves the alert episode to inactive on the first no-data run. |
 | \`none\` | No-data situations are ignored (default). |
 
 When setting \`no_data_strategy\` to anything other than \`'none'\`, add a \`no_data\` block to the standalone query:

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/README.md
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/README.md
@@ -128,7 +128,7 @@ The director writes one of these episode statuses:
 | `active` | `'recover'` | `inactive` |
 | `recovering` | `'recover'` | `inactive` |
 
-For `'recover'`, the episode resolves directly to `inactive` on the first no-data run, regardless of any configured recovery delay. No prior episode (null) always returns `pending`.
+For `'recover'`, the episode resolves directly to `inactive` on the first no-data run.
 
 ### `CountTimeframeStrategy`
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/README.md
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/README.md
@@ -125,10 +125,10 @@ The director writes one of these episode statuses:
 | any | `'last_known_status'` | (unchanged — preserve current status) |
 | `inactive` | `'recover'` | `inactive` |
 | `pending` | `'recover'` | `inactive` |
-| `active` | `'recover'` | `recovering` |
+| `active` | `'recover'` | `inactive` |
 | `recovering` | `'recover'` | `inactive` |
 
-For `'recover'`, the director applies the same FSM transitions as a `recovered` event would. No prior episode (null) always returns `pending`.
+For `'recover'`, the episode resolves directly to `inactive` on the first no-data run, regardless of any configured recovery delay. No prior episode (null) always returns `pending`.
 
 ### `CountTimeframeStrategy`
 
@@ -136,6 +136,8 @@ For `'recover'`, the director applies the same FSM transitions as a `recovered` 
 
 - `pending -> active`
 - `recovering -> inactive`
+
+A `no_data` event on a rule with `no_data_strategy: 'recover'` always bypasses this gating and resolves directly to `inactive`, regardless of `recovering_count` / `recovering_timeframe`.
 
 It supports:
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/strategies/basic_strategy.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/strategies/basic_strategy.test.ts
@@ -200,9 +200,9 @@ describe('BasicTransitionStrategy', () => {
     it.each<[AlertEpisodeStatus, AlertEpisodeStatus]>([
       [alertEpisodeStatus.inactive, alertEpisodeStatus.inactive],
       [alertEpisodeStatus.pending, alertEpisodeStatus.inactive],
-      [alertEpisodeStatus.active, alertEpisodeStatus.recovering],
+      [alertEpisodeStatus.active, alertEpisodeStatus.inactive],
       [alertEpisodeStatus.recovering, alertEpisodeStatus.inactive],
-    ])("'recover' transitions %s → %s (mirrors recovered-event FSM)", (from, to) => {
+    ])("'recover' transitions %s → %s (resolves immediately to inactive)", (from, to) => {
       const result = getNextState({
         eventStatus: alertEventStatus.no_data,
         noDataStrategy: 'recover',

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/strategies/basic_strategy.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/strategies/basic_strategy.ts
@@ -83,7 +83,7 @@ export class BasicTransitionStrategy implements ITransitionStrategy {
     if (noDataStrategy === 'emit') {
       noData = alertEpisodeStatus.active;
     } else if (noDataStrategy === 'recover') {
-      noData = base.recovered;
+      noData = alertEpisodeStatus.inactive;
     }
 
     return { breached: base.breached, recovered: base.recovered, no_data: noData };

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/strategies/count_timeframe_strategy.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/strategies/count_timeframe_strategy.test.ts
@@ -478,6 +478,55 @@ describe('CountTimeframeStrategy', () => {
     });
   });
 
+  describe("no_data event with no_data_strategy: 'recover'", () => {
+    const stateTransition: RuleResponse['state_transition'] = {
+      pending_count: 3,
+      recovering_count: 3,
+    };
+
+    it('transitions inactive → inactive immediately, ignoring pending gating', () => {
+      expectTransition({
+        from: alertEpisodeStatus.inactive,
+        on: alertEventStatus.no_data,
+        to: alertEpisodeStatus.inactive,
+        stateTransition,
+        noDataStrategy: 'recover',
+      });
+    });
+
+    it('transitions pending → inactive immediately, ignoring pending gating', () => {
+      expectTransition({
+        from: alertEpisodeStatus.pending,
+        on: alertEventStatus.no_data,
+        to: alertEpisodeStatus.inactive,
+        stateTransition,
+        noDataStrategy: 'recover',
+        statusCount: 1,
+      });
+    });
+
+    it('transitions active → inactive immediately, ignoring recovery delay', () => {
+      expectTransition({
+        from: alertEpisodeStatus.active,
+        on: alertEventStatus.no_data,
+        to: alertEpisodeStatus.inactive,
+        stateTransition,
+        noDataStrategy: 'recover',
+      });
+    });
+
+    it('transitions recovering → inactive immediately, ignoring recovery delay', () => {
+      expectTransition({
+        from: alertEpisodeStatus.recovering,
+        on: alertEventStatus.no_data,
+        to: alertEpisodeStatus.inactive,
+        stateTransition,
+        noDataStrategy: 'recover',
+        statusCount: 1,
+      });
+    });
+  });
+
   describe("no_data event with no_data_strategy: 'emit'", () => {
     const stateTransition: RuleResponse['state_transition'] = {
       pending_count: 3,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/strategies/count_timeframe_strategy.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/director/strategies/count_timeframe_strategy.ts
@@ -6,8 +6,9 @@
  */
 
 import { injectable } from 'inversify';
+import { noDataStrategy } from '@kbn/alerting-v2-schemas';
 import type { AlertEpisodeStatus } from '../../../resources/datastreams/alert_events';
-import { alertEpisodeStatus } from '../../../resources/datastreams/alert_events';
+import { alertEpisodeStatus, alertEventStatus } from '../../../resources/datastreams/alert_events';
 import type { RuleResponse } from '../../rules_client/types';
 import { parseDurationToMs } from '../../duration';
 import { BasicTransitionStrategy } from './basic_strategy';
@@ -122,6 +123,13 @@ export class CountTimeframeStrategy extends BasicTransitionStrategy {
     const basicResult = super.getNextState(ctx);
 
     if (!stateTransition) {
+      return basicResult;
+    }
+
+    if (
+      alertEvent.status === alertEventStatus.no_data &&
+      rule.no_data_strategy === noDataStrategy.recover
+    ) {
       return basicResult;
     }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/engine/api/tests/director.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/engine/api/tests/director.spec.ts
@@ -1482,7 +1482,7 @@ apiTest.describe('Director', { tag: tags.stateful.classic }, () => {
   );
 
   apiTest(
-    "no_data_strategy 'recover' transitions the episode toward recovery via a no_data event",
+    "no_data_strategy 'recover' resolves the episode to inactive via a no_data event",
     async ({ apiServices }) => {
       const HOST = 'host-director-no-data-recover';
 
@@ -1535,9 +1535,9 @@ apiTest.describe('Director', { tag: tags.stateful.classic }, () => {
       });
 
       expect(noDataEvents.length).toBeGreaterThanOrEqual(1);
-      // The director applies the recovered FSM transition: active → recovering.
+      // The director resolves the episode directly to inactive, ignoring recovering_count.
       for (const event of noDataEvents) {
-        expect(event.episode?.status).toBe('recovering');
+        expect(event.episode?.status).toBe('inactive');
       }
     }
   );

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/engine/api/tests/rule_executor.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/engine/api/tests/rule_executor.spec.ts
@@ -2141,7 +2141,7 @@ apiTest.describe('Rule executor', { tag: tags.stateful.classic }, () => {
         // Pair 'recover' no-data strategy with recovery_strategy 'none' so
         // the recovery step does not emit a recovered event for the group —
         // confirming the no_data event comes from the no-data step and the
-        // director drives the episode toward recovery.
+        // director resolves the episode directly to inactive.
         recovery_strategy: 'none',
         no_data_strategy: 'recover',
       })


### PR DESCRIPTION
## Summary

Closes [rna-program#775](https://github.com/elastic/rna-program/issues/775).

`no_data_strategy: 'recover'` currently routes a no-data event through the recovery FSM: from `active` it goes to `recovering` (not `inactive`), and it inherits any configured recovery delay (`recovering_count` / `recovering_timeframe` / `recovering_operator`). That means a "recover on no data" alert can take multiple runs to actually close, and its behavior depends on unrelated recovery-delay config — surprising, and the root cause of a real incident (Rootly 3361 "v2 alerts may not recover").

This PR makes `no_data_strategy: 'recover'` resolve the episode **immediately** — straight to `inactive` on the first no-data run, ignoring any recovery delay, independent of `recovery_strategy`. This matches the semantics of a manual resolve. The schema value stays `recover` (no rename).

### Notes
- No schema/model version change — `no_data_strategy` values are unchanged.
- No change to `recovery_strategy` or recovery-delay behavior for genuine `recovered` events.

## Changes

- `basic_strategy.ts`: the `recover` no-data branch now maps unconditionally to `inactive` (previously mirrored the `recovered`-event FSM, which took `active` through `recovering`).
- `count_timeframe_strategy.ts`: a `no_data` event on a `recover` rule now bypasses `recovering_count`/`recovering_timeframe` gating entirely, so a group already in `recovering` from a genuine prior recovery also closes immediately when a no-data run hits.
- UI labels ("Recover" → "Recover immediately") and descriptions in the rule form and rule-details sidebar, to reflect the new immediate-resolve behavior.
- API schema description for `no_data_strategy: 'recover'` updated to match.
- Director `README.md` updated (FSM table + prose).
- Tests updated/added for the new FSM transitions across `basic_strategy` and `count_timeframe_strategy`, plus Scout e2e coverage.

## Test plan

- [x] Unit tests: `basic_strategy.test.ts`, `count_timeframe_strategy.test.ts`
- [x] Type check: `alerting_v2` plugin, `alerting-v2-rule-form` package
- [x] Lint
- [ ] Manual: create a rule with `no_data_strategy: recover` and a non-zero recovery delay, drive it active, remove the data source — episode should go `active → inactive` in a single no-data run (no `recovering` step, delay ignored)
EOF
