### PR TITLE
[9.1] [Security Solution] Fix Cribl routing pipeline dataId handling (#284863)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2819,11 +2819,12 @@ x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/cloud_secur
 x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/cloud_security_posture/vulnerabilities_contextual_flyout.cy.ts @elastic/kibana-cloud-security-posture
 x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/asset_inventory @elastic/kibana-cloud-security-posture
 
-# Security Service Integrations
-x-pack/solutions/security/plugins/security_solution/common/security_integrations @elastic/security-service-integrations
-x-pack/solutions/security/plugins/security_solution/public/security_integrations @elastic/security-service-integrations
-x-pack/solutions/security/plugins/security_solution/server/security_integrations @elastic/security-service-integrations
-x-pack/solutions/security/plugins/security_solution/server/lib/security_integrations @elastic/security-service-integrations
+# Security integrations
+x-pack/solutions/security/plugins/security_solution/common/security_integrations @elastic/cloud-services
+x-pack/solutions/security/plugins/security_solution/public/security_integrations @elastic/cloud-services
+x-pack/solutions/security/plugins/security_solution/server/security_integrations @elastic/cloud-services
+x-pack/solutions/security/plugins/security_solution/server/lib/security_integrations @elastic/cloud-services
+x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/ @elastic/cloud-services
 
 # Kibana design
 # scss overrides should be below this line for specificity

--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -449,7 +449,7 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
       request.params.packagePolicyId,
       newData,
       { user, force },
-      packagePolicy.package?.version
+      context
     );
     return response.ok({
       body: {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -1960,6 +1960,96 @@ describe('Package policy service', () => {
       );
     });
 
+    it('should forward request context to packagePolicyUpdate external callbacks', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      const mockPackagePolicy = createPackagePolicyMock();
+      const attributes = {
+        ...mockPackagePolicy,
+        inputs: [],
+      };
+      const context = coreMock.createCustomRequestHandlerContext(
+        xpackMocks.createRequestHandlerContext()
+      );
+      const updateCallback = jest.fn(async (policy) => policy);
+
+      appContextService.addExternalCallback('packagePolicyUpdate', updateCallback);
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'test-package-policy',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            references: [],
+            attributes,
+          },
+        ],
+      });
+
+      soClient.update.mockResolvedValue({
+        id: 'test-package-policy',
+        type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+        references: [],
+        attributes,
+      });
+
+      await packagePolicyService.update(
+        soClient,
+        esClient,
+        'test-package-policy',
+        {
+          ...mockPackagePolicy,
+          inputs: [],
+        },
+        undefined,
+        context
+      );
+
+      expect(updateCallback).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'test-package-policy' }),
+        soClient,
+        esClient,
+        context,
+        undefined
+      );
+    });
+
+    it('should rethrow packagePolicyUpdate callback errors with apiPassThrough', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      const mockPackagePolicy = createPackagePolicyMock();
+      const attributes = {
+        ...mockPackagePolicy,
+        inputs: [],
+      };
+      const callbackError = Object.assign(new Error('validation failed'), {
+        apiPassThrough: true,
+      });
+      const updateCallback = jest.fn(async () => {
+        throw callbackError;
+      });
+
+      appContextService.addExternalCallback('packagePolicyUpdate', updateCallback);
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'test-package-policy',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            references: [],
+            attributes,
+          },
+        ],
+      });
+
+      await expect(
+        packagePolicyService.update(soClient, esClient, 'test-package-policy', {
+          ...mockPackagePolicy,
+          inputs: [],
+        })
+      ).rejects.toThrow('validation failed');
+    });
+
     describe('remove protections', () => {
       beforeEach(() => {
         mockAgentPolicyService.bumpRevision.mockReset();

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -1099,7 +1099,8 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       force?: boolean;
       skipUniqueNameVerification?: boolean;
       bumpRevision?: boolean;
-    }
+    },
+    context?: RequestHandlerContext
   ): Promise<PackagePolicy> {
     const logger = this.getLogger('update');
 
@@ -1129,7 +1130,8 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
         'packagePolicyUpdate',
         packagePolicyUpdate,
         soClient,
-        esClient
+        esClient,
+        context
       );
     } catch (error) {
       logger.error(`An error occurred executing "packagePolicyUpdate" callback: ${error}`);
@@ -2663,7 +2665,8 @@ class PackagePolicyClientWithAuthz extends PackagePolicyClientImpl {
           force?: boolean | undefined;
           skipUniqueNameVerification?: boolean | undefined;
         }
-      | undefined
+      | undefined,
+    context?: RequestHandlerContext
   ): Promise<PackagePolicy> {
     await this.#runPreflight({
       fleetAuthz: {
@@ -2671,7 +2674,7 @@ class PackagePolicyClientWithAuthz extends PackagePolicyClientImpl {
       },
     });
 
