### PR TITLE
[9.4] Fix ESO ci_checks snapshot after alert v14 and selective testing gap (#276289)

### DIFF
--- a/.buildkite/pipeline-utils/affected-packages/const.ts
+++ b/.buildkite/pipeline-utils/affected-packages/const.ts
@@ -47,3 +47,12 @@ export const CRITICAL_FILES_JEST_INTEGRATION_TESTS = [
   '.buildkite/pipeline-utils/affected-packages/**/*.{ts,js,sh}',
   '.buildkite/pipeline-utils/ci-stats/**/*.{ts,js}',
 ];
+
+// Integration configs that snapshot a global registry (rule-type params, connector types, task
+// types) fed by downstream plugins. Those publishers sit upstream of these configs, so
+// includeDownstream never marks them affected — they must run regardless of the graph. Keep tiny.
+export const ALWAYS_RUN_JEST_INTEGRATION_CONFIGS = [
+  'x-pack/platform/plugins/shared/alerting/jest.integration.config.js',
+  'x-pack/platform/plugins/shared/actions/jest.integration.config.js',
+  'x-pack/platform/plugins/shared/task_manager/jest.integration.config.js',
+];

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expandJestImplicitConsumers } from './jest_implicit_consumers';
+
+describe('expandJestImplicitConsumers', () => {
+  it('adds encrypted_saved_objects when an upstream plugin changes SO model versions', () => {
+    const affected = new Set(['@kbn/alerting-plugin']);
+    const changedFiles = [
+      'x-pack/platform/plugins/shared/alerting/server/saved_objects/model_versions/rule_model_versions.ts',
+    ];
+
+    const expanded = expandJestImplicitConsumers(affected, changedFiles);
+
+    expect(expanded.has('@kbn/encrypted-saved-objects-plugin')).toBe(true);
+    expect(expanded.has('@kbn/alerting-plugin')).toBe(true);
+  });
+
+  it('adds encrypted_saved_objects when an upstream plugin changes SO registration', () => {
+    const affected = new Set(['@kbn/fleet-plugin']);
+    const changedFiles = ['x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts'];
+
+    const expanded = expandJestImplicitConsumers(affected, changedFiles);
+
+    expect(expanded.has('@kbn/encrypted-saved-objects-plugin')).toBe(true);
+  });
+
+  it('does not add encrypted_saved_objects for unrelated changes', () => {
+    const affected = new Set(['@kbn/alerting-plugin']);
+    const changedFiles = ['x-pack/platform/plugins/shared/alerting/server/routes/foo.ts'];
+
+    const expanded = expandJestImplicitConsumers(affected, changedFiles);
+
+    expect(expanded.has('@kbn/encrypted-saved-objects-plugin')).toBe(false);
+  });
+});

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Overlay for Jest selective testing.
+ *
+ * The encrypted_saved_objects integration ci_checks test validates every
+ * registered encrypted SO type at runtime, but lives in @kbn/encrypted-saved-objects-plugin
+ * while publishers (alerting, actions, fleet, …) sit upstream in the dependency graph.
+ * Publisher-only model-version changes therefore skip that config under includeDownstream.
+ */
+
+import minimatch from 'minimatch';
+
+interface ImplicitConsumerRule {
+  reason: string;
+  patterns: readonly string[];
+  consumers: readonly string[];
+}
+
+const ENCRYPTED_SAVED_OBJECTS_PLUGIN = '@kbn/encrypted-saved-objects-plugin';
+
+const IMPLICIT_JEST_CONSUMERS: readonly ImplicitConsumerRule[] = [
+  {
+    reason:
+      'Encrypted SO registration, model-version, or schema changes must refresh the ESO ci_checks snapshot.',
+    patterns: [
+      '**/server/saved_objects/index.{ts,tsx}',
+      '**/server/saved_objects/model_versions/**/*.{ts,tsx}',
+      '**/server/saved_objects/schemas/**/*.{ts,tsx}',
+      '**/packages/**/server/saved_objects/index.{ts,tsx}',
+      '**/packages/**/server/saved_objects/model_versions/**/*.{ts,tsx}',
+      '**/packages/**/server/saved_objects/schemas/**/*.{ts,tsx}',
+    ],
+    consumers: [ENCRYPTED_SAVED_OBJECTS_PLUGIN],
+  },
+];
+
+export function expandJestImplicitConsumers(
+  affected: ReadonlySet<string>,
+  changedFiles: readonly string[]
+): Set<string> {
+  const expanded = new Set(affected);
+
+  for (const rule of IMPLICIT_JEST_CONSUMERS) {
+    const trigger = changedFiles.find((file) =>
+      rule.patterns.some((pattern) => minimatch(file, pattern, { dot: true }))
+    );
+    if (!trigger) continue;
+
+    for (const id of rule.consumers) {
+      if (!expanded.has(id)) {
+        expanded.add(id);
+        console.log(
+          `Implicit Jest consumer added: ${id} (triggered by '${trigger}' — ${rule.reason})`
+        );
+      }
+    }
+  }
+
+  return expanded;
+}

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  ALWAYS_RUN_JEST_INTEGRATION_CONFIGS,
   CRITICAL_FILES_JEST_INTEGRATION_TESTS,
   CRITICAL_FILES_JEST_UNIT_TESTS,
   filterFilesByPackages,
