### PR TITLE
[APM UI] Migrate Traces page to AppHeader

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/trace_overview/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/trace_overview/index.test.tsx
@@ -7,16 +7,19 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { APP_HEADER_TEST_SUBJECTS, AppHeader as MockAppHeaderComponent } from '@kbn/app-header';
+import { MockAppHeaderProvider } from '@kbn/app-header/mocks';
+import type { ApmMainTemplateHeaderProps } from '../../routing/templates/apm_main_template';
 import { TraceOverview } from '.';
 import { useApmIndexSettingsContext } from '../../../context/apm_index_settings/use_apm_index_settings_context';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 
-// `TraceOverview` renders `OpenInDiscover`, which transitively depends on the
-// APM index settings context and the Discover locator from `useApmPluginContext`
-// to compute its href. Both contexts are mocked here so we can exercise the
-// composed tree without spinning up the full APM providers.
+// `TraceOverview` uses `useDiscoverHref`, which depends on the APM index settings
+// context and the Discover locator from `useApmPluginContext` to compute its href.
+// Both contexts are mocked here so we can exercise the composed tree without
+// spinning up the full APM providers.
 jest.mock('../../../context/apm_index_settings/use_apm_index_settings_context');
 jest.mock('../../../context/apm_plugin/use_apm_plugin_context');
 jest.mock('../../../hooks/use_apm_params');