-    return super.update(soClient, esClient, id, packagePolicyUpdate, options);
+    return super.update(soClient, esClient, id, packagePolicyUpdate, options, context);
   }
 
   async create(

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy_service.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy_service.ts
@@ -170,7 +170,8 @@ export interface PackagePolicyClient {
       skipUniqueNameVerification?: boolean;
       bumpRevision?: boolean;
     },
-    currentVersion?: string
+    /** Request context so update callbacks can use the caller's Elasticsearch client. */
+    context?: RequestHandlerContext
   ): Promise<PackagePolicy>;
 
   delete(

--- a/x-pack/solutions/security/plugins/security_solution/common/security_integrations/cribl/sanitize.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/security_integrations/cribl/sanitize.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DATA_ID_MAX_LENGTH, isValidDataId } from './sanitize';
+
+describe('cribl dataId validate', () => {
+  describe('isValidDataId', () => {
+    it('accepts allowlisted ids', () => {
+      expect(isValidDataId('criblSource1')).toBe(true);
+      expect(isValidDataId('source.with.dots')).toBe(true);
+      expect(isValidDataId('a')).toBe(true);
+    });
+
+    it('rejects empty, injection, spaces, overlong, and control chars', () => {
+      expect(isValidDataId('')).toBe(false);
+      expect(isValidDataId(`x' || true || 'y`)).toBe(false);
+      expect(isValidDataId('has spaces')).toBe(false);
+      expect(isValidDataId('a'.repeat(DATA_ID_MAX_LENGTH + 1))).toBe(false);
+      expect(isValidDataId('ctrl\x00char')).toBe(false);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/common/security_integrations/cribl/sanitize.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/security_integrations/cribl/sanitize.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** Max length for Cribl `_dataId` values used in routing pipeline conditions. */
+export const DATA_ID_MAX_LENGTH = 100;
+
+const VALID_DATA_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+/** Returns true when `value` is a non-empty allowlisted Cribl `_dataId`. */
+export const isValidDataId = (value: string): boolean =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  value.length <= DATA_ID_MAX_LENGTH &&
+  VALID_DATA_ID_PATTERN.test(value);

--- a/x-pack/solutions/security/plugins/security_solution/public/security_integrations/cribl/components/custom_cribl_form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/security_integrations/cribl/components/custom_cribl_form.test.tsx
@@ -88,4 +88,47 @@ describe('<CustomCriblForm />', () => {
       },
     });
   });
+
+  it('rejects invalid dataId input without rewriting it', async () => {
+    (getFleetManagedIndexTemplates as jest.Mock).mockReturnValue({
+      indexTemplates: datastreamOpts,
+      permissionsError: false,
+      generalError: false,
+    });
+
+    const { getByLabelText, getByTestId } = render(
+      <WrappedComponent newPolicy={mockPackagePolicy} />
+    );
+    const dataId = getByLabelText('Cribl _dataId field');
+
+    await waitFor(() => {
+      expect(dataId).toBeInTheDocument();
+    });
+
+    const invalidDataId = `evil' || true || '`;
+    await userEvent.type(dataId, invalidDataId);
+
+    const datastreamComboBox = getByTestId('comboBoxSearchInput');
+    await userEvent.type(datastreamComboBox, datastreamOpts[0]);
+
+    const datastreamComboBoxOpts = getByTestId('comboBoxOptionsList');
+    await waitFor(() => {
+      expect(datastreamComboBoxOpts).toBeInTheDocument();
+    });
+
+    const ourOption = within(datastreamComboBoxOpts).getByRole('option');
+    ourOption.click();
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      isValid: false,
+      updatedPolicy: {
+        ...mockPackagePolicy,
+        vars: {
+          route_entries: {
+            value: `[{"dataId":"${invalidDataId}","datastream":"logs-destination1.cloud"}]`,
+          },
+        },
+      },
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/security_integrations/cribl/components/custom_cribl_form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/security_integrations/cribl/components/custom_cribl_form.tsx
@@ -9,7 +9,6 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import {
   EuiButton,
   EuiButtonIcon,
-  EuiCallOut,
   EuiComboBox,
   EuiFieldText,
   EuiFlexGroup,
@@ -23,12 +22,17 @@ import type {
   NewPackagePolicy,
   PackagePolicyReplaceDefineStepExtensionComponentProps,
 } from '@kbn/fleet-plugin/public/types';
+import { KbnInfoCallout } from '@kbn/ui-callout';
 import { getFleetManagedIndexTemplates } from '../api/api';
 import type { RouteEntry } from '../../../../common/security_integrations/cribl/types';
 import {
   getPolicyConfigValueFromRouteEntries,
   getRouteEntriesFromPolicyConfig,
 } from '../../../../common/security_integrations/cribl/translator';
+import {
+  DATA_ID_MAX_LENGTH,
+  isValidDataId,
+} from '../../../../common/security_integrations/cribl/sanitize';
 import { allRouteEntriesArePaired, hasAtLeastOneValidRouteEntry } from './util/validator';
 
 const getDefaultRouteEntry = () => {
@@ -57,6 +61,19 @@ const RouteEntryComponent = React.memo<RouteEntryComponentProps>(
     onDeleteEntry,
   }) => {
     const routeEntry = routeEntries[index]; // the route entry for this row
+    const namespaceValidation = routeEntry.namespace
+      ? isValidNamespace(routeEntry.namespace, false)
+      : undefined;
+    const isNamespaceInvalid = !!(namespaceValidation && !namespaceValidation.valid);
+    const isDataIdInvalid = !!routeEntry.dataId && !isValidDataId(routeEntry.dataId);
+    const dataIdError = i18n.translate(
+      'xpack.securitySolution.securityIntegration.cribl.invalidDataId',
+      {
+        defaultMessage:
+          "Invalid Cribl dataId. Only letters, numbers, '.', '_', and '-' are allowed (max {maxLength} characters).",
+        values: { maxLength: DATA_ID_MAX_LENGTH },
+      }
+    );
 
     const options = datastreamOpts.map((o) => ({
       label: o,
@@ -68,9 +85,14 @@ const RouteEntryComponent = React.memo<RouteEntryComponentProps>(
       <>
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiFormRow label="Cribl _dataId field">
+            <EuiFormRow
+              label="Cribl _dataId field"
+              isInvalid={isDataIdInvalid}
+              error={isDataIdInvalid ? dataIdError : undefined}
+            >
               <EuiFieldText
                 value={routeEntry.dataId}
+                isInvalid={isDataIdInvalid}
                 onChange={(e) => onChangeCriblDataId(index, e.currentTarget.value)}
               />
             </EuiFormRow>
@@ -197,10 +219,19 @@ export const CustomCriblForm = memo<PackagePolicyReplaceDefineStepExtensionCompo
         },
       };
 
+      const allNamespacesValid = updatedRouteEntries.every(
+        (entry) => !entry.namespace || isValidNamespace(entry.namespace, false).valid
+      );
+      const allDataIdsValid = updatedRouteEntries.every(
+        (entry) => !entry.dataId || isValidDataId(entry.dataId)
+      );
+
       // must have at least one filled in and all entries must have both filled in or neither
       const isValid =
         hasAtLeastOneValidRouteEntry(updatedRouteEntries) &&
-        allRouteEntriesArePaired(updatedRouteEntries);
+        allRouteEntriesArePaired(updatedRouteEntries) &&
+        allNamespacesValid &&
+        allDataIdsValid;
 
       onChange({
         isValid,
@@ -212,7 +243,8 @@ export const CustomCriblForm = memo<PackagePolicyReplaceDefineStepExtensionCompo
       <>
         {missingReqPermissions && (
           <>
-            <EuiCallOut
+            <KbnInfoCallout
+              announceOnMount={false}
               size="s"
               title={i18n.translate(
                 'xpack.securitySolution.securityIntegration.cribl.missingPermissionsCalloutTitle',
@@ -220,15 +252,15 @@ export const CustomCriblForm = memo<PackagePolicyReplaceDefineStepExtensionCompo
                   defaultMessage: 'Be sure you have the necessary privileges',
                 }
               )}
-              iconType="question"
-            >
-              <p>
-                <FormattedMessage
-                  id="xpack.securitySolution.securityIntegration.cribl.missingPermissionsCalloutDescription"
-                  defaultMessage="To configure this integration, you must have `manage_index_templates` privileges and `manage_pipeline` or `manage_ingest_pipelines` privileges."
-                />
-              </p>
-            </EuiCallOut>
+              text={
+                <p>
+                  <FormattedMessage
+                    id="xpack.securitySolution.securityIntegration.cribl.missingPermissionsCalloutDescription"
+                    defaultMessage="To configure this integration, you must have `manage_index_templates` privileges and `manage_pipeline` or `manage_ingest_pipelines` privileges."
+                  />
+                </p>
+              }
+            />
             <EuiSpacer size="l" />
           </>
         )}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/security_integrations/cribl/util/pipeline_builder.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/security_integrations/cribl/util/pipeline_builder.test.ts
@@ -19,7 +19,7 @@ describe('Put cribl routing pipeline tests', () => {
 
     req.processors?.forEach(function (processor, i) {
       expect(routeEntries[i].datastream).toContain(processor.reroute?.dataset);
-      expect(processor.reroute?.if).toContain(routeEntries[i].dataId);
+      expect(processor.reroute?.if).toEqual(`ctx['_dataId'] == '${routeEntries[i].dataId}'`);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -7,7 +7,13 @@
 
 import type { Observable } from 'rxjs';
 import { QUERY_RULE_TYPE_ID, SAVED_QUERY_RULE_TYPE_ID } from '@kbn/securitysolution-rules';
-import type { LogMeta, Logger } from '@kbn/core/server';
+import type {
+  ElasticsearchClient,
+  Logger,
+  LogMeta,
+  RequestHandlerContext,
+  SavedObjectsClientContract,
+} from '@kbn/core/server';
 import { SavedObjectsClient } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { ECS_COMPONENT_TEMPLATE_NAME } from '@kbn/alerting-plugin/server';
@@ -15,8 +21,8 @@ import { mappingFromFieldMap } from '@kbn/alerting-plugin/common';
 import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import { Dataset } from '@kbn/rule-registry-plugin/server';
 import type { ListPluginSetup } from '@kbn/lists-plugin/server';
-import type { ILicense } from '@kbn/licensing-plugin/server';
-import type { NewPackagePolicy, UpdatePackagePolicy } from '@kbn/fleet-plugin/common';
+import type { ILicense } from '@kbn/licensing-types';
+import type { NewPackagePolicy, UpdatePackagePolicyWithId } from '@kbn/fleet-plugin/common';
 import { FLEET_ENDPOINT_PACKAGE } from '@kbn/fleet-plugin/common';
 
 import { migrateEndpointDataToSupportSpaces } from './endpoint/migrations/space_awareness_migration';
@@ -831,11 +837,17 @@ export class Plugin implements ISecuritySolutionPlugin {
     if (registerIngestCallback) {
       registerIngestCallback(
         'packagePolicyCreate',
-        async (packagePolicy: NewPackagePolicy): Promise<NewPackagePolicy> => {
+        async (
+          packagePolicy: NewPackagePolicy,
+          _soClient: SavedObjectsClientContract,
+          esClient: ElasticsearchClient,
+          context?: RequestHandlerContext
+        ) => {
           await getCriblPackagePolicyPostCreateOrUpdateCallback(
-            core.elasticsearch.client.asInternalUser,
             packagePolicy,
-            this.logger
+            this.logger,
+            context,
+            esClient
           );
           return packagePolicy;
         }
@@ -843,11 +855,17 @@ export class Plugin implements ISecuritySolutionPlugin {
 
       registerIngestCallback(
         'packagePolicyUpdate',
-        async (packagePolicy: UpdatePackagePolicy): Promise<UpdatePackagePolicy> => {
+        async (
+          packagePolicy: UpdatePackagePolicyWithId,
+          _soClient: SavedObjectsClientContract,
+          esClient: ElasticsearchClient,
+          context?: RequestHandlerContext
+        ) => {
           await getCriblPackagePolicyPostCreateOrUpdateCallback(
-            core.elasticsearch.client.asInternalUser,
             packagePolicy,
-            this.logger
+            this.logger,
+            context,
+            esClient
           );
           return packagePolicy;
         }

--- a/x-pack/solutions/security/plugins/security_solution/server/security_integrations/handlers/put_cribl_routing_pipeline.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/security_integrations/handlers/put_cribl_routing_pipeline.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { NewPackagePolicy } from '@kbn/fleet-plugin/common';
+import { SECURITY_INTEGRATIONS_CRIBL_ROUTING_PIPELINE } from '../../../common/constants';
+import { putCriblRoutingPipeline } from './put_cribl_routing_pipeline';
+
+const createLogger = (): Logger =>
+  ({
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as Logger);
+
+const createPolicy = (routeEntriesJson: string): NewPackagePolicy =>
+  ({
+    name: 'cribl-1',
+    namespace: 'default',
+    enabled: true,
+    policy_ids: ['policy-1'],
+    inputs: [],
+    package: { name: 'cribl', title: 'Cribl', version: '1.0.0' },
+    vars: {
+      route_entries: {
+        value: routeEntriesJson,
+        type: 'textarea',
+      },
+    },
+  } as unknown as NewPackagePolicy);
+
+describe('putCriblRoutingPipeline', () => {
+  let esClient: jest.Mocked<ElasticsearchClient>;
+  let logger: Logger;
+
+  beforeEach(() => {
+    esClient = {
+      transport: {
+        request: jest.fn().mockResolvedValue({ acknowledged: true }),
+      },
+    } as unknown as jest.Mocked<ElasticsearchClient>;
+    logger = createLogger();
+  });
+
+  it('puts the routing pipeline for valid mappings', async () => {
+    const policy = createPolicy(
+      '[{"dataId":"criblSource1","datastream":"logs-destination1.cloud"}]'
+    );
+
+    await putCriblRoutingPipeline(esClient, policy, logger);
+
+    expect(esClient.transport.request).toHaveBeenCalledTimes(1);
+    expect(esClient.transport.request).toHaveBeenCalledWith({
+      method: 'PUT',
+      path: `_ingest/pipeline/${SECURITY_INTEGRATIONS_CRIBL_ROUTING_PIPELINE}`,
+      body: expect.objectContaining({
+        processors: [
+          expect.objectContaining({
+            reroute: expect.objectContaining({
+              if: "ctx['_dataId'] == 'criblSource1'",
+              dataset: 'destination1.cloud',
+            }),
+          }),
+        ],
+      }),
+    });
+  });
+
+  it('rejects invalid dataId and does not put the pipeline', async () => {
+    const policy = createPolicy(
+      `[{"dataId":"x' || true || 'y","datastream":"logs-destination1.cloud"}]`
+    );
+
+    await expect(putCriblRoutingPipeline(esClient, policy, logger)).rejects.toMatchObject({
+      message: expect.stringMatching(/Invalid Cribl dataId/),
+      statusCode: 400,
+      apiPassThrough: true,
+    });
+    expect(esClient.transport.request).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid namespace and does not put the pipeline', async () => {
+    const policy = createPolicy(
+      '[{"dataId":"criblSource1","datastream":"logs-destination1.cloud","namespace":"bad space"}]'
+    );
+
+    await expect(putCriblRoutingPipeline(esClient, policy, logger)).rejects.toMatchObject({
+      message: expect.stringMatching(/Invalid Cribl namespace/),
+      statusCode: 400,
+      apiPassThrough: true,
+    });
+    expect(esClient.transport.request).not.toHaveBeenCalled();
+  });
+
+  it('fails the entire put when one of multiple entries is invalid', async () => {
+    const policy = createPolicy(
+      '[{"dataId":"validSource","datastream":"logs-destination1.cloud"},{"dataId":"bad\'id","datastream":"logs-destination2"}]'
+    );
+
+    await expect(putCriblRoutingPipeline(esClient, policy, logger)).rejects.toThrow(
+      /Invalid Cribl dataId/
+    );
+    expect(esClient.transport.request).not.toHaveBeenCalled();
+  });
+
+  it('does not throw for empty route entries', async () => {
+    const policy = createPolicy('[]');
+
+    await putCriblRoutingPipeline(esClient, policy, logger);
+
+    expect(esClient.transport.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows Elasticsearch failures with apiPassThrough', async () => {
+    (esClient.transport.request as jest.Mock).mockRejectedValue({
+      statusCode: 403,
+      message: 'forbidden',
+    });
+    const policy = createPolicy(
+      '[{"dataId":"criblSource1","datastream":"logs-destination1.cloud"}]'
+    );
+
+    await expect(putCriblRoutingPipeline(esClient, policy, logger)).rejects.toMatchObject({
+      message: expect.stringContaining('Failed to put Cribl integration routing pipeline'),
+      apiPassThrough: true,
+      statusCode: 403,
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/security_integrations/handlers/put_cribl_routing_pipeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/security_integrations/handlers/put_cribl_routing_pipeline.ts
@@ -5,38 +5,83 @@
  * 2.0.
  */
 import type { NewPackagePolicy } from '@kbn/fleet-plugin/common';
+import { isValidNamespace } from '@kbn/fleet-plugin/common';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { transformError } from '@kbn/securitysolution-es-utils';
-import type { IngestPipelineRequest } from '../../../common/security_integrations/cribl/types';
+import type {
+  IngestPipelineRequest,
+  RouteEntry,
+} from '../../../common/security_integrations/cribl/types';
 import { getRouteEntriesFromPolicyConfig } from '../../../common/security_integrations/cribl/translator';
+import {
+  DATA_ID_MAX_LENGTH,
+  isValidDataId,
+} from '../../../common/security_integrations/cribl/sanitize';
 import { buildPipelineRequest } from '../../lib/security_integrations/cribl/util/pipeline_builder';
 import { SECURITY_INTEGRATIONS_CRIBL_ROUTING_PIPELINE } from '../../../common/constants';
+
+type ApiPassThroughError = Error & { apiPassThrough: boolean; statusCode?: number };
 
 export const putCriblRoutingPipeline = async (
   esClient: ElasticsearchClient,
   policy: NewPackagePolicy,
   logger: Logger
-) => {
+): Promise<void> => {
   const mappings = getRouteEntriesFromPolicyConfig(policy.vars);
+  validateRouteEntries(mappings);
   const pipelineConf = buildPipelineRequest(mappings);
   await createOrUpdatePipeline(esClient, pipelineConf, logger);
+};
+
+export const validateRouteEntries = (mappings: RouteEntry[]): void => {
+  for (const mapping of mappings) {
+    if (!isValidDataId(mapping.dataId)) {
+      throw createApiPassThroughError(
+        `Invalid Cribl dataId "${mapping.dataId}". Only letters, numbers, '.', '_', and '-' are allowed (max ${DATA_ID_MAX_LENGTH} characters).`,
+        400
+      );
+    }
+
+    if (mapping.namespace) {
+      const namespaceValidation = isValidNamespace(mapping.namespace, false);
+      if (!namespaceValidation.valid) {
+        throw createApiPassThroughError(
+          `Invalid Cribl namespace "${mapping.namespace}": ${
+            namespaceValidation.error ?? 'contains invalid characters'
+          }`,
+          400
+        );
+      }
+    }
+  }
+};
+
+const createApiPassThroughError = (message: string, statusCode?: number): ApiPassThroughError => {
+  const error = new Error(message) as ApiPassThroughError;
+  error.apiPassThrough = true;
+  if (statusCode !== undefined) {
+    error.statusCode = statusCode;
+  }
+  return error;
 };
 
 const createOrUpdatePipeline = async (
   esClient: ElasticsearchClient,
   pipelineConf: IngestPipelineRequest,
   logger: Logger
-) => {
+): Promise<void> => {
   try {
     await esClient.transport.request({
       method: 'PUT',
       path: `_ingest/pipeline/${SECURITY_INTEGRATIONS_CRIBL_ROUTING_PIPELINE}`,
       body: pipelineConf,
     });
-    return true;
   } catch (e) {
     const error = transformError(e);
     logger.error(`Failed to put Cribl integration routing pipeline. error: ${error.message}`);
+    throw createApiPassThroughError(
+      `Failed to put Cribl integration routing pipeline: ${error.message}`,
+      error.statusCode
+    );
   }
-  return false;
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/security_integrations/jest.config.js
+++ b/x-pack/solutions/security/plugins/security_solution/server/security_integrations/jest.config.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../../../../../../..',
+  roots: [
+    '<rootDir>/x-pack/solutions/security/plugins/security_solution/server/security_integrations',
+  ],
+  coverageDirectory:
+    '<rootDir>/target/kibana-coverage/jest/x-pack/solutions/security/plugins/security_solution/server/security_integrations',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/solutions/security/plugins/security_solution/server/security_integrations/**/*.{ts,tsx}',
+  ],
+  moduleNameMapper: require('../__mocks__/module_name_map'),
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/security_integrations/security_integrations.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/security_integrations/security_integrations.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger, RequestHandlerContext } from '@kbn/core/server';
+import type { NewPackagePolicy } from '@kbn/fleet-plugin/common';
+import { getCriblPackagePolicyPostCreateOrUpdateCallback } from './security_integrations';
+import { putCriblRoutingPipeline } from './handlers/put_cribl_routing_pipeline';
+
+jest.mock('./handlers/put_cribl_routing_pipeline', () => ({
+  putCriblRoutingPipeline: jest.fn(),
+}));
+
+const putCriblRoutingPipelineMock = putCriblRoutingPipeline as jest.MockedFunction<
+  typeof putCriblRoutingPipeline
+>;
+
+const createLogger = (): Logger =>
+  ({
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as Logger);
+
+describe('getCriblPackagePolicyPostCreateOrUpdateCallback', () => {
+  const logger = createLogger();
+  const asCurrentUser = { id: 'current-user-client' } as unknown as ElasticsearchClient;
+  const fallbackEsClient = { id: 'fallback-client' } as unknown as ElasticsearchClient;
+
+  const createContext = (): RequestHandlerContext =>
+    ({
+      core: Promise.resolve({
+        elasticsearch: {
+          client: {
+            asCurrentUser,
+          },
+        },
+      }),
+    } as unknown as RequestHandlerContext);
+
+  const criblPolicyWithRoutes = {
+    package: { name: 'cribl' },
+    vars: {
+      route_entries: {
+        value: '[{"dataId":"criblSource1","datastream":"logs-destination1.cloud"}]',
+        type: 'textarea',
+      },
+    },
+  } as unknown as NewPackagePolicy;
+
+  beforeEach(() => {
+    putCriblRoutingPipelineMock.mockReset();
+    putCriblRoutingPipelineMock.mockResolvedValue(undefined);
+  });
+
+  it('is a no-op for non-cribl package policies', async () => {
+    const policy = {
+      package: { name: 'endpoint' },
+      vars: {},
+    } as NewPackagePolicy;
+
+    await getCriblPackagePolicyPostCreateOrUpdateCallback(policy, logger, createContext());
+
+    expect(putCriblRoutingPipelineMock).not.toHaveBeenCalled();
+  });
+
+  it('still writes the pipeline when cribl policy has no route entries', async () => {
+    const policy = {
+      package: { name: 'cribl' },
+      vars: {},
+    } as NewPackagePolicy;
+
+    await getCriblPackagePolicyPostCreateOrUpdateCallback(policy, logger, createContext());
+
+    expect(putCriblRoutingPipelineMock).toHaveBeenCalledWith(asCurrentUser, policy, logger);
+  });
+
+  it('uses asCurrentUser when context is provided', async () => {
+    await getCriblPackagePolicyPostCreateOrUpdateCallback(
+      criblPolicyWithRoutes,
+      logger,
+      createContext(),
+      fallbackEsClient
+    );
+
+    expect(putCriblRoutingPipelineMock).toHaveBeenCalledWith(
+      asCurrentUser,
+      criblPolicyWithRoutes,
+      logger
+    );
+  });
+
+  it('falls back to the provided Elasticsearch client when context is missing', async () => {
+    await getCriblPackagePolicyPostCreateOrUpdateCallback(
+      criblPolicyWithRoutes,
+      logger,
+      undefined,
+      fallbackEsClient
+    );
+
+    expect(putCriblRoutingPipelineMock).toHaveBeenCalledWith(
+      fallbackEsClient,
+      criblPolicyWithRoutes,
+      logger
+    );
+  });
+
+  it('fails closed when context and fallback client are both missing', async () => {
+    await expect(
+      getCriblPackagePolicyPostCreateOrUpdateCallback(criblPolicyWithRoutes, logger, undefined)
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('request context is required'),
+      apiPassThrough: true,
+    });
+    expect(putCriblRoutingPipelineMock).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/security_integrations/security_integrations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/security_integrations/security_integrations.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Logger, ElasticsearchClient } from '@kbn/core/server';
+import type { Logger, ElasticsearchClient, RequestHandlerContext } from '@kbn/core/server';
 import type { NewPackagePolicy } from '@kbn/fleet-plugin/common';
 import { putCriblRoutingPipeline } from './handlers/put_cribl_routing_pipeline';
 
@@ -15,12 +15,43 @@ const isCriblPackagePolicy = <T extends { package?: { name: string } }>(
   return packagePolicy.package?.name === 'cribl';
 };
 
-export const getCriblPackagePolicyPostCreateOrUpdateCallback = async (
-  esClient: ElasticsearchClient,
-  packagePolicy: NewPackagePolicy,
-  logger: Logger
-): Promise<void> => {
-  if (isCriblPackagePolicy(packagePolicy)) {
-    return putCriblRoutingPipeline(esClient, packagePolicy, logger);
+const createApiPassThroughError = (
+  message: string,
+  statusCode?: number
+): Error & { apiPassThrough: boolean; statusCode?: number } => {
+  const error = new Error(message) as Error & { apiPassThrough: boolean; statusCode?: number };
+  error.apiPassThrough = true;
+  if (statusCode !== undefined) {
+    error.statusCode = statusCode;
   }
+  return error;
+};
+
+/**
+ * Writes the Cribl routing ingest pipeline for Cribl package policies.
+ * Prefers the request-scoped Elasticsearch client when `context` is available;
+ * falls back to `fallbackEsClient` for bulk/upgrade flows that do not provide context.
+ */
+export const getCriblPackagePolicyPostCreateOrUpdateCallback = async (
+  packagePolicy: NewPackagePolicy,
+  logger: Logger,
+  context?: RequestHandlerContext,
+  fallbackEsClient?: ElasticsearchClient
+): Promise<void> => {
+  if (!isCriblPackagePolicy(packagePolicy)) {
+    return;
+  }
+
+  const esClient = context
+    ? (await context.core).elasticsearch.client.asCurrentUser
+    : fallbackEsClient;
+
+  if (!esClient) {
+    throw createApiPassThroughError(
+      'Unable to update Cribl routing pipeline: request context is required',
+      500
+    );
+  }
+
+  return putCriblRoutingPipeline(esClient, packagePolicy, logger);
 };

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api/fixtures/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api/fixtures/constants.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRole } from '@kbn/scout-security';
+
+export const COMMON_HEADERS = {
+  'kbn-xsrf': 'some-xsrf-token',
+  'x-elastic-internal-origin': 'kibana',
+  'Content-Type': 'application/json;charset=UTF-8',
+};
+
+export const CRIBL_ROUTING_PIPELINE = 'cribl-routing-pipeline';
+
+/**
+ * Fleet privileges sufficient to manage package policies, without Elasticsearch
+ * ingest pipeline management rights.
+ */
+export const FLEET_ALL_NO_PIPELINE_ROLE: KibanaRole = {
+  elasticsearch: {
+    cluster: [],
+    indices: [],
+  },
+  kibana: [
+    {
+      base: [],
+      feature: { fleetv2: ['all'], fleet: ['all'] },
+      spaces: ['*'],
+    },
+  ],
+};

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api/fixtures/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api/fixtures/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { apiTest, tags } from '@kbn/scout-security';
+export * as testData from './constants';

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api/playwright.config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout-security';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api/tests/cribl_routing_pipeline.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api/tests/cribl_routing_pipeline.spec.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Client } from '@elastic/elasticsearch';
+import { expect } from '@kbn/scout-security/api';
+import { apiTest, tags } from '../fixtures';
+import {
+  COMMON_HEADERS,
+  CRIBL_ROUTING_PIPELINE,
+  FLEET_ALL_NO_PIPELINE_ROLE,
+} from '../fixtures/constants';
+
+const VALID_DATA_ID = 'criblSourceScout1';
+const UPDATED_DATA_ID = 'criblSourceScout2';
+const INVALID_DATA_ID = `x' || true || 'y`;
+const DATASTREAM = 'logs-destination1.cloud';
+
+const buildRouteEntries = (dataId: string): string =>
+  JSON.stringify([{ dataId, datastream: DATASTREAM }]);
+
+apiTest.describe('Cribl routing pipeline', { tag: [...tags.stateful.classic] }, () => {
+  let adminHeaders: Record<string, string>;
+  let fleetNoPipelineHeaders: Record<string, string>;
+  let criblPackageVersion = '';
+  let agentPolicyId = '';
+  let packagePolicyId = '';
+  let packagePolicyName = '';
+
+  const deletePipelineIfExists = async (
+    esClient: Client,
+    log: { debug: (msg: string) => void }
+  ) => {
+    try {
+      await esClient.ingest.deletePipeline({ id: CRIBL_ROUTING_PIPELINE });
+    } catch (error) {
+      log.debug(`Pipeline cleanup skipped: ${(error as Error).message}`);
+    }
+  };
+
+  const getPipeline = (esClient: Client) =>
+    esClient.ingest.getPipeline({ id: CRIBL_ROUTING_PIPELINE });
+
+  const createCriblPackagePolicyBody = (params: {
+    name: string;
+    agentPolicyId: string;
+    dataId: string;
+  }) => ({
+    policy_ids: [params.agentPolicyId],
+    package: { name: 'cribl', version: criblPackageVersion },
+    name: params.name,
+    description: '',
+    namespace: 'default',
+    // Simplified package-policy API: inputs is an object map and vars are plain values.
+    // `force` belongs in the request body (query `force` is rejected by the schema).
+    force: true,
+    inputs: {},
+    vars: {
+      route_entries: buildRouteEntries(params.dataId),
+    },
+  });
+
+  apiTest.beforeAll(async ({ samlAuth, requestAuth, apiClient, esClient, log }) => {
+    apiTest.setTimeout(300_000);
+
+    const adminCredentials = await samlAuth.asInteractiveUser('admin');
+    adminHeaders = { ...adminCredentials.cookieHeader, ...COMMON_HEADERS };
+
+    const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(FLEET_ALL_NO_PIPELINE_ROLE);
+    fleetNoPipelineHeaders = { ...apiKeyHeader, ...COMMON_HEADERS };
+
+    const packageInfoRes = await apiClient.get('/api/fleet/epm/packages/cribl', {
+      headers: adminHeaders,
+      responseType: 'json',
+    });
+    expect(packageInfoRes).toHaveStatusCode(200);
+    criblPackageVersion = packageInfoRes.body?.item?.version;
+    expect(criblPackageVersion).toBeDefined();
+
+    // Ensure package assets are installed before creating policies.
+    await apiClient
+      .post(`/api/fleet/epm/packages/cribl/${criblPackageVersion}`, {
+        headers: adminHeaders,
+        responseType: 'json',
+        body: { force: true },
+      })
+      .catch(() => undefined);
+
+    await deletePipelineIfExists(esClient, log);
+
+    const agentPolicyRes = await apiClient.post('/api/fleet/agent_policies?sys_monitoring=true', {
+      headers: adminHeaders,
+      responseType: 'json',
+      body: {
+        name: `cribl-scout-agent-policy-${Date.now()}`,
+        description: '',
+        namespace: 'default',
+        monitoring_enabled: ['logs', 'metrics'],
+      },
+    });
+    expect(agentPolicyRes).toHaveStatusCode(200);
+    agentPolicyId = agentPolicyRes.body?.item?.id;
+    expect(agentPolicyId).toBeDefined();
+
+    packagePolicyName = `cribl-scout-${Date.now()}`;
+    const createRes = await apiClient.post('/api/fleet/package_policies', {
+      headers: adminHeaders,
+      responseType: 'json',
+      body: createCriblPackagePolicyBody({
+        name: packagePolicyName,
+        agentPolicyId,
+        dataId: VALID_DATA_ID,
+      }),
+    });
+    expect(createRes).toHaveStatusCode(200);
+    packagePolicyId = createRes.body?.item?.id;
+    expect(packagePolicyId).toBeDefined();
+    expect(createRes.body?.item?.vars?.route_entries?.value).toBe(buildRouteEntries(VALID_DATA_ID));
+  });
+
+  apiTest.afterAll(async ({ apiClient, esClient, log }) => {
+    if (packagePolicyId) {
+      await apiClient
+        .post('/api/fleet/package_policies/delete', {
+          headers: adminHeaders,
+          responseType: 'json',
+          body: { packagePolicyIds: [packagePolicyId] },
+        })
+        .catch(() => undefined);
+    }
+
+    if (agentPolicyId) {
+      await apiClient
+        .post('/api/fleet/agent_policies/delete', {
+          headers: adminHeaders,
+          responseType: 'json',
+          body: { agentPolicyId },
+        })
+        .catch(() => undefined);
+    }
+
+    await deletePipelineIfExists(esClient, log);
+  });
+
+  apiTest('creates the routing pipeline with an exact dataId condition', async ({ esClient }) => {
+    const pipeline = await getPipeline(esClient);
+    const processors = pipeline[CRIBL_ROUTING_PIPELINE]?.processors ?? [];
+    expect(processors.some((p) => p?.reroute?.if === `ctx['_dataId'] == '${VALID_DATA_ID}'`)).toBe(
+      true
+    );
+  });
+
+  apiTest(
+    'updates the routing pipeline when route entries change',
+    async ({ apiClient, esClient }) => {
+      const currentRes = await apiClient.get(`/api/fleet/package_policies/${packagePolicyId}`, {
+        headers: adminHeaders,
+        responseType: 'json',
+      });
+      expect(currentRes).toHaveStatusCode(200);
+      const current = currentRes.body.item;
+
+      const updateRes = await apiClient.put(`/api/fleet/package_policies/${packagePolicyId}`, {
+        headers: adminHeaders,
+        responseType: 'json',
+        body: {
+          name: current.name,
+          description: current.description,
+          namespace: current.namespace,
+          policy_ids: current.policy_ids,
+          enabled: current.enabled,
+          package: current.package,
+          inputs: current.inputs,
+          vars: {
+            ...current.vars,
+            route_entries: {
+              type: 'textarea',
+              value: buildRouteEntries(UPDATED_DATA_ID),
+            },
+          },
+        },
+      });
+
+      expect(updateRes).toHaveStatusCode(200);
+      expect(updateRes.body?.item?.vars?.route_entries?.value).toBe(
+        buildRouteEntries(UPDATED_DATA_ID)
+      );
+
+      const pipeline = await getPipeline(esClient);
+      const processors = pipeline[CRIBL_ROUTING_PIPELINE]?.processors ?? [];
+      expect(
+        processors.some((p) => p?.reroute?.if === `ctx['_dataId'] == '${UPDATED_DATA_ID}'`)
+      ).toBe(true);
+      expect(
+        processors.some((p) => p?.reroute?.if === `ctx['_dataId'] == '${VALID_DATA_ID}'`)
+      ).toBe(false);
+    }
+  );
+
+  apiTest(
+    'rejects invalid dataId values and leaves the pipeline unchanged',
+    async ({ apiClient, esClient }) => {
+      const before = await getPipeline(esClient);
+
+      const currentRes = await apiClient.get(`/api/fleet/package_policies/${packagePolicyId}`, {
+        headers: adminHeaders,
+        responseType: 'json',
+      });
+      expect(currentRes).toHaveStatusCode(200);
+      const current = currentRes.body.item;
+
+      const updateRes = await apiClient.put(`/api/fleet/package_policies/${packagePolicyId}`, {
+        headers: adminHeaders,
+        responseType: 'json',
+        body: {
+          name: current.name,
+          description: current.description,
+          namespace: current.namespace,
+          policy_ids: current.policy_ids,
+          enabled: current.enabled,
+          package: current.package,
+          inputs: current.inputs,
+          vars: {
+            ...current.vars,
+            route_entries: {
+              type: 'textarea',
+              value: buildRouteEntries(INVALID_DATA_ID),
+            },
+          },
+        },
+      });
+
+      expect(updateRes).toHaveStatusCode(400);
+      expect(updateRes.body?.message).toMatch(/Invalid Cribl dataId/);
+
+      const after = await getPipeline(esClient);
+      expect(after[CRIBL_ROUTING_PIPELINE]).toStrictEqual(before[CRIBL_ROUTING_PIPELINE]);
+    }
+  );
+
+  apiTest(
+    'rejects create when the caller lacks ingest pipeline privileges',
+    async ({ apiClient, esClient, log }) => {
+      await deletePipelineIfExists(esClient, log);
+
+      const createRes = await apiClient.post('/api/fleet/package_policies', {
+        headers: fleetNoPipelineHeaders,
+        responseType: 'json',
+        body: createCriblPackagePolicyBody({
+          name: `cribl-scout-noprivs-${Date.now()}`,
+          agentPolicyId,
+          dataId: VALID_DATA_ID,
+        }),
+      });
+
+      expect(createRes).toHaveStatusCode(403);
+      expect(createRes.body?.message).toMatch(/Failed to put Cribl integration routing pipeline/);
+
+      let missingPipelineStatusCode: number | undefined;
+      try {
+        await getPipeline(esClient);
+      } catch (error) {
+        missingPipelineStatusCode = (error as { meta?: { statusCode?: number } }).meta?.statusCode;
+      }
+      expect(missingPipelineStatusCode).toBe(404);
+    }
+  );
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution] Fix Cribl routing pipeline dataId handling (#284863)](https://github.com/elastic/kibana/pull/284863)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bharat Pasupula","email":"123897612+bhapas@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-17T10:11:38Z","message":"[Security Solution] Fix Cribl routing pipeline dataId handling (#284863)\n\n## Release Note\nFix Cribl routing pipeline dataId handling\n\n## Summary\n- Sanitize and validate Cribl `dataId` values before they are written\ninto the routing ingest pipeline.\n- Fail package policy create/update when route entries are invalid or\nthe pipeline put fails.\n- Write the Cribl routing pipeline using the request-scoped\nElasticsearch client, with Fleet update callbacks now receiving request\ncontext.\n- Add unit coverage and Scout API tests for create/update, invalid\n`dataId` rejection, and missing ingest pipeline privileges.\n\n## Test plan\n- [x] Run unit tests for Cribl sanitize helpers, put handler, callback\nwiring, and Fleet update context forwarding\n- [x] Create a Cribl integration policy with a valid `dataId` and\nconfirm `cribl-routing-pipeline` is created with the expected `if`\ncondition\n- [x] Update route entries with a new valid `dataId` and confirm the\npipeline processors update\n- [x] Attempt create/update with an invalid `dataId` and confirm the\nrequest fails without changing the pipeline\n- [x] Attempt create without ingest pipeline privileges and confirm the\nrequest fails without creating the pipeline\n- [x] Run Scout API suite:\n`x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api`\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"1dc192114fa3e1cf978a6447abf5a3ac6dc0a2cb","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.1.11","v9.2.9","reviewer:scout","v9.6.0","Team:streams-ui","v9.3.9","v9.4.6","v9.5.2","v8.19.21"],"title":"[Security Solution] Fix Cribl routing pipeline dataId handling","number":284863,"url":"https://github.com/elastic/kibana/pull/284863","mergeCommit":{"message":"[Security Solution] Fix Cribl routing pipeline dataId handling (#284863)\n\n## Release Note\nFix Cribl routing pipeline dataId handling\n\n## Summary\n- Sanitize and validate Cribl `dataId` values before they are written\ninto the routing ingest pipeline.\n- Fail package policy create/update when route entries are invalid or\nthe pipeline put fails.\n- Write the Cribl routing pipeline using the request-scoped\nElasticsearch client, with Fleet update callbacks now receiving request\ncontext.\n- Add unit coverage and Scout API tests for create/update, invalid\n`dataId` rejection, and missing ingest pipeline privileges.\n\n## Test plan\n- [x] Run unit tests for Cribl sanitize helpers, put handler, callback\nwiring, and Fleet update context forwarding\n- [x] Create a Cribl integration policy with a valid `dataId` and\nconfirm `cribl-routing-pipeline` is created with the expected `if`\ncondition\n- [x] Update route entries with a new valid `dataId` and confirm the\npipeline processors update\n- [x] Attempt create/update with an invalid `dataId` and confirm the\nrequest fails without changing the pipeline\n- [x] Attempt create without ingest pipeline privileges and confirm the\nrequest fails without creating the pipeline\n- [x] Run Scout API suite:\n`x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api`\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"1dc192114fa3e1cf978a6447abf5a3ac6dc0a2cb"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.2","9.3","9.4","9.5","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284863","number":284863,"mergeCommit":{"message":"[Security Solution] Fix Cribl routing pipeline dataId handling (#284863)\n\n## Release Note\nFix Cribl routing pipeline dataId handling\n\n## Summary\n- Sanitize and validate Cribl `dataId` values before they are written\ninto the routing ingest pipeline.\n- Fail package policy create/update when route entries are invalid or\nthe pipeline put fails.\n- Write the Cribl routing pipeline using the request-scoped\nElasticsearch client, with Fleet update callbacks now receiving request\ncontext.\n- Add unit coverage and Scout API tests for create/update, invalid\n`dataId` rejection, and missing ingest pipeline privileges.\n\n## Test plan\n- [x] Run unit tests for Cribl sanitize helpers, put handler, callback\nwiring, and Fleet update context forwarding\n- [x] Create a Cribl integration policy with a valid `dataId` and\nconfirm `cribl-routing-pipeline` is created with the expected `if`\ncondition\n- [x] Update route entries with a new valid `dataId` and confirm the\npipeline processors update\n- [x] Attempt create/update with an invalid `dataId` and confirm the\nrequest fails without changing the pipeline\n- [x] Attempt create without ingest pipeline privileges and confirm the\nrequest fails without creating the pipeline\n- [x] Run Scout API suite:\n`x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/api`\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>","sha":"1dc192114fa3e1cf978a6447abf5a3ac6dc0a2cb"}},{"branch":"9.3","label":"v9.3.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.21","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->