### PR TITLE
[Alerting V2] Add recovery and no-data strategy eval examples

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/evals/rule_management/rule_management.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/evals/rule_management/rule_management.spec.ts
@@ -13,6 +13,8 @@ import {
 import { expect } from '@playwright/test';
 import { tags } from '@kbn/scout';
 import { evaluate } from '../../src/evaluate';
+import { noDataExample } from '../../src/no_data';
+import { recoveryExample } from '../../src/recovery';
 import {
   ALERTING_TOOL_IDS,
   CREATE_WITH_AGENT_INITIAL_PROMPT,
@@ -240,5 +242,106 @@ evaluate.describe(
         });
       }
     );
+  }
+);
+
+evaluate.describe(
+  'Alerting V2 rule-management skill - recovery strategy updates',
+  { tag: tags.serverless.observability.complete },
+  () => {
+    evaluate('recovery strategy updates', async ({ evaluateDataset, hostMetricsIndex }) => {
+      await evaluateDataset({
+        dataset: {
+          name: 'alerting-v2: recovery strategy updates',
+          description:
+            'Composes an alert, then applies one recovery behavior per example: custom ' +
+            'threshold, no automatic recovery, or recover when the breach clears. Separate ' +
+            'examples cover composed and standalone query formats.',
+          examples: [
+            recoveryExample({
+              hostMetricsIndex,
+              format: 'composed',
+              strategy: 'query',
+            }),
+            recoveryExample({
+              hostMetricsIndex,
+              format: 'composed',
+              strategy: 'none',
+            }),
+            recoveryExample({
+              hostMetricsIndex,
+              format: 'composed',
+              strategy: 'no_breach',
+            }),
+            recoveryExample({
+              hostMetricsIndex,
+              format: 'standalone',
+              strategy: 'query',
+            }),
+            recoveryExample({
+              hostMetricsIndex,
+              format: 'standalone',
+              strategy: 'none',
+            }),
+            recoveryExample({
+              hostMetricsIndex,
+              format: 'standalone',
+              strategy: 'no_breach',
+            }),
+          ],
+        },
+      });
+    });
+  }
+);
+
+evaluate.describe(
+  'Alerting V2 rule-management skill - no-data strategy updates',
+  { tag: tags.serverless.observability.complete },
+  () => {
+    evaluate('no-data strategy updates', async ({ evaluateDataset, hostMetricsIndex }) => {
+      await evaluateDataset({
+        dataset: {
+          name: 'alerting-v2: no-data strategy updates',
+          description:
+            'Composes an alert, then applies one no-data behavior per example: hold last ' +
+            'known status, recover when quiet, or ignore missing data. Separate examples ' +
+            'cover composed (base as data-presence query) and standalone (explicit no_data ' +
+            'query) formats.',
+          examples: [
+            noDataExample({
+              hostMetricsIndex,
+              format: 'composed',
+              strategy: 'last_known_status',
+            }),
+            noDataExample({
+              hostMetricsIndex,
+              format: 'composed',
+              strategy: 'recover',
+            }),
+            noDataExample({
+              hostMetricsIndex,
+              format: 'composed',
+              strategy: 'none',
+            }),
+            noDataExample({
+              hostMetricsIndex,
+              format: 'standalone',
+              strategy: 'last_known_status',
+            }),
+            noDataExample({
+              hostMetricsIndex,
+              format: 'standalone',
+              strategy: 'recover',
+            }),
+            noDataExample({
+              hostMetricsIndex,
+              format: 'standalone',
+              strategy: 'none',
+            }),
+          ],
+        },
+      });
+    });
   }
 );

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_attachment.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_attachment.test.ts
@@ -12,6 +12,8 @@ import {
   RENDER_ATTACHMENT_TAG_RE,
   createExpectedAttachmentDataEvaluator,
   createExpectedRenderAttachmentEvaluator,
+  getAttachmentVersionData,
+  getLatestAttachmentData,
 } from './expected_attachment';
 
 const attachment = (
@@ -66,6 +68,50 @@ const runAttachmentData = (output: TaskOutput, expected: Record<string, unknown>
     expected: expected ?? {},
     metadata: null,
   });