@@ -28,16 +31,22 @@ jest.mock('../../../context/apm_index_settings/apm_index_settings_context', () =
   ApmIndexSettingsContextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+// Render ApmMainTemplate as a thin wrapper that passes `header` straight into a real AppHeader
+// (so we exercise menu-building without the template's own dependencies).
+// MockAppHeaderComponent is aliased to start with "Mock" so Jest's factory out-of-scope check permits it.
 jest.mock('../../routing/templates/apm_main_template', () => ({
   ApmMainTemplate: ({
-    pageHeader,
+    header,
+    searchBar,
     children,
   }: {
-    pageHeader?: { rightSideItems?: React.ReactNode[] };
+    header?: ApmMainTemplateHeaderProps;
+    searchBar?: React.ReactNode;
     children: React.ReactNode;
   }) => (
     <div data-test-subj="apmMainTemplateMock">
-      <div data-test-subj="apmMainTemplatePageHeader">{pageHeader?.rightSideItems}</div>
+      {header ? <MockAppHeaderComponent {...header} /> : null}
+      {searchBar}
       {children}
     </div>
   ),
@@ -59,6 +68,18 @@ const mockUseApmParams = useApmParams as jest.MockedFunction<typeof useApmParams
 
 const mockGetRedirectUrl = jest.fn<string | undefined, [unknown]>();
 const mockLocatorGet = jest.fn().mockReturnValue({ getRedirectUrl: mockGetRedirectUrl });
+
+async function renderTraceOverview() {
+  const view = render(
+    <MockAppHeaderProvider>
+      <TraceOverview>
+        <div data-test-subj="content" />
+      </TraceOverview>
+    </MockAppHeaderProvider>
+  );
+  await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.title);
+  return view;
+}
 
 describe('TraceOverview', () => {
   beforeEach(() => {
@@ -90,25 +111,26 @@ describe('TraceOverview', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the Explore traces page-header button with a Discover href', () => {
-    render(
-      <TraceOverview>
-        <div />
-      </TraceOverview>
-    );
+  it('renders AppHeader with title "Traces"', async () => {
+    await renderTraceOverview();
+
+    expect(screen.getByTestId(APP_HEADER_TEST_SUBJECTS.title)).toHaveTextContent('Traces');
+  });
+
+  it('renders the Explore traces primary action with a Discover href', async () => {
+    await renderTraceOverview();
 
     const button = screen.getByTestId('apmTracesExploreInDiscoverButton');
     expect(button).toBeInTheDocument();
     expect(button).toHaveAttribute('href', 'http://test-discover-url');
     expect(button).toHaveTextContent('Explore traces');
+    expect(button).toHaveAttribute('data-ebt-action', 'exploreTraces');
+    expect(button).toHaveAttribute('data-ebt-element', 'appMenu');
+    expect(button).toHaveAttribute('data-ebt-detail', 'tracesPageHeader');
   });
 
-  it('passes the current time range and a traces-scoped ES|QL query to Discover', () => {
-    render(
-      <TraceOverview>
-        <div />
-      </TraceOverview>
-    );
+  it('passes the current time range and a traces-scoped ES|QL query to Discover', async () => {
+    await renderTraceOverview();
 
     expect(mockGetRedirectUrl).toHaveBeenCalled();
     const [args] = mockGetRedirectUrl.mock.calls.at(-1) as [

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/trace_overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/trace_overview/index.tsx
@@ -4,17 +4,27 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { useEuiTheme } from '@elastic/eui';
-import { css } from '@emotion/react';
+
+import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ApmMainTemplate } from '../../routing/templates/apm_main_template';
 import { Breadcrumb } from '../breadcrumb';
 import { useApmParams } from '../../../hooks/use_apm_params';
-import { OpenInDiscover } from '../../shared/links/discover_links/open_in_discover';
+import { useDiscoverHref } from '../../shared/links/discover_links/use_discover_href';
 import { ApmIndexSettingsContextProvider } from '../../../context/apm_index_settings/apm_index_settings_context';
+import { useApmIndexSettingsContext } from '../../../context/apm_index_settings/use_apm_index_settings_context';
+import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { APM_EBT_ACTIONS } from '../ebt_constants';
 import { TRACE_OVERVIEW_EBT_ELEMENTS } from './ebt_constants';
+
+const tracesTitle = i18n.translate('xpack.apm.views.traceOverview.title', {
+  defaultMessage: 'Traces',
+});
+
+const exploreTracesLabel = i18n.translate('xpack.apm.tracesOverview.exploreTracesInDiscover', {
+  defaultMessage: 'Explore traces',
+});
 
 export function TraceOverview({
   children,
@@ -23,64 +33,73 @@ export function TraceOverview({
   children: React.ReactElement;
   searchBar?: React.ReactNode;
 }) {
-  const title = i18n.translate('xpack.apm.views.traceOverview.title', {
-    defaultMessage: 'Traces',
-  });
+  return (
+    <ApmIndexSettingsContextProvider>
+      <Breadcrumb href="/traces" title={tracesTitle} omitOnServerless>
+        <TraceOverviewContent searchBar={searchBar}>{children}</TraceOverviewContent>
+      </Breadcrumb>
+    </ApmIndexSettingsContextProvider>
+  );
+}
 
+function TraceOverviewContent({
+  children,
+  searchBar,
+}: {
+  children: React.ReactElement;
+  searchBar?: React.ReactNode;
+}) {
   const {
     query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/traces');
+  const { indexSettingsStatus } = useApmIndexSettingsContext();
 
-  const { euiTheme } = useEuiTheme();
-  // Visually align `EuiButtonEmpty` with the larger page title baseline.
-  // `display: inline-flex` prevents the inline wrapper from adding extra
-  // line-height-driven height around the button.
-  const exploreTracesButtonCss = css({
-    display: 'inline-flex',
-    marginTop: euiTheme.size.xs,
+  const discoverHref = useDiscoverHref({
+    indexType: 'traces',
+    rangeFrom,
+    rangeTo,
+    queryParams: { kuery, environment, sortDirection: 'DESC' },
   });
 
+  const isExploreReady = Boolean(discoverHref) && indexSettingsStatus === FETCH_STATUS.SUCCESS;
+
+  const pageMenu = useMemo<AppMenuConfig>(() => {
+    return {
+      primaryActionItem: {
+        id: 'exploreTraces',
+        label: exploreTracesLabel,
+        iconType: 'discoverApp',
+        testId: 'apmTracesExploreInDiscoverButton',
+        ebt: {
+          action: APM_EBT_ACTIONS.EXPLORE_TRACES,
+          detail: TRACE_OVERVIEW_EBT_ELEMENTS.PAGE_HEADER,
+        },
+        disableButton: !isExploreReady,
+        isLoading: indexSettingsStatus === FETCH_STATUS.LOADING,
+        ...(discoverHref ? { href: discoverHref } : { run: () => undefined }),
+      },
+    };
+  }, [discoverHref, indexSettingsStatus, isExploreReady]);
+
   return (
-    <ApmIndexSettingsContextProvider>
-      <Breadcrumb href="/traces" title={title} omitOnServerless>
-        <ApmMainTemplate
-          pageTitle={title}
-          searchBar={searchBar}
-          pageHeader={{
-            rightSideItems: [
-              <span key="apmTracesExploreInDiscoverButton" css={exploreTracesButtonCss}>
-                <OpenInDiscover
-                  dataTestSubj="apmTracesExploreInDiscoverButton"
-                  variant="emptyButton"
-                  indexType="traces"
-                  label={i18n.translate('xpack.apm.tracesOverview.exploreTracesInDiscover', {
-                    defaultMessage: 'Explore traces',
-                  })}
-                  rangeFrom={rangeFrom}
-                  rangeTo={rangeTo}
-                  queryParams={{ kuery, environment, sortDirection: 'DESC' }}
-                  ebt={{
-                    action: APM_EBT_ACTIONS.EXPLORE_TRACES,
-                    element: TRACE_OVERVIEW_EBT_ELEMENTS.PAGE_HEADER,
-                  }}
-                />
-              </span>,
-            ],
-          }}
-          pageSectionProps={{
-            contentProps: {
-              style: {
-                display: 'flex',
-                flexDirection: 'column',
-                flexGrow: 1,
-                minInlineSize: 0,
-              },
-            },
-          }}
-        >
-          {children}
-        </ApmMainTemplate>
-      </Breadcrumb>
-    </ApmIndexSettingsContextProvider>
+    <ApmMainTemplate
+      header={{
+        title: tracesTitle,
+        menu: pageMenu,
+      }}
+      searchBar={searchBar}
+      pageSectionProps={{
+        contentProps: {
+          style: {
+            display: 'flex',
+            flexDirection: 'column',
+            flexGrow: 1,
+            minInlineSize: 0,
+          },
+        },
+      }}
+    >
+      {children}
+    </ApmMainTemplate>
   );
 }


### PR DESCRIPTION
## Summary

- Migrate the Traces overview (`/traces`) from the legacy `pageHeader` to `AppHeader`.
- Move **Explore traces** into `AppMenuConfig.primaryActionItem` (test subject `apmTracesExploreInDiscoverButton` unchanged). That takes the primary slot; **Add data** stays in More via `mergeAppMenuConfigs`.
- Discover URL still comes from `useDiscoverHref`. EBT: `action=exploreTraces`, `element=appMenu` (AppMenu default), `detail=tracesPageHeader` so clicks are still attributed to the Traces page header.

BEFORE
<img width="1678" height="508" alt="Screenshot 2026-08-18 at 11 51 29" src="https://github.com/user-attachments/assets/23c562b1-9839-4190-a5a6-7827e2424c63" />


AFTER
<img width="1678" height="535" alt="Screenshot 2026-08-18 at 11 50 55" src="https://github.com/user-attachments/assets/f06aec7b-82ba-474f-b658-fca58145fe7b" />


Closes #282989

## Test plan

- [ ] Classic and solution view: Traces title in AppHeader, no back control, search bar below the header.
- [ ] **Explore traces** is the primary header action, still opens Discover with the traces time range / ES|QL query, and **Add data** is under More.
- [ ] `apmTracesExploreInDiscoverButton` is still present.