### PR TITLE
[Flaky Test Fixer] Nudge codeowners to review, fix, or close open flaky fix PRs

### DIFF
--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -7,46 +7,35 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// Sweep logic for the "flaky fix review reminder" workflow.
-//
-// It finds open, ready-for-review PRs labeled `flaky-test-fixer` that have gone
-// without a human review for at least REMINDER_AFTER_DAYS days and pings the
-// codeowners of the changed files, re-pinging on the same cadence until a
-// review lands. These PRs are opened by a bot with no human author behind them,
-// so without a nudge they routinely sit unreviewed.
+// Finds open, ready-for-review PRs labeled `flaky-test-fixer` with no human
+// review for REMINDER_AFTER_DAYS days and pings the codeowners of the changed
+// files, re-pinging on the same cadence until a review lands.
 
 const fs = require('fs');
 const path = require('path');
-// `ignore` is the same gitignore-semantics matcher used by @kbn/code-owners, so
-// codeowner resolution here matches the rest of the repo exactly. It is a tiny,
-// dependency-free package installed by the workflow before this script runs.
+// Same gitignore-semantics matcher as @kbn/code-owners.
 const ignore = require('ignore');
 
 const LABEL = 'flaky-test-fixer';
 const REMINDER_MARKER = '<!-- flaky-fix-review-reminder -->';
 // The bot that authors our reminder comments (default GITHUB_TOKEN identity).
 const REMINDER_AUTHOR = 'github-actions[bot]';
-// Days a PR may sit without a human review before we ping, and the cadence at
-// which we re-ping afterwards. Calendar days, weekends included.
+// Calendar days (weekends included) before the first ping; also the re-ping cadence.
 const REMINDER_AFTER_DAYS = 4;
-// Cap pings per run so a daily sweep can never cause a notification storm,
-// even on the first pass over a large backlog. The backlog drains at this
-// rate per day; raise it once the reminder has proven itself in production.
+// Keeps a daily sweep from causing a notification storm; raise once proven.
 const MAX_PINGS_PER_RUN = 2;
-// Used when no codeowner can be resolved for the changed files.
 const FALLBACK_OWNER = '@elastic/appex-qa';
 const DEFAULT_CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');
 const QA_CHANNEL_URL = 'https://elastic.slack.com/archives/CTH3RN2GB';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-/** Whole days between an instant and now (calendar days, weekends included). */
+/** Whole calendar days between an instant and now. */
 function daysBetween(fromIso, now = Date.now()) {
   const to = now instanceof Date ? now.getTime() : now;
   return Math.floor((to - new Date(fromIso).getTime()) / MS_PER_DAY);
 }
 
