### PR TITLE
[9.5] [Security Solution] Support ip fields in alerts table group-by picker (#284769)

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/components/group_selector/custom_field_panel.test.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/group_selector/custom_field_panel.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { CustomFieldPanel } from './custom_field_panel';
+
+const baseFields = [
+  {
+    name: 'host.name',
+    type: 'string',
+    aggregatable: true,
+    searchable: true,
+    esTypes: ['keyword'],
+  },
+  {
+    name: 'source.ip',
+    type: 'ip',
+    aggregatable: true,
+    searchable: true,
+    esTypes: ['ip'],
+  },
+  {
+    name: 'destination.ip',
+    type: 'ip',
+    aggregatable: true,
+    searchable: true,
+    esTypes: ['ip'],
+  },
+  {
+    name: 'process.pid',
+    type: 'number',
+    aggregatable: true,
+    searchable: true,
+    esTypes: ['long'],
+  },
+  {
+    name: 'source.bytes',
+    type: 'number',
+    aggregatable: true,
+    searchable: true,
+    esTypes: ['long'],
+  },
+  {
+    name: 'source.ip.not_aggregatable',
+    type: 'ip',
+    aggregatable: false,
+    searchable: false,
+    esTypes: ['ip'],
+  },
+];
+
+const openCombobox = () => {
+  fireEvent.click(screen.getByRole('combobox'));
+};
+
+describe('CustomFieldPanel field type filtering', () => {
+  it('shows string and ip fields, excludes number and non-aggregatable fields by default', () => {
+    render(<CustomFieldPanel fields={baseFields} currentOptions={[]} onSubmit={jest.fn()} />);
+    openCombobox();
+
+    expect(screen.getByText('host.name')).toBeInTheDocument();
+    expect(screen.getByText('source.ip')).toBeInTheDocument();
+    expect(screen.getByText('destination.ip')).toBeInTheDocument();
+    expect(screen.queryByText('process.pid')).not.toBeInTheDocument();
+    expect(screen.queryByText('source.bytes')).not.toBeInTheDocument();
+    expect(screen.queryByText('source.ip.not_aggregatable')).not.toBeInTheDocument();
+  });
+
+  it('respects a custom allowedFieldTypes prop', () => {
+    render(
+      <CustomFieldPanel
+        fields={baseFields}
+        currentOptions={[]}
+        onSubmit={jest.fn()}
+        allowedFieldTypes={['number']}
+      />
+    );
+    openCombobox();
+
+    expect(screen.getByText('process.pid')).toBeInTheDocument();
+    expect(screen.getByText('source.bytes')).toBeInTheDocument();
+    expect(screen.queryByText('host.name')).not.toBeInTheDocument();
+    expect(screen.queryByText('source.ip')).not.toBeInTheDocument();
+  });
+
+  it('excludes already-selected options', () => {
+    render(
+      <CustomFieldPanel
+        fields={baseFields}
+        currentOptions={[{ text: 'Source IP', field: 'source.ip' }]}
+        onSubmit={jest.fn()}
+      />
+    );
+    openCombobox();
+
+    expect(screen.getByText('destination.ip')).toBeInTheDocument();
+    expect(screen.queryByText('source.ip')).not.toBeInTheDocument();
+  });
+});

--- a/src/platform/packages/shared/kbn-grouping/src/components/group_selector/custom_field_panel.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/group_selector/custom_field_panel.tsx
@@ -22,6 +22,7 @@ interface Props {
   onSubmit: (field: string) => void;
   fields: FieldSpec[];
   currentOptions: GroupByOptions[];
+  allowedFieldTypes?: string[];
 }
 
 interface SelectedOption {
@@ -38,12 +39,12 @@ export class CustomFieldPanel extends React.PureComponent<Props, State> {
   public static displayName = 'CustomFieldPanel';
   public readonly state: State = initialState;
   public render() {
-    const { fields, currentOptions } = this.props;
+    const { fields, currentOptions, allowedFieldTypes = ['string', 'ip'] } = this.props;
     const options = fields
       .filter(
         (f) =>
           f.aggregatable &&
-          f.type === 'string' &&
+          allowedFieldTypes.includes(f.type) &&
           !(currentOptions && currentOptions.some((o) => o.field === f.name))
       )
       .map<EuiComboBoxOptionOption>((f) => ({ label: f.name }));

--- a/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
@@ -59,6 +59,7 @@ const shouldDisableNone = ({
 
 export interface GroupSelectorProps {
   'data-test-subj'?: string;
+  allowedFieldTypes?: string[];
   fields: FieldSpec[];
   groupingId: string;
   groupsSelected: string[];
@@ -75,6 +76,7 @@ export interface GroupSelectorProps {
 }
 const GroupSelectorComponent = ({
   'data-test-subj': dataTestSubj,
+  allowedFieldTypes,
   fields,
   groupsSelected = ['none'],
   onGroupChange,
@@ -176,11 +178,13 @@ const GroupSelectorComponent = ({
               setIsPopoverOpen(false);
             }}
             fields={fields}
+            allowedFieldTypes={allowedFieldTypes}
           />
         ),
       },
     ];
   }, [
+    allowedFieldTypes,
     fields,
     isGroupSelected,
     maxGroupingLevels,

--- a/src/platform/packages/shared/kbn-grouping/src/hooks/use_get_group_selector.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/hooks/use_get_group_selector.tsx
@@ -20,6 +20,7 @@ import { validateEnforcedGroups, ensureEnforcedGroupsInFront } from '../helpers'
 import { getTelemetryEvent } from '../telemetry/const';
 
 export interface UseGetGroupSelectorArgs {
+  allowedFieldTypes?: string[];
   defaultGroupingOptions: GroupOption[];
   dispatch: React.Dispatch<Action>;
   fields: FieldSpec[];
@@ -49,7 +50,12 @@ export interface UseGetGroupSelectorArgs {
 interface UseGetGroupSelectorStateless
   extends Pick<
     UseGetGroupSelectorArgs,
-    'defaultGroupingOptions' | 'groupingId' | 'fields' | 'maxGroupingLevels' | 'settings'
+    | 'allowedFieldTypes'
+    | 'defaultGroupingOptions'
+    | 'groupingId'
+    | 'fields'
+    | 'maxGroupingLevels'
+    | 'settings'
   > {
   onGroupChange: (selectedGroups: string[]) => void;
 }
@@ -60,6 +66,7 @@ interface UseGetGroupSelectorStateless
 // the grouping component will handle the group selector. When the group selector is set back to none,
 // the consumer can again use the groupSelectorStateless component to select a new group
 export const useGetGroupSelectorStateless = ({
+  allowedFieldTypes,
   defaultGroupingOptions,
   groupingId,
   fields,
@@ -78,6 +85,7 @@ export const useGetGroupSelectorStateless = ({
     return (
       <GroupSelector
         {...{
+          allowedFieldTypes,
           groupingId,
           groupsSelected: ['none'],
           'data-test-subj': 'alerts-table-group-selector',
@@ -89,10 +97,19 @@ export const useGetGroupSelectorStateless = ({
         }}
       />
     );
-  }, [groupingId, fields, maxGroupingLevels, defaultGroupingOptions, onChange, settings]);
+  }, [
+    allowedFieldTypes,
+    groupingId,
+    fields,
+    maxGroupingLevels,
+    defaultGroupingOptions,
+    onChange,
+    settings,
+  ]);
 };
 
 export const useGetGroupSelector = ({
+  allowedFieldTypes,
   defaultGroupingOptions,
   dispatch,
   fields,
@@ -255,6 +272,7 @@ export const useGetGroupSelector = ({
   return useMemo(
     () => (
       <GroupSelector
+        allowedFieldTypes={allowedFieldTypes}
         groupingId={groupingId}
         groupsSelected={selectedGroups}
         data-test-subj="alerts-table-group-selector"
@@ -268,6 +286,7 @@ export const useGetGroupSelector = ({
       />
     ),
     [
+      allowedFieldTypes,
       groupingId,
       selectedGroups,
       onChange,

--- a/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
@@ -67,6 +67,7 @@ export type DynamicGroupingProps<T> = Pick<
  *  @interface GroupingArgs<T>
  */
 export interface GroupingArgs<T> {
+  allowedFieldTypes?: string[];
   componentProps: StaticGroupingProps<T>;
   defaultGroupingOptions: GroupOption[];
   fields: FieldSpec[];
@@ -112,6 +113,7 @@ export interface GroupingArgs<T> {
  * @returns {@link Grouping} the grouping constructor { getGrouping, groupSelector, pagination, selectedGroups }
  */
 export const useGrouping = <T,>({
+  allowedFieldTypes,
   componentProps,
   defaultGroupingOptions,
   initialGroupings,
@@ -147,6 +149,7 @@ export const useGrouping = <T,>({
   );
 
   const groupSelector = useGetGroupSelector({
+    allowedFieldTypes,
     defaultGroupingOptions,
     dispatch,
     fields,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
@@ -276,7 +276,7 @@ describe('GroupedAlertsTable', () => {
       tableId: testProps.tableId,
     });
     expect(mockDispatch.mock.calls[1][0].payload).toEqual({
-      options: mockOptions,
+      options: defaultGroupingOptions,
       tableId: testProps.tableId,
     });
     expect(mockDispatch.mock.calls[2][0].payload).toEqual({

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_stats_aggregations.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_stats_aggregations.test.tsx
@@ -179,4 +179,38 @@ describe('defaultGroupStatsAggregations', () => {
       },
     ]);
   });
+
+  it('should return values depending for destination.ip input field', () => {
+    const aggregations = defaultGroupStatsAggregations('destination.ip');
+    expect(aggregations).toEqual([
+      {
+        unitsCount: {
+          cardinality: {
+            field: 'kibana.alert.uuid',
+          },
+        },
+      },
+      {
+        rulesCountAggregation: {
+          cardinality: {
+            field: 'kibana.alert.rule.rule_id',
+          },
+        },
+      },
+      {
+        severitiesSubAggregation: {
+          terms: {
+            field: 'kibana.alert.severity',
+          },
+        },
+      },
+      {
+        hostsCountAggregation: {
+          cardinality: {
+            field: 'host.name',
+          },
+        },
+      },
+    ]);
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_stats_aggregations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_stats_aggregations.ts
@@ -81,6 +81,7 @@ export const defaultGroupStatsAggregations = (field: string): NamedAggregation[]
       aggMetrics.push(RULE_COUNT_AGGREGATION, SEVERITY_SUB_AGGREGATION, HOST_COUNT_AGGREGATION);
       break;
     case 'source.ip':
+    case 'destination.ip':
       aggMetrics.push(RULE_COUNT_AGGREGATION, SEVERITY_SUB_AGGREGATION, HOST_COUNT_AGGREGATION);
       break;
     default:

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_stats_renderers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_stats_renderers.test.tsx
@@ -240,6 +240,50 @@ describe('defaultGroupStatsRenderer', () => {
     ).toBeTruthy();
   });
 
+  it('should return array of badges for destination.ip field', () => {
+    const badges = defaultGroupStatsRenderer('destination.ip', {
+      key: '',
+      severitiesSubAggregation: { buckets: [{ key: 'medium', doc_count: 10 }] },
+      rulesCountAggregation: { value: 7 },
+      hostsCountAggregation: { value: 4 },
+      doc_count: 9,
+    });
+
+    expect(badges.length).toBe(4);
+    expect(
+      badges.find(
+        (badge) => badge.title === 'Severity:' && badge.component != null && badge.badge == null
+      )
+    ).toBeTruthy();
+    expect(
+      badges.find(
+        (badge) =>
+          badge.title === 'Hosts:' &&
+          badge.component == null &&
+          badge.badge != null &&
+          badge.badge.value === 4
+      )
+    ).toBeTruthy();
+    expect(
+      badges.find(
+        (badge) =>
+          badge.title === 'Rules:' &&
+          badge.component == null &&
+          badge.badge != null &&
+          badge.badge.value === 7
+      )
+    ).toBeTruthy();
+    expect(
+      badges.find(
+        (badge) =>
+          badge.title === 'Alerts:' &&
+          badge.component == null &&
+          badge.badge != null &&
+          badge.badge.value === 9
+      )
+    ).toBeTruthy();
+  });
+
   it('should return default badges if the field specific does not exist', () => {
     const badges = defaultGroupStatsRenderer('process.name', {
       key: '',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_stats_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_stats_renderers.tsx
@@ -149,6 +149,7 @@ export const defaultGroupStatsRenderer = (
       return [...severityComponent, usersBadge, rulesBadge, ...defaultBadges];
     case 'user.name':
     case 'source.ip':
+    case 'destination.ip':
       return [...severityComponent, hostsBadge, rulesBadge, ...defaultBadges];
   }
   return [...severityComponent, rulesBadge, ...defaultBadges];

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_title_renderers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_title_renderers.test.tsx
@@ -80,6 +80,21 @@ describe('defaultGroupTitleRenderers', () => {
     expect(getByTestId('source-ip-group-renderer')).toBeInTheDocument();
   });
 
+  it('should render correctly for destination.ip field', () => {
+    const { getByTestId } = render(
+      defaultGroupTitleRenderers(
+        'destination.ip',
+        {
+          key: '1.2.3.4',
+          doc_count: 5,
+        },
+        'This is a null group!'
+      )!
+    );
+
+    expect(getByTestId('destination-ip-group-renderer')).toBeInTheDocument();
+  });
+
   it('should return undefined when the renderer does not exist', () => {
     const wrapper = defaultGroupTitleRenderers(
       'process.name',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_title_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_group_title_renderers.tsx
@@ -78,6 +78,15 @@ export const defaultGroupTitleRenderers: GroupPanelRenderer<AlertsGroupingAggreg
           dataTestSubj="source-ip"
         />
       );
+    case 'destination.ip':
+      return (
+        <GroupWithIconContent
+          title={bucket.key}
+          icon="globe"
+          nullGroupMessage={nullGroupMessage}
+          dataTestSubj="destination-ip"
+        />
+      );
   }
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_grouping_options.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/default_grouping_options.tsx
@@ -24,6 +24,10 @@ const SOURCE_IP = i18n.translate('xpack.securitySolution.alertsTable.groups.sour
   defaultMessage: 'Source IP',
 });
 
+const DESTINATION_IP = i18n.translate('xpack.securitySolution.alertsTable.groups.destinationIP', {
+  defaultMessage: 'Destination IP',
+});
+
 /**
  * Returns a list of fields for the default grouping options. These are displayed in the `Group alerts by` dropdown button.
  *
@@ -45,5 +49,9 @@ export const defaultGroupingOptions: GroupOption[] = [
   {
     label: SOURCE_IP,
     key: 'source.ip',
+  },
+  {
+    label: DESTINATION_IP,
+    key: 'destination.ip',
   },
 ];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Security Solution] Support ip fields in alerts table group-by picker (#284769)](https://github.com/elastic/kibana/pull/284769)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-08-18T05:47:06Z","message":"[Security Solution] Support ip fields in alerts table group-by picker (#284769)\n\n## Summary\n\n### What\nExpands alert grouping in the Security alerts table to support IP\naddress fields in two ways:\n\n1. `destination.ip` is added as a built-in top-level \"Group alerts by\"\noption alongside the existing `source.ip`.\n2. All aggregatable `ip`-type fields (e.g. `related.ip`,\n`dns.resolved_ip`, `client.ip`, `server.ip`, `network.forwarded_ip`) are\nnow selectable via the \"Custom Field\" picker — previously only\n`string`-type fields appeared there.\n\n### Why\nThe `ip` field type in Elasticsearch is distinct from `string` (it is\nstored as binary for efficient range queries) and was excluded from the\ncustom field picker's hardcoded `f.type === 'string'` filter. This meant\nnone of the 17 aggregatable `*.ip` fields in the security alert index\nwere reachable via grouping, except `source.ip` which was hardcoded as a\ntop-level option.\n\nCloses elastic/security-team#16899\n\n\n\nhttps://github.com/user-attachments/assets/c00f7687-961a-42f0-9e88-dc731882944b\n\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Regressions in `kbn-grouping` consumers** (low): The\n`allowedFieldTypes` prop defaults to `['string', 'ip']`, so existing\ncallers that pass no value get the same `string` fields plus `ip`\nfields. Any consumer that intentionally wanted only `string` types is\nunaffected unless they relied on `ip` fields being absent — which was\nunintentional behaviour, not a contract. Mitigation: the default is\nopt-in additive; callers can pass `allowedFieldTypes={['string']}` to\nrestore the old behaviour.\n- **Multi-value IP field grouping** (low): Fields like `related.ip` and\n`dns.resolved_ip` are arrays; a single alert can appear in multiple\ngroups simultaneously when grouped by these fields. This is expected ES\nterms aggregation behaviour, not a bug, but could surprise users. No\nmitigation needed at the grouping layer.\n- No data loss, no HTTP API changes, no breaking changes.\n\n### Release note\n\n> `destination.ip` is now available as a built-in group-by option in the\nSecurity alerts table, and all aggregatable IP-type fields are\nselectable in the custom field group-by picker.\n\n**Suggested label:** `release_note:enhancement`\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"b13ea78221acb8e043d87530bf4de89da3898379","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Threat Hunting","backport:all-open","v9.6.0"],"title":"[Security Solution] Support ip fields in alerts table group-by picker","number":284769,"url":"https://github.com/elastic/kibana/pull/284769","mergeCommit":{"message":"[Security Solution] Support ip fields in alerts table group-by picker (#284769)\n\n## Summary\n\n### What\nExpands alert grouping in the Security alerts table to support IP\naddress fields in two ways:\n\n1. `destination.ip` is added as a built-in top-level \"Group alerts by\"\noption alongside the existing `source.ip`.\n2. All aggregatable `ip`-type fields (e.g. `related.ip`,\n`dns.resolved_ip`, `client.ip`, `server.ip`, `network.forwarded_ip`) are\nnow selectable via the \"Custom Field\" picker — previously only\n`string`-type fields appeared there.\n\n### Why\nThe `ip` field type in Elasticsearch is distinct from `string` (it is\nstored as binary for efficient range queries) and was excluded from the\ncustom field picker's hardcoded `f.type === 'string'` filter. This meant\nnone of the 17 aggregatable `*.ip` fields in the security alert index\nwere reachable via grouping, except `source.ip` which was hardcoded as a\ntop-level option.\n\nCloses elastic/security-team#16899\n\n\n\nhttps://github.com/user-attachments/assets/c00f7687-961a-42f0-9e88-dc731882944b\n\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Regressions in `kbn-grouping` consumers** (low): The\n`allowedFieldTypes` prop defaults to `['string', 'ip']`, so existing\ncallers that pass no value get the same `string` fields plus `ip`\nfields. Any consumer that intentionally wanted only `string` types is\nunaffected unless they relied on `ip` fields being absent — which was\nunintentional behaviour, not a contract. Mitigation: the default is\nopt-in additive; callers can pass `allowedFieldTypes={['string']}` to\nrestore the old behaviour.\n- **Multi-value IP field grouping** (low): Fields like `related.ip` and\n`dns.resolved_ip` are arrays; a single alert can appear in multiple\ngroups simultaneously when grouped by these fields. This is expected ES\nterms aggregation behaviour, not a bug, but could surprise users. No\nmitigation needed at the grouping layer.\n- No data loss, no HTTP API changes, no breaking changes.\n\n### Release note\n\n> `destination.ip` is now available as a built-in group-by option in the\nSecurity alerts table, and all aggregatable IP-type fields are\nselectable in the custom field group-by picker.\n\n**Suggested label:** `release_note:enhancement`\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"b13ea78221acb8e043d87530bf4de89da3898379"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284769","number":284769,"mergeCommit":{"message":"[Security Solution] Support ip fields in alerts table group-by picker (#284769)\n\n## Summary\n\n### What\nExpands alert grouping in the Security alerts table to support IP\naddress fields in two ways:\n\n1. `destination.ip` is added as a built-in top-level \"Group alerts by\"\noption alongside the existing `source.ip`.\n2. All aggregatable `ip`-type fields (e.g. `related.ip`,\n`dns.resolved_ip`, `client.ip`, `server.ip`, `network.forwarded_ip`) are\nnow selectable via the \"Custom Field\" picker — previously only\n`string`-type fields appeared there.\n\n### Why\nThe `ip` field type in Elasticsearch is distinct from `string` (it is\nstored as binary for efficient range queries) and was excluded from the\ncustom field picker's hardcoded `f.type === 'string'` filter. This meant\nnone of the 17 aggregatable `*.ip` fields in the security alert index\nwere reachable via grouping, except `source.ip` which was hardcoded as a\ntop-level option.\n\nCloses elastic/security-team#16899\n\n\n\nhttps://github.com/user-attachments/assets/c00f7687-961a-42f0-9e88-dc731882944b\n\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Regressions in `kbn-grouping` consumers** (low): The\n`allowedFieldTypes` prop defaults to `['string', 'ip']`, so existing\ncallers that pass no value get the same `string` fields plus `ip`\nfields. Any consumer that intentionally wanted only `string` types is\nunaffected unless they relied on `ip` fields being absent — which was\nunintentional behaviour, not a contract. Mitigation: the default is\nopt-in additive; callers can pass `allowedFieldTypes={['string']}` to\nrestore the old behaviour.\n- **Multi-value IP field grouping** (low): Fields like `related.ip` and\n`dns.resolved_ip` are arrays; a single alert can appear in multiple\ngroups simultaneously when grouped by these fields. This is expected ES\nterms aggregation behaviour, not a bug, but could surprise users. No\nmitigation needed at the grouping layer.\n- No data loss, no HTTP API changes, no breaking changes.\n\n### Release note\n\n> `destination.ip` is now available as a built-in group-by option in the\nSecurity alerts table, and all aggregatable IP-type fields are\nselectable in the custom field group-by picker.\n\n**Suggested label:** `release_note:enhancement`\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"b13ea78221acb8e043d87530bf4de89da3898379"}}]}] BACKPORT-->