@@ -15,6 +16,8 @@ import {
   listChangedFiles,
   touchedCriticalFiles,
 } from '../../affected-packages';
+
+import { SHARD_ANNOTATION_SEP } from './jest_configs';
 
 /**
  * The shared inputs both per-variant filters need: which packages the PR
@@ -67,7 +70,7 @@ export function filterJestUnitConfigsByAffected(
   });
 }
 
-/** Narrow Jest integration configs to those owned by affected packages, unless a critical file changed. */
+/** Like the unit filter, but always re-adds ALWAYS_RUN_JEST_INTEGRATION_CONFIGS. */
 export function filterJestIntegrationConfigsByAffected(
   jestIntegrationConfigs: string[],
   context: SelectiveTestingContext
@@ -76,6 +79,7 @@ export function filterJestIntegrationConfigsByAffected(
     label: 'integration',
     configs: jestIntegrationConfigs,
     criticalFiles: CRITICAL_FILES_JEST_INTEGRATION_TESTS,
+    alwaysRun: ALWAYS_RUN_JEST_INTEGRATION_CONFIGS,
     context,
   });
 }
@@ -84,9 +88,10 @@ function filterByAffected(args: {
   label: 'unit' | 'integration';
   configs: string[];
   criticalFiles: string[];
+  alwaysRun?: readonly string[];
   context: SelectiveTestingContext;
 }): string[] {
-  const { label, configs, criticalFiles, context } = args;
+  const { label, configs, criticalFiles, alwaysRun = [], context } = args;
 
   if (touchedCriticalFiles(context.prChangedFiles, criticalFiles)) {
     console.log(`Not filtering Jest ${label} tests because critical files changed`);
@@ -94,6 +99,33 @@ function filterByAffected(args: {
   }
 
   const filtered = filterFilesByPackages(configs, context.affectedPackages);
-  console.log(`Filtering Jest ${label} tests: ${configs.length} -> ${filtered.length}`);
-  return filtered;
+  const withAlwaysRun = addAlwaysRunConfigs(filtered, configs, alwaysRun);
+  console.log(`Filtering Jest ${label} tests: ${configs.length} -> ${withAlwaysRun.length}`);
+  return withAlwaysRun;
+}
+
+// Matches on the base path so every shard of an always-run config is restored.
+function addAlwaysRunConfigs(
+  filtered: string[],
+  allConfigs: string[],
+  alwaysRun: readonly string[]
+): string[] {
+  if (alwaysRun.length === 0) {
+    return filtered;
+  }
+
+  const alwaysRunSet = new Set(alwaysRun);
+  const result = new Set(filtered);
+  for (const config of allConfigs) {
+    if (alwaysRunSet.has(baseConfigPath(config)) && !result.has(config)) {
+      result.add(config);
+      console.log(`Always-run Jest integration config re-added: ${config}`);
+    }
+  }
+  return [...result];
+}
+
+function baseConfigPath(config: string): string {
+  const idx = config.indexOf(SHARD_ANNOTATION_SEP);
+  return idx === -1 ? config : config.slice(0, idx);
 }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
@@ -74,7 +74,7 @@ export function filterJestUnitConfigsByAffected(
   });
 }
 
