### PR TITLE
[9.4] [ci] Always run global-registry snapshot integration tests (#282283)

### DIFF
--- a/.buildkite/pipeline-utils/affected-packages/README.md
+++ b/.buildkite/pipeline-utils/affected-packages/README.md
@@ -134,6 +134,10 @@ const filteredFiles = filterFilesByPackages(
 
 On pull request builds, Jest unit and integration test groups are narrowed to configs under affected packages (see `pick_test_group_run_order` in CI stats). Add the GitHub label `ci:prevent-selective-testing` to run the full Jest suite instead. Touching files listed in `CRITICAL_FILES_JEST_*` in `const.ts` also skips filtering for the relevant test type.
 
+### Always-run integration configs
+
+Some integration suites boot a full Kibana and snapshot a *global registry* (rule-type params, connector types, task types, …) populated at runtime by downstream publishers that sit **upstream** of the suite's own package. `includeDownstream` expansion never reaches them, so a publisher-only change can silently skip the snapshot. Configs listed in `ALWAYS_RUN_JEST_INTEGRATION_CONFIGS` (`const.ts`) are re-added after affected-filtering so they run on every PR regardless of the graph. Keep the list tiny — it is a deliberate escape hatch.
+
 ## Scout selective testing: git -> Moon (shadow mode)
 
 `resolve_selective_testing.ts` still uses **git** as the authoritative strategy (written to `.scout/code_changes.json`, no behavior change). In parallel, it runs the **Moon** strategy above for observation only, and writes the result plus a diff of `affectedModules` to `.scout/code_changes.moon_shadow.json` (uploaded as a Buildkite artifact). Mismatches are logged as a warning via `ToolingLog`; a Moon failure is swallowed and logged, never fails the build.

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+jest.mock('../../affected-packages', () => ({
+  ALWAYS_RUN_JEST_INTEGRATION_CONFIGS: ['always/jest.integration.config.js'],
+  CRITICAL_FILES_JEST_INTEGRATION_TESTS: ['CRITICAL_INT'],
+  CRITICAL_FILES_JEST_UNIT_TESTS: ['CRITICAL_UNIT'],
+  getAffectedPackages: jest.fn(),
+  listChangedFiles: jest.fn(),
+  filterFilesByPackages: (files: string[], pkgs: Set<string>) =>
+    files.filter((f) => [...pkgs].some((pkg) => f.startsWith(pkg))),
+  touchedCriticalFiles: (files: string[], critical: string[]) =>
+    files.some((f) => critical.includes(f)),
+}));
+
+jest.mock('./jest_configs', () => ({ SHARD_ANNOTATION_SEP: '||shard=' }));
+
+import type { SelectiveTestingContext } from './selective_testing';
+import {
+  filterJestIntegrationConfigsByAffected,
+  filterJestUnitConfigsByAffected,
+} from './selective_testing';
+
+const context = (
+  affected: string[],
+  changed: string[] = ['irrelevant.ts']
+): SelectiveTestingContext => ({
+  affectedPackages: new Set(affected),
+  prChangedFiles: changed,
+});
+
+describe('filterJestIntegrationConfigsByAffected', () => {
+  it('drops unaffected configs but re-adds always-run configs', () => {
+    const configs = [
+      'always/jest.integration.config.js',
+      'other/jest.integration.config.js',
+      'affected/jest.integration.config.js',
+    ];
+
+    const result = filterJestIntegrationConfigsByAffected(configs, context(['affected/']));
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        'always/jest.integration.config.js',
+        'affected/jest.integration.config.js',
+      ])
+    );
+    expect(result).not.toContain('other/jest.integration.config.js');
+  });
+
+  it('re-adds an always-run config even when no package is affected', () => {
+    const configs = ['always/jest.integration.config.js', 'other/jest.integration.config.js'];
+
+    const result = filterJestIntegrationConfigsByAffected(configs, context([]));
+
+    expect(result).toEqual(['always/jest.integration.config.js']);
+  });
+
+  it('restores every shard of an always-run config', () => {
+    const configs = [
+      'always/jest.integration.config.js||shard=1/2',
+      'always/jest.integration.config.js||shard=2/2',
+      'other/jest.integration.config.js',
+    ];
+
+    const result = filterJestIntegrationConfigsByAffected(configs, context(['nothing/']));
+
+    expect(result).toEqual([
+      'always/jest.integration.config.js||shard=1/2',
+      'always/jest.integration.config.js||shard=2/2',
+    ]);
+  });
+
+  it('returns all configs unchanged when a critical file changed', () => {
+    const configs = ['other/jest.integration.config.js'];
+
+    const result = filterJestIntegrationConfigsByAffected(configs, context([], ['CRITICAL_INT']));
+
+    expect(result).toEqual(configs);
+  });
+});
+
+describe('filterJestUnitConfigsByAffected', () => {
+  it('does not force always-run integration configs into unit runs', () => {
+    const configs = ['always/jest.integration.config.js', 'affected/jest.config.js'];
+
+    const result = filterJestUnitConfigsByAffected(configs, context(['affected/']));
+
+    expect(result).toEqual(['affected/jest.config.js']);
+  });
+});

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_testing.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  ALWAYS_RUN_JEST_INTEGRATION_CONFIGS,
   CRITICAL_FILES_JEST_INTEGRATION_TESTS,
   CRITICAL_FILES_JEST_UNIT_TESTS,
   filterFilesByPackages,
