### PR TITLE
[Accessibility] Fix missing Title error text and focus order in Observability annotations form

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/annotation_apearance.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/annotation_apearance.tsx
@@ -14,7 +14,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { IconSelect, LineStyleSettings } from '@kbn/visualization-ui-components';
 import React from 'react';
 import { Select } from './components/forward_refs';
@@ -24,9 +24,9 @@ import { FillOptions } from './components/fill_option';
 import { iconsSet } from './icon_set';
 
 export function AnnotationAppearance() {
-  const { control, watch } = useFormContext<Annotation>();
+  const { control } = useFormContext<Annotation>();
 
-  const eventEnd = watch('event.end');
+  const eventEnd = useWatch({ control, name: 'event.end' });
 
   return (
     <>

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/annotation_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/annotation_form.tsx
@@ -8,7 +8,7 @@
 import { EuiForm, EuiFormRow, EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useFormContext, Controller } from 'react-hook-form';
+import { useFormContext, useWatch, Controller } from 'react-hook-form';
 import { defaultAnnotationColor } from '@kbn/event-annotation-common';
 import type { CreateAnnotationForm } from './components/create_annotation';
 import { AnnotationApplyTo } from './components/annotation_apply_to';
@@ -18,10 +18,9 @@ import { AnnotationRange } from './components/annotation_range';
 import { AnnotationAppearance } from './annotation_apearance';
 
 export function AnnotationForm({ editAnnotation }: { editAnnotation?: Annotation | null }) {
-  const { control, formState, watch, unregister, setValue } =
-    useFormContext<CreateAnnotationForm>();
+  const { control, formState, unregister, setValue } = useFormContext<CreateAnnotationForm>();
 
-  const timestampStart = watch('@timestamp');
+  const timestampStart = useWatch({ control, name: '@timestamp' });
 
   return (
     <EuiForm id="annotationForm" component="form">
@@ -61,15 +60,20 @@ export function AnnotationForm({ editAnnotation }: { editAnnotation?: Annotation
         })}
         display="columnCompressed"
         fullWidth
-        error={formState.errors.message?.message}
-        isInvalid={Boolean(formState.errors.message?.message)}
+        error={formState.errors.annotation?.title?.message}
+        isInvalid={Boolean(formState.errors.annotation?.title?.message)}
       >
         <Controller
           defaultValue=""
           name="annotation.title"
           control={control}
           rules={{
-            required: 'title is required',
+            required: i18n.translate(
+              'xpack.observability.annotationForm.titleRequiredErrorMessage',
+              {
+                defaultMessage: 'Title is required.',
+              }
+            ),
           }}
           render={({ field, fieldState }) => (
             <FieldText

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/annotation_range.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/annotation_range.tsx
@@ -7,7 +7,7 @@
 
 import { EuiFormRow, EuiDatePicker } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import React from 'react';
 import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import type { CreateAnnotationForm } from './create_annotation';
@@ -21,9 +21,9 @@ const getHelpfulDateFormat = (dateFormat: string) => {
 };
 
 export function AnnotationRange() {
-  const { control, watch } = useFormContext<CreateAnnotationForm>();
+  const { control } = useFormContext<CreateAnnotationForm>();
 
-  const eventEnd = watch('event.end');
+  const eventEnd = useWatch({ control, name: 'event.end' });
   const dateFormatDefault = useUiSetting<string>('dateFormat');
   const dateFormat = getHelpfulDateFormat(dateFormatDefault);
 

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/create_annotation.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/create_annotation.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FormProvider, useForm } from 'react-hook-form';
+import { core, render } from '../../../utils/test_helper';
+import { getDefaultAnnotation } from '../default_annotation';
+import type { CreateAnnotationForm } from './create_annotation';
+import CreateAnnotation from './create_annotation';
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const methods = useForm<CreateAnnotationForm>({
+    defaultValues: getDefaultAnnotation({}),
+    mode: 'all',
+  });
+
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+describe('CreateAnnotation', () => {
+  const createAnnotation = jest.fn();
+
+  const renderFlyout = () =>
+    render(
+      <Wrapper>
+        <CreateAnnotation
+          isCreateAnnotationsOpen
+          isLoading={false}
+          onSave={jest.fn()}
+          onCancel={jest.fn()}
+          createAnnotation={createAnnotation}
+          updateAnnotation={jest.fn()}
+          deleteAnnotation={jest.fn()}
+        />
+      </Wrapper>
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    core.settings.client.get.mockReturnValue('MMM D, YYYY @ HH:mm:ss.SSS');
+  });
+
+  it('shows an error message below the title field when it is emptied', async () => {
+    renderFlyout();
+
+    const title = await screen.findByTestId('annotationTitle');
+    await userEvent.clear(title);
+
+    expect(await screen.findByText('Title is required.')).toBeInTheDocument();
+  });
+
+  it('moves focus to the title field when saving without a title', async () => {
+    renderFlyout();
+
+    const title = await screen.findByTestId('annotationTitle');
+    await userEvent.clear(title);
+    await userEvent.click(await screen.findByTestId('annotationSaveButton'));
+
+    await waitFor(() => expect(title).toHaveFocus());
+    expect(createAnnotation).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/create_annotation.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/create_annotation.tsx
@@ -56,7 +56,8 @@ function CreateAnnotation({
   const { trigger, getValues } = useFormContext<CreateAnnotationForm>();
 
   const onSubmit = useCallback(async () => {
-    const isValid = await trigger();
+    // move focus to the first invalid field so the error is announced (WCAG 2.4.3 / 3.3.1)
+    const isValid = await trigger(undefined, { shouldFocus: true });
     if (!isValid) return;
     const values = getValues();
     const timestamp = values['@timestamp'].toISOString();

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/new_line_annotation.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/new_line_annotation.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import moment from 'moment';
 import { AnnotationDomainType, LineAnnotation } from '@elastic/charts';
 import { EuiText, useEuiTheme } from '@elastic/eui';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
 import { cloneDeep } from 'lodash';
 import { AnnotationIcon } from '.';
@@ -23,15 +23,15 @@ export function NewLineAnnotation({
   slo?: SLOWithSummaryResponse;
   isCreateOpen: boolean;
 }) {
-  const { watch, getValues } = useFormContext<CreateAnnotationParams>();
-  const eventEnd = watch('event.end');
+  const { control, getValues } = useFormContext<CreateAnnotationParams>();
+  const eventEnd = useWatch({ control, name: 'event.end' });
+  const annotationStyle = useWatch({ control, name: 'annotation.style' });
+  const annotationType = useWatch({ control, name: 'annotation.type' });
 
   if (eventEnd || !isCreateOpen) {
     return null;
   }
   const values = getValues();
-  const annotationStyle = watch('annotation.style');
-  const annotationType = watch('annotation.type');
 
   return (
     <ObsLineAnnotation

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/new_rect_annotation.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/components/new_rect_annotation.tsx
@@ -9,7 +9,7 @@ import { RectAnnotation } from '@elastic/charts';
 import React from 'react';
 import { useEuiTheme } from '@elastic/eui';
 import moment from 'moment';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
 import { cloneDeep } from 'lodash';
 import { AnnotationTooltip } from './annotation_tooltip';
@@ -22,17 +22,16 @@ export function NewRectAnnotation({
   isCreateOpen: boolean;
   slo?: SLOWithSummaryResponse;
 }) {
-  const { watch, getValues } = useFormContext<CreateAnnotationParams>();
-  const timestamp = watch('@timestamp');
-  const eventEnd = watch('event.end');
+  const { control, getValues } = useFormContext<CreateAnnotationParams>();
+  const timestamp = useWatch({ control, name: '@timestamp' });
+  const eventEnd = useWatch({ control, name: 'event.end' });
+  const annotationStyle = useWatch({ control, name: 'annotation.style' });
+  const annotationType = useWatch({ control, name: 'annotation.type' });
 
   if (!timestamp || !eventEnd || !isCreateOpen) {
     return null;
   }
   const values = getValues();
-
-  const annotationStyle = watch('annotation.style');
-  const annotationType = watch('annotation.type');
 
   return (
     <ObsRectAnnotation


### PR DESCRIPTION
## Summary

Fixes two WCAG A issues in the Observability **Annotations** create/edit flyout.

Closes #220834

## 1. Error text never rendered (SC 3.3.1 Error Identification)

The Title `EuiFormRow` read its error from the **Description** field's error slot:

```tsx
error={formState.errors.message?.message}
```

The Title input registers under `annotation.title`, so `errors.message` is always empty and the row never rendered any error text. The inner `EuiFieldText` used `fieldState.invalid` (correctly scoped), which is why the field *looked* invalid while no message appeared below it. The validation message was also a raw, untranslated string (`'title is required'`).

Now bound to `formState.errors.annotation?.title?.message` and translated via `xpack.observability.annotationForm.titleRequiredErrorMessage`.

## 2. Focus stayed on Save (SC 2.4.3 Focus Order)

`onSubmit` called `await trigger()`, which validates but never focuses — react-hook-form only moves focus via `handleSubmit` (`shouldFocusError`) or `trigger(name, { shouldFocus: true })`. Focus remained on the Save button and Tab went to the flyout close button. Now uses `trigger(undefined, { shouldFocus: true })`.

## 3. `watch()` → `useWatch()`

`watch()` called from a component that did not itself call `useForm` does not subscribe that component. It registers the field name in the form's global watch set, and any change to a watched field then pushes a **full** form-state event that re-renders whoever owns the form — here the chart hosting the flyout. `useWatch` subscribes only the component that needs the value.

Swapped in `annotation_form`, `annotation_range`, `annotation_apearance`, `new_line_annotation` and `new_rect_annotation`. In the latter two the calls also move above the early `return null`, since `useWatch` is a hook and must not be called conditionally.

## How to test

1. Observability → Annotations → **Create annotation**.
2. Clear the Title field — an error message appears below it.
3. Press **Save** — focus moves to the Title input instead of staying on the button.

## Verification

Run against this branch:

- `node scripts/eslint` on the annotations directory — clean
- `node scripts/type_check --project x-pack/solutions/observability/plugins/observability/tsconfig.json` — clean
- `node scripts/type_check --project x-pack/solutions/observability/plugins/slo/tsconfig.json` — clean (other `useAnnotations` consumer)
- `node scripts/jest .../components/annotations/` — 2 passing
- `node scripts/i18n_check` — clean

## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)