### PR TITLE
[SigEvents][Investigator] Prevent investigator from auto-loading management skill

### DIFF
--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/skills/investigation_management/index.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/skills/investigation_management/index.ts
@@ -18,6 +18,7 @@ export const streamsInvestigationManagementSkill = defineSkillType({
     'Streams investigation management: trigger a root-cause analysis workflow for an observability issue, significant event, or alert; check the status of a running investigation; and summarise the structured findings once complete. Load when the user asks to investigate an incident, error, or anomaly — including a significant event attached to the conversation or a fired alert — optionally scoped to specific data streams.',
   content,
   experimental: true,
+  excludeFromElasticCapabilities: true,
   getRegistryTools: () => [
     platformCoreTools.executeWorkflow,
     // Used when execute_workflow returns before completion: the tool waits up to ~120s and

--- a/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/skills/investigation_management/skill.md.text
+++ b/x-pack/platform/plugins/shared/significant_events/server/memory_and_investigation/skills/investigation_management/skill.md.text
@@ -21,7 +21,7 @@ workflowId: "system-significant-events-investigation"
 inputs:
   message: "<required – describe the issue or event to investigate>"
   stream_names: ["<optional – data stream names to scope the investigation>"]
-  context: { <optional – any structured context, e.g. sig event or alert metadata> }
+  context: { <optional – any structured context, e.g. significant event or alert metadata> }
   concurrency_key: "<optional – stable key to de-duplicate repeated investigations>"
 waitForCompletion: true
 ```
@@ -35,8 +35,8 @@ waitForCompletion: true
 **Input schema:**
 - `message` (string, required) — a clear description of the issue to investigate. Include symptoms, time range, and any relevant context. Be specific.
 - `stream_names` (string array, optional) — data stream names to scope observability queries. Leave empty to let the investigation agent discover relevant streams.
-- `context` (object, optional) — structured context such as sig event metadata, alert payload, or environment info. Passed verbatim to the investigation agent.
-- `concurrency_key` (string, optional) — a stable key (e.g. a sig event's discovery slug or an alert id). Investigations sharing a key are de-duplicated: starting a new one cancels any in-progress investigation with the same key.
+- `context` (object, optional) — structured context such as significant event metadata, alert payload, or environment info. Passed verbatim to the investigation agent.
+- `concurrency_key` (string, optional) — a stable key (e.g. a significant event's event id or an alert id). Investigations sharing a key are de-duplicated: starting a new one cancels any in-progress investigation with the same key.
 
 **Example call (free-form issue):**
 ```
@@ -64,7 +64,7 @@ When the user wants to investigate a Significant Event, gather the event's metad
 - `concurrency_key`: the event's `Event ID` — this de-duplicates with the investigation that the significant-events discovery automatically launches for promoted events (so a chat-initiated investigation supersedes an in-flight automatic one rather than running twice).
 - `context`: a structured object with the event metadata you can read from the attachment.
 
-**Example call (sig event context):**
+**Example call (significant event context):**
 ```
 execute_workflow({
   workflowId: "system-significant-events-investigation",


### PR DESCRIPTION
## Summary

Fixes the Nightshift Investigator agent silently cancelling itself mid-run.

The `streams-investigation-management` skill was registered without `excludeFromElasticCapabilities: true`. Because the investigator agent has `enable_elastic_capabilities: true`, the runtime auto-injected the skill into its available skills list. The skill's description — "Load when the user asks to investigate an incident, error, or anomaly" — matched the agent's current task exactly, so the agent loaded it and followed its instructions: call `execute_workflow('system-significant-events-investigation', { concurrency_key: event_id })`.

That triggered a second investigation for the same event. The workflow's `strategy: cancel-in-progress` concurrency policy cancelled the running investigation. The AbortMonitor detected `status: aborted` and fired the abort signal → "Converse request was aborted" → no hypotheses recorded → "Investigation result unavailable" in the UI.

**Evidence from nightshift-customer0 (Aug 13–17):**

## Self-cancellation evidence 

Each investigator conversation loaded `streams-investigation-management`, then called
`execute_workflow(system-significant-events-investigation, {concurrency_key: <event_id>})` —
the same key the running investigation was registered under. The new execution's
`cancel-in-progress` policy killed the caller within seconds.

| Time (UTC) | Conv (first 8) | `load_skill` | `execute_workflow` | Gap | Abort dur |
|---|---|---|---|---|---|
| Aug 13 13:34 | `c7d5244c` | 13:34:18 | 13:34:31 | 13 s | 30 s |
| Aug 14 12:02 | `86b08ba2` | 12:02:27 | 12:02:40 | 13 s | 34 s |
| Aug 14 14:18 | `8869008a` | 14:18:55 | 14:19:11 | 16 s | 24 s |
| Aug 14 15:04 | `38d7b71e` | 15:04:31 | 15:04:47 | 16 s | 24 s |
| Aug 17 05:36 | `3d8d8bc3` | 05:36:21 | 05:36:35 | 14 s | 22 s |
| Aug 17 10:29 | `b472d965` | 10:29:29 | 10:29:48 | 19 s | 38 s |
| Aug 17 12:51 | `9cbb2edd` | 12:51:46 | 12:52:01 | 15 s | — |
| Aug 17 18:02 | `18fb2c40` | 18:02:55 | 18:03:13 | 18 s | — |
| Aug 17 20:10 | `7c354be1` | 20:10:30 | 20:10:42 | 12 s | — |
| Aug 18 00:23 | `9a86c4c8` | 00:23:49 | 00:23:58 | 9 s | — |
| Aug 18 05:06 | `b59623a3` | 05:06:03 | 05:06:38 | 35 s | — |
| Aug 18 06:28 | `2cfb8b61` | 06:28:14 | 06:28:30 | 16 s | — |

**Source:** `traces-agent_builder.otel-*` on nightshift-customer0.
36 total `load_skill(streams-investigation-management)` calls recorded since Aug 13.
12 followed through to `execute_workflow` and self-cancelled; the remaining 24 did not call it.

### Sequence (per conversation)

1. `invoke_agent Streams Investigator` starts — workflow already running under `concurrency_key = <event_id>`
2. Agent loads `streams-investigation-management` (~10–35 s in)
3. Skill instructs agent to call `execute_workflow(system-significant-events-investigation, {concurrency_key: <event_id>})`
4. New execution fires with the same key → `cancel-in-progress` policy cancels the running one
5. `AbortMonitor` detects `status = aborted` → fires abort signal → **"Converse request was aborted"**
6. UI shows **"Investigation result unavailable"**

Healthy investigations (from API conversations + traces):
- Agent loads `significant-events-memory` + `rca` + `streams-management`
- Does memory searches, ES|QL, inspect_streams, etc.
- Completes normally, conversation appears in API

9 self-triggering `execute_workflow` calls confirmed in traces across Aug 13–17. All trace entries show `gen_ai.agent.id: significant-events.investigation` as the caller — not a chat agent.

**Fix:** Add `excludeFromElasticCapabilities: true` — same pattern already applied to `ki-grounding`, `memory-synthesis`, `memory-consolidation`, `gap-detection`, `conversation-scraper`, and `ki-identification-management`. Chat agents that need the skill still load it via `load_skill`.

Also updates two stale "sig event" / "discovery slug" references in the skill instructions.

Closes https://github.com/elastic/nightshift-program/issues/1160

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk: one-line config change, no runtime behaviour change for agents that don't auto-load the skill. Chat agents still load it on demand via `load_skill`.