+
+describe('getAttachmentVersionData', () => {
+  it('returns an empty array when no attachment of that type exists', () => {
+    expect(getAttachmentVersionData([attachment('a1', RULE_ATTACHMENT_TYPE)], 'missing')).toEqual(
+      []
+    );
+  });
+
+  it('returns version payloads ordered by version number', () => {
+    const versioned = {
+      ...attachment('rule-1', RULE_ATTACHMENT_TYPE, { recovery_strategy: 'none' }),
+      current_version: 3,
+      versions: [
+        {
+          version: 3,
+          data: { recovery_strategy: 'no_breach' },
+          created_at: '2026-01-01T00:00:03.000Z',
+          content_hash: 'hash-3',
+        },
+        {
+          version: 1,
+          data: { recovery_strategy: 'query' },
+          created_at: '2026-01-01T00:00:01.000Z',
+          content_hash: 'hash-1',
+        },
+        {
+          version: 2,
+          data: { recovery_strategy: 'none' },
+          created_at: '2026-01-01T00:00:02.000Z',
+          content_hash: 'hash-2',
+        },
+      ],
+    } as VersionedAttachment;
+
+    expect(getAttachmentVersionData([versioned], RULE_ATTACHMENT_TYPE)).toEqual([
+      { recovery_strategy: 'query' },
+      { recovery_strategy: 'none' },
+      { recovery_strategy: 'no_breach' },
+    ]);
+    expect(getLatestAttachmentData([versioned], RULE_ATTACHMENT_TYPE)).toEqual({
+      recovery_strategy: 'no_breach',
+    });
+  });
+});
 
 describe('RENDER_ATTACHMENT_TAG_RE', () => {
   it('matches a self-closing tag with id and version', () => {

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_attachment.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_attachment.ts
@@ -19,6 +19,14 @@ export interface RenderAttachmentRef {
   tag: string;
 }
 
+const getLatestAttachmentOfType = (
+  attachments: VersionedAttachment[],
+  type: string
+): VersionedAttachment | undefined => {
+  const ofType = attachments.filter((attachment) => attachment.type === type);
+  return ofType[ofType.length - 1];
+};
+
 /**
  * Latest current-version data among attachments of the given type
  * (filters by type, then takes the last match).
@@ -27,12 +35,29 @@ export const getLatestAttachmentData = <T>(
   attachments: VersionedAttachment[],
   type: string
 ): T | undefined => {
-  const ofType = attachments.filter((attachment) => attachment.type === type);
-  const latest = ofType[ofType.length - 1];
+  const latest = getLatestAttachmentOfType(attachments, type);
   if (!latest) {
     return undefined;
   }
   return getLatestVersion<T>(latest as VersionedAttachment<string, T>)?.data;
+};
+
+/**
+ * All version payloads for the latest attachment of the given type, ordered
+ * by version number. Used to assert multi-turn updates (each manage_rule call
+ * appends a version).
+ */
+export const getAttachmentVersionData = <T>(
+  attachments: VersionedAttachment[],
+  type: string
+): T[] => {
+  const latest = getLatestAttachmentOfType(attachments, type);
+  if (!latest) {
+    return [];
+  }
+  return [...latest.versions]
+    .sort((left, right) => left.version - right.version)
+    .map((version) => version.data as T);
 };
 
 export const parseRenderAttachmentRef = (message: string): RenderAttachmentRef | null => {

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/no_data.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/no_data.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  getBreachEsqlQuery,
+  getNoDataEsqlQuery,
+  type RuleAttachmentData,
+} from '@kbn/alerting-v2-schemas';
+import { expect } from '@playwright/test';
+import type { RuleManagementExample } from './types';
+import {
+  assertLatestHostCpuAlert,
+  assertQueriedFormat,
+  hostCpuCreateTurn,
+  isComposedQuery,
+  isStandaloneQuery,
+  MANAGE_RULE_SKILL_OUTPUT,
+  PERSIST_VIA_ATTACHMENT_CRITERION,
+  requireRuleVersions,
+  type QueryFormat,
+} from './rule_example_helpers';
+
+const NO_DATA_REQUESTS = {
+  last_known_status:
+    'If a host goes quiet and stops sending metrics, keep whatever alert status it already had.',
+  recover:
+    'If a host goes quiet and stops sending metrics, treat that as recovered instead of holding the old status.',
+  none: 'If a host stops sending metrics, leave the alert unchanged — ignore missing data.',
+} as const;
+
+const NO_DATA_CRITERIA = {
+  last_known_status:
+    'The second turn holds the last known alert status when a host stops sending data.',
+  recover:
+    'The second turn recovers the episode when a host goes quiet, instead of holding the previous status.',
+  none: 'The second turn ignores missing data — no status change when a host stops sending metrics.',
+} as const;
+
+const STANDALONE_PRESENCE_QUERY =
+  ' Detect missing data with a separate query that counts documents per host.name — not the CPU average.';
+
+export type NoDataExampleStrategy = keyof typeof NO_DATA_REQUESTS;
+
+const needsStandalonePresenceQuery = (strategy: NoDataExampleStrategy): boolean =>
+  strategy !== 'none';
+
+const noDataRequest = (format: QueryFormat, strategy: NoDataExampleStrategy): string => {
+  const request = NO_DATA_REQUESTS[strategy];
+  if (format === 'standalone' && needsStandalonePresenceQuery(strategy)) {
+    return `${request}${STANDALONE_PRESENCE_QUERY}`;
+  }
+  return request;
+};
+
+const assertCustomStandaloneNoDataQuery = (
+  versions: RuleAttachmentData[],
+  hostMetricsIndex: string
+) => {
+  const customNoData = versions.find((version) => {
+    if (version.no_data_strategy === 'none' || !version.query) {
+      return false;
+    }
+    return Boolean(getNoDataEsqlQuery(version.query, version.no_data_strategy));
+  });
+  expect(customNoData).toBeDefined();
+  expect(isStandaloneQuery(customNoData!.query)).toBe(true);
+  const noDataEsql = getNoDataEsqlQuery(customNoData!.query!, customNoData!.no_data_strategy);
+  expect(noDataEsql).toBeDefined();
+  expect(noDataEsql).toContain(hostMetricsIndex);
+  expect(noDataEsql).toContain('host.name');
+  expect(noDataEsql?.toLowerCase()).toMatch(/count/);
+  const breachEsql = customNoData!.query ? getBreachEsqlQuery(customNoData!.query) : '';
+  expect(noDataEsql).not.toEqual(breachEsql);
+};
+
+export const noDataExample = ({
+  hostMetricsIndex,
+  format,
+  strategy,
+}: {
+  hostMetricsIndex: string;
+  format: QueryFormat;
+  strategy: NoDataExampleStrategy;
+}): RuleManagementExample => ({
+  input: {
+    turns: [
+      hostCpuCreateTurn({ index: hostMetricsIndex, format }),
+      noDataRequest(format, strategy),
+    ],
+  },
+  output: {
+    criteria: [
+      format === 'composed'
+        ? 'The first-turn rule uses composed query format (shared base + breach segment), not standalone.'
+        : 'The first-turn rule uses standalone query format (independent full ES|QL queries), not composed.',
+      NO_DATA_CRITERIA[strategy],
+      ...(format === 'composed'
+        ? [
+            'Composed-format rules do not add a standalone no_data query block — the base query is the data-presence query.',
+          ]
+        : needsStandalonePresenceQuery(strategy)
+        ? [
+            'The rule uses an explicit data-presence query that counts documents per host.name (distinct from the CPU breach query).',
+          ]
+        : []),
+      'The no-data change is applied with manage_rule against the existing attachment (not a new rule), and the final manage_rule call ends with a validate operation.',
+      PERSIST_VIA_ATTACHMENT_CRITERION,
+    ],
+    ...MANAGE_RULE_SKILL_OUTPUT,
+    expectAttachmentData: (attachments) => {
+      const versions = requireRuleVersions(attachments);
+      assertQueriedFormat(versions, format);
+      if (format === 'composed') {
+        for (const version of versions) {
+          if (isComposedQuery(version.query)) {
+            expect(version.query).not.toHaveProperty('no_data');
+          }
+        }
+      } else if (needsStandalonePresenceQuery(strategy)) {
+        assertCustomStandaloneNoDataQuery(versions, hostMetricsIndex);
+      }
+      const latest = assertLatestHostCpuAlert(attachments, hostMetricsIndex);
+      expect(latest.grouping?.fields).toEqual(expect.arrayContaining(['host.name']));
+      expect(latest.no_data_strategy).toEqual(strategy);
+    },
+  },
+});

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/no_data.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/no_data.ts
@@ -32,14 +32,6 @@ const NO_DATA_REQUESTS = {
   none: 'If a host stops sending metrics, leave the alert unchanged — ignore missing data.',
 } as const;
 
-const NO_DATA_CRITERIA = {
-  last_known_status:
-    'The second turn holds the last known alert status when a host stops sending data.',
-  recover:
-    'The second turn recovers the episode when a host goes quiet, instead of holding the previous status.',
-  none: 'The second turn ignores missing data — no status change when a host stops sending metrics.',
-} as const;
-
 const STANDALONE_PRESENCE_QUERY =
   ' Detect missing data with a separate query that counts documents per host.name — not the CPU average.';
 
@@ -95,16 +87,15 @@ export const noDataExample = ({
   output: {
     criteria: [
       format === 'composed'
-        ? 'The first-turn rule uses composed query format (shared base + breach segment), not standalone.'
-        : 'The first-turn rule uses standalone query format (independent full ES|QL queries), not composed.',
-      NO_DATA_CRITERIA[strategy],
+        ? 'The first-turn set_query uses `query.format: composed` (shared `base` + `breach.segment`), not standalone.'
+        : 'The first-turn set_query uses `query.format: standalone` (full independent ES|QL queries), not composed.',
       ...(format === 'composed'
         ? [
-            'Composed-format rules do not add a standalone no_data query block — the base query is the data-presence query.',
+            'Composed format has no `query.no_data` block — the `base` query is the data-presence query.',
           ]
         : needsStandalonePresenceQuery(strategy)
         ? [
-            'The rule uses an explicit data-presence query that counts documents per host.name (distinct from the CPU breach query).',
+            'Standalone format includes a `query.no_data` ES|QL block that counts documents per host.name, distinct from the breach query.',
           ]
         : []),
       'The no-data change is applied with manage_rule against the existing attachment (not a new rule), and the final manage_rule call ends with a validate operation.',

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/recovery.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/recovery.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getRecoverEsqlQuery, type RuleAttachmentData } from '@kbn/alerting-v2-schemas';
+import { expect } from '@playwright/test';
+import type { RuleManagementExample } from './types';
+import {
+  assertLatestHostCpuAlert,
+  assertQueriedFormat,
+  hostCpuCreateTurn,
+  isComposedQuery,
+  isStandaloneQuery,
+  MANAGE_RULE_SKILL_OUTPUT,
+  PERSIST_VIA_ATTACHMENT_CRITERION,
+  requireRuleVersions,
+  type QueryFormat,
+} from './rule_example_helpers';
+
+const RECOVERY_REQUESTS = {
+  query:
+    'Treat a host as recovered only when its average system.cpu.total.norm.pct ' +
+    'falls below 0.5 — not as soon as it drops back under 0.9.',
+  none: 'Do not recover these alerts automatically. Leave them active even after CPU is back to normal.',
+  no_breach: 'Recover automatically once CPU is no longer above 0.9.',
+} as const;
+
+const RECOVERY_CRITERIA = {
+  query:
+    'The second turn treats recovery as a custom condition: average CPU below 0.5 (or an equivalent threshold), not merely dropping back under 0.9.',
+  none: 'The second turn disables automatic recovery — alerts stay active after CPU returns to normal.',
+  no_breach:
+    'The second turn recovers automatically when the host is no longer above the 0.9 threshold.',
+} as const;
+
+export type RecoveryExampleStrategy = keyof typeof RECOVERY_REQUESTS;
+
+const assertCustomRecoveryQuery = (
+  versions: RuleAttachmentData[],
+  hostMetricsIndex: string,
+  format: QueryFormat
+) => {
+  const customRecovery = versions.find(
+    (version) => version.recovery_strategy === 'query' && version.query
+  );
+  expect(customRecovery).toBeDefined();
+  if (format === 'composed') {
+    expect(isComposedQuery(customRecovery!.query)).toBe(true);
+  } else {
+    expect(isStandaloneQuery(customRecovery!.query)).toBe(true);
+  }
+  const recoveryEsql = getRecoverEsqlQuery(customRecovery!.query!, 'query');
+  expect(recoveryEsql).toBeDefined();
+  expect(recoveryEsql).toContain(hostMetricsIndex);
+  expect(recoveryEsql).toContain('system.cpu.total.norm.pct');
+  expect(recoveryEsql).toMatch(/0\.5/);
+};
+
+export const recoveryExample = ({
+  hostMetricsIndex,
+  format,
+  strategy,
+}: {
+  hostMetricsIndex: string;
+  format: QueryFormat;
+  strategy: RecoveryExampleStrategy;
+}): RuleManagementExample => ({
+  input: {
+    turns: [hostCpuCreateTurn({ index: hostMetricsIndex, format }), RECOVERY_REQUESTS[strategy]],
+  },
+  output: {
+    criteria: [
+      format === 'composed'
+        ? 'The first-turn rule uses composed query format (shared base + breach segment), not standalone.'
+        : 'The first-turn rule uses standalone query format (independent full ES|QL queries), not composed.',
+      RECOVERY_CRITERIA[strategy],
+      'The recovery change is applied with manage_rule against the existing attachment (not a new rule), and the final manage_rule call ends with a validate operation.',
+      PERSIST_VIA_ATTACHMENT_CRITERION,
+    ],
+    ...MANAGE_RULE_SKILL_OUTPUT,
+    expectAttachmentData: (attachments) => {
+      const versions = requireRuleVersions(attachments);
+      assertQueriedFormat(versions, format);
+      const latest = assertLatestHostCpuAlert(attachments, hostMetricsIndex);
+      expect(latest.grouping?.fields).toEqual(expect.arrayContaining(['host.name']));
+      expect(latest.recovery_strategy).toEqual(strategy);
+      if (strategy === 'query') {
+        assertCustomRecoveryQuery(versions, hostMetricsIndex, format);
+      }
+    },
+  },
+});

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/recovery.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/recovery.ts
@@ -28,14 +28,6 @@ const RECOVERY_REQUESTS = {
   no_breach: 'Recover automatically once CPU is no longer above 0.9.',
 } as const;
 
-const RECOVERY_CRITERIA = {
-  query:
-    'The second turn treats recovery as a custom condition: average CPU below 0.5 (or an equivalent threshold), not merely dropping back under 0.9.',
-  none: 'The second turn disables automatic recovery — alerts stay active after CPU returns to normal.',
-  no_breach:
-    'The second turn recovers automatically when the host is no longer above the 0.9 threshold.',
-} as const;
-
 export type RecoveryExampleStrategy = keyof typeof RECOVERY_REQUESTS;
 
 const assertCustomRecoveryQuery = (
@@ -74,9 +66,13 @@ export const recoveryExample = ({
   output: {
     criteria: [
       format === 'composed'
-        ? 'The first-turn rule uses composed query format (shared base + breach segment), not standalone.'
-        : 'The first-turn rule uses standalone query format (independent full ES|QL queries), not composed.',
-      RECOVERY_CRITERIA[strategy],
+        ? 'The first-turn set_query uses `query.format: composed` (shared `base` + `breach.segment`), not standalone.'
+        : 'The first-turn set_query uses `query.format: standalone` (full independent ES|QL queries), not composed.',
+      ...(strategy === 'query'
+        ? [
+            'The second-turn set_query includes a `query.recovery` ES|QL block whose threshold is average `system.cpu.total.norm.pct` below 0.5 (not merely dropping back under 0.9).',
+          ]
+        : []),
       'The recovery change is applied with manage_rule against the existing attachment (not a new rule), and the final manage_rule call ends with a validate operation.',
       PERSIST_VIA_ATTACHMENT_CRITERION,
     ],

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/rule_example_helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/rule_example_helpers.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import {
+  getBreachEsqlQuery,
+  RULE_ATTACHMENT_TYPE,
+  type Query,
+  type RuleAttachmentData,
+} from '@kbn/alerting-v2-schemas';
+import { expect } from '@playwright/test';
+import {
+  ALERTING_TOOL_IDS,
+  DETECTION_RULE_EDIT_SKILL_ID,
+  RULE_MANAGEMENT_SKILL_ID,
+} from './constants';
+import {
+  getAttachmentVersionData,
+  getLatestAttachmentData,
+} from './evaluators/expected_attachment';
+
+export type QueryFormat = NonNullable<Query>['format'];
+
+export const MANAGE_RULE_SKILL_OUTPUT = {
+  expectedSkills: [RULE_MANAGEMENT_SKILL_ID],
+  notExpectedSkills: [DETECTION_RULE_EDIT_SKILL_ID],
+  expectedToolIds: [ALERTING_TOOL_IDS.manageRule],
+  expectRenderAttachment: [RULE_ATTACHMENT_TYPE],
+} as const;
+
+export const PERSIST_VIA_ATTACHMENT_CRITERION =
+  'The assistant directs the user to the Create rule button / attachment actions instead of claiming the rule was persisted via API.';
+
+export const isComposedQuery = (
+  query: Query | undefined
+): query is Extract<Query, { format: 'composed' }> => query?.format === 'composed';
+
+export const isStandaloneQuery = (
+  query: Query | undefined
+): query is Extract<Query, { format: 'standalone' }> => query?.format === 'standalone';
+
+export const requireRuleVersions = (attachments: VersionedAttachment[]) => {
+  const versions = getAttachmentVersionData<RuleAttachmentData>(attachments, RULE_ATTACHMENT_TYPE);
+  expect(versions.length).toBeGreaterThan(0);
+  return versions;
+};
+
+export const hostCpuCreateTurn = ({
+  index,
+  format,
+}: {
+  index: string;
+  format: QueryFormat;
+}): string => {
+  const formatClause =
+    format === 'composed'
+      ? 'with a shared base ES|QL query and a breach segment appended to it'
+      : 'with a complete standalone ES|QL breach query (not a shared base plus segment)';
+  return (
+    `Create an alert rule on ${index} ${formatClause}. Fire when average ` +
+    `system.cpu.total.norm.pct stays above 0.9 for 5 minutes, grouped by host.name. ` +
+    'Check every 1 minute.'
+  );
+};
+
+export const assertQueriedFormat = (versions: RuleAttachmentData[], format: QueryFormat) => {
+  const queried = versions.filter((version) => version.query);
+  expect(queried.length).toBeGreaterThan(0);
+  for (const version of queried) {
+    expect(version.query?.format).toEqual(format);
+  }
+};
+
+export const assertLatestHostCpuAlert = (
+  attachments: VersionedAttachment[],
+  hostMetricsIndex: string
+): RuleAttachmentData => {
+  const latest = getLatestAttachmentData<RuleAttachmentData>(attachments, RULE_ATTACHMENT_TYPE);
+  expect(latest).toBeDefined();
+  expect(latest!.kind).toEqual('alert');
+  const breachEsql = latest!.query ? getBreachEsqlQuery(latest!.query) : '';
+  expect(breachEsql).toContain(hostMetricsIndex);
+  expect(breachEsql).toContain('system.cpu.total.norm.pct');
+  return latest!;
+};


### PR DESCRIPTION
## Summary
- Adds rule-management eval examples that compose an alert, then apply one recovery strategy (`query` / `none` / `no_breach`) or one no-data strategy (`last_known_status` / `recover` / `none`) per example.
- Covers composed and standalone query formats as separate examples, asserting the latest attachment instead of a multi-turn strategy sequence.
- Extracts shared example helpers and adds `getAttachmentVersionData` for ordered attachment version payloads.

## Test plan
- [ ] `node scripts/jest x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2`
- [ ] `node scripts/evals start --suite alerting-v2 --grep "recovery strategy" --judge eis-google-gemini-3-1-pro`
- [ ] `node scripts/evals start --suite alerting-v2 --grep "no-data strategy" --judge eis-google-gemini-3-1-pro`


Made with [Cursor](https://cursor.com)