### PR TITLE
[ci] Include node_modules.tar.zst

### DIFF
--- a/.buildkite/scripts/packer_cache.sh
+++ b/.buildkite/scripts/packer_cache.sh
@@ -12,6 +12,8 @@ yarn kbn bootstrap
 
 cd .buildkite && npm ci && cd ..
 
+tar -cf - node_modules | zstd -T0 -o node_modules.tar.zst
+
 for version in $(cat versions.json | jq -r '.versions[].version'); do
   node scripts/es snapshot --download-only --base-path "$ES_CACHE_DIR" --version "$version"
 done

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ node_modules
 !/src/dev/notice/__fixtures__/node_modules
 !/src/platform/packages/private/kbn-import-resolver/src/__fixtures__/node_modules
 !/src/platform/packages/private/kbn-import-resolver/src/__fixtures__/packages/box/node_modules
+/node_modules.tar.zst
 trash
 /optimize
 /built_assets


### PR DESCRIPTION
Experimenting with running a few CI steps on ram disk.  The archive is 500mb, we have disk capacity for it.

Moving node_modules (many small files) across filesystems is slow (90s), I'm expecting this approach to take <5s.