### PR TITLE
Fix RSPack plugin path forwarding

### DIFF
--- a/packages/kbn-cli-dev-mode/src/optimizer.test.ts
+++ b/packages/kbn-cli-dev-mode/src/optimizer.test.ts
@@ -331,6 +331,8 @@ describe('rspack path', () => {
         cache: true,
         dist: true,
         examples: true,
+        pluginPaths: ['/some/dir'],
+        pluginScanDirs: ['/some-scan-path'],
         basePath: '/s/kibana',
         log: expect.any(Object),
       })

--- a/packages/kbn-cli-dev-mode/src/optimizer.ts
+++ b/packages/kbn-cli-dev-mode/src/optimizer.ts
@@ -143,6 +143,8 @@ export class Optimizer {
             cache: options.cache,
             dist: options.dist,
             examples: options.runExamples,
+            pluginPaths: options.pluginPaths,
+            pluginScanDirs: options.pluginScanDirs,
             basePath: options.basePath,
             log,
           });

--- a/packages/kbn-rspack-optimizer/src/config/create_single_compile_config.ts
+++ b/packages/kbn-rspack-optimizer/src/config/create_single_compile_config.ts
@@ -80,6 +80,10 @@ export interface SingleCompileConfigOptions {
   cache?: boolean;
   examples?: boolean;
   testPlugins?: boolean;
+  /** Explicit plugin paths passed via --plugin-path */
+  pluginPaths?: string[];
+  /** Directories scanned for plugins */
+  pluginScanDirs?: string[];
   themeTags?: ThemeTag[];
   /** ToolingLog instance for consistent logging with Kibana's dev mode */
   log?: ToolingLog;
@@ -117,6 +121,8 @@ export async function createSingleCompileConfig(
     cache = true,
     examples = false,
     testPlugins = false,
+    pluginPaths,
+    pluginScanDirs,
     themeTags = [...DEFAULT_THEME_TAGS],
     log,
     profile = false,
@@ -134,11 +140,13 @@ export async function createSingleCompileConfig(
   }
   const resolvedHmrPort = hmrPort as number;
 
-  // Discover all plugins
+  // Discover all plugins, including plugins explicitly passed via --plugin-path.
   const plugins = await discoverPlugins({
     repoRoot,
     examples,
     testPlugins,
+    paths: pluginPaths,
+    parentDirs: pluginScanDirs,
   });
 
   // Create a SINGLE unified entry that imports ALL plugins

--- a/packages/kbn-rspack-optimizer/src/optimizer.test.ts
+++ b/packages/kbn-rspack-optimizer/src/optimizer.test.ts
@@ -69,7 +69,12 @@ describe('RspackOptimizer', () => {
     const child = createMockChildProcess();
     mockFork.mockReturnValue(child);
 
-    const optimizer = createOptimizer({ dist: true, basePath: '/bp' });
+    const optimizer = createOptimizer({
+      dist: true,
+      basePath: '/bp',
+      pluginPaths: ['/repo/analytics_ftr_helpers'],
+      pluginScanDirs: ['/repo/plugins'],
+    });
     const runPromise = optimizer.run();
 
     child.emit('message', { type: 'ready' });
@@ -85,6 +90,8 @@ describe('RspackOptimizer', () => {
         examples: undefined,
         themeTags: ['borealislight', 'borealisdark'],
         hmr: undefined,
+        pluginPaths: ['/repo/analytics_ftr_helpers'],
+        pluginScanDirs: ['/repo/plugins'],
         basePath: '/bp',
       },
     });

--- a/packages/kbn-rspack-optimizer/src/optimizer.ts
+++ b/packages/kbn-rspack-optimizer/src/optimizer.ts
@@ -23,6 +23,10 @@ export interface RspackOptimizerOptions {
   dist?: boolean;
   examples?: boolean;
   themeTags?: ThemeTag[];
+  /** Explicit plugin paths passed via --plugin-path */
+  pluginPaths?: string[];
+  /** Directories scanned for plugins */
+  pluginScanDirs?: string[];
   /** Enable HMR in watch mode (undefined = auto-detect) */
   hmr?: boolean;
   /** Dev server base path (e.g. "/abc") for HMR auto-reload on server restart */
@@ -129,6 +133,8 @@ export class RspackOptimizer {
                 examples: this.options.examples,
                 themeTags: this.options.themeTags ?? [...DEFAULT_THEME_TAGS],
                 hmr: this.options.hmr,
+                pluginPaths: this.options.pluginPaths,
+                pluginScanDirs: this.options.pluginScanDirs,
                 basePath: this.options.basePath,
               },
             });

--- a/packages/kbn-rspack-optimizer/src/plugins/plugin_watch_plugin.ts
+++ b/packages/kbn-rspack-optimizer/src/plugins/plugin_watch_plugin.ts
@@ -95,6 +95,8 @@ export class PluginWatchPlugin {
           repoRoot: this.options.repoRoot,
           examples: this.options.examples || false,
           testPlugins: this.options.testPlugins || false,
+          paths: this.options.pluginPaths,
+          parentDirs: this.options.pluginScanDirs,
         });
 
         // Collect plugin entries

--- a/packages/kbn-rspack-optimizer/src/run_build.ts
+++ b/packages/kbn-rspack-optimizer/src/run_build.ts
@@ -39,6 +39,10 @@ export interface BuildOptions {
   cache?: boolean;
   examples?: boolean;
   testPlugins?: boolean;
+  /** Explicit plugin paths passed via --plugin-path */
+  pluginPaths?: string[];
+  /** Directories scanned for plugins */
+  pluginScanDirs?: string[];
   themeTags?: ThemeTag[];
   log?: ToolingLog;
   /** Enable profiling - writes stats.json and RsDoctor report */
@@ -87,6 +91,8 @@ export async function runBuild(options: BuildOptions): Promise<BuildResult> {
     cache = true,
     examples = false,
     testPlugins = false,
+    pluginPaths,
+    pluginScanDirs,
     themeTags = [...DEFAULT_THEME_TAGS],
     log,
     profile = false,
@@ -124,6 +130,8 @@ export async function runBuild(options: BuildOptions): Promise<BuildResult> {
       cache,
       examples,
       testPlugins,
+      pluginPaths,
+      pluginScanDirs,
       themeTags,
       log,
       profile,

--- a/packages/kbn-rspack-optimizer/src/utils/plugin_discovery.test.ts
+++ b/packages/kbn-rspack-optimizer/src/utils/plugin_discovery.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import Path from 'path';
 import Fs from 'fs';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { discoverPlugins } from './plugin_discovery';
@@ -112,4 +113,26 @@ describe('plugin_discovery', () => {
       expect(pluginsWithTest.length).toBeGreaterThanOrEqual(pluginsWithoutTest.length);
     });
   });
+});
+
+describe('discoverPlugins with explicit paths', () => {
+  it('includes an explicitly selected test plugin', async () => {
+    const pluginPath = Path.resolve(
+      REPO_ROOT,
+      'src/platform/test/analytics/plugins/analytics_ftr_helpers'
+    );
+    const plugins = await discoverPlugins({
+      repoRoot: REPO_ROOT,
+      examples: false,
+      testPlugins: false,
+      paths: [pluginPath],
+    });
+
+    expect(plugins).toContainEqual(
+      expect.objectContaining({
+        id: 'analyticsFtrHelpers',
+        contextDir: pluginPath,
+      })
+    );
+  }, 30000);
 });

