### PR TITLE
[Index Management] Fix issue with primaryMetricTotal in actions 

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/test/scout/api/tests/indices/indices_actions.spec.ts
+++ b/x-pack/platform/plugins/shared/index_management/test/scout/api/tests/indices/indices_actions.spec.ts
@@ -20,6 +20,12 @@ const indexStatus = async (esClient: EsClient) => {
   return index.status;
 };
 
+// `total` sums primaries and replicas, so one action bumps it once per assigned replica.
+const primaryMetricTotal = async (esClient: EsClient, metric: 'flush' | 'refresh') => {
+  const { indices } = await esClient.indices.stats({ index: INDEX_NAME, metric });
+  return indices?.[INDEX_NAME].primaries?.[metric]?.total ?? 0;
+};
+
 // Closing, opening, flushing, refreshing, force merging and clearing the cache are not exposed in Serverless.
 apiTest.describe('Indices actions API', { tag: tags.stateful.classic }, () => {
   let credentials: RoleApiCredentials;
@@ -62,27 +68,19 @@ apiTest.describe('Indices actions API', { tag: tags.stateful.classic }, () => {
   });
 
   apiTest('flushes an index', async ({ apiClient, esClient }) => {
-    const flushCount = async () => {
-      const { indices } = await esClient.indices.stats({ index: INDEX_NAME, metric: 'flush' });
-      return indices?.[INDEX_NAME].total?.flush?.total;
-    };
-    expect(await flushCount()).toBe(0);
+    expect(await primaryMetricTotal(esClient, 'flush')).toBe(0);
 
     expect(await executeAction(apiClient, 'flush')).toHaveStatusCode(200);
 
-    expect(await flushCount()).toBe(1);
+    expect(await primaryMetricTotal(esClient, 'flush')).toBe(1);
   });
 
   apiTest('refreshes an index', async ({ apiClient, esClient }) => {
-    const refreshCount = async () => {
-      const { indices } = await esClient.indices.stats({ index: INDEX_NAME, metric: 'refresh' });
-      return indices?.[INDEX_NAME].total?.refresh?.total ?? 0;
-    };
-    const before = await refreshCount();
+    const before = await primaryMetricTotal(esClient, 'refresh');
 
     expect(await executeAction(apiClient, 'refresh')).toHaveStatusCode(200);
 
-    expect(await refreshCount()).toBe(before + 1);
+    expect(await primaryMetricTotal(esClient, 'refresh')).toBe(before + 1);
   });
 
   apiTest('force merges an index', async ({ apiClient }) => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/285168
Closes https://github.com/elastic/kibana/issues/285169

## Summary

The Scout tests `flushes an index` and `refreshes an index` failed on `cloud-stateful-classic` with **Expected**: `1` / **Received**: `2` for flush and **Expected**: `9` / **Received**: `10` for refresh.

Both read their counters from `indices[index].total`, which aggregates every shard copy. The test index uses the cluster defaults (1 primary, 1 replica), so on a single-node local cluster the unassigned replica leaves the counter moving by 1, while on a multi-node deployment like ECH the assigned replica makes the same single action move it by 2.

The counters now come from `indices[index].primaries`, which only accounts for primary shards and is therefore independent of node count and replica allocation. Both tests share one `primaryMetricTotal` helper. No product code changed and the assertions stay exact: `0 → 1` for flush, `before + 1` for refresh.

### Test plan

Automated: no new tests, only the two assertions corrected in `indices_actions.spec.ts`. All 7 tests in the suite pass locally:

```bash
node scripts/scout run-tests --arch stateful --domain classic \
  --testFiles x-pack/platform/plugins/shared/index_management/test/scout/api/tests/indices/indices_actions.spec.ts
```

Manual: verified on a local two-node cluster, where the replica is assigned as it is on ECH. Note that the PR's Scout lane and the flaky test runner cannot catch this, since both run single-node targets where `primaries` and `total` are identical.

### Evidence

Two-node cluster, replica assigned:

| action | `primaries` (used now) | `total` (used before) |
|---|---|---|
| one `_flush` | 0 → 1 | 0 → 2 |
| one `_refresh` | 5 → 6 | 8 → 10 |

The `total` column reproduces both CI failures exactly; the `primaries` column matches the new assertions on one and on two nodes.