@@ -17,6 +18,7 @@ import {
 } from '../../affected-packages';
 
 import { expandJestImplicitConsumers } from './jest_implicit_consumers';
+import { SHARD_ANNOTATION_SEP } from './jest_configs';
 
 /**
  * The shared inputs both per-variant filters need: which packages the PR
@@ -74,7 +76,7 @@ export function filterJestUnitConfigsByAffected(
   });
 }
 
-/** Narrow Jest integration configs to those owned by affected packages, unless a critical file changed. */
+/** Like the unit filter, but always re-adds ALWAYS_RUN_JEST_INTEGRATION_CONFIGS. */
 export function filterJestIntegrationConfigsByAffected(
   jestIntegrationConfigs: string[],
   context: SelectiveTestingContext
@@ -83,6 +85,7 @@ export function filterJestIntegrationConfigsByAffected(
     label: 'integration',
     configs: jestIntegrationConfigs,
     criticalFiles: CRITICAL_FILES_JEST_INTEGRATION_TESTS,
+    alwaysRun: ALWAYS_RUN_JEST_INTEGRATION_CONFIGS,
     context,
   });
 }
@@ -91,9 +94,10 @@ function filterByAffected(args: {
   label: 'unit' | 'integration';
   configs: string[];
   criticalFiles: string[];
+  alwaysRun?: readonly string[];
   context: SelectiveTestingContext;
 }): string[] {
-  const { label, configs, criticalFiles, context } = args;
+  const { label, configs, criticalFiles, alwaysRun = [], context } = args;
 
   if (touchedCriticalFiles(context.prChangedFiles, criticalFiles)) {
     console.log(`Not filtering Jest ${label} tests because critical files changed`);
@@ -101,6 +105,33 @@ function filterByAffected(args: {
   }
 
   const filtered = filterFilesByPackages(configs, context.affectedPackages);
-  console.log(`Filtering Jest ${label} tests: ${configs.length} -> ${filtered.length}`);
-  return filtered;
+  const withAlwaysRun = addAlwaysRunConfigs(filtered, configs, alwaysRun);
+  console.log(`Filtering Jest ${label} tests: ${configs.length} -> ${withAlwaysRun.length}`);
+  return withAlwaysRun;
+}
+
+// Matches on the base path so every shard of an always-run config is restored.
+function addAlwaysRunConfigs(
+  filtered: string[],
+  allConfigs: string[],
+  alwaysRun: readonly string[]
+): string[] {
+  if (alwaysRun.length === 0) {
+    return filtered;
+  }
+
+  const alwaysRunSet = new Set(alwaysRun);
+  const result = new Set(filtered);
+  for (const config of allConfigs) {
+    if (alwaysRunSet.has(baseConfigPath(config)) && !result.has(config)) {
+      result.add(config);
+      console.log(`Always-run Jest integration config re-added: ${config}`);
+    }
+  }
+  return [...result];
+}
+
+function baseConfigPath(config: string): string {
+  const idx = config.indexOf(SHARD_ANNOTATION_SEP);
+  return idx === -1 ? config : config.slice(0, idx);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ci] Always run global-registry snapshot integration tests (#282283)](https://github.com/elastic/kibana/pull/282283)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-08-06T15:15:46Z","message":"[ci] Always run global-registry snapshot integration tests (#282283)\n\n## Summary\n\nSelective testing narrows Jest integration configs to affected packages\n+ their **downstream** dependents. A few integration suites boot a full\nKibana and snapshot a *global registry* (rule-type params, connector\ntypes, task types) that downstream publishers populate at runtime — but\nthose suites live **upstream** of the publishers in the dependency\ngraph. `includeDownstream` expansion never reaches them, so a\npublisher-only change silently skips the snapshot and a stale snapshot\nmerges.\n\nThis is what happened in #275753: adding\n`endpoint_custom_yara_signatures` mutated the `siem.*` rule-type param\nsnapshot, but `@kbn/alerting-plugin`'s integration config wasn't in the\naffected graph of a security-solution-only change, so\n`serverless_upgrade_and_rollback_checks.test.ts` never ran and the\nsnapshot update was missed (fixed separately in #282247). It's the same\nclass of problem the existing ESO `jest_implicit_consumers` overlay\nsolves.\n\nThis PR adds `ALWAYS_RUN_JEST_INTEGRATION_CONFIGS` — a tiny, explicit\nallowlist of integration configs that are re-added *after*\naffected-filtering, so graph-independent snapshot suites run on every PR\nregardless of the affected graph (shard-annotated entries handled). Unit\nruns are unaffected.\n\n### Suites included\n\n| Config | Global-registry snapshots it guards |\n|---|---|\n| `alerting/jest.integration.config.js` | rule-type params +\nalert-as-data fields (rule types from security, o11y, ml, apm, stack,\nmonitoring, …) |\n| `actions/jest.integration.config.js` | connector-type registry\n(stack_connectors et al.) |\n| `task_manager/jest.integration.config.js` | task cost/priority\nregistries (task types from many plugins) |\n\n### Tradeoff / follow-up\n\nSelective testing's granularity is the whole\n`jest.integration.config.js`, so always-running these re-runs the\n*entire* alerting/actions/task_manager integration suites (a few min\neach) on every PR — i.e. pre-selective behavior for just these three. If\nthe cost is unwelcome, the cheaper follow-up is to split the snapshot\ntests into a dedicated `ci_checks` config per plugin (as ESO already\ndoes) and allowlist only that. Kept the list minimal and documented so\nit doesn't become a dumping ground.\n\n## Test plan\n\n- [x] New unit tests in `selective_testing.test.ts` (re-adds always-run\nconfig when dropped / no package affected / per shard; critical-file\npassthrough; unit runs unaffected)\n- [x] `.buildkite` typecheck + eslint clean\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"e094cabc9d478a59c1879be26972ed61aa6c5aec","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport missing","backport:all-open","v9.6.0","v9.5.2"],"title":"[ci] Always run global-registry snapshot integration tests","number":282283,"url":"https://github.com/elastic/kibana/pull/282283","mergeCommit":{"message":"[ci] Always run global-registry snapshot integration tests (#282283)\n\n## Summary\n\nSelective testing narrows Jest integration configs to affected packages\n+ their **downstream** dependents. A few integration suites boot a full\nKibana and snapshot a *global registry* (rule-type params, connector\ntypes, task types) that downstream publishers populate at runtime — but\nthose suites live **upstream** of the publishers in the dependency\ngraph. `includeDownstream` expansion never reaches them, so a\npublisher-only change silently skips the snapshot and a stale snapshot\nmerges.\n\nThis is what happened in #275753: adding\n`endpoint_custom_yara_signatures` mutated the `siem.*` rule-type param\nsnapshot, but `@kbn/alerting-plugin`'s integration config wasn't in the\naffected graph of a security-solution-only change, so\n`serverless_upgrade_and_rollback_checks.test.ts` never ran and the\nsnapshot update was missed (fixed separately in #282247). It's the same\nclass of problem the existing ESO `jest_implicit_consumers` overlay\nsolves.\n\nThis PR adds `ALWAYS_RUN_JEST_INTEGRATION_CONFIGS` — a tiny, explicit\nallowlist of integration configs that are re-added *after*\naffected-filtering, so graph-independent snapshot suites run on every PR\nregardless of the affected graph (shard-annotated entries handled). Unit\nruns are unaffected.\n\n### Suites included\n\n| Config | Global-registry snapshots it guards |\n|---|---|\n| `alerting/jest.integration.config.js` | rule-type params +\nalert-as-data fields (rule types from security, o11y, ml, apm, stack,\nmonitoring, …) |\n| `actions/jest.integration.config.js` | connector-type registry\n(stack_connectors et al.) |\n| `task_manager/jest.integration.config.js` | task cost/priority\nregistries (task types from many plugins) |\n\n### Tradeoff / follow-up\n\nSelective testing's granularity is the whole\n`jest.integration.config.js`, so always-running these re-runs the\n*entire* alerting/actions/task_manager integration suites (a few min\neach) on every PR — i.e. pre-selective behavior for just these three. If\nthe cost is unwelcome, the cheaper follow-up is to split the snapshot\ntests into a dedicated `ci_checks` config per plugin (as ESO already\ndoes) and allowlist only that. Kept the list minimal and documented so\nit doesn't become a dumping ground.\n\n## Test plan\n\n- [x] New unit tests in `selective_testing.test.ts` (re-adds always-run\nconfig when dropped / no package affected / per shard; critical-file\npassthrough; unit runs unaffected)\n- [x] `.buildkite` typecheck + eslint clean\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"e094cabc9d478a59c1879be26972ed61aa6c5aec"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282283","number":282283,"mergeCommit":{"message":"[ci] Always run global-registry snapshot integration tests (#282283)\n\n## Summary\n\nSelective testing narrows Jest integration configs to affected packages\n+ their **downstream** dependents. A few integration suites boot a full\nKibana and snapshot a *global registry* (rule-type params, connector\ntypes, task types) that downstream publishers populate at runtime — but\nthose suites live **upstream** of the publishers in the dependency\ngraph. `includeDownstream` expansion never reaches them, so a\npublisher-only change silently skips the snapshot and a stale snapshot\nmerges.\n\nThis is what happened in #275753: adding\n`endpoint_custom_yara_signatures` mutated the `siem.*` rule-type param\nsnapshot, but `@kbn/alerting-plugin`'s integration config wasn't in the\naffected graph of a security-solution-only change, so\n`serverless_upgrade_and_rollback_checks.test.ts` never ran and the\nsnapshot update was missed (fixed separately in #282247). It's the same\nclass of problem the existing ESO `jest_implicit_consumers` overlay\nsolves.\n\nThis PR adds `ALWAYS_RUN_JEST_INTEGRATION_CONFIGS` — a tiny, explicit\nallowlist of integration configs that are re-added *after*\naffected-filtering, so graph-independent snapshot suites run on every PR\nregardless of the affected graph (shard-annotated entries handled). Unit\nruns are unaffected.\n\n### Suites included\n\n| Config | Global-registry snapshots it guards |\n|---|---|\n| `alerting/jest.integration.config.js` | rule-type params +\nalert-as-data fields (rule types from security, o11y, ml, apm, stack,\nmonitoring, …) |\n| `actions/jest.integration.config.js` | connector-type registry\n(stack_connectors et al.) |\n| `task_manager/jest.integration.config.js` | task cost/priority\nregistries (task types from many plugins) |\n\n### Tradeoff / follow-up\n\nSelective testing's granularity is the whole\n`jest.integration.config.js`, so always-running these re-runs the\n*entire* alerting/actions/task_manager integration suites (a few min\neach) on every PR — i.e. pre-selective behavior for just these three. If\nthe cost is unwelcome, the cheaper follow-up is to split the snapshot\ntests into a dedicated `ci_checks` config per plugin (as ESO already\ndoes) and allowlist only that. Kept the list minimal and documented so\nit doesn't become a dumping ground.\n\n## Test plan\n\n- [x] New unit tests in `selective_testing.test.ts` (re-adds always-run\nconfig when dropped / no package affected / per shard; critical-file\npassthrough; unit runs unaffected)\n- [x] `.buildkite` typecheck + eslint clean\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"e094cabc9d478a59c1879be26972ed61aa6c5aec"}},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/285418","number":285418,"state":"MERGED","mergeCommit":{"sha":"602c8ff65816e0c99b8ad7451929aed16b3a19e8","message":"[9.5] [ci] Always run global-registry snapshot integration tests (#282283) (#285418)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[ci] Always run global-registry snapshot integration tests\n(#282283)](https://github.com/elastic/kibana/pull/282283)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Cursor <cursoragent@cursor.com>"}}]}] BACKPORT-->