--- a/packages/kbn-rspack-optimizer/src/utils/plugin_discovery.ts
+++ b/packages/kbn-rspack-optimizer/src/utils/plugin_discovery.ts
@@ -19,6 +19,10 @@ export interface DiscoverPluginsOptions {
   repoRoot: string;
   examples?: boolean;
   testPlugins?: boolean;
+  /** Explicit plugin paths passed via --plugin-path */
+  paths?: string[];
+  /** Directories scanned for plugins */
+  parentDirs?: string[];
 }
 
 const isDefaultPlugin = getPluginPackagesFilter();
@@ -50,9 +54,14 @@ function toPluginEntry(repoRoot: string, pkg: PluginPackage): PluginEntry | null
  * Discover all Kibana plugins with UI bundles using the repo package map.
  */
 export async function discoverPlugins(options: DiscoverPluginsOptions): Promise<PluginEntry[]> {
-  const { repoRoot, examples = false, testPlugins = false } = options;
-
-  const pluginFilter = getPluginPackagesFilter({ examples, testPlugins, browser: true });
+  const { repoRoot, examples = false, testPlugins = false, paths, parentDirs } = options;
+  const pluginFilter = getPluginPackagesFilter({
+    examples,
+    testPlugins,
+    browser: true,
+    paths,
+    parentDirs,
+  });
 
   const plugins: PluginEntry[] = [];
   for (const pkg of getPackages(repoRoot)) {

--- a/packages/kbn-rspack-optimizer/src/worker.ts
+++ b/packages/kbn-rspack-optimizer/src/worker.ts
@@ -34,6 +34,8 @@ interface StartMessage {
     dist?: boolean;
     examples?: boolean;
     themeTags?: ThemeTag[];
+    pluginPaths?: string[];
+    pluginScanDirs?: string[];
     hmr?: boolean;
     basePath?: string;
   };
@@ -63,6 +65,8 @@ async function handleStart(options: StartMessage['options']) {
       dist: options.dist,
       examples: options.examples,
       themeTags: options.themeTags ?? [...DEFAULT_THEME_TAGS],
+      pluginPaths: options.pluginPaths,
+      pluginScanDirs: options.pluginScanDirs,
       hmr: options.hmr,
       basePath: options.basePath,
       log,


### PR DESCRIPTION
## Summary
- forward explicit `--plugin-path` values through the RSPack optimizer
- include explicitly requested test plugins in the unified browser entry
- preserve explicit paths during plugin watcher rediscovery

## Verification
- `node scripts/jest packages/kbn-rspack-optimizer/src/optimizer.test.ts packages/kbn-rspack-optimizer/src/utils/plugin_discovery.test.ts`
- `node scripts/jest packages/kbn-cli-dev-mode/src/optimizer.test.ts`
- `node scripts/type_check --project packages/kbn-rspack-optimizer/tsconfig.json`
- `node scripts/type_check --project packages/kbn-cli-dev-mode/tsconfig.json`

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->