### PR TITLE
[AIOps] Skip failing dashboard log rate analysis test

### DIFF
--- a/x-pack/platform/test/functional/apps/aiops/log_rate_analysis_dashboard_embeddable.ts
+++ b/x-pack/platform/test/functional/apps/aiops/log_rate_analysis_dashboard_embeddable.ts
@@ -90,7 +90,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.dashboard.saveDashboard(testDataPanel.dashboardTitle);
       });
 
-      it('should run log rate analysis', async () => {
+      // Failing: See https://github.com/elastic/kibana/issues/285513
+      it.skip('should run log rate analysis', async () => {
         await aiops.dashboardEmbeddables.assertDashboardPanelExists(testDataPanel.panelTitle);
         await aiops.logRateAnalysisPage.clickAutoRunButton();
         // Wait for the analysis to finish


### PR DESCRIPTION
## Summary

Skips the failing dashboard log rate analysis test while the change-point behavior is investigated.

Addresses #285513

## Validation

- `git diff --check`
- `node scripts/eslint x-pack/platform/test/functional/apps/aiops/log_rate_analysis_dashboard_embeddable.ts`