### PR TITLE
[Discover] Update leftover arrow icons to chevron icons

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/json_tree_viewer/tree_rows.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/json_tree_viewer/tree_rows.tsx
@@ -85,7 +85,11 @@ export const NodeRowView = memo(function NodeRowView({
     >
       {hasChildren ? (
         <span css={styles.caret}>
-          <EuiIcon type={isExpanded ? 'arrowDown' : 'arrowRight'} size="s" aria-hidden />
+          <EuiIcon
+            type={isExpanded ? 'chevronSingleDown' : 'chevronSingleRight'}
+            size="s"
+            aria-hidden
+          />
         </span>
       ) : (
         <span css={styles.caret} aria-hidden />

--- a/src/platform/plugins/shared/discover/public/components/view_mode_toggle/view_mode_toggle.tsx
+++ b/src/platform/plugins/shared/discover/public/components/view_mode_toggle/view_mode_toggle.tsx
@@ -369,7 +369,7 @@ const ViewModeSelector = ({
           buttonRef={buttonRef}
           data-test-subj={`${dataTestSubj}Button`}
           data-selected-value={dataSelectedValue}
-          iconType="arrowDown"
+          iconType="chevronSingleDown"
           iconSide="right"
           onClick={togglePopover}
         >

--- a/src/platform/plugins/shared/discover/public/context_awareness/inspector/profiles_inspector_view/document_profiles_section/get_expanded_action.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/inspector/profiles_inspector_view/document_profiles_section/get_expanded_action.test.tsx
@@ -31,7 +31,7 @@ describe('getExpandAction', () => {
   describe('when isExpanded is true', () => {
     const isExpanded = () => true;
 
-    it('returns an action with arrowDown icon', () => {
+    it('returns an action with chevronSingleDown icon', () => {
       // When
       const { icon } = setup({ isExpanded });
 
@@ -56,7 +56,7 @@ describe('getExpandAction', () => {
   describe('when isExpanded is false', () => {
     const isExpanded = () => false;
 
-    it('returns an action with arrowRight icon', () => {
+    it('returns an action with chevronSingleRight icon', () => {
       // When
       const { icon } = setup({ isExpanded });
 


### PR DESCRIPTION
## Summary

Several deprecated icons were fully removed in EUI v119.0.0: #284032. We still have some leftover arrow icon usages after the upgrade PR due to other in-flight PRs, e.g. #282141, causing the icons to render as missing:
<img src="https://github.com/user-attachments/assets/50e41c46-8eec-489c-b237-836d7258d125" />

This PR updates those dangling usages.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.