### PR TITLE
[Fleet] Integration sync - Don't query ES if no CCR follower index exists

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_on_remote.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_on_remote.test.ts
@@ -143,6 +143,21 @@ describe('syncIntegrationsOnRemote', () => {
     };
   }
 
+  it('should do nothing if no follower index exists', async () => {
+    getIndicesMock.mockResolvedValue({});
+
+    await syncIntegrationsOnRemote(
+      esClientMock,
+      soClientMock,
+      packageClientMock,
+      signal,
+      loggerMock
+    );
+
+    expect(searchMock).not.toHaveBeenCalled();
+    expect(packageClientMock.getInstallation).not.toHaveBeenCalled();
+  });
+
   it('should do nothing if no matching remote output has sync enabled', async () => {
     getIndicesMock.mockResolvedValue({
       'fleet-synced-integrations-ccr-remote1': {},

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_on_remote.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_on_remote.ts
@@ -62,6 +62,7 @@ const getSyncedIntegrationsCCRDoc = async (
   logger: Logger
 ): Promise<SyncIntegrationsData | undefined> => {
   const index = await getFollowerIndex(esClient, signal);
+  if (!index) return undefined;
 
   const response = await esClient.search(
     {


### PR DESCRIPTION
## Summary

[Fleet's integration sync feature](https://www.elastic.co/docs/reference/fleet/automatic-integrations-synchronization) runs the `fleet:sync-integrations` task every 5 minutes for syncing integrations across clusters. When integration sync is not configured, it still runs a broad search against all Elasticsearch indices, including frozen tier data streams. This happens because the `syncIntegrationsOnRemote` function is called unconditionally in `runTask`, and within it `getSyncedIntegrationsCCRDoc` passes `index: undefined` to `esClient.search()` when no CCR follower index exists. On Enterprise license deployments (where the task is active by default), this produces CPU spikes on the frozen tier on every task run.

This fix adds an early return immediately after the call to `getFollowerIndex` when no CCR follower index exists (normal state for a user who hasn't configured it). The sync function now returns without issuing an Elasticsearch search instead of calling `esClient.search({ index: undefined })` which was causing the full-cluster scan.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Very low. The change is a single-line guard in a private function with a well-defined contract. The new code path (no follower index → return undefined) is functionally equivalent to what `syncIntegrationsOnRemote` does when the CCR doc's `isSyncIntegrationsEnabled` check fails: it returns early without side effects. The fix does not affect any path where sync-integrations is properly configured (follower index exists), so intentional users of the feature are unaffected.

## Release note

The task run by automatic integrations synchronization every 5 minutes now returns early if the feature is not configured, avoiding unnecessary intensive searches in Elasticsearch.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->