### PR TITLE
[9.5] [Fleet] Integration sync - Don't query ES if no CCR follower index exists (#285526)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_on_remote.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_on_remote.test.ts
@@ -143,6 +143,21 @@ describe('syncIntegrationsOnRemote', () => {
     };
   }
 
+  it('should do nothing if no follower index exists', async () => {
+    getIndicesMock.mockResolvedValue({});
+
+    await syncIntegrationsOnRemote(
+      esClientMock,
+      soClientMock,
+      packageClientMock,
+      abortController,
+      loggerMock
+    );
+
+    expect(searchMock).not.toHaveBeenCalled();
+    expect(packageClientMock.getInstallation).not.toHaveBeenCalled();
+  });
+
   it('should do nothing if no matching remote output has sync enabled', async () => {
     getIndicesMock.mockResolvedValue({
       'fleet-synced-integrations-ccr-remote1': {},

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_on_remote.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/sync_integrations_on_remote.ts
@@ -62,6 +62,7 @@ const getSyncedIntegrationsCCRDoc = async (
   logger: Logger
 ): Promise<SyncIntegrationsData | undefined> => {
   const index = await getFollowerIndex(esClient, abortController);
+  if (!index) return undefined;
 
   const response = await esClient.search(
     {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Fleet] Integration sync - Don't query ES if no CCR follower index exists (#285526)](https://github.com/elastic/kibana/pull/285526)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jill Guyonnet","email":"jill.guyonnet@elastic.co"},"sourceCommit":{"committedDate":"2026-08-18T09:51:14Z","message":"[Fleet] Integration sync - Don't query ES if no CCR follower index exists (#285526)\n\n## Summary\n\n[Fleet's integration sync\nfeature](https://www.elastic.co/docs/reference/fleet/automatic-integrations-synchronization)\nruns the `fleet:sync-integrations` task every 5 minutes for syncing\nintegrations across clusters. When integration sync is not configured,\nit still runs a broad search against all Elasticsearch indices,\nincluding frozen tier data streams. This happens because the\n`syncIntegrationsOnRemote` function is called unconditionally in\n`runTask`, and within it `getSyncedIntegrationsCCRDoc` passes `index:\nundefined` to `esClient.search()` when no CCR follower index exists. On\nEnterprise license deployments (where the task is active by default),\nthis produces CPU spikes on the frozen tier on every task run.\n\nThis fix adds an early return immediately after the call to\n`getFollowerIndex` when no CCR follower index exists (normal state for a\nuser who hasn't configured it). The sync function now returns without\nissuing an Elasticsearch search instead of calling `esClient.search({\nindex: undefined })` which was causing the full-cluster scan.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nVery low. The change is a single-line guard in a private function with a\nwell-defined contract. The new code path (no follower index → return\nundefined) is functionally equivalent to what `syncIntegrationsOnRemote`\ndoes when the CCR doc's `isSyncIntegrationsEnabled` check fails: it\nreturns early without side effects. The fix does not affect any path\nwhere sync-integrations is properly configured (follower index exists),\nso intentional users of the feature are unaffected.\n\n## Release note\n\nThe task run by automatic integrations synchronization every 5 minutes\nnow returns early if the feature is not configured, avoiding unnecessary\nintensive searches in Elasticsearch.","sha":"e0366cc01c54daa975d4c02b380459ee6f5a0b4b","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.6.0","Team:streams-ui","v9.4.6","v9.5.2"],"title":"[Fleet] Integration sync - Don't query ES if no CCR follower index exists","number":285526,"url":"https://github.com/elastic/kibana/pull/285526","mergeCommit":{"message":"[Fleet] Integration sync - Don't query ES if no CCR follower index exists (#285526)\n\n## Summary\n\n[Fleet's integration sync\nfeature](https://www.elastic.co/docs/reference/fleet/automatic-integrations-synchronization)\nruns the `fleet:sync-integrations` task every 5 minutes for syncing\nintegrations across clusters. When integration sync is not configured,\nit still runs a broad search against all Elasticsearch indices,\nincluding frozen tier data streams. This happens because the\n`syncIntegrationsOnRemote` function is called unconditionally in\n`runTask`, and within it `getSyncedIntegrationsCCRDoc` passes `index:\nundefined` to `esClient.search()` when no CCR follower index exists. On\nEnterprise license deployments (where the task is active by default),\nthis produces CPU spikes on the frozen tier on every task run.\n\nThis fix adds an early return immediately after the call to\n`getFollowerIndex` when no CCR follower index exists (normal state for a\nuser who hasn't configured it). The sync function now returns without\nissuing an Elasticsearch search instead of calling `esClient.search({\nindex: undefined })` which was causing the full-cluster scan.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nVery low. The change is a single-line guard in a private function with a\nwell-defined contract. The new code path (no follower index → return\nundefined) is functionally equivalent to what `syncIntegrationsOnRemote`\ndoes when the CCR doc's `isSyncIntegrationsEnabled` check fails: it\nreturns early without side effects. The fix does not affect any path\nwhere sync-integrations is properly configured (follower index exists),\nso intentional users of the feature are unaffected.\n\n## Release note\n\nThe task run by automatic integrations synchronization every 5 minutes\nnow returns early if the feature is not configured, avoiding unnecessary\nintensive searches in Elasticsearch.","sha":"e0366cc01c54daa975d4c02b380459ee6f5a0b4b"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/285526","number":285526,"mergeCommit":{"message":"[Fleet] Integration sync - Don't query ES if no CCR follower index exists (#285526)\n\n## Summary\n\n[Fleet's integration sync\nfeature](https://www.elastic.co/docs/reference/fleet/automatic-integrations-synchronization)\nruns the `fleet:sync-integrations` task every 5 minutes for syncing\nintegrations across clusters. When integration sync is not configured,\nit still runs a broad search against all Elasticsearch indices,\nincluding frozen tier data streams. This happens because the\n`syncIntegrationsOnRemote` function is called unconditionally in\n`runTask`, and within it `getSyncedIntegrationsCCRDoc` passes `index:\nundefined` to `esClient.search()` when no CCR follower index exists. On\nEnterprise license deployments (where the task is active by default),\nthis produces CPU spikes on the frozen tier on every task run.\n\nThis fix adds an early return immediately after the call to\n`getFollowerIndex` when no CCR follower index exists (normal state for a\nuser who hasn't configured it). The sync function now returns without\nissuing an Elasticsearch search instead of calling `esClient.search({\nindex: undefined })` which was causing the full-cluster scan.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nVery low. The change is a single-line guard in a private function with a\nwell-defined contract. The new code path (no follower index → return\nundefined) is functionally equivalent to what `syncIntegrationsOnRemote`\ndoes when the CCR doc's `isSyncIntegrationsEnabled` check fails: it\nreturns early without side effects. The fix does not affect any path\nwhere sync-integrations is properly configured (follower index exists),\nso intentional users of the feature are unaffected.\n\n## Release note\n\nThe task run by automatic integrations synchronization every 5 minutes\nnow returns early if the feature is not configured, avoiding unnecessary\nintensive searches in Elasticsearch.","sha":"e0366cc01c54daa975d4c02b380459ee6f5a0b4b"}},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->