### PR TITLE
[Agent Builder] chat: fix model_usage reporting the wrong connector

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
@@ -436,6 +436,7 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
       pendingRound,
       startTime,
       modelProvider,
+      mainConnectorId: model.connector.connectorId,
       stateManager,
       attachmentStateManager: context.attachmentStateManager,
       configurationOverrides: effectiveOverrides,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.test.ts
@@ -30,6 +30,7 @@ describe('addRoundCompleteEvent', () => {
     modelProvider: {
       getUsageStats: jest.fn(() => ({ calls: [] })),
     } as unknown as ModelProvider,
+    mainConnectorId: 'default-connector',
     stateManager: {} as unknown as ConversationStateManager,
     attachmentStateManager: {
       getAccessedRefs: jest.fn(() => []),
@@ -77,6 +78,58 @@ describe('addRoundCompleteEvent', () => {
       id: 'U123',
       full_name: 'Jane Doe',
       username: 'jane',
+    });
+  });
+
+  it('attributes model_usage to the main connector, not a faster helper call that completed first', async () => {
+    const messageCompleteEvent: ChatEvent = {
+      type: ChatEventType.messageComplete,
+      data: {
+        message_id: 'message-1',
+        message_content: 'Done',
+      },
+    };
+
+    const events = await firstValueFrom(
+      of(
+        createFinalStateEvent({ currentCycle: 0, errorCount: 0 } as never) as ConvertedEvents,
+        messageCompleteEvent as ConvertedEvents
+      ).pipe(
+        addRoundCompleteEvent({
+          ...createDeps(),
+          modelProvider: {
+            getUsageStats: jest.fn(() => ({
+              calls: [
+                {
+                  connectorId: 'fast-connector',
+                  model: 'anthropic-claude-4.5-haiku',
+                  tokens: { prompt: 10, completion: 5, total: 15 },
+                },
+                {
+                  connectorId: 'default-connector',
+                  model: 'anthropic-claude-4.5-sonnet',
+                  tokens: { prompt: 100, completion: 50, total: 150 },
+                },
+              ],
+            })),
+          } as unknown as ModelProvider,
+          mainConnectorId: 'default-connector',
+          pendingRound: undefined,
+          userInput: { message: 'use Sonnet' },
+          startTime: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        toArray()
+      )
+    );
+
+    const roundCompleteEvent = events.find(isRoundCompleteEvent);
+
+    expect(roundCompleteEvent?.data.round.model_usage).toEqual({
+      connector_id: 'default-connector',
+      model: 'anthropic-claude-4.5-sonnet',
+      llm_calls: 2,
+      input_tokens: 110,
+      output_tokens: 55,
     });
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
@@ -99,6 +99,7 @@ export const addRoundCompleteEvent = ({
   endTime,
   getConversationState,
   modelProvider,
+  mainConnectorId,
   stateManager,
   attachmentStateManager,
   configurationOverrides,
@@ -122,6 +123,11 @@ export const addRoundCompleteEvent = ({
   author?: ConversationRoundAuthor;
   startTime: Date;
   modelProvider: ModelProvider;
+  /**
+   * Connector id of the model driving the agent graph for this round. Used to
+   * attribute `model_usage` to the right connector.
+   */
+  mainConnectorId: string;
   stateManager: ConversationStateManager;
   getConversationState: () => ConversationInternalState;
   attachmentStateManager: AttachmentStateManager;
@@ -154,6 +160,7 @@ export const addRoundCompleteEvent = ({
                 startTime,
                 endTime,
                 modelProvider,
+                mainConnectorId,
                 attachmentRefs,
                 configurationOverrides,
                 compactionResult,
@@ -167,6 +174,7 @@ export const addRoundCompleteEvent = ({
                 startTime,
                 endTime,
                 modelProvider,
+                mainConnectorId,
                 attachmentRefs,
                 configurationOverrides,
                 compactionResult,
@@ -212,6 +220,7 @@ const resumeRound = ({
   startTime,
   endTime = new Date(),
   modelProvider,
+  mainConnectorId,
   attachmentRefs,
   configurationOverrides,
   compactionResult,
@@ -222,6 +231,7 @@ const resumeRound = ({
   startTime: Date;
   endTime?: Date;
   modelProvider: ModelProvider;
+  mainConnectorId: string;
   attachmentRefs: AttachmentVersionRef[];
   configurationOverrides?: RuntimeAgentConfigurationOverrides;
   compactionResult?: CompactedConversation;
@@ -264,6 +274,7 @@ const resumeRound = ({
     startTime,
     endTime,
     modelProvider,
+    mainConnectorId,
     attachmentRefs,
     configurationOverrides,
     compactionResult,
@@ -346,6 +357,7 @@ const createRound = ({
   startTime,
   endTime = new Date(),
   modelProvider,
+  mainConnectorId,
   attachmentRefs,
   configurationOverrides,
   compactionResult,
@@ -360,6 +372,7 @@ const createRound = ({
   startTime: Date;
   endTime?: Date;
   modelProvider: ModelProvider;
+  mainConnectorId: string;
   attachmentRefs: AttachmentVersionRef[];
   configurationOverrides?: RuntimeAgentConfigurationOverrides;
   compactionResult?: CompactedConversation;
@@ -484,7 +497,7 @@ const createRound = ({
     started_at: startTime.toISOString(),
     time_to_first_token: timeToFirstToken,
     time_to_last_token: timeToLastToken,
-    model_usage: getModelUsage(modelProvider.getUsageStats()),
+    model_usage: getModelUsage(modelProvider.getUsageStats(), mainConnectorId),
     response: lastMessage
       ? {
           message: lastMessage.message_content,
@@ -540,7 +553,10 @@ const createToolCallStep = ({
   };
 };
 
-const getModelUsage = (stats: ModelProviderStats): RoundModelUsageStats => {
+const getModelUsage = (
+  stats: ModelProviderStats,
+  mainConnectorId: string
+): RoundModelUsageStats => {
   let inputTokens = 0;
   let outputTokens = 0;
   let cachedInputTokens = 0;
@@ -553,11 +569,13 @@ const getModelUsage = (stats: ModelProviderStats): RoundModelUsageStats => {
       hasCachedInputTokens = true;
     }
   }
-  const modelFromResponse = stats.calls.find((call) => call.model)?.model;
+  const modelFromResponse = stats.calls.find(
+    (call) => call.connectorId === mainConnectorId && call.model
+  )?.model;
+
 
   return {
-    // we don't support multi-models yet, so we can just pick from the first call
-    connector_id: stats.calls.length ? stats.calls[0].connectorId : 'unknown',
+    connector_id: mainConnectorId,
     llm_calls: stats.calls.length,
     input_tokens: inputTokens,
     output_tokens: outputTokens,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/add_round_complete_event.ts
@@ -573,7 +573,6 @@ const getModelUsage = (
     (call) => call.connectorId === mainConnectorId && call.model
   )?.model;
 
-
   return {
     connector_id: mainConnectorId,
     llm_calls: stats.calls.length,


### PR DESCRIPTION
## Summary

Fixes `model_usage` showing the wrong model on a conversation round.

When relevant-skills selection is on, each round makes two LLM calls: a quick call on a fast/cheap model to pick relevant skills, then the real call on your chosen model to write the answer. The fast call always finishes first, so the old code picked "whichever call finished first" and always reported the fast model — even though your chosen model wrote the actual answer.

Now it reports the model that actually drove the round's answer, not just the first one to finish.

Closes #285515

## Test plan

- [x] Unit tests added covering a round with a fast helper call finishing before the main answer call — asserts `model_usage` reports the main model
- [x] `node scripts/jest` on affected test files — all green
- [x] Typecheck on the plugin — no errors
- [x] Manually reproduced the bug locally (relevant-skills on, Sonnet as default) and confirmed the conversation doc now stores the correct model

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->