-/** Like the unit filter, but always re-adds ALWAYS_RUN_JEST_INTEGRATION_CONFIGS. */
+/** Narrow Jest integration configs to those owned by affected packages, unless a critical file changed. */
 export function filterJestIntegrationConfigsByAffected(
   jestIntegrationConfigs: string[],
   context: SelectiveTestingContext
@@ -83,7 +83,6 @@ export function filterJestIntegrationConfigsByAffected(
     label: 'integration',
     configs: jestIntegrationConfigs,
     criticalFiles: CRITICAL_FILES_JEST_INTEGRATION_TESTS,
-    alwaysRun: ALWAYS_RUN_JEST_INTEGRATION_CONFIGS,
     context,
   });
 }
@@ -92,10 +91,9 @@ function filterByAffected(args: {
   label: 'unit' | 'integration';
   configs: string[];
   criticalFiles: string[];
-  alwaysRun?: readonly string[];
   context: SelectiveTestingContext;
 }): string[] {
-  const { label, configs, criticalFiles, alwaysRun = [], context } = args;
+  const { label, configs, criticalFiles, context } = args;
 
   if (touchedCriticalFiles(context.prChangedFiles, criticalFiles)) {
     console.log(`Not filtering Jest ${label} tests because critical files changed`);
@@ -103,5 +101,6 @@ function filterByAffected(args: {
   }
 
   const filtered = filterFilesByPackages(configs, context.affectedPackages);
+  console.log(`Filtering Jest ${label} tests: ${configs.length} -> ${filtered.length}`);
   return filtered;
 }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
@@ -8,7 +8,6 @@
  */
 
 import {
-  ALWAYS_RUN_JEST_INTEGRATION_CONFIGS,
   CRITICAL_FILES_JEST_INTEGRATION_TESTS,
   CRITICAL_FILES_JEST_UNIT_TESTS,
   filterFilesByPackages,
@@ -18,7 +17,6 @@ import {
 } from '../../affected-packages';
 
 import { expandJestImplicitConsumers } from './jest_implicit_consumers';
-import { SHARD_ANNOTATION_SEP } from './jest_configs';
 
 /**
  * The shared inputs both per-variant filters need: which packages the PR
@@ -105,33 +103,5 @@ function filterByAffected(args: {
   }
 
   const filtered = filterFilesByPackages(configs, context.affectedPackages);
-  const withAlwaysRun = addAlwaysRunConfigs(filtered, configs, alwaysRun);
-  console.log(`Filtering Jest ${label} tests: ${configs.length} -> ${withAlwaysRun.length}`);
-  return withAlwaysRun;
-}
-
-// Matches on the base path so every shard of an always-run config is restored.
-function addAlwaysRunConfigs(
-  filtered: string[],
-  allConfigs: string[],
-  alwaysRun: readonly string[]
-): string[] {
-  if (alwaysRun.length === 0) {
-    return filtered;
-  }
-
-  const alwaysRunSet = new Set(alwaysRun);
-  const result = new Set(filtered);
-  for (const config of allConfigs) {
-    if (alwaysRunSet.has(baseConfigPath(config)) && !result.has(config)) {
-      result.add(config);
-      console.log(`Always-run Jest integration config re-added: ${config}`);
-    }
-  }
-  return [...result];
-}
-
-function baseConfigPath(config: string): string {
-  const idx = config.indexOf(SHARD_ANNOTATION_SEP);
-  return idx === -1 ? config : config.slice(0, idx);
+  return filtered;
 }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
@@ -17,6 +17,7 @@ import {
   touchedCriticalFiles,
 } from '../../affected-packages';
 
+import { expandJestImplicitConsumers } from './jest_implicit_consumers';
 import { SHARD_ANNOTATION_SEP } from './jest_configs';
 
 /**
@@ -54,7 +55,12 @@ export async function resolveSelectiveTestingContext(
 
   console.log('Filtering Jest unit/integration tests for affected packages:', affectedPackages);
   const prChangedFiles = listChangedFiles({ mergeBase, commit: 'HEAD' });
-  return { affectedPackages, prChangedFiles };
+  const expandedAffectedPackages = expandJestImplicitConsumers(affectedPackages, prChangedFiles);
+  console.log(
+    'Filtering Jest unit/integration tests for affected packages:',
+    expandedAffectedPackages
+  );
+  return { affectedPackages: expandedAffectedPackages, prChangedFiles };
 }
 
 /** Narrow Jest unit configs to those owned by affected packages, unless a critical file changed. */

--- a/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
+++ b/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
@@ -128,6 +128,8 @@ describe('checking changes on all registered encrypted SO types', () => {
         "alert|4",
         "alert|3",
         "alert|2",
+        "alert|14",
+        "alert|13",
         "alert|12",
         "alert|11",
         "alert|10",

--- a/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
+++ b/x-pack/platform/plugins/shared/encrypted_saved_objects/integration_tests/ci_checks/check_registered_types.test.ts
@@ -128,8 +128,6 @@ describe('checking changes on all registered encrypted SO types', () => {
         "alert|4",
         "alert|3",
         "alert|2",
-        "alert|14",
-        "alert|13",
         "alert|12",
         "alert|11",
         "alert|10",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix ESO ci_checks snapshot after alert v14 and selective testing gap (#276289)](https://github.com/elastic/kibana/pull/276289)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-07-04T13:01:51Z","message":"Fix ESO ci_checks snapshot after alert v14 and selective testing gap (#276289)\n\n## Summary\n- Update the encrypted_saved_objects ci_checks snapshot for `alert|14`\nintroduced by #276204.\n- Add a Jest selective-testing implicit consumer so upstream SO\nmodel-version/schema changes trigger\n`@kbn/encrypted-saved-objects-plugin` integration tests.\n\nFixes #240719\nCloses https://github.com/elastic/kibana-operations/issues/575\n\n## Test plan\n- [x] `node scripts/jest\n.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts`\n- [ ] CI: encrypted_saved_objects jest integration ci_checks passes\n- [ ] CI: PR selective testing includes ESO integration config when\nalerting SO schemas change\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"16aa4d66eaaaa3e4f942d585800446d02fd60fee","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:version","v9.5.0","v9.6.0","v9.4.6"],"title":"Fix ESO ci_checks snapshot after alert v14 and selective testing gap","number":276289,"url":"https://github.com/elastic/kibana/pull/276289","mergeCommit":{"message":"Fix ESO ci_checks snapshot after alert v14 and selective testing gap (#276289)\n\n## Summary\n- Update the encrypted_saved_objects ci_checks snapshot for `alert|14`\nintroduced by #276204.\n- Add a Jest selective-testing implicit consumer so upstream SO\nmodel-version/schema changes trigger\n`@kbn/encrypted-saved-objects-plugin` integration tests.\n\nFixes #240719\nCloses https://github.com/elastic/kibana-operations/issues/575\n\n## Test plan\n- [x] `node scripts/jest\n.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts`\n- [ ] CI: encrypted_saved_objects jest integration ci_checks passes\n- [ ] CI: PR selective testing includes ESO integration config when\nalerting SO schemas change\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"16aa4d66eaaaa3e4f942d585800446d02fd60fee"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276289","number":276289,"mergeCommit":{"message":"Fix ESO ci_checks snapshot after alert v14 and selective testing gap (#276289)\n\n## Summary\n- Update the encrypted_saved_objects ci_checks snapshot for `alert|14`\nintroduced by #276204.\n- Add a Jest selective-testing implicit consumer so upstream SO\nmodel-version/schema changes trigger\n`@kbn/encrypted-saved-objects-plugin` integration tests.\n\nFixes #240719\nCloses https://github.com/elastic/kibana-operations/issues/575\n\n## Test plan\n- [x] `node scripts/jest\n.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/jest_implicit_consumers.test.ts`\n- [ ] CI: encrypted_saved_objects jest integration ci_checks passes\n- [ ] CI: PR selective testing includes ESO integration config when\nalerting SO schemas change\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"16aa4d66eaaaa3e4f942d585800446d02fd60fee"}},{"branch":"9.6","label":"v9.6.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->