### PR TITLE
Support regular expressions when filtering users from audit events

### DIFF
--- a/docs/reference/configuration-reference/security-settings.yml
+++ b/docs/reference/configuration-reference/security-settings.yml
@@ -820,8 +820,27 @@ groups:
       - setting: xpack.security.audit.ignore_filters[].users[]
         description: |
           List of values matched against the `user.name` field of an audit event. This represents the `username` associated with the audit event.
+
+          Each value can take one of three forms:
+
+          * A plain string, which must equal the username exactly.
+          * {applies_to}`stack: ga 9.6+` A regular expression wrapped in slashes (`/pattern/`), which matches if the pattern is found anywhere in the username. Patterns use [RE2 syntax](https://github.com/google/re2/wiki/Syntax) and are unanchored; use `^` and `$` to match the entire username.
+          * {applies_to}`stack: ga 9.6+` A negated regular expression (`!/pattern/`), which matches if the pattern is not found in the username. Use this form to exclude all events except those from usernames matching the pattern.
+
+          {applies_to}`stack: ga 9.6+` To match a literal username that itself begins and ends with a slash, write it as an escaped regular expression (for example, `/^\/name\/$/`).
         datatype: string
         applies_to:
           stack: ga
           ech: ga
           self: ga
+        example: |
+          For example:
+
+          ```yaml
+          xpack.security.audit.ignore_filters:
+          - users: [kibana_system, '/^svc-.*/'] <1>
+          - users: ['!/^dept-a-.*/'] <2>
+          ```
+
+          1. Filters out events from the `kibana_system` user and from usernames starting with `svc-`
+          2. Filters out events from all usernames except those starting with `dept-a-`

--- a/docs/reference/configuration-reference/security-settings.yml
+++ b/docs/reference/configuration-reference/security-settings.yml
@@ -825,7 +825,7 @@ groups:
 
           * A plain string, which must equal the username exactly.
           * {applies_to}`stack: ga 9.6+` A regular expression wrapped in slashes (`/pattern/`), which matches if the pattern is found anywhere in the username. Patterns use [RE2 syntax](https://github.com/google/re2/wiki/Syntax) and are unanchored; use `^` and `$` to match the entire username.
-          * {applies_to}`stack: ga 9.6+` A negated regular expression (`!/pattern/`), which matches if the pattern is not found in the username. Use this form to exclude all events except those from usernames matching the pattern.
+          * {applies_to}`stack: ga 9.6+` A negated regular expression (`!/pattern/`), which matches if the pattern is not found in the username. When used as the only entry, this lets you filter all usernames except those matching the pattern.
 
           {applies_to}`stack: ga 9.6+` To match a literal username that itself begins and ends with a slash, write it as an escaped regular expression (for example, `/^\/name\/$/`).
         datatype: string

--- a/x-pack/platform/plugins/shared/security/server/audit/audit_ignore_filters.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/audit/audit_ignore_filters.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  compileAuditIgnoreFilters,
+  compileUsersFilter,
+  parseUsersFilterEntry,
+  validateUsersFilter,
+} from './audit_ignore_filters';
+
+describe('parseUsersFilterEntry', () => {
+  it('parses a plain string as a literal', () => {
+    expect(parseUsersFilterEntry('jdoe')).toEqual({ type: 'literal', value: 'jdoe' });
+  });
+
+  it('parses a slash-delimited string as a regex', () => {
+    expect(parseUsersFilterEntry('/^svc-.*/')).toEqual({
+      type: 'regex',
+      pattern: '^svc-.*',
+      negated: false,
+    });
+  });
+
+  it('parses a string prefixed with an exclamation mark as a negated regex', () => {
+    expect(parseUsersFilterEntry('!/^svc-.*/')).toEqual({
+      type: 'regex',
+      pattern: '^svc-.*',
+      negated: true,
+    });
+  });
+
+  it('parses too-short delimiter-only strings as literals', () => {
+    expect(parseUsersFilterEntry('/')).toEqual({ type: 'literal', value: '/' });
+    expect(parseUsersFilterEntry('!/')).toEqual({ type: 'literal', value: '!/' });
+  });
+
+  it('parses empty patterns as regexes', () => {
+    expect(parseUsersFilterEntry('//')).toEqual({ type: 'regex', pattern: '', negated: false });
+    expect(parseUsersFilterEntry('!//')).toEqual({ type: 'regex', pattern: '', negated: true });
+  });
+
+  it('parses a username wrapped in slashes as a regex, not a literal', () => {
+    expect(parseUsersFilterEntry('/jdoe/')).toEqual({
+      type: 'regex',
+      pattern: 'jdoe',
+      negated: false,
+    });
+  });
+});
+
+describe('compileUsersFilter', () => {
+  it('matches literals exactly', () => {
+    const matcher = compileUsersFilter(['jdoe', 'jsmith']);
+    expect(matcher('jdoe')).toBe(true);
+    expect(matcher('jsmith')).toBe(true);
+    expect(matcher('jd')).toBe(false);
+    expect(matcher('JDOE')).toBe(false);
+  });
+
+  it('matches regex entries', () => {
+    const matcher = compileUsersFilter(['/^[0-9]+$/']);
+    expect(matcher('123')).toBe(true);
+    expect(matcher('abc')).toBe(false);
+    expect(matcher('123abc')).toBe(false);
+  });
+
+  it('matches regex entries anywhere in the username unless anchored', () => {
+    const matcher = compileUsersFilter(['/dmi/']);
+    expect(matcher('admin')).toBe(true);
+    expect(matcher('jdoe')).toBe(false);
+  });
+
+  it('matches negated regex entries when the pattern does not match', () => {
+    const matcher = compileUsersFilter(['!/^svc-.*/']);
+    expect(matcher('jdoe')).toBe(true);
+    expect(matcher('svc-deploy')).toBe(false);
+  });
+
+  it('matches when any literal, regex, or negated regex entry matches', () => {
+    const matcher = compileUsersFilter(['jdoe', '/^svc-/', '!/^[a-z]/']);
+    expect(matcher('jdoe')).toBe(true);
+    expect(matcher('svc-deploy')).toBe(true);
+    expect(matcher('Admin')).toBe(true);
+    expect(matcher('jsmith')).toBe(false);
+  });
+
+  it('throws when a regex entry contains an invalid pattern', () => {
+    expect(() => compileUsersFilter(['/(/'])).toThrowErrorMatchingInlineSnapshot(
+      `"error parsing regexp: missing closing ): \`(\`"`
+    );
+  });
+});
+
+describe('validateUsersFilter', () => {
+  it('returns undefined for literals and valid regex entries', () => {
+    expect(validateUsersFilter(['jdoe', '/^svc-.*/', '!/^[0-9]+$/'])).toBeUndefined();
+  });
+
+  it('returns an error naming the array position of an invalid regex entry', () => {
+    expect(validateUsersFilter(['jdoe', '/(/'])).toMatchInlineSnapshot(
+      `"\\"error parsing regexp: missing closing ): \`(\`\\" at array position 1"`
+    );
+  });
+
+  it('joins errors when multiple entries are invalid', () => {
+    const errors = validateUsersFilter(['/(/', '/[/']);
+    expect(errors).toContain('at array position 0');
+    expect(errors).toContain('at array position 1');
+    expect(errors).toContain('. ');
+  });
+
+  it('rejects patterns using unsupported syntax such as lookahead', () => {
+    expect(validateUsersFilter(['/foo(?=bar)/'])).toContain('invalid or unsupported Perl syntax');
+  });
+});
+
+describe('compileAuditIgnoreFilters', () => {
+  it('returns undefined when no filters are configured', () => {
+    expect(compileAuditIgnoreFilters(undefined)).toBeUndefined();
+  });
+
+  it('compiles users entries into a matcher and leaves other fields untouched', () => {
+    const compiled = compileAuditIgnoreFilters([
+      { actions: ['http_request'], users: ['jdoe', '/^svc-/'] },
+      { spaces: ['default'] },
+    ]);
+
+    expect(compiled).toHaveLength(2);
+    expect(compiled![0].actions).toEqual(['http_request']);
+    expect(compiled![0].users!('jdoe')).toBe(true);
+    expect(compiled![0].users!('svc-deploy')).toBe(true);
+    expect(compiled![0].users!('jsmith')).toBe(false);
+    expect(compiled![1]).toEqual({ spaces: ['default'] });
+  });
+});

--- a/x-pack/platform/plugins/shared/security/server/audit/audit_ignore_filters.ts
+++ b/x-pack/platform/plugins/shared/security/server/audit/audit_ignore_filters.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { RE2JS } from 're2js';
+
+/**
+ * Structurally matches `ConfigType['audit']['ignore_filters'][number]`.
+ */
+export interface AuditIgnoreFilter {
+  actions?: string[];
+  categories?: string[];
+  outcomes?: string[];
+  spaces?: string[];
+  types?: string[];
+  users?: string[];
+}
+
+export type UserMatcher = (username: string) => boolean;
+
+/**
+ * An ignore filter with the `users` entries precompiled into a matcher function.
+ */
+export interface CompiledAuditIgnoreFilter extends Omit<AuditIgnoreFilter, 'users'> {
+  users?: UserMatcher;
+}
+
+export type ParsedUsersFilterEntry =
+  | { type: 'literal'; value: string }
+  | { type: 'regex'; pattern: string; negated: boolean };
+
+/**
+ * Parses a single `users` ignore filter entry. Entries wrapped in slashes (`/pattern/`) are
+ * regular expressions and entries prefixed with an exclamation mark (`!/pattern/`) are negated
+ * regular expressions; anything else is an exact-match literal.
+ */
+export function parseUsersFilterEntry(entry: string): ParsedUsersFilterEntry {
+  if (entry.startsWith('!/') && entry.endsWith('/') && entry.length >= 3) {
+    return { type: 'regex', pattern: entry.slice(2, -1), negated: true };
+  }
+  if (entry.startsWith('/') && entry.endsWith('/') && entry.length >= 2) {
+    return { type: 'regex', pattern: entry.slice(1, -1), negated: false };
+  }
+  return { type: 'literal', value: entry };
+}
+
+/**
+ * Compiles `users` ignore filter entries into a single matcher. The matcher returns `true` if any
+ * literal entry equals the username, any regex entry matches it, or any negated regex entry does
+ * not match it. Regular expressions are compiled once here, using RE2 to guarantee linear-time
+ * matching, and are unanchored: patterns match anywhere within the username unless anchored with
+ * `^` and `$`. Throws if an entry contains an invalid pattern.
+ */
+export function compileUsersFilter(users: string[]): UserMatcher {
+  const literals = new Set<string>();
+  const patterns: Array<{ re: RE2JS; negated: boolean }> = [];
+
+  for (const entry of users) {
+    const parsed = parseUsersFilterEntry(entry);
+    if (parsed.type === 'literal') {
+      literals.add(parsed.value);
+    } else {
+      patterns.push({ re: RE2JS.compile(parsed.pattern), negated: parsed.negated });
+    }
+  }
+
+  if (patterns.length === 0) {
+    return (username) => literals.has(username);
+  }
+  return (username) =>
+    literals.has(username) || patterns.some(({ re, negated }) => re.test(username) !== negated);
+}
+
+/**
+ * Validates that every regex entry compiles; intended for use as a `schema.arrayOf` validator.
+ */
+export function validateUsersFilter(users: readonly string[]): string | undefined {
+  const errors = users.flatMap((entry, index) => {
+    const parsed = parseUsersFilterEntry(entry);
+    if (parsed.type === 'literal') {
+      return [];
+    }
+    try {
+      RE2JS.compile(parsed.pattern);
+      return [];
+    } catch (error) {
+      return [`"${error.message}" at array position ${index}`];
+    }
+  });
+  return errors.length !== 0 ? errors.join('. ') : undefined;
+}
+
+/**
+ * Compiles the `users` entries of each ignore filter once so that per-event filtering never
+ * parses or compiles patterns.
+ */
+export function compileAuditIgnoreFilters(
+  filters: AuditIgnoreFilter[] | undefined
+): CompiledAuditIgnoreFilter[] | undefined {
+  return filters?.map(({ users, ...rest }) => ({
+    ...rest,
+    ...(users && { users: compileUsersFilter(users) }),
+  }));
+}

--- a/x-pack/platform/plugins/shared/security/server/audit/audit_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/audit/audit_service.test.ts
@@ -17,6 +17,8 @@ import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { asSpaceId } from '@kbn/core-spaces-common';
 import type { AuditEvent } from '@kbn/security-plugin-types-server';
 
+import type { AuditIgnoreFilter } from './audit_ignore_filters';
+import { compileAuditIgnoreFilters } from './audit_ignore_filters';
 import {
   applyAuditOtelFieldMap,
   AUDIT_OTEL_PROMOTE_RESOURCE_ATTRIBUTES,
@@ -829,6 +831,9 @@ describe('#getForwardedFor', () => {
 describe('#filterEvent', () => {
   let event: AuditEvent;
 
+  const filterEventWithRules = (auditEvent: AuditEvent, rules?: AuditIgnoreFilter[]) =>
+    filterEvent(auditEvent, compileAuditIgnoreFilters(rules));
+
   beforeEach(() => {
     event = {
       message: 'this is my audit message',
@@ -848,23 +853,23 @@ describe('#filterEvent', () => {
   });
 
   test('keeps event when ignore filters are undefined or empty', () => {
-    expect(filterEvent(event, undefined)).toBeTruthy();
-    expect(filterEvent(event, [])).toBeTruthy();
+    expect(filterEventWithRules(event, undefined)).toBeTruthy();
+    expect(filterEventWithRules(event, [])).toBeTruthy();
   });
 
   test('filters event correctly when a single match is found per criteria', () => {
-    expect(filterEvent(event, [{ actions: ['NO_MATCH'] }])).toBeTruthy();
-    expect(filterEvent(event, [{ actions: ['NO_MATCH', 'http_request'] }])).toBeFalsy();
-    expect(filterEvent(event, [{ categories: ['NO_MATCH', 'web'] }])).toBeFalsy();
-    expect(filterEvent(event, [{ types: ['NO_MATCH', 'access'] }])).toBeFalsy();
-    expect(filterEvent(event, [{ outcomes: ['NO_MATCH', 'success'] }])).toBeFalsy();
-    expect(filterEvent(event, [{ spaces: ['NO_MATCH', 'default'] }])).toBeFalsy();
-    expect(filterEvent(event, [{ users: ['NO_MATCH', 'jdoe'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ actions: ['NO_MATCH'] }])).toBeTruthy();
+    expect(filterEventWithRules(event, [{ actions: ['NO_MATCH', 'http_request'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ categories: ['NO_MATCH', 'web'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ types: ['NO_MATCH', 'access'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ outcomes: ['NO_MATCH', 'success'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ spaces: ['NO_MATCH', 'default'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ users: ['NO_MATCH', 'jdoe'] }])).toBeFalsy();
   });
 
   test('keeps event when one criteria per rule does not match', () => {
     expect(
-      filterEvent(event, [
+      filterEventWithRules(event, [
         {
           actions: ['NO_MATCH'],
           categories: ['web'],
@@ -935,7 +940,7 @@ describe('#filterEvent', () => {
     };
 
     expect(
-      filterEvent(event, [
+      filterEventWithRules(event, [
         {
           actions: ['http_request'],
           categories: ['web', 'NO_MATCH'],
@@ -966,7 +971,7 @@ describe('#filterEvent', () => {
     };
 
     expect(
-      filterEvent(event, [
+      filterEventWithRules(event, [
         {
           actions: ['http_request'],
           categories: ['web'],
@@ -981,7 +986,7 @@ describe('#filterEvent', () => {
 
   test('filters out event when all criteria in a single rule match', () => {
     expect(
-      filterEvent(event, [
+      filterEventWithRules(event, [
         {
           actions: ['NO_MATCH'],
           categories: ['NO_MATCH'],
@@ -1020,7 +1025,7 @@ describe('#filterEvent', () => {
     };
 
     expect(
-      filterEvent(event, [
+      filterEventWithRules(event, [
         {
           actions: ['http_request'],
           categories: ['authentication', 'web'],
@@ -1051,7 +1056,7 @@ describe('#filterEvent', () => {
     };
 
     expect(
-      filterEvent(event, [
+      filterEventWithRules(event, [
         {
           actions: ['http_request'],
           categories: ['web'],
@@ -1061,5 +1066,35 @@ describe('#filterEvent', () => {
         },
       ])
     ).toBeFalsy();
+  });
+
+  test('filters out event when a regex users entry matches the username', () => {
+    expect(filterEventWithRules(event, [{ users: ['/^jd/'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ users: ['/oe$/'] }])).toBeFalsy();
+  });
+
+  test('keeps event when a regex users entry does not match the username', () => {
+    expect(filterEventWithRules(event, [{ users: ['/^svc-/'] }])).toBeTruthy();
+  });
+
+  test('filters out event when a negated regex users entry does not match the username', () => {
+    expect(filterEventWithRules(event, [{ users: ['!/^svc-/'] }])).toBeFalsy();
+  });
+
+  test('keeps event when a negated regex users entry matches the username', () => {
+    expect(filterEventWithRules(event, [{ users: ['!/^jd/'] }])).toBeTruthy();
+  });
+
+  test('matches users criteria when any literal or regex entry matches', () => {
+    expect(filterEventWithRules(event, [{ users: ['jdoe', '/^svc-/'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ users: ['NO_MATCH', '/^jd/'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ users: ['NO_MATCH', '/^svc-/'] }])).toBeTruthy();
+  });
+
+  test('matches users criteria regardless of entry type when event has no username', () => {
+    delete event.user;
+    expect(filterEventWithRules(event, [{ users: ['NO_MATCH'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ users: ['/^svc-/'] }])).toBeFalsy();
+    expect(filterEventWithRules(event, [{ users: ['!/^svc-/'] }])).toBeFalsy();
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/audit/audit_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/audit/audit_service.ts
@@ -18,6 +18,8 @@ import type { AuditEvent, AuditLogger, AuditServiceSetup } from '@kbn/security-p
 import type { SpacesPluginSetup } from '@kbn/spaces-plugin/server';
 
 import { httpRequestEvent } from './audit_events';
+import type { CompiledAuditIgnoreFilter } from './audit_ignore_filters';
+import { compileAuditIgnoreFilters } from './audit_ignore_filters';
 import {
   applyAuditOtelFieldMap,
   AUDIT_OTEL_PROMOTE_RESOURCE_ATTRIBUTES,
@@ -99,11 +101,13 @@ export class AuditService {
       });
     }
 
+    const ignoreFilters = compileAuditIgnoreFilters(config.ignore_filters);
+
     const log = (event: AuditEvent | undefined) => {
       if (!event) {
         return;
       }
-      if (filterEvent(event, config.ignore_filters)) {
+      if (filterEvent(event, ignoreFilters)) {
         const { message, ...eventMeta } = event;
         this.logger.info(message, eventMeta);
       }
@@ -231,7 +235,7 @@ export const createLoggingConfig = (config: ConfigType['audit'], isServerless = 
  */
 export function filterEvent(
   event: AuditEvent,
-  ignoreFilters: ConfigType['audit']['ignore_filters']
+  ignoreFilters: CompiledAuditIgnoreFilter[] | undefined
 ) {
   if (ignoreFilters) {
     return !ignoreFilters.some(
@@ -243,7 +247,7 @@ export function filterEvent(
           normalize(event.event?.type)?.every((t) => rule.types?.includes(t || ''))) &&
         (!rule.outcomes || rule.outcomes.includes(event.event?.outcome!)) &&
         (!rule.spaces || rule.spaces.includes(event.kibana?.space_id!)) &&
-        (!rule.users || !event.user?.name || rule.users.includes(event.user.name))
+        (!rule.users || !event.user?.name || rule.users(event.user.name))
     );
   }
   return true;

--- a/x-pack/platform/plugins/shared/security/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/config.test.ts
@@ -2337,7 +2337,7 @@ describe('createConfig()', () => {
               outcomes: ['unknown'],
               spaces: ['default'],
               types: ['index'],
-              users: ['elastic'],
+              users: ['elastic', '/^svc-.*/', '!/^[0-9]+$/'],
             },
           ],
         },
@@ -2363,10 +2363,36 @@ describe('createConfig()', () => {
           ],
           "users": Array [
             "elastic",
+            "/^svc-.*/",
+            "!/^[0-9]+$/",
           ],
         },
       ]
     `);
+  });
+
+  it('rejects an audit ignore filter with an invalid users regex', () => {
+    expect(() =>
+      ConfigSchema.validate({
+        audit: {
+          ignore_filters: [{ users: ['elastic', '/(/'] }],
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"[audit.ignore_filters.0.users]: \\"error parsing regexp: missing closing ): \`(\`\\" at array position 1"`
+    );
+  });
+
+  it('rejects an audit ignore filter with an unsupported users regex such as lookahead', () => {
+    expect(() =>
+      ConfigSchema.validate({
+        audit: {
+          ignore_filters: [{ users: ['/foo(?=bar)/'] }],
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"[audit.ignore_filters.0.users]: \\"error parsing regexp: invalid or unsupported Perl syntax: \`(?=\`\\" at array position 0"`
+    );
   });
 
   describe('#getExpirationTimeouts', () => {

--- a/x-pack/platform/plugins/shared/security/server/config.ts
+++ b/x-pack/platform/plugins/shared/security/server/config.ts
@@ -16,6 +16,7 @@ import { config as coreConfig } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import { getLogsPath } from '@kbn/utils';
 
+import { validateUsersFilter } from './audit/audit_ignore_filters';
 import type { AuthenticationProvider } from '../common';
 
 export type ConfigType = ReturnType<typeof createConfig>;
@@ -312,7 +313,9 @@ export const ConfigSchema = schema.object({
           outcomes: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
           spaces: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
           types: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
-          users: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
+          users: schema.maybe(
+            schema.arrayOf(schema.string(), { minSize: 1, validate: validateUsersFilter })
+          ),
         })
       )
     ),


### PR DESCRIPTION
## Summary

Allows administrators to filter users from audit events whose username matches a regular expression, in addition to exact name match.

For example:

```yaml
# Filters out events from the `kibana_system` user and from usernames starting with `svc-`
xpack.security.audit.ignore_filters:
- users: [kibana_system, '/^svc-.*/']
```


```yaml
# Filters out events from all usernames except those starting with `dept-a-`
xpack.security.audit.ignore_filters:
- users: ['!/^dept-a-.*/']
```