### PR TITLE
[Security Solution] Fall back Explore Hosts/Users KPIs when Entity Store is not installed

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_items.test.tsx
@@ -13,6 +13,9 @@ import { TestProviders } from '../../../common/mock/test_providers';
 import { useToggleStatus } from './use_toggle_status';
 
 jest.mock('../../../common/components/visualization_actions/visualization_embeddable');
+jest.mock('../../hooks/use_explore_entity_store_v2_enabled', () => ({
+  useExploreEntityStoreV2Enabled: jest.fn(() => false),
+}));
 jest.mock('./use_toggle_status', () => ({
   useToggleStatus: jest.fn().mockReturnValue({ isToggleExpanded: true, onToggle: jest.fn() }),
 }));

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_items.tsx
@@ -6,9 +6,7 @@
  */
 
 import { EuiFlexGroup, EuiHorizontalRule, EuiPanel } from '@elastic/eui';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import React, { useMemo } from 'react';
-import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
 import { StatItemHeader } from './stat_item_header';
 import { useToggleStatus } from './use_toggle_status';
 import type { StatItemsProps } from './types';
@@ -17,6 +15,7 @@ import { MetricEmbeddable } from './metric_embeddable';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { PageScope } from '../../../data_view_manager/constants';
+import { useExploreEntityStoreV2Enabled } from '../../hooks/use_explore_entity_store_v2_enabled';
 
 export const StatItemsComponent = React.memo<StatItemsProps>(({ statItems, from, id, to }) => {
   const timerange = useMemo(
@@ -38,7 +37,7 @@ export const StatItemsComponent = React.memo<StatItemsProps>(({ statItems, from,
 
   const { isToggleExpanded, onToggle } = useToggleStatus({ id });
   const spaceId = useSpaceId();
-  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
+  const entityStoreV2Enabled = useExploreEntityStoreV2Enabled();
 
   const kpiLensExtraOptions = useMemo(
     () => (entityStoreV2Enabled ? { entityStoreV2Enabled: true, spaceId } : undefined),

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hooks/use_explore_entity_store_v2_enabled.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hooks/use_explore_entity_store_v2_enabled.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { useIsEntityStoreV2Available } from '../../flyout/shared/hooks/use_is_entity_store_v2_available';
+import { useExploreEntityStoreV2Enabled } from './use_explore_entity_store_v2_enabled';
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  ...jest.requireActual('@kbn/kibana-react-plugin/public'),
+  useUiSetting: jest.fn(),
+}));
+jest.mock('../../flyout/shared/hooks/use_is_entity_store_v2_available');
+
+const mockUseUiSetting = useUiSetting as jest.MockedFunction<typeof useUiSetting>;
+const mockUseIsEntityStoreV2Available = useIsEntityStoreV2Available as jest.Mock;
+
+describe('useExploreEntityStoreV2Enabled', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseUiSetting.mockReturnValue(true);
+    mockUseIsEntityStoreV2Available.mockReturnValue({
+      data: { indexExists: true },
+      isLoading: false,
+    });
+  });
+
+  it('returns true when the UI setting is on and the entity-store index exists', () => {
+    const { result } = renderHook(() => useExploreEntityStoreV2Enabled());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the UI setting is off', () => {
+    mockUseUiSetting.mockReturnValue(false);
+
+    const { result } = renderHook(() => useExploreEntityStoreV2Enabled());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when the entity-store index is missing', () => {
+    mockUseIsEntityStoreV2Available.mockReturnValue({
+      data: { indexExists: false },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useExploreEntityStoreV2Enabled());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false while the index probe is loading', () => {
+    mockUseIsEntityStoreV2Available.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+
+    const { result } = renderHook(() => useExploreEntityStoreV2Enabled());
+    expect(result.current).toBe(false);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hooks/use_explore_entity_store_v2_enabled.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hooks/use_explore_entity_store_v2_enabled.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
+import { useIsEntityStoreV2Available } from '../../flyout/shared/hooks/use_is_entity_store_v2_available';
+
+/**
+ * Explore Hosts/Users v2 queries require both the UI setting and a live
+ * entity-store latest index. Fall back to legacy while the index probe is in
+ * flight so Lens does not flash field-not-found errors when the store is not
+ * installed.
+ */
+export const useExploreEntityStoreV2Enabled = (): boolean => {
+  const entityStoreV2SettingEnabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
+  const { data, isLoading } = useIsEntityStoreV2Available();
+
+  if (!entityStoreV2SettingEnabled) {
+    return false;
+  }
+
+  if (isLoading || data == null) {
+    return false;
+  }
+
+  return data.indexExists === true;
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/kpi_hosts/hosts/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/kpi_hosts/hosts/index.test.tsx
@@ -12,6 +12,9 @@ import { HostsKpiHosts } from '.';
 import { KpiBaseComponent } from '../../../../components/kpi';
 
 jest.mock('../../../../components/kpi');
+jest.mock('../../../../hooks/use_explore_entity_store_v2_enabled', () => ({
+  useExploreEntityStoreV2Enabled: jest.fn(() => false),
+}));
 
 describe('Hosts KPI', () => {
   const from = new Date('2023-12-30').toISOString();

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/kpi_hosts/hosts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/kpi_hosts/hosts/index.tsx
@@ -7,15 +7,13 @@
 
 import React, { useMemo } from 'react';
 import { useEuiTheme } from '@elastic/eui';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
-
-import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
 
 import type { StatItems } from '../../../../components/stat_items';
 import { useSpaceId } from '../../../../../common/hooks/use_space_id';
 import { getKpiHostAreaLensAttributes } from '../../../../../common/components/visualization_actions/lens_attributes/hosts/kpi_host_area';
 import { buildKpiHostMetricLensAttributes } from '../../../../../common/components/visualization_actions/lens_attributes/hosts/kpi_host_metric';
 import { KpiBaseComponent } from '../../../../components/kpi';
+import { useExploreEntityStoreV2Enabled } from '../../../../hooks/use_explore_entity_store_v2_enabled';
 import type { HostsKpiProps } from '../types';
 import * as i18n from './translations';
 
@@ -24,7 +22,7 @@ export const ID = 'hostsKpiHostsQuery';
 export const useGetHostsStatItems: () => Readonly<StatItems[]> = () => {
   const { euiTheme } = useEuiTheme();
   const spaceId = useSpaceId();
-  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
+  const entityStoreV2Enabled = useExploreEntityStoreV2Enabled();
 
   return useMemo(
     () => [

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/navigation/hosts_query_tab_body.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/navigation/hosts_query_tab_body.test.tsx
@@ -12,15 +12,19 @@ import { useAllEntityStoreHosts, useAllHost } from '../../containers/hosts';
 import { useQueryToggle } from '../../../../common/containers/query_toggle';
 import { HostsQueryTabBody } from './hosts_query_tab_body';
 import { HostsType } from '../../store/model';
+import { useExploreEntityStoreV2Enabled } from '../../../hooks/use_explore_entity_store_v2_enabled';
 
 jest.mock('../../containers/hosts');
 jest.mock('../../../../common/containers/query_toggle');
-jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../hooks/use_explore_entity_store_v2_enabled', () => ({
+  useExploreEntityStoreV2Enabled: jest.fn(() => false),
+}));
 
 describe('Hosts query tab body', () => {
   const mockUseAllHost = useAllHost as jest.Mock;
   const mockUseAllEntityStoreHosts = useAllEntityStoreHosts as jest.Mock;
   const mockUseQueryToggle = useQueryToggle as jest.Mock;
+  const mockUseExploreEntityStoreV2Enabled = useExploreEntityStoreV2Enabled as jest.Mock;
   const defaultProps = {
     indexNames: [],
     setQuery: jest.fn(),
@@ -47,6 +51,7 @@ describe('Hosts query tab body', () => {
     };
     mockUseAllHost.mockReturnValue([false, emptyHostsArgs]);
     mockUseAllEntityStoreHosts.mockReturnValue([false, emptyHostsArgs]);
+    mockUseExploreEntityStoreV2Enabled.mockReturnValue(false);
   });
   it('toggleStatus=true, do not skip', () => {
     render(
@@ -64,5 +69,16 @@ describe('Hosts query tab body', () => {
       </TestProviders>
     );
     expect(mockUseAllHost.mock.calls[0][0].skip).toEqual(true);
+  });
+
+  it('skips legacy hosts query when entity store v2 is available', () => {
+    mockUseExploreEntityStoreV2Enabled.mockReturnValue(true);
+    render(
+      <TestProviders>
+        <HostsQueryTabBody {...defaultProps} />
+      </TestProviders>
+    );
+    expect(mockUseAllHost.mock.calls[0][0].skip).toEqual(true);
+    expect(mockUseAllEntityStoreHosts.mock.calls[0][0].skip).toEqual(false);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/navigation/hosts_query_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/navigation/hosts_query_tab_body.tsx
@@ -7,13 +7,12 @@
 
 import { getOr } from 'lodash/fp';
 import React, { useEffect, useState } from 'react';
-import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
 import { useAllEntityStoreHosts, useAllHost, ID } from '../../containers/hosts';
 import type { HostsComponentsQueryProps } from './types';
-import { useUiSetting } from '../../../../common/lib/kibana';
 import { HostsTable } from '../../components/hosts_table';
 import { manageQuery } from '../../../../common/components/page/manage_query';
 import { useQueryToggle } from '../../../../common/containers/query_toggle';
+import { useExploreEntityStoreV2Enabled } from '../../../hooks/use_explore_entity_store_v2_enabled';
 
 const HostsTableManage = manageQuery(HostsTable);
 
@@ -27,7 +26,7 @@ export const HostsQueryTabBody = ({
   startDate,
   type,
 }: HostsComponentsQueryProps) => {
-  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
+  const entityStoreV2Enabled = useExploreEntityStoreV2Enabled();
   const { toggleStatus } = useQueryToggle(ID);
   const [querySkip, setQuerySkip] = useState(skip || !toggleStatus);
   useEffect(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/kpi_users/total_users/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/kpi_users/total_users/index.test.tsx
@@ -12,6 +12,9 @@ import { TotalUsersKpi } from '.';
 import { KpiBaseComponent } from '../../../../components/kpi';
 
 jest.mock('../../../../components/kpi');
+jest.mock('../../../../hooks/use_explore_entity_store_v2_enabled', () => ({
+  useExploreEntityStoreV2Enabled: jest.fn(() => false),
+}));
 
 describe('Users KPI', () => {
   const from = new Date('2023-12-30').toISOString();

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/kpi_users/total_users/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/components/kpi_users/total_users/index.tsx
@@ -7,22 +7,20 @@
 
 import React, { useMemo } from 'react';
 import { useEuiTheme } from '@elastic/eui';
-import { useUiSetting } from '@kbn/kibana-react-plugin/public';
-
-import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
 
 import type { StatItems } from '../../../../components/stat_items';
 import { useSpaceId } from '../../../../../common/hooks/use_space_id';
 import { KpiBaseComponent } from '../../../../components/kpi';
 import { buildKpiTotalUsersMetricLensAttributes } from '../../../../../common/components/visualization_actions/lens_attributes/users/kpi_total_users_metric';
 import { getKpiTotalUsersAreaLensAttributes } from '../../../../../common/components/visualization_actions/lens_attributes/users/kpi_total_users_area';
+import { useExploreEntityStoreV2Enabled } from '../../../../hooks/use_explore_entity_store_v2_enabled';
 import * as i18n from './translations';
 import type { UsersKpiProps } from '../types';
 
 export const useGetUsersStatItems: () => Readonly<StatItems[]> = () => {
   const { euiTheme } = useEuiTheme();
   const spaceId = useSpaceId();
-  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
+  const entityStoreV2Enabled = useExploreEntityStoreV2Enabled();
 
   return useMemo(
     () => [

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/all_users_query_tab_body.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/all_users_query_tab_body.test.tsx
@@ -13,10 +13,13 @@ import { useQueryToggle } from '../../../../common/containers/query_toggle';
 import { useAllEntityStoreUsers } from '../../containers/users/use_all_entity_store_users';
 import { AllUsersQueryTabBody } from './all_users_query_tab_body';
 import { UsersType } from '../../store/model';
+import { useExploreEntityStoreV2Enabled } from '../../../hooks/use_explore_entity_store_v2_enabled';
 
 jest.mock('../../containers/users/use_all_entity_store_users');
 jest.mock('../../../../common/containers/query_toggle');
-jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../hooks/use_explore_entity_store_v2_enabled', () => ({
+  useExploreEntityStoreV2Enabled: jest.fn(() => false),
+}));
 
 const mockSearch = jest.fn();
 
@@ -44,6 +47,7 @@ jest.mock('../../../../common/containers/use_search_strategy', () => {
 describe('All users query tab body', () => {
   const mockUseAllEntityStoreUsers = useAllEntityStoreUsers as jest.Mock;
   const mockUseQueryToggle = useQueryToggle as jest.Mock;
+  const mockUseExploreEntityStoreV2Enabled = useExploreEntityStoreV2Enabled as jest.Mock;
   const defaultProps = {
     skip: false,
     indexNames: [],
@@ -72,6 +76,7 @@ describe('All users query tab body', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseAllEntityStoreUsers.mockReturnValue([false, emptyUsersArgs]);
+    mockUseExploreEntityStoreV2Enabled.mockReturnValue(false);
   });
 
   it('calls search when toggleStatus=true and entity store v2 is disabled', () => {
@@ -94,5 +99,17 @@ describe('All users query tab body', () => {
     );
     expect(mockSearch).not.toHaveBeenCalled();
     expect(mockUseAllEntityStoreUsers.mock.calls[0][0].skip).toEqual(true);
+  });
+
+  it('skips the legacy search when entity store v2 is available', () => {
+    mockUseQueryToggle.mockReturnValue({ toggleStatus: true, setToggleStatus: jest.fn() });
+    mockUseExploreEntityStoreV2Enabled.mockReturnValue(true);
+    render(
+      <TestProviders>
+        <AllUsersQueryTabBody {...defaultProps} />
+      </TestProviders>
+    );
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockUseAllEntityStoreUsers.mock.calls[0][0].skip).toEqual(false);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/all_users_query_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/all_users_query_tab_body.tsx
@@ -7,7 +7,6 @@
 
 import { getOr, noop } from 'lodash/fp';
 import React, { useEffect, useMemo, useState } from 'react';
-import { FF_ENABLE_ENTITY_STORE_V2 } from '@kbn/entity-store/public';
 
 import type { UsersComponentsQueryProps } from './types';
 
@@ -20,8 +19,8 @@ import { generateTablePaginationOptions } from '../../../components/paginated_ta
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { usersSelectors } from '../../store';
 import { useQueryToggle } from '../../../../common/containers/query_toggle';
-import { useUiSetting } from '../../../../common/lib/kibana';
 import { useAllEntityStoreUsers } from '../../containers/users/use_all_entity_store_users';
+import { useExploreEntityStoreV2Enabled } from '../../../hooks/use_explore_entity_store_v2_enabled';
 
 const UsersTableManage = manageQuery(UsersTable);
 
@@ -37,7 +36,7 @@ export const AllUsersQueryTabBody = ({
   type,
   deleteQuery,
 }: UsersComponentsQueryProps) => {
-  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2) === true;
+  const entityStoreV2Enabled = useExploreEntityStoreV2Enabled();
   const { toggleStatus } = useQueryToggle(QUERY_ID);
   const [querySkip, setQuerySkip] = useState(skip || !toggleStatus);
   useEffect(() => {


### PR DESCRIPTION
## Summary

Explore Hosts/Users KPI panels and All hosts/users tables were gated only on `securitySolution:entityStoreEnableV2` (default `true` since 9.4). When Entity Analytics / Entity Store was never installed, Lens queried `.entities.v2.latest.*` and showed `Field entity.id was not found` / `Field @timestamp was not found`. Unique IPs, authentications, and Events were unaffected.

This treats v2 Explore queries as enabled only when the UI setting is on **and** the entity-store latest index exists (same probe Graph already uses). If the index is missing or the probe is still loading, Explore falls back to legacy `host.name` / `user.name` queries.

Addresses [elastic/sdh-security-team#1767](https://github.com/elastic/sdh-security-team/issues/1767). Related but different from #264671 (wrong index name when the store **is** running).

## Test plan

- [ ] Entity Store **not** installed (`GET /api/security/entity_store/status` → `not_installed`)
  - [ ] Security → Explore → Hosts: Hosts KPI shows an event-based count, no field-not-found. Unique IPs still work.
  - [ ] Security → Explore → Users: Total Users KPI has no field-not-found. Authentications still work.
  - [ ] All hosts / All users tables list data from events, not empty.
- [ ] After installing Entity Store, Hosts/Users KPIs query `.entities.v2.latest.<space>-00001` and use `entity.id`.
- [ ] With `uiSettings.overrides.securitySolution:entityStoreEnableV2: false`, Explore stays on the legacy path.


<details>
<summary>Before / after</summary>

**Before** (Entity Store not installed — Explore Hosts/Users KPI field-not-found)

<img width="707" height="819" alt="Screenshot_2026-08-18_at_12 03 22-d93c8bb3-dc0a-40" src="https://github.com/user-attachments/assets/468b4dcb-906a-44a0-bb44-9004fa977ec3" />
<img width="824" height="821" alt="Screenshot_2026-08-18_at_12 03 03-acb25cad-8883-4c" src="https://github.com/user-attachments/assets/f43c6eeb-d26e-4136-9653-0bc65fdd9a23" />

**After** (same cluster — legacy Hosts/Users KPIs, no Lens errors)

<img width="521" height="621" alt="Screenshot 2026-08-18 at 12 28 10" src="https://github.com/user-attachments/assets/04a4e0d2-3052-4adf-b08a-4d2d51417e6e" />
<img width="532" height="622" alt="Screenshot 2026-08-18 at 12 27 59" src="https://github.com/user-attachments/assets/49c7035f-f4eb-4102-991e-4fb759cb2d39" />

</details>