-/** The later of two ISO timestamps; tolerates either being null. */
 function laterOf(a, b) {
   if (!a) return b;
   if (!b) return a;
@@ -54,9 +43,8 @@ function laterOf(a, b) {
 }
 
 /**
- * Build codeowner entries from a CODEOWNERS file, mirroring @kbn/code-owners:
- * each entry gets its own `ignore` matcher, and entries are reversed so the
- * last matching line in the file wins (GitHub's precedence rule).
+ * Parse CODEOWNERS into per-line `ignore` matchers, reversed so the last
+ * matching line wins (GitHub's precedence rule), mirroring @kbn/code-owners.
  */
 function buildCodeownersEntries(contents) {
   const entries = [];
@@ -81,7 +69,6 @@ function buildCodeownersEntries(contents) {
   return entries.reverse();
 }
 
-/** Owning team handles for a set of changed files, de-duplicated in first-seen order. */
 function resolveOwners(entries, files) {
   const owners = new Set();
   for (const file of files) {
@@ -112,9 +99,8 @@ const isBot = (user) =>
   Boolean(user) && (user.type === 'Bot' || user.login.endsWith('[bot]'));
 
 /**
- * Whether the PR has a review that should stop reminders: a human (non-author,
- * non-bot) APPROVED / CHANGES_REQUESTED / COMMENTED review. PENDING and
- * DISMISSED reviews do not count.
+ * Whether a human (non-author, non-bot) submitted an APPROVED /
+ * CHANGES_REQUESTED / COMMENTED review; such a review stops reminders.
  */
 async function hasHumanReview({ github, owner, repo, pr }) {
   const reviews = await github.paginate(github.rest.pulls.listReviews, {
@@ -143,7 +129,7 @@ async function getReadyForReviewTime({ github, owner, repo, pr }) {
   let readyAt = null;
   for (const event of events) {
     if (event.event === 'ready_for_review' && event.created_at) {
-      readyAt = event.created_at; // keep the most recent
+      readyAt = event.created_at;
     }
   }
   return readyAt || pr.created_at;
@@ -179,14 +165,11 @@ module.exports = async function flakyFixReviewReminder({ github, context, core }
     fs.readFileSync(process.env.CODEOWNERS_PATH || DEFAULT_CODEOWNERS_PATH, 'utf8')
   );
 
-  // CODEOWNERS is read from the checked-out ref (the default branch), so we only
-  // reason about PRs that target it. flaky-test-fixer PRs are opened against the
-  // default branch, so this is a no-op guard in practice.
+  // CODEOWNERS comes from the checked-out default branch, so only consider PRs
+  // targeting it (flaky-test-fixer PRs always do).
   const { data: repository } = await github.rest.repos.get({ owner, repo });
   const baseBranch = repository.default_branch;
 
-  // Server-side label filter keeps this cheap even though the repo has hundreds
-  // of open PRs (mirrors close-stale-failed-test-issues.yml).
   const candidates = await github.paginate(github.rest.issues.listForRepo, {
     owner,
     repo,
@@ -244,8 +227,7 @@ module.exports = async function flakyFixReviewReminder({ github, context, core }
       continue;
     }
 
-    // Re-check freshness right before commenting to narrow races with reviews,
-    // label removals, and conversions back to draft.
+    // Re-check freshness right before commenting to narrow races.
     const { data: fresh } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
     const freshLabels = fresh.labels.map((l) => (typeof l === 'string' ? l : l.name));
     if (

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -86,7 +86,7 @@ function buildCommentBody(ownerHandles) {
   return [
     `Hey ${mentions} 👋 this flaky test fix has been open for a while and needs an owner decision. Any of these helps:`,
     '',
-    '* ✅ Review & merge if it looks good',
+    '* ✅ Review and merge if it looks good',
     '* ✏️ Need tweaks? Mention `@copilot` in a comment',
     '* ❌ Not worth shipping? Just close it (drop a comment to help our workflow improve)',
     '',

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -25,7 +25,8 @@ const REMINDER_AFTER_DAYS = 4;
 // Max reminder comments posted per run. Bounds the noise (and API writes) of a
 // single sweep: with a large unreviewed backlog, at most this many PRs get a
 // codeowner ping per day; the rest are picked up on subsequent daily runs.
-const MAX_PINGS_PER_RUN = 20;
+// Temporary, will be increased as soon as we validate the workflow.
+const MAX_PINGS_PER_RUN = 1;
 const DEFAULT_CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');
 const QA_CHANNEL_URL = 'https://elastic.slack.com/archives/C04HT4P1YS3';
 

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -86,11 +86,13 @@ function resolveOwners(entries, files) {
 function buildCommentBody(ownerHandles) {
   const mentions = ownerHandles.length ? ownerHandles.join(' ') : FALLBACK_OWNER;
   return [
-    `Hey ${mentions} 👋 this flaky test fix has been open for a while and needs an owner decision. Any of these helps:`,
+    `Hey ${mentions} 👋 this flaky test fix has been open for a while and needs an owner decision.`,
     '',
-    '* ✅ Review and merge if it looks good',
-    '* ✏️ Need to make changes or resolve merge conflicts? Ask `@copilot`',
-    '* ❌ Not worth shipping? Just close it (drop a comment to help our workflow improve)',
+    '**Hints:**',
+    '',
+    '- ✅ Review and merge if it looks good',
+    '- ✏️ Need to make changes to or resolve merge conflicts? Ask `@copilot`',
+    '- ❌ Not worth shipping? Just close it (drop a comment to help our workflow improve)',
     '',
     `Questions? Find the Applications DX team in [#kibana-qa](${QA_CHANNEL_URL}).`,
     '',

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -22,8 +22,10 @@ const REMINDER_MARKER = '<!-- flaky-fix-review-reminder -->';
 const REMINDER_AUTHOR = 'github-actions[bot]';
 // Calendar days (weekends included) before the first ping; also the re-ping cadence.
 const REMINDER_AFTER_DAYS = 4;
-// Keeps a daily sweep from causing a notification storm; raise once proven.
-const MAX_PINGS_PER_RUN = 2;
+// Max reminder comments posted per run. Bounds the noise (and API writes) of a
+// single sweep: with a large unreviewed backlog, at most this many PRs get a
+// codeowner ping per day; the rest are picked up on subsequent daily runs.
+const MAX_PINGS_PER_RUN = 20;
 const FALLBACK_OWNER = '@elastic/appex-qa';
 const DEFAULT_CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');
 const QA_CHANNEL_URL = 'https://elastic.slack.com/archives/CTH3RN2GB';
@@ -263,3 +265,4 @@ module.exports.resolveOwners = resolveOwners;
 module.exports.buildCommentBody = buildCommentBody;
 module.exports.REMINDER_AFTER_DAYS = REMINDER_AFTER_DAYS;
 module.exports.REMINDER_MARKER = REMINDER_MARKER;
+module.exports.MAX_PINGS_PER_RUN = MAX_PINGS_PER_RUN;

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -33,7 +33,7 @@ const REMINDER_AFTER_DAYS = 4;
 // first sweep over the backlog.
 const MAX_PINGS_PER_RUN = 50;
 // Used when no codeowner can be resolved for the changed files.
-const FALLBACK_OWNER = '@elastic/kibana-qa';
+const FALLBACK_OWNER = '@elastic/appex-qa';
 const DEFAULT_CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');
 const QA_CHANNEL_URL = 'https://elastic.slack.com/archives/CTH3RN2GB';
 

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -34,7 +34,7 @@ const REMINDER_AFTER_DAYS = 4;
 const MAX_PINGS_PER_RUN = 50;
 // Used when no codeowner can be resolved for the changed files.
 const FALLBACK_OWNER = '@elastic/kibana-qa';
-const CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');
+const DEFAULT_CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');
 const QA_CHANNEL_URL = 'https://elastic.slack.com/archives/CTH3RN2GB';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -174,7 +174,9 @@ module.exports = async function flakyFixReviewReminder({ github, context, core }
   const { owner, repo } = context.repo;
   const dryRun = process.env.DRY_RUN === 'true';
 
-  const entries = buildCodeownersEntries(fs.readFileSync(CODEOWNERS_PATH, 'utf8'));
+  const entries = buildCodeownersEntries(
+    fs.readFileSync(process.env.CODEOWNERS_PATH || DEFAULT_CODEOWNERS_PATH, 'utf8')
+  );
 
   // CODEOWNERS is read from the checked-out ref (the default branch), so we only
   // reason about PRs that target it. flaky-test-fixer PRs are opened against the

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -180,9 +180,11 @@ module.exports = async function flakyFixReviewReminder({ github, context, core }
     repo,
     state: 'open',
     labels: LABEL,
+    state: 'open',
+    labels: LABEL,
+    sort: 'created',
+    direction: 'asc',
     per_page: 100,
-  });
-
   let pinged = 0;
   let considered = 0;
 

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -29,9 +29,10 @@ const REMINDER_AUTHOR = 'github-actions[bot]';
 // Days a PR may sit without a human review before we ping, and the cadence at
 // which we re-ping afterwards. Calendar days, weekends included.
 const REMINDER_AFTER_DAYS = 4;
-// Cap pings per run to avoid a notification storm / secondary rate limits on the
-// first sweep over the backlog.
-const MAX_PINGS_PER_RUN = 50;
+// Cap pings per run so a daily sweep can never cause a notification storm,
+// even on the first pass over a large backlog. The backlog drains at this
+// rate per day; raise it once the reminder has proven itself in production.
+const MAX_PINGS_PER_RUN = 2;
 // Used when no codeowner can be resolved for the changed files.
 const FALLBACK_OWNER = '@elastic/appex-qa';
 const DEFAULT_CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -1,0 +1,279 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Sweep logic for the "flaky fix review reminder" workflow.
+//
+// It finds open, ready-for-review PRs labeled `flaky-test-fixer` that have gone
+// without a human review for at least REMINDER_AFTER_DAYS days and pings the
+// codeowners of the changed files, re-pinging on the same cadence until a
+// review lands. These PRs are opened by a bot with no human author behind them,
+// so without a nudge they routinely sit unreviewed.
+
+const fs = require('fs');
+const path = require('path');
+// `ignore` is the same gitignore-semantics matcher used by @kbn/code-owners, so
+// codeowner resolution here matches the rest of the repo exactly. It is a tiny,
+// dependency-free package installed by the workflow before this script runs.
+const ignore = require('ignore');
+
+const LABEL = 'flaky-test-fixer';
+const REMINDER_MARKER = '<!-- flaky-fix-review-reminder -->';
+// The bot that authors our reminder comments (default GITHUB_TOKEN identity).
+const REMINDER_AUTHOR = 'github-actions[bot]';
+// Days a PR may sit without a human review before we ping, and the cadence at
+// which we re-ping afterwards. Calendar days, weekends included.
+const REMINDER_AFTER_DAYS = 4;
+// Cap pings per run to avoid a notification storm / secondary rate limits on the
+// first sweep over the backlog.
+const MAX_PINGS_PER_RUN = 50;
+// Used when no codeowner can be resolved for the changed files.
+const FALLBACK_OWNER = '@elastic/kibana-qa';
+const CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');
+const QA_CHANNEL_URL = 'https://elastic.slack.com/archives/CTH3RN2GB';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Whole days between an instant and now (calendar days, weekends included). */
+function daysBetween(fromIso, now = Date.now()) {
+  const to = now instanceof Date ? now.getTime() : now;
+  return Math.floor((to - new Date(fromIso).getTime()) / MS_PER_DAY);
+}
+
+/** The later of two ISO timestamps; tolerates either being null. */
+function laterOf(a, b) {
+  if (!a) return b;
+  if (!b) return a;
+  return new Date(a).getTime() >= new Date(b).getTime() ? a : b;
+}
+
+/**
+ * Build codeowner entries from a CODEOWNERS file, mirroring @kbn/code-owners:
+ * each entry gets its own `ignore` matcher, and entries are reversed so the
+ * last matching line in the file wins (GitHub's precedence rule).
+ */
+function buildCodeownersEntries(contents) {
+  const entries = [];
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+    // Backport branches override ownership with `* @kibanamachine`; ignore it.
+    if (/^\*\s+@kibanamachine$/.test(line)) {
+      continue;
+    }
+    const [pattern, ...owners] = line.replace(/#.*$/, '').trim().split(/\s+/);
+    if (!pattern) {
+      continue;
+    }
+    entries.push({
+      owners: owners.filter((o) => o.startsWith('@')),
+      matcher: ignore().add(pattern.replace(/\/$/, '')),
+    });
+  }
+  return entries.reverse();
+}
+
+/** Owning team handles for a set of changed files, de-duplicated in first-seen order. */
+function resolveOwners(entries, files) {
+  const owners = new Set();
+  for (const file of files) {
+    const normalized = file.replace(/^\/+/, '');
+    const match = entries.find((entry) => entry.matcher.test(normalized).ignored);
+    if (match) {
+      match.owners.forEach((o) => owners.add(o));
+    }
+  }
+  return [...owners];
+}
+
+function buildCommentBody(ownerHandles) {
+  const mentions = ownerHandles.length ? ownerHandles.join(' ') : FALLBACK_OWNER;
+  return [
+    `Hey ${mentions} — could you please review this flaky-fix PR?`,
+    '',
+    '**Recommendations:**',
+    `- Ask for help in the [#kibana-qa](${QA_CHANNEL_URL}) channel if you have any questions`,
+    '- Mention `@copilot` if you need to make quick changes',
+    "- Close the PR if you don't find the fix valuable (you can leave a comment to explain why)",
+    '',
+    REMINDER_MARKER,
+  ].join('\n');
+}
+
+const isBot = (user) =>
+  Boolean(user) && (user.type === 'Bot' || user.login.endsWith('[bot]'));
+
+/**
+ * Whether the PR has a review that should stop reminders: a human (non-author,
+ * non-bot) APPROVED / CHANGES_REQUESTED / COMMENTED review. PENDING and
+ * DISMISSED reviews do not count.
+ */
+async function hasHumanReview({ github, owner, repo, pr }) {
+  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner,
+    repo,
+    pull_number: pr.number,
+    per_page: 100,
+  });
+  return reviews.some(
+    (review) =>
+      ['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED'].includes(review.state) &&
+      review.user &&
+      review.user.login !== pr.user.login &&
+      !isBot(review.user)
+  );
+}
+
+/** Instant the PR became ready for review, falling back to its creation time. */
+async function getReadyForReviewTime({ github, owner, repo, pr }) {
+  const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+    owner,
+    repo,
+    issue_number: pr.number,
+    per_page: 100,
+  });
+  let readyAt = null;
+  for (const event of events) {
+    if (event.event === 'ready_for_review' && event.created_at) {
+      readyAt = event.created_at; // keep the most recent
+    }
+  }
+  return readyAt || pr.created_at;
+}
+
+/** Timestamp of the most recent reminder we posted, or null if we never have. */
+async function getLastReminderTime({ github, owner, repo, prNumber }) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 100,
+  });
+  let lastAt = null;
+  for (const comment of comments) {
+    if (
+      comment.user &&
+      comment.user.login === REMINDER_AUTHOR &&
+      comment.body &&
+      comment.body.includes(REMINDER_MARKER)
+    ) {
+      lastAt = comment.created_at;
+    }
+  }
+  return lastAt;
+}
+
+module.exports = async function flakyFixReviewReminder({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  const dryRun = process.env.DRY_RUN === 'true';
+
+  const entries = buildCodeownersEntries(fs.readFileSync(CODEOWNERS_PATH, 'utf8'));
+
+  // CODEOWNERS is read from the checked-out ref (the default branch), so we only
+  // reason about PRs that target it. flaky-test-fixer PRs are opened against the
+  // default branch, so this is a no-op guard in practice.
+  const { data: repository } = await github.rest.repos.get({ owner, repo });
+  const baseBranch = repository.default_branch;
+
+  // Server-side label filter keeps this cheap even though the repo has hundreds
+  // of open PRs (mirrors close-stale-failed-test-issues.yml).
+  const candidates = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state: 'open',
+    labels: LABEL,
+    per_page: 100,
+  });
+
+  let pinged = 0;
+  let considered = 0;
+
+  for (const candidate of candidates) {
+    if (!candidate.pull_request) {
+      continue;
+    }
+    if (pinged >= MAX_PINGS_PER_RUN) {
+      core.info(`Reached the limit of ${MAX_PINGS_PER_RUN} pings, stopping`);
+      break;
+    }
+
+    const { data: pr } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: candidate.number,
+    });
+    if (pr.draft || pr.base.ref !== baseBranch) {
+      continue;
+    }
+    considered += 1;
+
+    if (await hasHumanReview({ github, owner, repo, pr })) {
+      continue;
+    }
+
+    const readyAt = await getReadyForReviewTime({ github, owner, repo, pr });
+    const lastReminderAt = await getLastReminderTime({ github, owner, repo, prNumber: pr.number });
+    const reference = laterOf(readyAt, lastReminderAt);
+    const elapsed = daysBetween(reference);
+    if (elapsed < REMINDER_AFTER_DAYS) {
+      continue;
+    }
+
+    const files = await github.paginate(github.rest.pulls.listFiles, {
+      owner,
+      repo,
+      pull_number: pr.number,
+      per_page: 100,
+    });
+    const owners = resolveOwners(entries, files.map((f) => f.filename));
+    const mentioned = owners.length ? owners.join(' ') : FALLBACK_OWNER;
+
+    if (dryRun) {
+      pinged += 1;
+      core.info(`[dry run] would ping #${pr.number} (${elapsed}d since ${reference}) -> ${mentioned}`);
+      continue;
+    }
+
+    // Re-check freshness right before commenting to narrow races with reviews,
+    // label removals, and conversions back to draft.
+    const { data: fresh } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
+    const freshLabels = fresh.labels.map((l) => (typeof l === 'string' ? l : l.name));
+    if (
+      fresh.state !== 'open' ||
+      fresh.draft ||
+      !freshLabels.includes(LABEL) ||
+      (await hasHumanReview({ github, owner, repo, pr: fresh }))
+    ) {
+      continue;
+    }
+
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pr.number,
+      body: buildCommentBody(owners),
+    });
+    pinged += 1;
+    core.info(`Pinged #${pr.number} (${elapsed}d since ${reference}) -> ${mentioned}`);
+  }
+
+  core.info(
+    `Checked ${considered} open ready "${LABEL}" PR(s), pinged ${pinged}${dryRun ? ' (dry run)' : ''}`
+  );
+};
+
+// Exported for unit testing.
+module.exports.daysBetween = daysBetween;
+module.exports.laterOf = laterOf;
+module.exports.buildCodeownersEntries = buildCodeownersEntries;
+module.exports.resolveOwners = resolveOwners;
+module.exports.buildCommentBody = buildCommentBody;
+module.exports.REMINDER_AFTER_DAYS = REMINDER_AFTER_DAYS;
+module.exports.REMINDER_MARKER = REMINDER_MARKER;

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -89,7 +89,7 @@ function buildCommentBody(ownerHandles) {
     `Hey ${mentions} 👋 this flaky test fix has been open for a while and needs an owner decision. Any of these helps:`,
     '',
     '* ✅ Review and merge if it looks good',
-    '* ✏️ Need tweaks? Mention `@copilot` in a comment',
+    '* ✏️ Need to make changes or resolve merge conflicts? Ask `@copilot`',
     '* ❌ Not worth shipping? Just close it (drop a comment to help our workflow improve)',
     '',
     `Questions? Find the Applications DX team in [#kibana-qa](${QA_CHANNEL_URL}).`,

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -26,7 +26,6 @@ const REMINDER_AFTER_DAYS = 4;
 // single sweep: with a large unreviewed backlog, at most this many PRs get a
 // codeowner ping per day; the rest are picked up on subsequent daily runs.
 const MAX_PINGS_PER_RUN = 20;
-const FALLBACK_OWNER = '@elastic/appex-qa';
 const DEFAULT_CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');
 const QA_CHANNEL_URL = 'https://elastic.slack.com/archives/CTH3RN2GB';
 
@@ -84,7 +83,7 @@ function resolveOwners(entries, files) {
 }
 
 function buildCommentBody(ownerHandles) {
-  const mentions = ownerHandles.length ? ownerHandles.join(' ') : FALLBACK_OWNER;
+  const mentions = ownerHandles.join(' ');
   return [
     `Hey ${mentions} 👋 this flaky test fix has been open for a while and needs an owner decision.`,
     '',
@@ -224,7 +223,11 @@ module.exports = async function flakyFixReviewReminder({ github, context, core }
       per_page: 100,
     });
     const owners = resolveOwners(entries, files.map((f) => f.filename));
-    const mentioned = owners.length ? owners.join(' ') : FALLBACK_OWNER;
+    if (owners.length === 0) {
+      core.info(`No codeowners resolved for #${pr.number}, skipping`);
+      continue;
+    }
+    const mentioned = owners.join(' ');
 
     if (dryRun) {
       pinged += 1;

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -27,7 +27,7 @@ const REMINDER_AFTER_DAYS = 4;
 // codeowner ping per day; the rest are picked up on subsequent daily runs.
 const MAX_PINGS_PER_RUN = 20;
 const DEFAULT_CODEOWNERS_PATH = path.resolve(process.cwd(), '.github/CODEOWNERS');
-const QA_CHANNEL_URL = 'https://elastic.slack.com/archives/CTH3RN2GB';
+const QA_CHANNEL_URL = 'https://elastic.slack.com/archives/C04HT4P1YS3';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -84,12 +84,13 @@ function resolveOwners(entries, files) {
 function buildCommentBody(ownerHandles) {
   const mentions = ownerHandles.length ? ownerHandles.join(' ') : FALLBACK_OWNER;
   return [
-    `Hey ${mentions} — could you please review this flaky-fix PR?`,
+    `Hey ${mentions} 👋 this flaky test fix has been open for a while and needs an owner decision. Any of these helps:`,
     '',
-    '**Recommendations:**',
-    `- Ask for help in the [#kibana-qa](${QA_CHANNEL_URL}) channel if you have any questions`,
-    '- Mention `@copilot` if you need to make quick changes',
-    "- Close the PR if you don't find the fix valuable (you can leave a comment to explain why)",
+    '* ✅ Review & merge if it looks good',
+    '* ✏️ Need tweaks? Mention `@copilot` in a comment',
+    '* ❌ Not worth shipping? Just close it (drop a comment to help our workflow improve)',
+    '',
+    `Questions? Find the Applications DX team in [#kibana-qa](${QA_CHANNEL_URL}).`,
     '',
     REMINDER_MARKER,
   ].join('\n');

--- a/.github/scripts/flaky_fix_review_reminder.test.js
+++ b/.github/scripts/flaky_fix_review_reminder.test.js
@@ -204,21 +204,30 @@ function withFixtureAndNow(fn) {
 const context = { repo: { owner: 'elastic', repo: 'kibana' } };
 const silentCore = { info() {}, warning() {} };
 
-test('sweep pings only due, ready, unreviewed PRs and re-pings on cadence', async () => {
+test('sweep pings the first due, ready, unreviewed PR with its codeowners', async () => {
   await withFixtureAndNow(async () => {
     const state = scenarioState();
     process.env.DRY_RUN = 'false';
-    await reminder(
-      { github: makeGithub(state), context, core: silentCore }
-    );
+    await reminder({ github: makeGithub(state), context, core: silentCore });
 
-    const posted = state.posted.map((c) => c.issue_number).sort((a, b) => a - b);
-    assert.deepEqual(posted, [1, 5]);
+    // #1 is the first due PR; the cap of MAX_PINGS_PER_RUN stops the run there.
+    const posted = state.posted.map((c) => c.issue_number);
+    assert.deepEqual(posted, [1]);
+    assert.match(state.posted[0].body, /@elastic\/security-solution/);
+  });
+});
 
-    const first = state.posted.find((c) => c.issue_number === 1).body;
-    assert.match(first, /@elastic\/security-solution/);
-    const fifth = state.posted.find((c) => c.issue_number === 5).body;
-    assert.match(fifth, /@elastic\/kibana-core/);
+test('a PR already pinged 4+ days ago is re-pinged', async () => {
+  await withFixtureAndNow(async () => {
+    const state = scenarioState();
+    // Take #1 out of the running so the re-ping candidate #5 is reached.
+    state.reviews[1] = [{ state: 'APPROVED', user: { login: 'dev', type: 'User' } }];
+    process.env.DRY_RUN = 'false';
+    await reminder({ github: makeGithub(state), context, core: silentCore });
+
+    const posted = state.posted.map((c) => c.issue_number);
+    assert.deepEqual(posted, [5]);
+    assert.match(state.posted[0].body, /@elastic\/kibana-core/);
   });
 });
 
@@ -235,7 +244,6 @@ test('dry run logs intentions without commenting', async () => {
 
     assert.equal(state.posted.length, 0);
     assert.ok(logs.some((l) => l.includes('[dry run] would ping #1')));
-    assert.ok(logs.some((l) => l.includes('[dry run] would ping #5')));
   });
 });
 

--- a/.github/scripts/flaky_fix_review_reminder.test.js
+++ b/.github/scripts/flaky_fix_review_reminder.test.js
@@ -1,0 +1,255 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Zero-framework tests for the flaky-fix review reminder sweep. These scripts
+// run via actions/github-script (plain CommonJS, outside the Jest project), so
+// they are tested with Node's built-in runner:
+//
+//   node --test .github/scripts/flaky_fix_review_reminder.test.js
+//
+// `ignore` is a repo devDependency, so it resolves after bootstrap.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const reminder = require('./flaky_fix_review_reminder');
+
+const NOW = new Date('2026-08-18T12:00:00Z').getTime();
+const iso = (d) => new Date(d).toISOString();
+
+// A small, hermetic CODEOWNERS fixture exercising the precedence rules we rely
+// on: a broad directory owner, a more specific nested owner that must win, and
+// an extension rule that must win over both when it appears later in the file.
+const CODEOWNERS_FIXTURE = [
+  'src/core @elastic/kibana-core',
+  'x-pack/plugins/security_solution @elastic/security-solution',
+  'x-pack/plugins/security_solution/public/integrations @elastic/cloud-services',
+  '*.md @elastic/docs-team',
+].join('\n');
+
+test('daysBetween counts whole calendar days', () => {
+  assert.equal(reminder.daysBetween('2026-08-14T12:00:00Z', NOW), 4);
+  assert.equal(reminder.daysBetween('2026-08-14T13:00:00Z', NOW), 3);
+  assert.equal(reminder.daysBetween('2026-08-18T00:00:00Z', NOW), 0);
+});
+
+test('laterOf returns the more recent timestamp, tolerating null', () => {
+  assert.equal(reminder.laterOf(null, '2026-01-01'), '2026-01-01');
+  assert.equal(reminder.laterOf('2026-01-01', null), '2026-01-01');
+  assert.equal(reminder.laterOf('2026-01-02', '2026-01-01'), '2026-01-02');
+  assert.equal(reminder.laterOf('2026-01-01', '2026-01-03'), '2026-01-03');
+});
+
+test('resolveOwners applies last-matching-entry-wins precedence', () => {
+  const entries = reminder.buildCodeownersEntries(CODEOWNERS_FIXTURE);
+
+  assert.deepEqual(reminder.resolveOwners(entries, ['src/core/server/index.ts']), [
+    '@elastic/kibana-core',
+  ]);
+  // Broad security_solution owner...
+  assert.deepEqual(
+    reminder.resolveOwners(entries, ['x-pack/plugins/security_solution/public/app.tsx']),
+    ['@elastic/security-solution']
+  );
+  // ...overridden by the more specific nested integrations owner.
+  assert.deepEqual(
+    reminder.resolveOwners(entries, [
+      'x-pack/plugins/security_solution/public/integrations/cribl/form.test.tsx',
+    ]),
+    ['@elastic/cloud-services']
+  );
+  // Extension rule listed later wins over the directory rule.
+  assert.deepEqual(
+    reminder.resolveOwners(entries, ['x-pack/plugins/security_solution/README.md']),
+    ['@elastic/docs-team']
+  );
+});
+
+test('resolveOwners de-duplicates owners across multiple files', () => {
+  const entries = reminder.buildCodeownersEntries(CODEOWNERS_FIXTURE);
+  const owners = reminder.resolveOwners(entries, [
+    'src/core/a.ts',
+    'src/core/b.ts',
+    'x-pack/plugins/security_solution/public/app.tsx',
+  ]);
+  assert.deepEqual(owners, ['@elastic/kibana-core', '@elastic/security-solution']);
+});
+
+test('buildCommentBody mentions the owners and includes the marker', () => {
+  const body = reminder.buildCommentBody(['@elastic/kibana-core', '@elastic/docs-team']);
+  assert.match(body, /@elastic\/kibana-core @elastic\/docs-team/);
+  assert.ok(body.includes(reminder.REMINDER_MARKER));
+  assert.ok(body.includes('@copilot'));
+});
+
+test('buildCommentBody falls back to the QA team when no owners resolve', () => {
+  assert.match(reminder.buildCommentBody([]), /@elastic\/kibana-qa/);
+});
+
+// --- Full sweep integration against a mocked Octokit -----------------------
+
+function makeGithub(state) {
+  const paginate = (fn, params) => fn(params).then((r) => r.data);
+  return {
+    paginate,
+    rest: {
+      repos: { get: async () => ({ data: { default_branch: 'main' } }) },
+      issues: {
+        listForRepo: async () => ({ data: state.candidates }),
+        listEventsForTimeline: async ({ issue_number }) => ({
+          data: state.timeline[issue_number] || [],
+        }),
+        listComments: async ({ issue_number }) => ({ data: state.comments[issue_number] || [] }),
+        createComment: async (args) => {
+          state.posted.push(args);
+          return { data: {} };
+        },
+      },
+      pulls: {
+        get: async ({ pull_number }) => ({ data: state.prs[pull_number] }),
+        listReviews: async ({ pull_number }) => ({ data: state.reviews[pull_number] || [] }),
+        listFiles: async ({ pull_number }) => ({
+          data: (state.files[pull_number] || []).map((filename) => ({ filename })),
+        }),
+      },
+    },
+  };
+}
+
+function scenarioState() {
+  const flaky = [{ name: 'flaky-test-fixer' }];
+  const bot = { login: 'kibanamachine', type: 'Bot' };
+  const openPr = (number, overrides) => ({
+    number,
+    draft: false,
+    base: { ref: 'main' },
+    state: 'open',
+    user: bot,
+    created_at: iso('2026-08-01'),
+    labels: flaky,
+    ...overrides,
+  });
+
+  return {
+    posted: [],
+    candidates: [
+      { number: 1, pull_request: {} }, // due, never pinged
+      { number: 2, pull_request: {} }, // human review -> skip
+      { number: 3, pull_request: {} }, // draft -> skip
+      { number: 4, pull_request: {} }, // not yet due -> skip
+      { number: 5, pull_request: {} }, // last ping 4d ago -> re-ping
+      { number: 6, pull_request: {} }, // non-default base -> skip
+      { number: 7 }, // an issue, not a PR -> skip
+    ],
+    prs: {
+      1: openPr(1, { created_at: iso('2026-08-10') }),
+      2: openPr(2),
+      3: openPr(3, { draft: true }),
+      4: openPr(4, { created_at: iso('2026-08-16') }),
+      5: openPr(5),
+      6: openPr(6, { base: { ref: '8.19' } }),
+    },
+    reviews: {
+      // A bot COMMENTED review must NOT suppress reminders for #1.
+      1: [{ state: 'COMMENTED', user: { login: 'elastic-vault[bot]', type: 'Bot' } }],
+      2: [{ state: 'APPROVED', user: { login: 'dev', type: 'User' } }],
+    },
+    timeline: {
+      1: [{ event: 'ready_for_review', created_at: iso('2026-08-13') }],
+      4: [{ event: 'ready_for_review', created_at: iso('2026-08-16') }],
+      5: [{ event: 'ready_for_review', created_at: iso('2026-08-05') }],
+    },
+    comments: {
+      // #5 was already pinged by us 4 days ago -> due for a re-ping.
+      5: [
+        {
+          user: { login: 'github-actions[bot]' },
+          body: `...\n${reminder.REMINDER_MARKER}`,
+          created_at: iso('2026-08-14'),
+        },
+      ],
+    },
+    files: {
+      1: ['x-pack/plugins/security_solution/public/app.tsx'],
+      5: ['src/core/server/index.ts'],
+    },
+  };
+}
+
+function withFixtureAndNow(fn) {
+  const codeownersPath = path.join(os.tmpdir(), `codeowners-${process.pid}-${Math.random()}`);
+  fs.writeFileSync(codeownersPath, CODEOWNERS_FIXTURE);
+  const realNow = Date.now;
+  Date.now = () => NOW;
+  process.env.CODEOWNERS_PATH = codeownersPath;
+  return Promise.resolve(fn()).finally(() => {
+    Date.now = realNow;
+    delete process.env.CODEOWNERS_PATH;
+    fs.rmSync(codeownersPath, { force: true });
+  });
+}
+
+const context = { repo: { owner: 'elastic', repo: 'kibana' } };
+const silentCore = { info() {}, warning() {} };
+
+test('sweep pings only due, ready, unreviewed PRs and re-pings on cadence', async () => {
+  await withFixtureAndNow(async () => {
+    const state = scenarioState();
+    process.env.DRY_RUN = 'false';
+    await reminder(
+      { github: makeGithub(state), context, core: silentCore }
+    );
+
+    const posted = state.posted.map((c) => c.issue_number).sort((a, b) => a - b);
+    assert.deepEqual(posted, [1, 5]);
+
+    const first = state.posted.find((c) => c.issue_number === 1).body;
+    assert.match(first, /@elastic\/security-solution/);
+    const fifth = state.posted.find((c) => c.issue_number === 5).body;
+    assert.match(fifth, /@elastic\/kibana-core/);
+  });
+});
+
+test('dry run logs intentions without commenting', async () => {
+  await withFixtureAndNow(async () => {
+    const state = scenarioState();
+    const logs = [];
+    process.env.DRY_RUN = 'true';
+    await reminder({
+      github: makeGithub(state),
+      context,
+      core: { info: (m) => logs.push(m), warning() {} },
+    });
+
+    assert.equal(state.posted.length, 0);
+    assert.ok(logs.some((l) => l.includes('[dry run] would ping #1')));
+    assert.ok(logs.some((l) => l.includes('[dry run] would ping #5')));
+  });
+});
+
+test('a spoofed marker from a non-bot user does not suppress reminders', async () => {
+  await withFixtureAndNow(async () => {
+    const state = scenarioState();
+    // A human drops the marker text 1 day ago; it must be ignored so #1 still pings.
+    state.comments[1] = [
+      {
+        user: { login: 'random-dev' },
+        body: `looks fine ${reminder.REMINDER_MARKER}`,
+        created_at: iso('2026-08-17'),
+      },
+    ];
+    process.env.DRY_RUN = 'false';
+    await reminder({ github: makeGithub(state), context, core: silentCore });
+
+    assert.ok(state.posted.some((c) => c.issue_number === 1));
+  });
+});

--- a/.github/scripts/flaky_fix_review_reminder.test.js
+++ b/.github/scripts/flaky_fix_review_reminder.test.js
@@ -92,7 +92,7 @@ test('buildCommentBody mentions the owners and includes the marker', () => {
 });
 
 test('buildCommentBody falls back to the QA team when no owners resolve', () => {
-  assert.match(reminder.buildCommentBody([]), /@elastic\/kibana-qa/);
+  assert.match(reminder.buildCommentBody([]), /@elastic\/appex-qa/);
 });
 
 // --- Full sweep integration against a mocked Octokit -----------------------

--- a/.github/scripts/flaky_fix_review_reminder.test.js
+++ b/.github/scripts/flaky_fix_review_reminder.test.js
@@ -253,3 +253,20 @@ test('a spoofed marker from a non-bot user does not suppress reminders', async (
     assert.ok(state.posted.some((c) => c.issue_number === 1));
   });
 });
+
+test('pings per run are capped at MAX_PINGS_PER_RUN', async () => {
+  await withFixtureAndNow(async () => {
+    const state = scenarioState();
+    // Make a third PR due so the sweep would ping 3 without the cap.
+    state.candidates.push({ number: 8, pull_request: {} });
+    state.prs[8] = { ...state.prs[1], number: 8 };
+    state.reviews[8] = [];
+    state.timeline[8] = [{ event: 'ready_for_review', created_at: iso('2026-08-12') }];
+    state.files[8] = ['src/core/server/index.ts'];
+
+    process.env.DRY_RUN = 'false';
+    await reminder({ github: makeGithub(state), context, core: silentCore });
+
+    assert.equal(state.posted.length, 2);
+  });
+});

--- a/.github/scripts/flaky_fix_review_reminder.test.js
+++ b/.github/scripts/flaky_fix_review_reminder.test.js
@@ -7,13 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// Zero-framework tests for the flaky-fix review reminder sweep. These scripts
-// run via actions/github-script (plain CommonJS, outside the Jest project), so
-// they are tested with Node's built-in runner:
-//
+// These scripts run via actions/github-script outside the Jest project, so
+// they use Node's built-in runner:
 //   node --test .github/scripts/flaky_fix_review_reminder.test.js
-//
-// `ignore` is a repo devDependency, so it resolves after bootstrap.
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
@@ -26,9 +22,7 @@ const reminder = require('./flaky_fix_review_reminder');
 const NOW = new Date('2026-08-18T12:00:00Z').getTime();
 const iso = (d) => new Date(d).toISOString();
 
-// A small, hermetic CODEOWNERS fixture exercising the precedence rules we rely
-// on: a broad directory owner, a more specific nested owner that must win, and
-// an extension rule that must win over both when it appears later in the file.
+// Hermetic CODEOWNERS fixture covering the precedence rules we rely on.
 const CODEOWNERS_FIXTURE = [
   'src/core @elastic/kibana-core',
   'x-pack/plugins/security_solution @elastic/security-solution',

--- a/.github/scripts/flaky_fix_review_reminder.test.js
+++ b/.github/scripts/flaky_fix_review_reminder.test.js
@@ -251,16 +251,20 @@ test('a spoofed marker from a non-bot user does not suppress reminders', async (
 test('pings per run are capped at MAX_PINGS_PER_RUN', async () => {
   await withFixtureAndNow(async () => {
     const state = scenarioState();
-    // Make a third PR due so the sweep would ping 3 without the cap.
-    state.candidates.push({ number: 8, pull_request: {} });
-    state.prs[8] = { ...state.prs[1], number: 8 };
-    state.reviews[8] = [];
-    state.timeline[8] = [{ event: 'ready_for_review', created_at: iso('2026-08-12') }];
-    state.files[8] = ['src/core/server/index.ts'];
+    // Add enough due PRs to exceed the cap by one.
+    const extra = reminder.MAX_PINGS_PER_RUN + 1 - 2; // #1 and #5 are already due
+    for (let i = 0; i < extra; i++) {
+      const number = 100 + i;
+      state.candidates.push({ number, pull_request: {} });
+      state.prs[number] = { ...state.prs[1], number };
+      state.reviews[number] = [];
+      state.timeline[number] = [{ event: 'ready_for_review', created_at: iso('2026-08-12') }];
+      state.files[number] = ['src/core/server/index.ts'];
+    }
 
     process.env.DRY_RUN = 'false';
     await reminder({ github: makeGithub(state), context, core: silentCore });
 
-    assert.equal(state.posted.length, 2);
+    assert.equal(state.posted.length, reminder.MAX_PINGS_PER_RUN);
   });
 });

--- a/.github/scripts/flaky_fix_review_reminder.test.js
+++ b/.github/scripts/flaky_fix_review_reminder.test.js
@@ -85,8 +85,17 @@ test('buildCommentBody mentions the owners and includes the marker', () => {
   assert.ok(body.includes('@copilot'));
 });
 
-test('buildCommentBody falls back to the QA team when no owners resolve', () => {
-  assert.match(reminder.buildCommentBody([]), /@elastic\/appex-qa/);
+test('a PR whose files resolve no codeowners is not pinged', async () => {
+  await withFixtureAndNow(async () => {
+    const state = scenarioState();
+    state.files[1] = ['totally/unowned/path.xyz'];
+    process.env.DRY_RUN = 'false';
+    await reminder({ github: makeGithub(state), context, core: silentCore });
+
+    assert.ok(!state.posted.some((c) => c.issue_number === 1));
+    // Other due PRs are unaffected.
+    assert.ok(state.posted.some((c) => c.issue_number === 5));
+  });
 });
 
 // --- Full sweep integration against a mocked Octokit -----------------------

--- a/.github/workflows/flaky-fix-review-reminder.yml
+++ b/.github/workflows/flaky-fix-review-reminder.yml
@@ -1,15 +1,19 @@
 name: Flaky fix review reminder
 
-# Daily sweep that pings the codeowners of the changed files when a
-# `flaky-test-fixer` PR has been ready for review for 4 days (weekends
-# included) without a review. These PRs are opened by kibanamachine with no
-# human author behind them, so without a nudge they often sit unreviewed.
+# Daily sweep over open pull requests that carry the `flaky-test-fixer` label
+# (draft PRs opened against main by kibanamachine via the flaky-test-fixer
+# agentic workflow, then marked ready for review by a developer). When such a
+# PR has been ready for 4 days (weekends included) without a human review, this
+# pings the codeowners of the changed files in a comment.
 #
-# The reminder re-pings on the same 4-day cadence until a review is submitted.
-# Draft PRs are skipped until they are marked ready for review.
+# Although the sweep runs daily, it does not ping daily: each reminder embeds a
+# hidden marker comment, and a PR is only pinged again once 4 days have passed
+# since the later of (ready for review, our last reminder). A submitted human
+# review stops the reminders entirely; drafts are skipped until marked ready.
 
 on:
   schedule:
+    # daily at 07:00 UTC (early morning CET, before the EU workday)
     - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
@@ -24,7 +28,7 @@ permissions:
 
 jobs:
   remind:
-    name: Ping codeowners on unreviewed flaky-fix PRs
+    name: Ping codeowners of PRs labeled flaky-test-fixer with no review for 4+ days
     runs-on: ubuntu-latest
     if: github.repository == 'elastic/kibana'
     concurrency:
@@ -43,7 +47,9 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run == true }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # No github-token needed: github-script defaults to the workflow's
+          # own GITHUB_TOKEN, whose `pull-requests: write` permission is enough
+          # to comment. Reminder comments are authored by github-actions[bot].
           script: |
             const flakyFixReviewReminder = require('./.github/scripts/flaky_fix_review_reminder');
             await flakyFixReviewReminder({ github, context, core });

--- a/.github/workflows/flaky-fix-review-reminder.yml
+++ b/.github/workflows/flaky-fix-review-reminder.yml
@@ -38,7 +38,7 @@ jobs:
             .github/scripts/flaky_fix_review_reminder.js
           sparse-checkout-cone-mode: false
       - name: Install matcher dependency
-        run: npm install --no-save --no-package-lock ignore@5.3.2
+        run: npm install --no-save --no-package-lock ignore@7.0.5
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           DRY_RUN: ${{ inputs.dry_run == true }}

--- a/.github/workflows/flaky-fix-review-reminder.yml
+++ b/.github/workflows/flaky-fix-review-reminder.yml
@@ -1,0 +1,49 @@
+name: Flaky fix review reminder
+
+# Daily sweep that pings the codeowners of the changed files when a
+# `flaky-test-fixer` PR has been ready for review for 4 days (weekends
+# included) without a review. These PRs are opened by kibanamachine with no
+# human author behind them, so without a nudge they often sit unreviewed.
+#
+# The reminder re-pings on the same 4-day cadence until a review is submitted.
+# Draft PRs are skipped until they are marked ready for review.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log what would be pinged instead of commenting'
+        type: boolean
+        default: false
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  remind:
+    name: Ping codeowners on unreviewed flaky-fix PRs
+    runs-on: ubuntu-latest
+    if: github.repository == 'elastic/kibana'
+    concurrency:
+      group: flaky-fix-review-reminder
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/CODEOWNERS
+            .github/scripts/flaky_fix_review_reminder.js
+          sparse-checkout-cone-mode: false
+      - name: Install matcher dependency
+        run: npm install --no-save --no-package-lock ignore@5.3.2
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DRY_RUN: ${{ inputs.dry_run == true }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const flakyFixReviewReminder = require('./.github/scripts/flaky_fix_review_reminder');
+            await flakyFixReviewReminder({ github, context, core });

--- a/.github/workflows/flaky-fix-review-reminder.yml
+++ b/.github/workflows/flaky-fix-review-reminder.yml
@@ -1,19 +1,15 @@
 name: Flaky fix review reminder
 
-# Daily sweep over open pull requests that carry the `flaky-test-fixer` label
-# (draft PRs opened against main by kibanamachine via the flaky-test-fixer
-# agentic workflow, then marked ready for review by a developer). When such a
-# PR has been ready for 4 days (weekends included) without a human review, this
-# pings the codeowners of the changed files in a comment.
-#
-# Although the sweep runs daily, it does not ping daily: each reminder embeds a
-# hidden marker comment, and a PR is only pinged again once 4 days have passed
-# since the later of (ready for review, our last reminder). A submitted human
-# review stops the reminders entirely; drafts are skipped until marked ready.
+# Daily sweep over open PRs labeled `flaky-test-fixer` (opened against main by
+# kibanamachine, later marked ready for review). Once such a PR has had no human
+# review for 4 days (weekends included), this pings the codeowners of the
+# changed files. Despite the daily schedule it never pings daily: reminders
+# embed a hidden marker, and a PR is only re-pinged 4+ days after the last one.
+# A submitted human review stops the reminders; drafts are skipped.
 
 on:
   schedule:
-    # daily at 07:00 UTC (early morning CET, before the EU workday)
+    # daily at 07:00 UTC
     - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
@@ -47,9 +43,7 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run == true }}
         with:
-          # No github-token needed: github-script defaults to the workflow's
-          # own GITHUB_TOKEN, whose `pull-requests: write` permission is enough
-          # to comment. Reminder comments are authored by github-actions[bot].
+          # github-script defaults to GITHUB_TOKEN; pull-requests: write suffices.
           script: |
             const flakyFixReviewReminder = require('./.github/scripts/flaky_fix_review_reminder');
             await flakyFixReviewReminder({ github, context, core });


### PR DESCRIPTION
This PR encourages teams to review open flaky test fix PRs by pinging codeowners with a reminder comment. 

* Posts a reminder comment every 4 calendar days on `flaky-test-fixer` open PRs only.
* Sample message:

> Hey @team 👋 this flaky test fix has been open for a while and needs an owner decision.
>
> **Hints:**
>
> - ✅ Review and merge if it looks good
> - ✏️ Need to make changes to or resolve merge conflicts? Ask `@copilot`
> - ❌ Not worth shipping? Just close it (drop a comment to help our workflow improve)
>
> Questions? Find the Applications DX team in #kibana-qa.