### PR TITLE
[Security Solution][CPS] Fix detection rules skipping execution when indices only exist on linked projects

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -310,6 +310,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             secondaryTimestamp,
             ruleExecutionLogger,
             isServerless: isServerless ?? false,
+            cpsData: options.cpsData,
           });
 
           warnings.forEach((warningMessage) => ruleExecutionLogger.warn(warningMessage));

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/validation/run_execution_validation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/validation/run_execution_validation.test.ts
@@ -11,12 +11,11 @@ import type { RuleParams } from '../../rule_schema';
 import { getQueryRuleParams, getMlRuleParams } from '../../rule_schema/mocks';
 import { runExecutionValidation } from './run_execution_validation';
 
+const mockGetIndexPatternMatches = jest.fn();
+
 jest.mock('@kbn/data-views-plugin/server', () => ({
   IndexPatternsFetcher: jest.fn().mockImplementation(() => ({
-    getIndexPatternMatches: jest.fn().mockResolvedValue({
-      matchedIndexPatterns: ['auditbeat-*'],
-      matchedIndices: ['auditbeat-1'],
-    }),
+    getIndexPatternMatches: mockGetIndexPatternMatches,
   })),
 }));
 
@@ -39,7 +38,8 @@ describe('runExecutionValidation', () => {
 
   const run = (
     params: RuleParams = getQueryRuleParams(),
-    secondaryTimestamp: string | undefined = undefined
+    secondaryTimestamp: string | undefined = undefined,
+    cpsData?: Parameters<typeof runExecutionValidation>[0]['cpsData']
   ) =>
     runExecutionValidation({
       params,
@@ -51,12 +51,49 @@ describe('runExecutionValidation', () => {
       secondaryTimestamp,
       ruleExecutionLogger,
       isServerless: false,
+      cpsData,
     });
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetIndexPatternMatches.mockResolvedValue({
+      matchedIndexPatterns: ['auditbeat-*'],
+      matchedIndices: ['auditbeat-1'],
+    });
     scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
     ruleExecutionLogger = ruleExecutionLogMock.forExecutors.create();
+  });
+
+  describe('CPS linked project index patterns', () => {
+    const cpsData = {
+      linkedProjects: [
+        { id: 'proj-1', alias: 'linked_one', type: 'security', organization: 'org-1' },
+        { id: 'proj-2', alias: 'linked_two', type: 'security', organization: 'org-1' },
+      ],
+    };
+
+    it('checks only local patterns when no cpsData is provided', async () => {
+      await run();
+      expect(mockGetIndexPatternMatches).toHaveBeenCalledWith(['auditbeat-*']);
+    });
+
+    it('checks local and remote-qualified patterns when linked projects exist', async () => {
+      await run(getQueryRuleParams(), undefined, cpsData);
+      expect(mockGetIndexPatternMatches).toHaveBeenCalledWith([
+        'auditbeat-*',
+        'linked_one:auditbeat-*',
+        'linked_two:auditbeat-*',
+      ]);
+    });
+
+    it('skips execution when no pattern matches locally or on linked projects', async () => {
+      mockGetIndexPatternMatches.mockResolvedValue({
+        matchedIndexPatterns: [],
+        matchedIndices: [],
+      });
+      const result = await run(getQueryRuleParams(), undefined, cpsData);
+      expect(result.skipExecution).toBe(true);
+    });
   });
 
   describe('dateNanosTimestampFields', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/validation/run_execution_validation.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/validation/run_execution_validation.ts
@@ -8,6 +8,7 @@
 import type { estypes } from '@elastic/elasticsearch';
 import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import { IndexPatternsFetcher } from '@kbn/data-views-plugin/server';
+import type { CpsData } from '@kbn/alerting-plugin/server/types';
 import type { IRuleExecutionLogForExecutors } from '../../rule_monitoring';
 import type { RuleParams } from '../../rule_schema';
 import {
@@ -28,6 +29,7 @@ export interface RunExecutionValidationParams {
   secondaryTimestamp: string | undefined;
   ruleExecutionLogger: IRuleExecutionLogForExecutors;
   isServerless: boolean;
+  cpsData?: CpsData;
 }
 
 export interface RunExecutionValidationResult {
@@ -37,6 +39,9 @@ export interface RunExecutionValidationResult {
   dateNanosTimestampFields: string[];
   mixedTimestampFields: string[];
 }
+
+const buildRemoteIndexPatterns = (localPatterns: string[], linkedProjectAliases: string[]) =>
+  linkedProjectAliases.flatMap((alias) => localPatterns.map((pattern) => `${alias}:${pattern}`));
 
 /**
  * Runs pre-execution validation for a security rule: index pattern resolution,
@@ -56,7 +61,10 @@ export const runExecutionValidation = async (
     secondaryTimestamp,
     ruleExecutionLogger,
     isServerless,
+    cpsData,
   } = options;
+
+  const linkedProjectAliases = cpsData?.linkedProjects.map(({ alias }) => alias) ?? [];
 
   const warnings: string[] = [];
   let skipExecution = false;
@@ -80,8 +88,13 @@ export const runExecutionValidation = async (
   const indexPatterns = new IndexPatternsFetcher(scopedClusterClient.asCurrentUser);
 
   try {
+    const patternsToCheck =
+      linkedProjectAliases.length > 0
+        ? [...inputIndex, ...buildRemoteIndexPatterns(inputIndex, linkedProjectAliases)]
+        : inputIndex;
+
     const { matchedIndexPatterns, matchedIndices } = await indexPatterns.getIndexPatternMatches(
-      inputIndex
+      patternsToCheck
     );
 
     // Collect rule execution metrics
@@ -99,8 +112,16 @@ export const runExecutionValidation = async (
 
   if (isThreatParams(params)) {
     try {
+      const threatPatternsToCheck =
+        linkedProjectAliases.length > 0
+          ? [
+              ...params.threatIndex,
+              ...buildRemoteIndexPatterns(params.threatIndex, linkedProjectAliases),
+            ]
+          : params.threatIndex;
+
       const { matchedIndexPatterns: matchedThreatIndexPatterns } =
-        await indexPatterns.getIndexPatternMatches(params.threatIndex);
+        await indexPatterns.getIndexPatternMatches(threatPatternsToCheck);
 
       if (matchedThreatIndexPatterns.length === 0) {
         warnings.push(


### PR DESCRIPTION
## Summary

Fixes #283236. Rules whose index patterns matched nothing on the origin project were skipped by the pre-execution index check even when matching indices exist on CPS linked projects — silently producing no alerts.

When linked projects exist, the index-existence check now consults both the local patterns and remote-qualified ones (`<alias>:<pattern>`), for the input index and the threat index. A rule is skipped only when nothing matches locally or on any linked project. No behavior change without linked projects.

## Reproduce / verify locally

**The key condition: the rule's index pattern must match indices only on a linked (remote) project — nothing on the origin.** That's what trips the pre-execution check.

1. Start a CPS stack (origin ES :9220, linked ES :9230, Kibana :5620, projects pre-linked, UIAM enabled):

   ```bash
   node scripts/scout start-server --arch serverless --domain security_complete --serverConfigSet cps_local
   ```

2. Seed a document on the **linked** cluster only (writes don't route cross-project, so curl the linked ES directly):

   ```bash
   curl -sk -u elastic_serverless:changeme -X POST "https://localhost:9230/cps-test-events/_doc?refresh=true" \
     -H 'Content-Type: application/json' \
     -d "{\"@timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)\", \"host\": {\"name\": \"linked-host\"}}"
   ```

3. Open http://localhost:5620 and log in through the mock IdP page with the `admin` role (defaults are fine).

4. Create a detection rule: Security → Rules → Create new rule → **Custom query**:
   - Index patterns: just `cps-test-events*` (the UI will warn the index doesn't exist — that's the local-only preview check, ignore it)
   - Query: `*`, schedule: every 1m with generous look-back (e.g. 50m), enable it.

5. The rule runs on enable — check its last response:
   - **Without this fix:** `Warning` — "Unable to find matching indices"; the rule never runs, no alerts.
   - **With this fix:** `Succeeded`, and an alert from the linked-project document (`host.name: linked-host`) appears in the Alerts table.

Regression check: repeat with the document indexed on the **origin** only (`https://localhost:9220/...`) — the rule must still execute. (An earlier revision replaced local patterns with remote-only ones and failed this; the union approach passes both.)

If the rule warns even with the fix, check the Kibana logs for `Failed to create UIAM API key for alerting rule` — that means the rule's key isn't UIAM (e.g. it was created by the file-realm `elastic_serverless` user) and linked projects are invisible to it by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
