### PR TITLE
[APM] Fix anomaly badge expected-bounds comparison

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.test.tsx
@@ -12,16 +12,18 @@ import { AnomalyDetectorType } from '@kbn/apm-types';
 import type { AnomaliesBadgeNavigationProps } from './anomalies_badge';
 import { AnomaliesBadge } from './anomalies_badge';
 
-const mockGetUrl = jest.fn().mockImplementation(async ({ serviceName, isMobileAgentName, query }: any) => {
-  const base = isMobileAgentName
-    ? `/app/apm/mobile-services/${serviceName}/overview`
-    : `/app/apm/services/${serviceName}/overview`;
-  const params = new URLSearchParams();
-  Object.entries(query ?? {}).forEach(([k, v]) => {
-    if (v !== undefined) params.set(k, String(v));
+const mockGetUrl = jest
+  .fn()
+  .mockImplementation(async ({ serviceName, isMobileAgentName, query }: any) => {
+    const base = isMobileAgentName
+      ? `/app/apm/mobile-services/${serviceName}/overview`
+      : `/app/apm/services/${serviceName}/overview`;
+    const params = new URLSearchParams();
+    Object.entries(query ?? {}).forEach(([k, v]) => {
+      if (v !== undefined) params.set(k, String(v));
+    });
+    return `${base}?${params.toString()}`;
   });
-  return `${base}?${params.toString()}`;
-});
 
 const mockLocators = {
   get: jest.fn().mockReturnValue({ getUrl: mockGetUrl }),

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.test.tsx
@@ -12,21 +12,19 @@ import { AnomalyDetectorType } from '@kbn/apm-types';
 import type { AnomaliesBadgeNavigationProps } from './anomalies_badge';
 import { AnomaliesBadge } from './anomalies_badge';
 
-const mockGetRedirectUrl = jest
-  .fn()
-  .mockImplementation(({ serviceName, isMobileAgentName, query }: any) => {
-    const base = isMobileAgentName
-      ? `/mobile-services/${serviceName}/overview`
-      : `/services/${serviceName}/overview`;
-    const params = new URLSearchParams();
-    Object.entries(query ?? {}).forEach(([k, v]) => {
-      if (v !== undefined) params.set(k, String(v));
-    });
-    return `${base}?${params.toString()}`;
+const mockGetUrl = jest.fn().mockImplementation(async ({ serviceName, isMobileAgentName, query }: any) => {
+  const base = isMobileAgentName
+    ? `/app/apm/mobile-services/${serviceName}/overview`
+    : `/app/apm/services/${serviceName}/overview`;
+  const params = new URLSearchParams();
+  Object.entries(query ?? {}).forEach(([k, v]) => {
+    if (v !== undefined) params.set(k, String(v));
   });
+  return `${base}?${params.toString()}`;
+});
 
 const mockLocators = {
-  get: jest.fn().mockReturnValue({ getRedirectUrl: mockGetRedirectUrl }),
+  get: jest.fn().mockReturnValue({ getUrl: mockGetUrl }),
 } as unknown as AnomaliesBadgeNavigationProps['locators'];
 
 const regularClickProps: AnomaliesBadgeNavigationProps = {
@@ -66,8 +64,11 @@ async function getTooltipText(): Promise<string | null | undefined> {
   return document.querySelector('.euiToolTipPopover')?.textContent;
 }
 
-function getBadgeHrefParts(): [string, string] {
-  const href = screen.getByTestId('apmAnomaliesBadge').closest('a')?.getAttribute('href');
+async function getBadgeHrefParts(): Promise<[string, string]> {
+  await waitFor(() => {
+    expect(screen.getByTestId('apmAnomaliesBadge')).toHaveAttribute('href');
+  });
+  const href = screen.getByTestId('apmAnomaliesBadge').getAttribute('href');
   const [pathname, search] = href!.split('?');
   return [pathname, search];
 }
@@ -140,7 +141,7 @@ describe('AnomaliesBadge', () => {
       />
     );
 
-    const [pathname, search] = getBadgeHrefParts();
+    const [pathname, search] = await getBadgeHrefParts();
 
     expect(pathname).toContain('/services/opbeans-java/overview');
     expect(Object.fromEntries(new URLSearchParams(search))).toMatchObject({
@@ -162,7 +163,7 @@ describe('AnomaliesBadge', () => {
       />
     );
 
-    const [pathname, search] = getBadgeHrefParts();
+    const [pathname, search] = await getBadgeHrefParts();
 
     expect(pathname).toContain('/mobile-services/opbeans-android/overview');
     expect(Object.fromEntries(new URLSearchParams(search))).toMatchObject({
@@ -194,7 +195,7 @@ describe('AnomaliesBadge', () => {
       />
     );
 
-    const [pathname, search] = getBadgeHrefParts();
+    const [pathname, search] = await getBadgeHrefParts();
 
     expect(pathname).toContain('/services/opbeans-java/overview');
     expect(Object.fromEntries(new URLSearchParams(search))).toMatchObject({
@@ -217,7 +218,7 @@ describe('AnomaliesBadge', () => {
       />
     );
 
-    const [pathname, search] = getBadgeHrefParts();
+    const [pathname, search] = await getBadgeHrefParts();
 
     expect(pathname).toContain('/services/opbeans-java/overview');
     expect(Object.fromEntries(new URLSearchParams(search))).toMatchObject({

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.test.tsx
@@ -12,6 +12,12 @@ import { AnomalyDetectorType } from '@kbn/apm-types';
 import type { AnomaliesBadgeNavigationProps } from './anomalies_badge';
 import { AnomaliesBadge } from './anomalies_badge';
 
+// Production `getRedirectUrl` builds `/app/r?...` (share redirect). The mock must
+// return that path so tests fail if the badge uses it instead of `getUrl`.
+const SHARE_REDIRECT_URL = '/app/r?l=APM_LOCATOR&lz=compressed-payload';
+
+const mockGetRedirectUrl = jest.fn().mockReturnValue(SHARE_REDIRECT_URL);
+
 const mockGetUrl = jest
   .fn()
   .mockImplementation(async ({ serviceName, isMobileAgentName, query }: any) => {
@@ -26,7 +32,7 @@ const mockGetUrl = jest
   });
 
 const mockLocators = {
-  get: jest.fn().mockReturnValue({ getUrl: mockGetUrl }),
+  get: jest.fn().mockReturnValue({ getUrl: mockGetUrl, getRedirectUrl: mockGetRedirectUrl }),
 } as unknown as AnomaliesBadgeNavigationProps['locators'];
 
 const regularClickProps: AnomaliesBadgeNavigationProps = {
@@ -66,16 +72,38 @@ async function getTooltipText(): Promise<string | null | undefined> {
   return document.querySelector('.euiToolTipPopover')?.textContent;
 }
 
-async function getBadgeHrefParts(): Promise<[string, string]> {
+async function getBadgeHref(): Promise<string> {
   await waitFor(() => {
     expect(screen.getByTestId('apmAnomaliesBadge')).toHaveAttribute('href');
   });
-  const href = screen.getByTestId('apmAnomaliesBadge').getAttribute('href');
-  const [pathname, search] = href!.split('?');
+  return screen.getByTestId('apmAnomaliesBadge').getAttribute('href')!;
+}
+
+async function getBadgeHrefParts(): Promise<[string, string]> {
+  const href = await getBadgeHref();
+  const [pathname, search] = href.split('?');
   return [pathname, search];
 }
 
+function expectInAppExpectedBoundsNavigation(pathname: string, search: string) {
+  expect(pathname).toMatch(/^\/app\/apm\//);
+  expect(pathname).not.toContain('/app/r');
+  expect(Object.fromEntries(new URLSearchParams(search)).offset).toBe('expected_bounds');
+  expect(mockGetUrl).toHaveBeenCalledWith(
+    expect.objectContaining({
+      query: expect.objectContaining({ offset: 'expected_bounds' }),
+    }),
+    undefined
+  );
+  expect(mockGetRedirectUrl).not.toHaveBeenCalled();
+}
+
 describe('AnomaliesBadge', () => {
+  beforeEach(() => {
+    mockGetUrl.mockClear();
+    mockGetRedirectUrl.mockClear();
+  });
+
   it('names the anomalous detector in the tooltip when a detectorType is provided', async () => {
     renderBadge(
       <AnomaliesBadge score={CRITICAL_SEVERITY} detectorType={AnomalyDetectorType.txFailureRate} />
@@ -153,6 +181,7 @@ describe('AnomaliesBadge', () => {
       comparisonEnabled: 'true',
       offset: 'expected_bounds',
     });
+    expectInAppExpectedBoundsNavigation(pathname, search);
     expect(await getTooltipText()).toContain('Click to view more.');
   });
 
@@ -175,6 +204,7 @@ describe('AnomaliesBadge', () => {
       comparisonEnabled: 'true',
       offset: 'expected_bounds',
     });
+    expectInAppExpectedBoundsNavigation(pathname, search);
     expect(await getTooltipText()).toContain('Click to view more.');
   });
 
@@ -204,6 +234,7 @@ describe('AnomaliesBadge', () => {
       comparisonEnabled: 'false',
       offset: 'expected_bounds',
     });
+    expectInAppExpectedBoundsNavigation(pathname, search);
     expect(await getTooltipText()).toContain('Click to hide expected bounds.');
   });
 
@@ -227,6 +258,27 @@ describe('AnomaliesBadge', () => {
       comparisonEnabled: 'true',
       offset: 'expected_bounds',
     });
+    expectInAppExpectedBoundsNavigation(pathname, search);
     expect(await getTooltipText()).toContain('Click to view expected bounds.');
+  });
+
+  it('does not use getRedirectUrl (/app/r), which full-reloads APM and drops expected-bounds comparison', async () => {
+    renderBadge(
+      <AnomaliesBadge
+        score={CRITICAL_SEVERITY}
+        detectorType={AnomalyDetectorType.txLatency}
+        navigationProps={regularClickProps}
+      />
+    );
+
+    const href = await getBadgeHref();
+
+    expect(href).not.toBe(SHARE_REDIRECT_URL);
+    expect(href).not.toMatch(/\/app\/r(\?|$)/);
+    expect(href).toContain('/app/apm/services/opbeans-java/overview');
+    expect(href).toContain('offset=expected_bounds');
+    expect(href).toContain('comparisonEnabled=true');
+    expect(mockGetUrl).toHaveBeenCalled();
+    expect(mockGetRedirectUrl).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { EuiBadge, EuiHealth, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -15,6 +15,7 @@ import type { EbtClickAttrs } from '@kbn/ebt-click';
 import { getEbtProps } from '@kbn/ebt-click';
 import { ML_ANOMALY_SEVERITY } from '@kbn/ml-anomaly-utils/anomaly_severity';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
+import { useLocatorUrl } from '@kbn/share-plugin/public';
 import { isMobileAgentName } from '../../../../../common/agent_name';
 import {
   getApmMlDetectorLabel,
@@ -22,6 +23,7 @@ import {
   getSeverityColor,
   isNoAnomalyScore,
 } from '../../../../../common/anomaly_detection';
+import type { APMLocatorPayload } from '../../../../locator/helpers';
 import { APM_APP_LOCATOR_ID } from '../../../../locator/service_detail_locator';
 
 const COMPARISON_ENABLED_DEFAULT = true;
@@ -171,23 +173,35 @@ export function AnomaliesBadge({ score, detectorType, navigationProps, ebt }: An
       })
     : formatLabelWithScore(getI18nLabel(severity), score);
 
-  const href =
-    navigationProps && score !== undefined && !isNone
-      ? navigationProps.locators.get(APM_APP_LOCATOR_ID)?.getRedirectUrl({
-          serviceName: navigationProps.serviceName,
-          isMobileAgentName: isMobileAgentName(navigationProps.agentName),
-          query: {
-            environment: navigationProps.anomalyEnvironment,
-            rangeFrom: navigationProps.rangeFrom,
-            rangeTo: navigationProps.rangeTo,
-            kuery: '',
-            transactionType: navigationProps.transactionType,
-            anomalyThreshold: severity === ML_ANOMALY_SEVERITY.UNKNOWN ? undefined : severity,
-            comparisonEnabled: navigationProps.comparisonEnabled ?? COMPARISON_ENABLED_DEFAULT,
-            offset: 'expected_bounds',
-          },
-        })
-      : undefined;
+  const isInteractive = Boolean(navigationProps && score !== undefined && !isNone);
+  const locator = isInteractive
+    ? (navigationProps?.locators.get(APM_APP_LOCATOR_ID) ?? null)
+    : null;
+
+  // `getRedirectUrl` points at `/app/r` (share redirect) and causes a full Kibana reload
+  // that can drop comparison query params. `getUrl` (via useLocatorUrl) is the in-app path.
+  const locatorParams = useMemo<APMLocatorPayload>(() => {
+    if (!navigationProps) {
+      return {};
+    }
+    return {
+      serviceName: navigationProps.serviceName,
+      isMobileAgentName: isMobileAgentName(navigationProps.agentName),
+      query: {
+        environment: navigationProps.anomalyEnvironment,
+        rangeFrom: navigationProps.rangeFrom,
+        rangeTo: navigationProps.rangeTo,
+        kuery: '',
+        transactionType: navigationProps.transactionType,
+        anomalyThreshold: severity === ML_ANOMALY_SEVERITY.UNKNOWN ? undefined : severity,
+        comparisonEnabled: navigationProps.comparisonEnabled ?? COMPARISON_ENABLED_DEFAULT,
+        offset: 'expected_bounds',
+      },
+    };
+  }, [navigationProps, severity]);
+
+  const locatorUrl = useLocatorUrl(locator, locatorParams, undefined, [locator, locatorParams]);
+  const href = isInteractive && locatorUrl ? locatorUrl : undefined;
 
   const tooltipContent = getTooltipContent({
     isNone,

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/anomalies_badge.tsx
@@ -174,9 +174,7 @@ export function AnomaliesBadge({ score, detectorType, navigationProps, ebt }: An
     : formatLabelWithScore(getI18nLabel(severity), score);
 
   const isInteractive = Boolean(navigationProps && score !== undefined && !isNone);
-  const locator = isInteractive
-    ? (navigationProps?.locators.get(APM_APP_LOCATOR_ID) ?? null)
-    : null;
+  const locator = isInteractive ? navigationProps?.locators.get(APM_APP_LOCATOR_ID) ?? null : null;
 
   // `getRedirectUrl` points at `/app/r` (share redirect) and causes a full Kibana reload
   // that can drop comparison query params. `getUrl` (via useLocatorUrl) is the in-app path.

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/apm_services_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/apm_services_table.test.tsx
@@ -440,10 +440,18 @@ describe('ApmServicesTable', () => {
     });
 
     describe('anomaly badge navigation', () => {
-      it('renders anomaly badge with href when locators is provided and service has anomaly score', () => {
-        const mockGetRedirectUrl = jest.fn().mockReturnValue('/services/opbeans-python/overview');
+      it('renders anomaly badge with href when locators is provided and service has anomaly score', async () => {
+        const mockGetUrl = jest
+          .fn()
+          .mockResolvedValue('/app/apm/services/opbeans-python/overview');
+        const mockGetRedirectUrl = jest
+          .fn()
+          .mockReturnValue('/app/r?l=APM_LOCATOR&lz=compressed-payload');
         const mockLocators = {
-          get: jest.fn().mockReturnValue({ getRedirectUrl: mockGetRedirectUrl }),
+          get: jest.fn().mockReturnValue({
+            getUrl: mockGetUrl,
+            getRedirectUrl: mockGetRedirectUrl,
+          }),
         } as any;
 
         const columns = getServiceColumns({
@@ -478,17 +486,25 @@ describe('ApmServicesTable', () => {
           </EuiThemeProvider>
         );
 
+        await waitFor(() => {
+          expect(screen.getByTestId('apmAnomaliesBadge')).toHaveAttribute('href');
+        });
         const badge = screen.getByTestId('apmAnomaliesBadge');
         expect(badge.closest('a')).not.toBeNull();
-        expect(mockGetRedirectUrl).toHaveBeenCalledWith(
+        expect(badge.getAttribute('href')).toContain('/app/apm/services/opbeans-python/overview');
+        expect(badge.getAttribute('href')).not.toMatch(/\/app\/r(\?|$)/);
+        expect(mockGetUrl).toHaveBeenCalledWith(
           expect.objectContaining({
             serviceName: 'opbeans-python',
             query: expect.objectContaining({
               environment: 'production',
               comparisonEnabled: true,
+              offset: 'expected_bounds',
             }),
-          })
+          }),
+          undefined
         );
+        expect(mockGetRedirectUrl).not.toHaveBeenCalled();
       });
     });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/apm_services_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/apm_services_table.test.tsx
@@ -441,9 +441,7 @@ describe('ApmServicesTable', () => {
 
     describe('anomaly badge navigation', () => {
       it('renders anomaly badge with href when locators is provided and service has anomaly score', async () => {
-        const mockGetUrl = jest
-          .fn()
-          .mockResolvedValue('/app/apm/services/opbeans-python/overview');
+        const mockGetUrl = jest.fn().mockResolvedValue('/app/apm/services/opbeans-python/overview');
         const mockGetRedirectUrl = jest
           .fn()
           .mockReturnValue('/app/r?l=APM_LOCATOR&lz=compressed-payload');

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import type { AgentName } from '@kbn/elastic-agent-utils';
 import { ServiceHeaderBadges } from './service_header_badges';
@@ -27,13 +27,12 @@ const mockShare = {
   url: {
     locators: {
       get: jest.fn().mockReturnValue({
-        getRedirectUrl: jest
+        getUrl: jest
           .fn()
-          .mockImplementation(
-            ({ serviceName, query }: any) =>
-              `/services/${serviceName}/overview?comparisonEnabled=${
-                query?.comparisonEnabled ?? true
-              }`
+          .mockImplementation(async ({ serviceName, query }: any) =>
+            `/app/apm/services/${serviceName}/overview?comparisonEnabled=${
+              query?.comparisonEnabled ?? true
+            }`
           ),
       }),
     },
@@ -304,7 +303,7 @@ describe('ServiceHeaderBadges', () => {
     expect(badge).toHaveAttribute('data-slo-status', 'violated');
   });
 
-  it('shows anomalies badge when ML jobs can be read and a score is returned', () => {
+  it('shows anomalies badge when ML jobs can be read and a score is returned', async () => {
     setupMocks({
       canReadMlJobs: true,
       alertsCount: 0,
@@ -316,9 +315,12 @@ describe('ServiceHeaderBadges', () => {
 
     expect(screen.getByTestId('serviceHeaderAnomaliesBadge')).toBeInTheDocument();
     expect(screen.getByText(/Critical \(82\)/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('apmAnomaliesBadge')).toHaveAttribute('href');
+    });
   });
 
-  it('links the anomalies badge to the service overview tab', () => {
+  it('links the anomalies badge to the service overview tab', async () => {
     setupMocks({
       canReadMlJobs: true,
       alertsCount: 0,
@@ -328,7 +330,10 @@ describe('ServiceHeaderBadges', () => {
     });
     renderBadges();
 
-    const href = screen.getByTestId('apmAnomaliesBadge').closest('a')?.getAttribute('href');
+    await waitFor(() => {
+      expect(screen.getByTestId('apmAnomaliesBadge')).toHaveAttribute('href');
+    });
+    const href = screen.getByTestId('apmAnomaliesBadge').getAttribute('href');
     expect(href).toContain('/services/test-service/overview');
   });
 
@@ -383,12 +388,15 @@ describe('ServiceHeaderBadges', () => {
       sloFetchStatus: FETCH_STATUS.NOT_INITIATED,
     };
 
-    function getAnomalyBadgeSearchParams(): Record<string, string> {
-      const href = screen.getByTestId('apmAnomaliesBadge').closest('a')?.getAttribute('href');
+    async function getAnomalyBadgeSearchParams(): Promise<Record<string, string>> {
+      await waitFor(() => {
+        expect(screen.getByTestId('apmAnomaliesBadge')).toHaveAttribute('href');
+      });
+      const href = screen.getByTestId('apmAnomaliesBadge').getAttribute('href');
       return Object.fromEntries(new URLSearchParams(href!.split('?')[1]));
     }
 
-    it('always targets expected bounds ON when not on the overview tab', () => {
+    it('always targets expected bounds ON when not on the overview tab', async () => {
       setupMocks({
         ...anomalySetup,
         routePath: '/services/{serviceName}/transactions',
@@ -397,10 +405,10 @@ describe('ServiceHeaderBadges', () => {
       });
       renderBadges();
 
-      expect(getAnomalyBadgeSearchParams()).toMatchObject({ comparisonEnabled: 'true' });
+      expect(await getAnomalyBadgeSearchParams()).toMatchObject({ comparisonEnabled: 'true' });
     });
 
-    it('targets toggling expected bounds OFF when on overview tab and bounds are showing', () => {
+    it('targets toggling expected bounds OFF when on overview tab and bounds are showing', async () => {
       setupMocks({
         ...anomalySetup,
         routePath: '/services/{serviceName}/overview',
@@ -409,10 +417,10 @@ describe('ServiceHeaderBadges', () => {
       });
       renderBadges();
 
-      expect(getAnomalyBadgeSearchParams()).toMatchObject({ comparisonEnabled: 'false' });
+      expect(await getAnomalyBadgeSearchParams()).toMatchObject({ comparisonEnabled: 'false' });
     });
 
-    it('targets toggling expected bounds ON when on overview tab and bounds are not showing', () => {
+    it('targets toggling expected bounds ON when on overview tab and bounds are not showing', async () => {
       setupMocks({
         ...anomalySetup,
         routePath: '/services/{serviceName}/overview',
@@ -421,7 +429,7 @@ describe('ServiceHeaderBadges', () => {
       });
       renderBadges();
 
-      expect(getAnomalyBadgeSearchParams()).toMatchObject({ comparisonEnabled: 'true' });
+      expect(await getAnomalyBadgeSearchParams()).toMatchObject({ comparisonEnabled: 'true' });
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.test.tsx
@@ -23,18 +23,26 @@ jest.mock('../../../../context/apm_plugin/use_apm_plugin_context', () => ({
   useApmPluginContext: () => mockUseApmPluginContext(),
 }));
 
+// Production `getRedirectUrl` builds `/app/r?...`. The mock must return that path so
+// tests fail if the badge uses it instead of `getUrl` (in-app `/app/apm/...`).
+const SHARE_REDIRECT_URL = '/app/r?l=APM_LOCATOR&lz=compressed-payload';
+
+const mockGetRedirectUrl = jest.fn().mockReturnValue(SHARE_REDIRECT_URL);
+
+const mockGetUrl = jest.fn().mockImplementation(async ({ serviceName, query }: any) => {
+  const params = new URLSearchParams();
+  Object.entries(query ?? {}).forEach(([k, v]) => {
+    if (v !== undefined) params.set(k, String(v));
+  });
+  return `/app/apm/services/${serviceName}/overview?${params.toString()}`;
+});
+
 const mockShare = {
   url: {
     locators: {
       get: jest.fn().mockReturnValue({
-        getUrl: jest
-          .fn()
-          .mockImplementation(
-            async ({ serviceName, query }: any) =>
-              `/app/apm/services/${serviceName}/overview?comparisonEnabled=${
-                query?.comparisonEnabled ?? true
-              }`
-          ),
+        getUrl: mockGetUrl,
+        getRedirectUrl: mockGetRedirectUrl,
       }),
     },
   },
@@ -335,7 +343,11 @@ describe('ServiceHeaderBadges', () => {
       expect(screen.getByTestId('apmAnomaliesBadge')).toHaveAttribute('href');
     });
     const href = screen.getByTestId('apmAnomaliesBadge').getAttribute('href');
-    expect(href).toContain('/services/test-service/overview');
+    expect(href).toContain('/app/apm/services/test-service/overview');
+    expect(href).not.toMatch(/\/app\/r(\?|$)/);
+    expect(href).toContain('offset=expected_bounds');
+    expect(href).toContain('comparisonEnabled=true');
+    expect(mockGetRedirectUrl).not.toHaveBeenCalled();
   });
 
   it('renders the anomalies badge as non-interactive when the agent name is not yet resolved', () => {
@@ -389,12 +401,19 @@ describe('ServiceHeaderBadges', () => {
       sloFetchStatus: FETCH_STATUS.NOT_INITIATED,
     };
 
-    async function getAnomalyBadgeSearchParams(): Promise<Record<string, string>> {
+    async function getAnomalyBadgeHref(): Promise<string> {
       await waitFor(() => {
         expect(screen.getByTestId('apmAnomaliesBadge')).toHaveAttribute('href');
       });
-      const href = screen.getByTestId('apmAnomaliesBadge').getAttribute('href');
-      return Object.fromEntries(new URLSearchParams(href!.split('?')[1]));
+      return screen.getByTestId('apmAnomaliesBadge').getAttribute('href')!;
+    }
+
+    async function getAnomalyBadgeSearchParams(): Promise<Record<string, string>> {
+      const href = await getAnomalyBadgeHref();
+      expect(href).not.toMatch(/\/app\/r(\?|$)/);
+      expect(href).toContain('/app/apm/services/');
+      expect(mockGetRedirectUrl).not.toHaveBeenCalled();
+      return Object.fromEntries(new URLSearchParams(href.split('?')[1]));
     }
 
     it('always targets expected bounds ON when not on the overview tab', async () => {
@@ -406,7 +425,10 @@ describe('ServiceHeaderBadges', () => {
       });
       renderBadges();
 
-      expect(await getAnomalyBadgeSearchParams()).toMatchObject({ comparisonEnabled: 'true' });
+      expect(await getAnomalyBadgeSearchParams()).toMatchObject({
+        comparisonEnabled: 'true',
+        offset: 'expected_bounds',
+      });
     });
 
     it('targets toggling expected bounds OFF when on overview tab and bounds are showing', async () => {
@@ -418,7 +440,10 @@ describe('ServiceHeaderBadges', () => {
       });
       renderBadges();
 
-      expect(await getAnomalyBadgeSearchParams()).toMatchObject({ comparisonEnabled: 'false' });
+      expect(await getAnomalyBadgeSearchParams()).toMatchObject({
+        comparisonEnabled: 'false',
+        offset: 'expected_bounds',
+      });
     });
 
     it('targets toggling expected bounds ON when on overview tab and bounds are not showing', async () => {
@@ -430,7 +455,35 @@ describe('ServiceHeaderBadges', () => {
       });
       renderBadges();
 
-      expect(await getAnomalyBadgeSearchParams()).toMatchObject({ comparisonEnabled: 'true' });
+      expect(await getAnomalyBadgeSearchParams()).toMatchObject({
+        comparisonEnabled: 'true',
+        offset: 'expected_bounds',
+      });
+    });
+
+    it('does not use getRedirectUrl (/app/r), which full-reloads APM and drops expected-bounds comparison', async () => {
+      setupMocks({
+        ...anomalySetup,
+        routePath: '/services/{serviceName}/overview',
+        comparisonEnabled: true,
+        offset: '1d',
+      });
+      renderBadges();
+
+      const href = await getAnomalyBadgeHref();
+
+      expect(href).not.toBe(SHARE_REDIRECT_URL);
+      expect(href).not.toMatch(/\/app\/r(\?|$)/);
+      expect(href).toContain('/app/apm/services/test-service/overview');
+      expect(href).toContain('offset=expected_bounds');
+      expect(href).toContain('comparisonEnabled=true');
+      expect(mockGetUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({ offset: 'expected_bounds' }),
+        }),
+        undefined
+      );
+      expect(mockGetRedirectUrl).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/templates/apm_service_template/service_header_badges.test.tsx
@@ -29,10 +29,11 @@ const mockShare = {
       get: jest.fn().mockReturnValue({
         getUrl: jest
           .fn()
-          .mockImplementation(async ({ serviceName, query }: any) =>
-            `/app/apm/services/${serviceName}/overview?comparisonEnabled=${
-              query?.comparisonEnabled ?? true
-            }`
+          .mockImplementation(
+            async ({ serviceName, query }: any) =>
+              `/app/apm/services/${serviceName}/overview?comparisonEnabled=${
+                query?.comparisonEnabled ?? true
+              }`
           ),
       }),
     },

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/header/service_badges.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/header/service_badges.test.tsx
@@ -7,7 +7,7 @@
 
 import type { ServiceAnomalyScoreResponse } from '@kbn/apm-api-shared';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import type { ServiceFlyoutService } from '..';
 import { ServiceBadges } from './service_badges';
@@ -194,22 +194,32 @@ describe('ServiceBadges', () => {
       expect(screen.queryByTestId('serviceFlyoutAnomaliesBadge')).not.toBeInTheDocument();
     });
 
-    it('passes transactionType from context to the anomaly badge navigation link', () => {
+    it('passes transactionType from context to the anomaly badge navigation link', async () => {
+      const mockGetUrl = jest.fn().mockResolvedValue('/app/apm/services/opbeans-java/overview');
       const mockGetRedirectUrl = jest
         .fn()
-        .mockReturnValue('/app/apm/services/opbeans-java/overview');
+        .mockReturnValue('/app/r?l=APM_LOCATOR&lz=compressed-payload');
       setupContext({
         transactionType: 'request',
-        locators: { get: jest.fn().mockReturnValue({ getRedirectUrl: mockGetRedirectUrl }) },
+        locators: {
+          get: jest.fn().mockReturnValue({
+            getUrl: mockGetUrl,
+            getRedirectUrl: mockGetRedirectUrl,
+          }),
+        },
       });
       setupBadgesData({ anomalyData: { anomalyScore: 75, anomalyEnvironment: 'production' } });
       renderBadges();
 
-      expect(mockGetRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: expect.objectContaining({ transactionType: 'request' }),
-        })
-      );
+      await waitFor(() => {
+        expect(mockGetUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.objectContaining({ transactionType: 'request' }),
+          }),
+          undefined
+        );
+      });
+      expect(mockGetRedirectUrl).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Clicking the ML anomaly badge on a service page should switch the comparison to expected bounds without a full Kibana reload.
- This regressed in https://github.com/elastic/kibana/pull/277482, which replaced `apmRouter.link(...)` with `locator.getRedirectUrl()`. That API builds `/app/r?l=APM_LOCATOR&lz=...`, so the click left APM, remounted the app, and `TimeComparison` replaced `offset=expected_bounds` with a day/week-before offset before ML jobs were ready.
- Use `useLocatorUrl` / `getUrl()` so in-app clicks stay on `/app/apm/services/.../overview?comparisonEnabled=...&offset=expected_bounds`. Keep the locator API so the service flyout can still mount outside APM (for example Discover).

## Test plan

- [ ] On a service Overview with an ML anomaly, click the anomaly badge: comparison should switch to expected bounds and the page should not full-reload.
- [ ] Click the badge again: comparison should leave expected bounds (toggle).
- [ ] From a non-Overview tab, click the badge: navigate to Overview with expected bounds enabled.
- [ ] Service flyout (for example from Discover): anomaly badge still links to the service Overview with expected bounds.