### PR TITLE
[9.5] [Entity Store] Introduce resilience task that reinstalls missing assets (#282548)

### DIFF
--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -204,6 +204,7 @@ export default function ({ getService }: FtrProviderContext) {
         'entity_store:v2:extract_entity_task:service',
         'entity_store:v2:extract_entity_task:user',
         'entity_store:v2:history_snapshot_task',
+        'entity_store:v2:resilience_task',
         'entity_store:v2:status_report_task',
         'fleet:agent-status-change-task',
         'fleet:agentless-deployment-sync-task',

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
@@ -27,6 +27,7 @@ import {
   stopHistorySnapshotTask,
 } from '../../tasks/history_snapshot_task';
 import { scheduleStatusReportTask, stopStatusReportTask } from '../../tasks/status_report_task';
+import { scheduleResilienceTask, stopResilienceTask } from '../../tasks/resilience_task';
 import { removeEntityMaintainer } from '../../tasks/entity_maintainers';
 import { entityMaintainersRegistry } from '../../tasks/entity_maintainers/entity_maintainers_registry';
 import { stopAndRemoveV1, stopAndRemoveV1SharedTasks } from '../../infra/remove_v1';
@@ -36,6 +37,7 @@ jest.mock('./euid_stored_scripts');
 jest.mock('../../tasks/extract_entity_task');
 jest.mock('../../tasks/history_snapshot_task');
 jest.mock('../../tasks/status_report_task');
+jest.mock('../../tasks/resilience_task');
 jest.mock('../../tasks/entity_maintainers', () => ({
   removeEntityMaintainer: jest.fn(),
 }));
@@ -78,6 +80,10 @@ const mockScheduleStatusReportTask = scheduleStatusReportTask as jest.MockedFunc
 const mockStopStatusReportTask = stopStatusReportTask as jest.MockedFunction<
   typeof stopStatusReportTask
 >;
+const mockScheduleResilienceTask = scheduleResilienceTask as jest.MockedFunction<
+  typeof scheduleResilienceTask
+>;
+const mockStopResilienceTask = stopResilienceTask as jest.MockedFunction<typeof stopResilienceTask>;
 const mockRemoveEntityMaintainer = removeEntityMaintainer as jest.MockedFunction<
   typeof removeEntityMaintainer
 >;
@@ -122,6 +128,8 @@ describe('AssetManagerClient', () => {
     mockStopHistorySnapshotTask.mockResolvedValue(undefined);
     mockScheduleStatusReportTask.mockResolvedValue(undefined);
     mockStopStatusReportTask.mockResolvedValue(undefined);
+    mockScheduleResilienceTask.mockResolvedValue(undefined);
+    mockStopResilienceTask.mockResolvedValue(undefined);
     mockRemoveEntityMaintainer.mockResolvedValue(undefined);
     mockEntityMaintainersGetAll.mockReturnValue([
       { id: 'automated-resolution', interval: '1h', minLicense: 'basic' },
@@ -520,5 +528,132 @@ describe('AssetManagerClient', () => {
         })
       );
     });
+  });
+});
+
+describe('AssetManagerClient.reinstallSharedAssetsIfMissing', () => {
+  const namespace = 'default';
+
+  let client: AssetManagerClient;
+  let mockUserEsClient: jest.Mocked<ElasticsearchClient>;
+  let mockLogger: ReturnType<typeof loggerMock.create>;
+
+  const buildClient = (
+    overrides: Partial<{
+      latestExists: boolean;
+      updatesExists: boolean;
+      metadataExists: boolean;
+    }> = {}
+  ) => {
+    const { latestExists = true, updatesExists = true, metadataExists = true } = overrides;
+
+    mockUserEsClient = {
+      indices: {
+        exists: jest.fn().mockResolvedValue(latestExists),
+        getDataStream: jest.fn().mockImplementation(async ({ name }: { name: string }) => {
+          if (name.includes('updates')) {
+            return updatesExists ? { data_streams: [{ name }] } : { data_streams: [] };
+          } else {
+            return metadataExists ? { data_streams: [{ name }] } : { data_streams: [] };
+          }
+        }),
+      },
+    } as unknown as jest.Mocked<ElasticsearchClient>;
+
+    mockLogger = loggerMock.create();
+
+    client = new AssetManagerClient({
+      logger: mockLogger,
+      esClient: mockUserEsClient,
+      internalEsClient: {} as jest.Mocked<ElasticsearchClient>,
+      taskManager: {} as jest.Mocked<TaskManagerStartContract>,
+      engineDescriptorClient: {
+        getAll: jest.fn().mockResolvedValue([]),
+        init: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      } as unknown as import('../saved_objects').EngineDescriptorClient,
+      globalStateClient: {
+        init: jest.fn(),
+        findOrThrow: jest.fn(),
+        find: jest.fn(),
+        delete: jest.fn(),
+      } as unknown as import('../saved_objects').EntityStoreGlobalStateClient,
+      remoteLogExtractionStateClient: {
+        delete: jest.fn(),
+      } as unknown as import('../saved_objects/remote_log_extraction_state').RemoteLogExtractionStateClient,
+      namespace,
+      isServerless: false,
+      logsExtractionClient: {} as unknown as import('../logs_extraction').LogsExtractionClient,
+      security: {} as import('@kbn/security-plugin/server').SecurityPluginStart,
+      analytics: {
+        reportEvent: jest.fn(),
+      } as unknown as import('../../telemetry/events').TelemetryReporter,
+      savedObjectsClient: {} as SavedObjectsClientContract,
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInstallSharedElasticsearchAssets.mockResolvedValue(undefined);
+  });
+
+  it('returns false and does not reinstall when all assets are present', async () => {
+    buildClient({ latestExists: true, updatesExists: true, metadataExists: true });
+
+    const result = await client.reinstallSharedAssetsIfMissing();
+
+    expect(result).toBe(false);
+    expect(mockInstallSharedElasticsearchAssets).not.toHaveBeenCalled();
+  });
+
+  it('returns true and reinstalls when the latest index is missing', async () => {
+    buildClient({ latestExists: false, updatesExists: true, metadataExists: true });
+
+    const result = await client.reinstallSharedAssetsIfMissing();
+
+    expect(result).toBe(true);
+    expect(mockInstallSharedElasticsearchAssets).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('.entities.v2.latest.security_default-00001')
+    );
+  });
+
+  it('returns true and reinstalls when the updates data stream is missing', async () => {
+    buildClient({ latestExists: true, updatesExists: false, metadataExists: true });
+
+    const result = await client.reinstallSharedAssetsIfMissing();
+
+    expect(result).toBe(true);
+    expect(mockInstallSharedElasticsearchAssets).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('.entities.v2.updates.security_default')
+    );
+  });
+
+  it('returns true and reinstalls when the metadata data stream is missing', async () => {
+    buildClient({ latestExists: true, updatesExists: true, metadataExists: false });
+
+    const result = await client.reinstallSharedAssetsIfMissing();
+
+    expect(result).toBe(true);
+    expect(mockInstallSharedElasticsearchAssets).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('.entities.v2.metadata.security_default')
+    );
+  });
+
+  it('propagates non-404 errors from getDataStream instead of treating them as missing', async () => {
+    buildClient();
+
+    mockUserEsClient.indices.getDataStream = jest
+      .fn()
+      .mockRejectedValue({ statusCode: 503, message: 'Service Unavailable' });
+
+    await expect(client.reinstallSharedAssetsIfMissing()).rejects.toMatchObject({
+      statusCode: 503,
+    });
+    expect(mockInstallSharedElasticsearchAssets).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -27,6 +27,7 @@ import {
   stopHistorySnapshotTask,
 } from '../../tasks/history_snapshot_task';
 import { scheduleStatusReportTask, stopStatusReportTask } from '../../tasks/status_report_task';
+import { scheduleResilienceTask, stopResilienceTask } from '../../tasks/resilience_task';
 import { removeEntityMaintainer } from '../../tasks/entity_maintainers';
 import { entityMaintainersRegistry } from '../../tasks/entity_maintainers/entity_maintainers_registry';
 import { installSharedElasticsearchAssets, uninstallElasticsearchAssets } from './install_assets';
@@ -194,6 +195,13 @@ export class AssetManagerClient {
           namespace: this.namespace,
           request,
         }),
+
+        scheduleResilienceTask({
+          logger: this.logger,
+          taskManager: this.taskManager,
+          namespace: this.namespace,
+          request,
+        }),
       ]);
     } catch (error) {
       this.analytics.reportEvent(ENTITY_STORE_INITIALIZATION_FAILURE_EVENT, {
@@ -294,6 +302,11 @@ export class AssetManagerClient {
         namespace: this.namespace,
       }),
       stopStatusReportTask({
+        taskManager: this.taskManager,
+        logger: this.logger,
+        namespace: this.namespace,
+      }),
+      stopResilienceTask({
         taskManager: this.taskManager,
         logger: this.logger,
         namespace: this.namespace,
@@ -575,6 +588,49 @@ export class AssetManagerClient {
       }
       throw e;
     }
+  }
+
+  /**
+   * Checks whether the three shared per-namespace assets exist (latest index, updates data stream,
+   * metadata data stream) and reinstalls any that are missing. Returns true if anything was
+   * recreated, false if all assets were already present.
+   *
+   * Safe to call from a running task — the underlying creates use `throwIfExists: false`.
+   */
+  public async reinstallSharedAssetsIfMissing(): Promise<boolean> {
+    const latestIndex = getLatestEntitiesIndexName(this.namespace);
+    const updatesDataStream = getUpdatesEntitiesDataStreamName(this.namespace);
+    const metadataDataStream = getMetadataEntitiesDataStreamName(this.namespace);
+
+    const [latestExists, updatesExists, metadataExists] = await Promise.all([
+      this.esClient.indices.exists({ index: latestIndex }),
+      this.esClient.indices
+        .getDataStream({ name: updatesDataStream }, { ignore: [404] })
+        .then((r) => (r?.data_streams?.length ?? 0) > 0),
+      this.esClient.indices
+        .getDataStream({ name: metadataDataStream }, { ignore: [404] })
+        .then((r) => (r?.data_streams?.length ?? 0) > 0),
+    ]);
+
+    if (latestExists && updatesExists && metadataExists) {
+      return false;
+    }
+
+    const missing = [
+      !latestExists && latestIndex,
+      !updatesExists && updatesDataStream,
+      !metadataExists && metadataDataStream,
+    ].filter(Boolean);
+    this.logger.warn(
+      `Recreating missing entity store assets in ${this.namespace}: ${missing.join(', ')}`
+    );
+
+    await installSharedElasticsearchAssets({
+      esClient: this.esClient,
+      logger: this.logger,
+      namespace: this.namespace,
+    });
+    return true;
   }
 
   /**

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/config.ts
@@ -31,6 +31,12 @@ export const TasksConfig = {
     type: 'entity_store:v2:history_snapshot_task',
     timeout: '30m',
   },
+  [EntityStoreTaskType.enum.resilience]: {
+    title: 'Entity Store - Resilience Task',
+    type: 'entity_store:v2:resilience_task',
+    timeout: '5m',
+    interval: '1h',
+  },
   [EntityStoreTaskType.enum.statusReport]: {
     title: 'Entity Store - Status Report Task',
     type: 'entity_store:v2:status_report_task',

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/constants.ts
@@ -12,5 +12,6 @@ export const EntityStoreTaskType = z.enum([
   'extractEntity',
   'entityMaintainer',
   'historySnapshot',
+  'resilience',
   'statusReport',
 ]);

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/register_tasks.ts
@@ -10,6 +10,7 @@ import type { TaskManagerSetupContract } from '@kbn/task-manager-plugin/server';
 
 import { registerExtractEntityTasks } from './extract_entity_task';
 import { registerHistorySnapshotTask } from './history_snapshot_task';
+import { registerResilienceTask } from './resilience_task';
 import { registerStatusReportTask } from './status_report_task';
 import type { EntityStoreCoreSetup } from '../types';
 import { ALL_ENTITY_TYPES } from '../../common/domain/definitions/entity_schema';
@@ -28,5 +29,6 @@ export function registerTasks(
     isServerless,
   });
   registerHistorySnapshotTask({ taskManager, logger, core });
+  registerResilienceTask({ taskManager, logger, core });
   registerStatusReportTask({ taskManager, logger, core });
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/resilience_task.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/resilience_task.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TaskManagerSetupContract } from '@kbn/task-manager-plugin/server';
+import { loggerMock, type MockedLogger } from '@kbn/logging-mocks';
+
+import { registerResilienceTask } from './resilience_task';
+import { createAssetManagerClient } from './factories';
+import { shouldDeleteOrphanedEntityStoreTask } from './should_delete_orphaned_task';
+import type { EntityStoreCoreSetup } from '../types';
+
+jest.mock('./factories');
+jest.mock('./should_delete_orphaned_task');
+// wrapTaskRun adds a tracing span around the run callback; here it just invokes it.
+jest.mock('../telemetry/traces', () => ({
+  wrapTaskRun: jest.fn(({ run }: { run: () => Promise<unknown> }) => run()),
+}));
+jest.mock('../telemetry/events', () => ({
+  createReportEvent: jest.fn().mockReturnValue({ reportEvent: jest.fn() }),
+}));
+
+const createAssetManagerClientMock = createAssetManagerClient as jest.Mock;
+const shouldDeleteOrphanedEntityStoreTaskMock = shouldDeleteOrphanedEntityStoreTask as jest.Mock;
+
+const NAMESPACE = 'default';
+
+describe('resilience task', () => {
+  let logger: MockedLogger;
+  let reinstallSharedAssetsIfMissing: jest.Mock;
+
+  const runResilienceTask = async ({
+    namespace = NAMESPACE,
+    hasFakeRequest = true,
+  }: { namespace?: string; hasFakeRequest?: boolean } = {}) => {
+    const taskManager = {
+      registerTaskDefinitions: jest.fn(),
+    } as unknown as TaskManagerSetupContract;
+    const core = {
+      analytics: {},
+      getStartServices: jest.fn().mockResolvedValue([{}]),
+    } as unknown as EntityStoreCoreSetup;
+
+    registerResilienceTask({ taskManager, logger, core });
+
+    const [definitions] = (taskManager.registerTaskDefinitions as jest.Mock).mock.calls[0];
+    const [taskType] = Object.keys(definitions);
+    const runner = definitions[taskType].createTaskRunner({
+      taskInstance: { id: `resilience:${namespace}`, state: { namespace } },
+      fakeRequest: hasFakeRequest ? {} : undefined,
+      signal: new AbortController().signal,
+    });
+    return runner.run();
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logger = loggerMock.create();
+    reinstallSharedAssetsIfMissing = jest.fn().mockResolvedValue(false);
+
+    shouldDeleteOrphanedEntityStoreTaskMock.mockResolvedValue(false);
+    createAssetManagerClientMock.mockResolvedValue({
+      assetManagerClient: { reinstallSharedAssetsIfMissing },
+    });
+  });
+
+  it('self-deletes when the entity store is orphaned (no engine descriptors)', async () => {
+    shouldDeleteOrphanedEntityStoreTaskMock.mockResolvedValue(true);
+
+    const result = await runResilienceTask();
+
+    expect(reinstallSharedAssetsIfMissing).not.toHaveBeenCalled();
+    expect(result).toEqual({ state: { namespace: NAMESPACE }, shouldDeleteTask: true });
+  });
+
+  it('calls reinstallSharedAssetsIfMissing when entity store is installed', async () => {
+    const result = await runResilienceTask();
+
+    expect(reinstallSharedAssetsIfMissing).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ state: { namespace: NAMESPACE } });
+  });
+
+  it('returns state and logs error when fakeRequest is missing', async () => {
+    const result = await runResilienceTask({ hasFakeRequest: false });
+
+    expect(reinstallSharedAssetsIfMissing).not.toHaveBeenCalled();
+    expect(result).toEqual({ state: { namespace: NAMESPACE } });
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('No fake request found'));
+  });
+
+  it('throws when namespace is missing from task state', async () => {
+    const taskManager = {
+      registerTaskDefinitions: jest.fn(),
+    } as unknown as TaskManagerSetupContract;
+    const core = { analytics: {} } as unknown as EntityStoreCoreSetup;
+
+    registerResilienceTask({ taskManager, logger, core });
+
+    const [definitions] = (taskManager.registerTaskDefinitions as jest.Mock).mock.calls[0];
+    const [taskType] = Object.keys(definitions);
+    const runner = definitions[taskType].createTaskRunner({
+      taskInstance: { id: 'resilience:missing', state: {} },
+      fakeRequest: {},
+      signal: new AbortController().signal,
+    });
+
+    await expect(runner.run()).rejects.toThrow('Namespace is required');
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/resilience_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/resilience_task.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { RunContext, RunResult } from '@kbn/task-manager-plugin/server/task';
+import type { Logger } from '@kbn/logging';
+import type { KibanaRequest } from '@kbn/core/server';
+import { getErrorMessage } from '../../common';
+import { TasksConfig } from './config';
+import { EntityStoreTaskType } from './constants';
+import { createAssetManagerClient } from './factories';
+import type { EntityStoreCoreSetup } from '../types';
+import { createReportEvent } from '../telemetry/events';
+import { wrapTaskRun } from '../telemetry/traces';
+import { shouldDeleteOrphanedEntityStoreTask } from './should_delete_orphaned_task';
+
+const config = TasksConfig[EntityStoreTaskType.enum.resilience];
+
+const getResilienceTaskId = (namespace: string): string => `${config.type}:${namespace}`;
+
+async function runTask({
+  taskInstance,
+  fakeRequest,
+  signal,
+  logger,
+  core,
+}: Pick<RunContext, 'taskInstance' | 'fakeRequest' | 'signal'> & {
+  logger: Logger;
+  core: EntityStoreCoreSetup;
+}): Promise<RunResult> {
+  const namespace = taskInstance.state.namespace as string | undefined;
+
+  if (!namespace) {
+    throw new Error('Namespace is required for resilience task');
+  }
+
+  if (!fakeRequest) {
+    logger.error('No fake request found, skipping resilience task');
+    return { state: { namespace } };
+  }
+
+  const [coreStart] = await core.getStartServices();
+  if (await shouldDeleteOrphanedEntityStoreTask({ coreStart, namespace, logger })) {
+    return { state: { namespace }, shouldDeleteTask: true };
+  }
+
+  const telemetryReporter = createReportEvent(core.analytics);
+
+  const { assetManagerClient } = await createAssetManagerClient({
+    core,
+    fakeRequest,
+    logger,
+    namespace,
+    analytics: telemetryReporter,
+  });
+
+  await assetManagerClient.reinstallSharedAssetsIfMissing();
+
+  return { state: { namespace } };
+}
+
+export function registerResilienceTask({
+  taskManager,
+  logger,
+  core,
+}: {
+  core: EntityStoreCoreSetup;
+  taskManager: TaskManagerSetupContract;
+  logger: Logger;
+}): void {
+  try {
+    taskManager.registerTaskDefinitions({
+      [config.type]: {
+        title: config.title,
+        timeout: config.timeout,
+        maxAttempts: 1,
+        createTaskRunner: ({ taskInstance, fakeRequest, signal }: RunContext) => ({
+          run: () =>
+            wrapTaskRun({
+              spanName: 'entityStore.task.resilience.run',
+              namespace: taskInstance.state.namespace,
+              attributes: {
+                'entity_store.task.id': taskInstance.id,
+              },
+              run: () =>
+                runTask({
+                  taskInstance,
+                  fakeRequest,
+                  signal,
+                  logger: logger.get(taskInstance.id),
+                  core,
+                }),
+            }),
+        }),
+      },
+    });
+  } catch (e) {
+    logger.error(`Error registering resilience task: ${getErrorMessage(e)}`);
+    throw e;
+  }
+}
+
+export async function scheduleResilienceTask({
+  logger,
+  taskManager,
+  namespace,
+  request,
+}: {
+  logger: Logger;
+  taskManager: TaskManagerStartContract;
+  namespace: string;
+  request: KibanaRequest;
+}): Promise<void> {
+  try {
+    await taskManager.ensureScheduled(
+      {
+        id: getResilienceTaskId(namespace),
+        taskType: config.type,
+        schedule: { interval: config.interval },
+        state: { namespace },
+        params: {},
+      },
+      { request }
+    );
+  } catch (e) {
+    logger.error(`Error scheduling resilience task: ${getErrorMessage(e)}`);
+    throw e;
+  }
+}
+
+export async function stopResilienceTask({
+  taskManager,
+  logger,
+  namespace,
+}: {
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+  namespace: string;
+}): Promise<void> {
+  const taskId = getResilienceTaskId(namespace);
+  await taskManager.removeIfExists(taskId);
+  logger.debug(`Removed resilience task: ${taskId}`);
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/tasks/resilience_task.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/tasks/resilience_task.ts
@@ -28,10 +28,9 @@ const getResilienceTaskId = (namespace: string): string => `${config.type}:${nam
 async function runTask({
   taskInstance,
   fakeRequest,
-  signal,
   logger,
   core,
-}: Pick<RunContext, 'taskInstance' | 'fakeRequest' | 'signal'> & {
+}: Pick<RunContext, 'taskInstance' | 'fakeRequest'> & {
   logger: Logger;
   core: EntityStoreCoreSetup;
 }): Promise<RunResult> {
@@ -81,7 +80,7 @@ export function registerResilienceTask({
         title: config.title,
         timeout: config.timeout,
         maxAttempts: 1,
-        createTaskRunner: ({ taskInstance, fakeRequest, signal }: RunContext) => ({
+        createTaskRunner: ({ taskInstance, fakeRequest }: RunContext) => ({
           run: () =>
             wrapTaskRun({
               spanName: 'entityStore.task.resilience.run',
@@ -93,7 +92,6 @@ export function registerResilienceTask({
                 runTask({
                   taskInstance,
                   fakeRequest,
-                  signal,
                   logger: logger.get(taskInstance.id),
                   core,
                 }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
- [[Entity Store] Introduce resilience task that reinstalls missing assets (#282548)](https://github.com/elastic/kibana/pull/282548)

<!--BACKPORT [{"sourcePullRequest":{"number":282548,"url":"https://github.com/elastic/kibana/pull/282548","title":"[Entity Store] Introduce resilience task that reinstalls missing assets"},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"sourceCommit":{"sha":"d8cc53961061a414bafd48a92bf5f31202dc0233"}}] BACKPORT-->