### PR TITLE
[embeddable] remove unused property hideInspector from PresentationPanel

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
@@ -296,10 +296,6 @@ export type LensComponentProps = Simplify<
        */
       disabledActions?: string[];
       /**
-       * Toggles the inspector
-       */
-      showInspector?: boolean;
-      /**
        * Toggle inline editing feature
        */
       canEditInline?: boolean;

--- a/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/types.ts
+++ b/src/platform/plugins/shared/embeddable/public/react_embeddable_system/panel_component/types.ts
@@ -44,7 +44,6 @@ export interface PresentationPanelProps<
    */
   hideLoader?: boolean;
   hideHeader?: boolean;
-  hideInspector?: boolean;
 
   // TODO remove these in favour of a more generic action management system
   actionPredicate?: (actionId: string) => boolean;

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_custom_renderer_component.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_custom_renderer_component.tsx
@@ -42,7 +42,6 @@ type PanelProps = Pick<
   | 'showBadges'
   | 'hideLoader'
   | 'hideHeader'
-  | 'hideInspector'
   | 'getActions'
   | 'titleHighlight'
 >;
@@ -57,7 +56,6 @@ export function LensRenderer({
   description,
   withDefaultActions,
   extraActions,
-  showInspector,
   syncColors,
   syncCursor,
   syncTooltips,
@@ -152,7 +150,6 @@ export function LensRenderer({
 
   const panelProps: PanelProps = useMemo(() => {
     return {
-      hideInspector: !showInspector,
       showShadow: false,
       showBadges: false,
       titleHighlight,
@@ -164,7 +161,7 @@ export function LensRenderer({
         return (extraActions ?? []).concat(actions || []);
       },
     };
-  }, [showInspector, withDefaultActions, extraActions, lensApi, titleHighlight]);
+  }, [withDefaultActions, extraActions, lensApi, titleHighlight]);
 
   return (
     <EmbeddableRenderer<LensWireAPIConfig, LensApi>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
@@ -261,7 +261,6 @@ const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
             onLoad={setInspectData}
             overrides={overrides}
             searchSessionId={searchSessionId}
-            showInspector={false}
             style={lensComponentStyle}
             css={{ minWidth: '100px' }}
             syncCursor={false}


### PR DESCRIPTION
`hideInspector` has no effect on `PresentationPanel`. Removing to avoid confusion and clean up props 