### PR TITLE
[Alerting V2] Split rule-management skill concepts into granular references

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -15370,11 +15370,11 @@ paths:
           required: false
           schema:
             anyOf:
-              - description: Default. Tracks each problem as an alert episode across state changes — lifecycle, recovery detection, and notification dispatch via workflows. Use when the user wants to be notified, needs lifecycle tracking, or wants recovery detection.
+              - description: Default. Tracks each problem as an alert episode and its lifecycle, link it to workflows to notify your team. Use when the user wants to detect and respond.
                 enum:
                   - alert
                 type: string
-              - description: Records each match as a queryable event with no alerts, lifecycle tracking, or notifications — just data. Use for logging or detection without automated action.
+              - description: Matches are stored as queryable events. No alerts, no notifications - just data. Use when the user wants to collect evidence.
                 enum:
                   - signal
                 type: string
@@ -82815,11 +82815,11 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_alerting_rule_grouping'
         kind:
           anyOf:
-            - description: Default. Tracks each problem as an alert episode across state changes — lifecycle, recovery detection, and notification dispatch via workflows. Use when the user wants to be notified, needs lifecycle tracking, or wants recovery detection.
+            - description: Default. Tracks each problem as an alert episode and its lifecycle, link it to workflows to notify your team. Use when the user wants to detect and respond.
               enum:
                 - alert
               type: string
-            - description: Records each match as a queryable event with no alerts, lifecycle tracking, or notifications — just data. Use for logging or detection without automated action.
+            - description: Matches are stored as queryable events. No alerts, no notifications - just data. Use when the user wants to collect evidence.
               enum:
                 - signal
               type: string
@@ -83312,11 +83312,11 @@ components:
           type: string
         kind:
           anyOf:
-            - description: Default. Tracks each problem as an alert episode across state changes — lifecycle, recovery detection, and notification dispatch via workflows. Use when the user wants to be notified, needs lifecycle tracking, or wants recovery detection.
+            - description: Default. Tracks each problem as an alert episode and its lifecycle, link it to workflows to notify your team. Use when the user wants to detect and respond.
               enum:
                 - alert
               type: string
-            - description: Records each match as a queryable event with no alerts, lifecycle tracking, or notifications — just data. Use for logging or detection without automated action.
+            - description: Matches are stored as queryable events. No alerts, no notifications - just data. Use when the user wants to collect evidence.
               enum:
                 - signal
               type: string

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -15807,11 +15807,11 @@ paths:
           required: false
           schema:
             anyOf:
-              - description: Default. Tracks each problem as an alert episode across state changes — lifecycle, recovery detection, and notification dispatch via workflows. Use when the user wants to be notified, needs lifecycle tracking, or wants recovery detection.
+              - description: Default. Tracks each problem as an alert episode and its lifecycle, link it to workflows to notify your team. Use when the user wants to detect and respond.
                 enum:
                   - alert
                 type: string
-              - description: Records each match as a queryable event with no alerts, lifecycle tracking, or notifications — just data. Use for logging or detection without automated action.
+              - description: Matches are stored as queryable events. No alerts, no notifications - just data. Use when the user wants to collect evidence.
                 enum:
                   - signal
                 type: string
@@ -96285,11 +96285,11 @@ components:
           $ref: '#/components/schemas/Kibana_HTTP_APIs_alerting_rule_grouping'
         kind:
           anyOf:
-            - description: Default. Tracks each problem as an alert episode across state changes — lifecycle, recovery detection, and notification dispatch via workflows. Use when the user wants to be notified, needs lifecycle tracking, or wants recovery detection.
+            - description: Default. Tracks each problem as an alert episode and its lifecycle, link it to workflows to notify your team. Use when the user wants to detect and respond.
               enum:
                 - alert
               type: string
-            - description: Records each match as a queryable event with no alerts, lifecycle tracking, or notifications — just data. Use for logging or detection without automated action.
+            - description: Matches are stored as queryable events. No alerts, no notifications - just data. Use when the user wants to collect evidence.
               enum:
                 - signal
               type: string
@@ -96782,11 +96782,11 @@ components:
           type: string
         kind:
           anyOf:
-            - description: Default. Tracks each problem as an alert episode across state changes — lifecycle, recovery detection, and notification dispatch via workflows. Use when the user wants to be notified, needs lifecycle tracking, or wants recovery detection.
+            - description: Default. Tracks each problem as an alert episode and its lifecycle, link it to workflows to notify your team. Use when the user wants to detect and respond.
               enum:
                 - alert
               type: string
-            - description: Records each match as a queryable event with no alerts, lifecycle tracking, or notifications — just data. Use for logging or detection without automated action.
+            - description: Matches are stored as queryable events. No alerts, no notifications - just data. Use when the user wants to collect evidence.
               enum:
                 - signal
               type: string

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -46,12 +46,12 @@ export const ruleKindSchema = z
     z
       .literal('alert')
       .describe(
-        'Default. Tracks each problem as an alert episode across state changes — lifecycle, recovery detection, and notification dispatch via workflows. Use when the user wants to be notified, needs lifecycle tracking, or wants recovery detection.'
+        'Default. Tracks each problem as an alert episode and its lifecycle, link it to workflows to notify your team. Use when the user wants to detect and respond.'
       ),
     z
       .literal('signal')
       .describe(
-        'Records each match as a queryable event with no alerts, lifecycle tracking, or notifications — just data. Use for logging or detection without automated action.'
+        'Matches are stored as queryable events. No alerts, no notifications - just data. Use when the user wants to collect evidence.'
       ),
   ])
   .describe('The kind of the rule.');

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_template_schema.test.ts
@@ -422,12 +422,12 @@ describe('rule template create-rule schema coupling', () => {
               "anyOf": Array [
                 Object {
                   "const": "alert",
-                  "description": "Default. Tracks each problem as an alert episode across state changes — lifecycle, recovery detection, and notification dispatch via workflows. Use when the user wants to be notified, needs lifecycle tracking, or wants recovery detection.",
+                  "description": "Default. Tracks each problem as an alert episode and its lifecycle, link it to workflows to notify your team. Use when the user wants to detect and respond.",
                   "type": "string",
                 },
                 Object {
                   "const": "signal",
-                  "description": "Records each match as a queryable event with no alerts, lifecycle tracking, or notifications — just data. Use for logging or detection without automated action.",
+                  "description": "Matches are stored as queryable events. No alerts, no notifications - just data. Use when the user wants to collect evidence.",
                   "type": "string",
                 },
               ],

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
@@ -164,8 +164,10 @@ Action policies only process Alerts (\`kind: alert\`). Events (\`kind: signal\`)
 
 When a user asks for notifications on a rule that is currently \`kind: signal\` (or when composing a new rule where the user wants notifications):
 
-1. Use \`set_kind\` to change it to \`alert\`, then load the \`action-policy-management\` skill for notification setup.
-2. After ensuring the rule is \`kind: alert\`, load the \`action-policy-management\` skill for notification setup."
+1. **Explain the difference**: Events (\`kind: signal\`) rules are observation-only and do not trigger notifications. Alerts (\`kind: alert\`) track episode lifecycle and can dispatch to action policies.
+2. If the rule is a **draft (in-memory)**: use \`set_kind\` to change it to \`alert\`, then load the \`action-policy-management\` skill for notification setup.
+3. If the rule is **persisted**: \`kind\` is immutable after creation. Inform the user that the existing Events (\`kind: signal\`) rule cannot be converted. Offer to create a new Alerts (\`kind: alert\`) rule with the same query and schedule, then set up notifications on the new rule.
+4. After ensuring the rule is \`kind: alert\`, load the \`action-policy-management\` skill for notification setup."
 `;
 
 exports[`schema_to_skill_docs generateRecoveryStrategyDoc matches the reviewed skill-doc snapshot 1`] = `

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/__snapshots__/schema_to_skill_docs.test.ts.snap
@@ -112,7 +112,7 @@ Rule names: \`{{ inputs.payload.rules[ep.rule_id].name }}\`.
 `;
 
 exports[`schema_to_skill_docs generateEpisodeLifecycleDoc matches the reviewed skill-doc snapshot 1`] = `
-"## Episode Lifecycle
+"# Episode Lifecycle
 
 Episodes are the unit of alert state. Each unique group (by \`group_hash\`) has its own episode. Each episode has a status that reflects where it is in the lifecycle:
 
@@ -134,7 +134,7 @@ exports[`schema_to_skill_docs generateGroupingModesDoc matches the reviewed skil
 `;
 
 exports[`schema_to_skill_docs generateNoDataStrategyDoc matches the reviewed skill-doc snapshot 1`] = `
-"## No-Data Strategy
+"# No-Data Strategy
 
 \`no_data_strategy\` is a **top-level rule field** that controls behaviour when no data is present.
 
@@ -148,14 +148,30 @@ exports[`schema_to_skill_docs generateNoDataStrategyDoc matches the reviewed ski
 When setting \`no_data_strategy\` to anything other than \`'none'\`, add a \`no_data\` block to the standalone query:
 \`no_data: { query: 'FROM heartbeat-* | STATS count = COUNT(*) BY host.name | WHERE count >= 1' }\`. For composed query format, the \`base\` query is used as the data query.
 
-Signal rules cannot set \`no_data_strategy\`.
-Refer to the [rule-schema reference](./references/rule-schema.md) for allowed values and constraints."
+Signal rules cannot set \`no_data_strategy\` ([rule-kind reference](./rule-kind.md))."
+`;
+
+exports[`schema_to_skill_docs generateNotificationsOverviewDoc matches the reviewed skill-doc snapshot 1`] = `
+"# Notifications via Action Policies
+
+Notifications are not configured on the rule itself. Alert episodes are matched and dispatched by **action policies** — space-scoped saved objects that send matched episodes to workflow destinations.
+
+When the user needs notifications (email, Slack, PagerDuty, etc.), load the \`action-policy-management\` skill. That skill owns action policy CRUD, workflow destination wiring, and the default notification setup flow.
+
+## Notifications Require Alert Kind
+
+Action policies only process Alerts (\`kind: alert\`). Events (\`kind: signal\`) do not participate in episode lifecycle or notification dispatch. See the [rule-kind reference](./rule-kind.md) and [episode-lifecycle reference](./episode-lifecycle.md).
+
+When a user asks for notifications on a rule that is currently \`kind: signal\` (or when composing a new rule where the user wants notifications):
+
+1. Use \`set_kind\` to change it to \`alert\`, then load the \`action-policy-management\` skill for notification setup.
+2. After ensuring the rule is \`kind: alert\`, load the \`action-policy-management\` skill for notification setup."
 `;
 
 exports[`schema_to_skill_docs generateRecoveryStrategyDoc matches the reviewed skill-doc snapshot 1`] = `
-"## Recovery Strategy
+"# Recovery Strategy
 
-\`recovery_strategy\` is a **top-level rule field** (not inside the query). It controls how episodes transition from active to recovering/inactive. Signal rules (\`kind: signal\`) cannot set \`recovery_strategy\`.
+\`recovery_strategy\` is a **top-level rule field** (not inside the query). It controls how episodes transition from active to recovering/inactive (see [episode-lifecycle reference](./episode-lifecycle.md)). Signal rules (\`kind: signal\`) cannot set \`recovery_strategy\` ([rule-kind reference](./rule-kind.md)).
 
 - \`no_breach\`: recovers groups that stop breaching (default).
 - \`query\`: uses a custom recovery query to detect recovery.
@@ -163,25 +179,23 @@ exports[`schema_to_skill_docs generateRecoveryStrategyDoc matches the reviewed s
 
 When using \`recovery_strategy: 'query'\`, add a \`set_query\` operation that includes a \`recovery\` block alongside \`breach\`:
 - **Composed**: \`recovery: { segment: 'WHERE cpu < 0.5' }\`
-- **Standalone**: \`recovery: { query: 'FROM metrics-* | WHERE cpu < 0.5' }\`
-
-Refer to the [rule-schema reference](./references/rule-schema.md) for allowed values and constraints."
+- **Standalone**: \`recovery: { query: 'FROM metrics-* | WHERE cpu < 0.5' }\`"
 `;
 
 exports[`schema_to_skill_docs generateRuleKindDoc matches the reviewed skill-doc snapshot 1`] = `
-"## Rule Kind: Alert vs Signal
+"# Rule Kind: Alerts vs Events
 
-Rules declare a \`kind\` of \`alert\` or \`signal\`. This is the most important behavioral split in the system.
+Rules declare a \`kind\` of \`alert\` (Alerts) or \`signal\` (Events). This is the most important behavioral split in the system.
 
-### Alert (\`kind: alert\`)
-Default. Tracks each problem as an alert episode across state changes — lifecycle, recovery detection, and notification dispatch via workflows. Use when the user wants to be notified, needs lifecycle tracking, or wants recovery detection.
+### Alerts (\`kind: alert\`)
+Default. Tracks each problem as an alert episode and its lifecycle, link it to workflows to notify your team. Use when the user wants to detect and respond.
 Episode statuses: \`inactive\`, \`pending\`, \`active\`, \`recovering\`.
 State transition fields: \`pending_count\`, \`pending_timeframe\`, \`recovering_count\`, \`recovering_timeframe\`.
 
-### Signal (\`kind: signal\`)
-Records each match as a queryable event with no alerts, lifecycle tracking, or notifications — just data. Use for logging or detection without automated action.
+### Events (\`kind: signal\`)
+Matches are stored as queryable events. No alerts, no notifications - just data. Use when the user wants to collect evidence.
 
-### Immutability
+## Immutability
 \`kind\` is **immutable on persisted rules** — it can only be set at creation time. The update API rejects changes to \`kind\`. For draft (in-memory) rules, \`set_kind\` can change it freely."
 `;
 
@@ -304,7 +318,7 @@ Standalone queries: independent full queries for breach, recovery, and no_data.
 `;
 
 exports[`schema_to_skill_docs generateSeverityDoc matches the reviewed skill-doc snapshot 1`] = `
-"## Alert Event Severity
+"# Alert Event Severity
 
 Severity is a per-event property on alert events and episodes, not a rule-level field. It is extracted at execution time from a column named \`severity\` in the ES|QL breach query output.
 
@@ -321,19 +335,6 @@ Severity is set by adding a \`severity\` column to the breach query via \`EVAL\`
   \`| EVAL severity = \\"critical\\"\`
 - **Conditional severity** — severity varies per group based on data:
   \`| EVAL severity = CASE(cpu > 0.95, \\"critical\\", cpu > 0.8, \\"high\\", \\"medium\\")\`"
-`;
-
-exports[`schema_to_skill_docs generateStateTransitionDoc matches the reviewed skill-doc snapshot 1`] = `
-"## State Transition
-
-Use \`set_state_transition\` to delay alert firing until the threshold is breached N times in a row. This reduces noise from transient spikes.
-
-- \`pending_count\` — Consecutive breaches before transitioning to active.
-- \`pending_timeframe\` — Time window for pending evaluation, e.g. 5m, 15m.
-- \`recovering_count\` — Consecutive recoveries before transitioning to inactive.
-- \`recovering_timeframe\` — Time window for recovering evaluation, e.g. 5m, 15m.
-
-State transition is only allowed on \`kind: alert\` rules. Refer to the [rule-operations-schema reference](./references/rule-operations-schema.md) for the full field schema."
 `;
 
 exports[`schema_to_skill_docs generateThrottleGroupingCompatibilityDoc matches the reviewed skill-doc snapshot 1`] = `

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -11,19 +11,17 @@ import {
   ALERTING_TOOL_IDS,
   ALERTING_V2_ENABLED_SETTING_ID,
   RULE_MANAGEMENT_SKILL_ID,
-  RULE_KIND_LABELS,
 } from '@kbn/alerting-v2-constants';
 import type { ManageRuleToolDeps } from '../tools/manage_rule';
 import { manageRuleTool } from '../tools/manage_rule';
 import {
-  generateRuleSchemaDoc,
   generateRuleOperationsDoc,
   generateRuleKindDoc,
   generateEpisodeLifecycleDoc,
   generateSeverityDoc,
-  generateStateTransitionDoc,
   generateRecoveryStrategyDoc,
   generateNoDataStrategyDoc,
+  generateNotificationsOverviewDoc,
 } from './schema_to_skill_docs';
 
 export const createRuleManagementSkill = (deps: ManageRuleToolDeps) =>
@@ -37,61 +35,50 @@ export const createRuleManagementSkill = (deps: ManageRuleToolDeps) =>
     uiSettingRequired: ALERTING_V2_ENABLED_SETTING_ID,
     referencedContent: [
       {
-        name: 'concepts',
+        name: 'rule-kind',
         relativePath: './references',
-        content: `# Alerting V2 Concepts
-
-${generateRuleKindDoc()}
-
----
-
-${generateEpisodeLifecycleDoc()}
-
----
-
-## Notifications via Action Policies
-
-Notifications are not configured on the rule itself. Alert episodes are matched and dispatched by **action policies** (notification policies) — space-scoped saved objects that send matched episodes to workflow destinations.
-
-When the user needs notifications (email, Slack, PagerDuty, etc.), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill. That skill owns action policy CRUD, workflow destination wiring, and the default notification setup flow.
-
----
-
-${generateSeverityDoc()}`,
+        content: generateRuleKindDoc(),
       },
       {
-        name: 'rule-schema',
+        name: 'episode-lifecycle',
         relativePath: './references',
-        content: generateRuleSchemaDoc(),
+        content: generateEpisodeLifecycleDoc(),
       },
       {
-        name: 'rule-operations-schema',
+        name: 'alert-event-severity',
         relativePath: './references',
-        content: generateRuleOperationsDoc(),
+        content: generateSeverityDoc(),
+      },
+      {
+        name: 'recovery-strategy',
+        relativePath: './references',
+        content: generateRecoveryStrategyDoc(),
+      },
+      {
+        name: 'no-data-strategy',
+        relativePath: './references',
+        content: generateNoDataStrategyDoc(),
+      },
+      {
+        name: 'notifications-overview',
+        relativePath: './references',
+        content: generateNotificationsOverviewDoc(),
       },
     ],
-    content: `## Domain Knowledge
-
-For questions about alerting concepts — rule kinds (alert vs signal), episode lifecycle, or how notifications relate to rules — consult the [concepts reference](./references/concepts.md).
-
----
-
-## When to Use This Skill
+    content: `## When to Use This Skill
 
 Use this skill when:
-- A user asks to find, list, inspect, or modify existing alerting V2 rules.
+- A user asks to find, list, inspect, or modify existing alerting rules.
 - A user asks to create a new alerting rule from natural language requirements.
 - A user asks to change a rule's query, schedule, thresholds, or metadata.
 
 Do **not** use this skill for:
-- Creating, inspecting, or modifying action policies (notification policies) — load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill instead.
+- Creating, inspecting, or modifying action policies — load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill instead.
 - Classic (V1) stack, Observability or Security detection rules.
 - Action connector configuration (connectors are managed separately).
 - Querying or analyzing data — use data exploration skills for that.
 
 ---
-
-# Part 1: Rules
 
 ## Rule Discovery
 
@@ -115,6 +102,10 @@ For a new rule, start with \`set_metadata\` (name required), then \`set_kind\`, 
 
 For an existing rule, pass the \`ruleAttachmentId\` and only include the operations needed for the changes requested.
 
+See the [rule-kind reference](./references/rule-kind.md) when choosing between \`alert\` and \`signal\`.
+
+${generateRuleOperationsDoc()}
+
 ## ES|QL Query Guidance
 
 - Every \`set_query\` call **must** include \`format: "composed"\` or \`format: "standalone"\`. Omitting \`format\` will fail validation.
@@ -133,16 +124,6 @@ For an existing rule, pass the \`ruleAttachmentId\` and only include the operati
   with the Elasticsearch error message. Inspect the error, fix the query, and retry.
 - If grouping fields are set after a query, they are validated against the query's
   output columns. Use fields that appear in the query results.
-
-${generateStateTransitionDoc()}
-
-## Severity
-
-When the user specifies a severity (e.g. "make this a critical alert"), add an \`EVAL severity = "..."\` pipe to the breach query or segment via \`set_query\`. Refer to the [concepts reference](./references/concepts.md) for valid values, the extraction model, and literal vs conditional patterns.
-
-${generateRecoveryStrategyDoc()}
-
-${generateNoDataStrategyDoc()}
 
 ## Final Validation
 
@@ -182,31 +163,36 @@ where \`attachmentId\` is \`ruleAttachment.id\` and \`version\` is \`version\` f
 
 ---
 
-## Notifications Require Alert Kind
-
-Action policies only process alert episodes. Signal rules (\`kind: signal\`) do not participate in episode lifecycle or notification dispatch.
-
-When a user asks for notifications on a rule that is currently \`kind: signal\` (or when composing a new rule where the user wants notifications):
-
-1. **Explain the difference**: signal rules are observation-only ("${
-      RULE_KIND_LABELS.signal
-    }") and do not trigger notifications. Alert rules ("${
-      RULE_KIND_LABELS.alert
-    }") track episode lifecycle and can dispatch to action policies.
-2. If the rule is a **draft (in-memory)**: use \`set_kind\` to change it to \`alert\`, then load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill for notification setup.
-3. If the rule is **persisted**: \`kind\` is immutable after creation. Inform the user that the existing signal rule cannot be converted. Offer to create a new alert rule with the same query and schedule, then set up notifications on the new rule.
-4. After ensuring the rule is \`kind: alert\`, load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill for notification setup.
-
----
-
 ## Offering Notifications After Rule Compose
 
 After composing a complete **alert** rule (has name, query, schedule, and \`kind: alert\`), proactively ask the user:
 **"Would you like to set up email notifications for this rule?"**
 
 Do not offer notifications if the rule is still incomplete (missing name, query, or schedule).
-If the rule's kind is \`signal\`, follow the "Notifications Require Alert Kind" guidance above before proceeding.
+If the rule's kind is \`signal\`, follow **Notifications Require Alert Kind** in the [notifications-overview reference](./references/notifications-overview.md) before proceeding.
 
-If the user agrees (or asks for notifications directly), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill via \`filestore.read\` (path: \`skills/platform/alerting/${ACTION_POLICY_MANAGEMENT_SKILL_ID}/SKILL.md\`) and let that skill own the workflow + action policy setup. Do **not** compose action policies or notification workflows from this skill.`,
+If the user agrees (or asks for notifications directly), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill via \`filestore.read\` (path: \`skills/platform/alerting/${ACTION_POLICY_MANAGEMENT_SKILL_ID}/SKILL.md\`) and let that skill own the workflow + action policy setup (see [notifications-overview reference](./references/notifications-overview.md)). Do **not** compose action policies or notification workflows from this skill.
+
+---
+
+## When to Load References
+
+### Rule Kind
+When the user asks whether a rule should notify, record events only, or about the difference between Alerts and Events, consult the [rule-kind reference](./references/rule-kind.md).
+
+### Episode Lifecycle
+When the user asks what \`active\` / \`pending\` / \`recovering\` / \`inactive\` means, why an alert has not fired yet, or how group state works, consult the [episode-lifecycle reference](./references/episode-lifecycle.md).
+
+### Severity
+When the user specifies a severity (e.g. "make this a critical alert"), add an \`EVAL severity = "..."\` pipe to the breach query or segment via \`set_query\`. Consult the [alert-event-severity reference](./references/alert-event-severity.md) for valid values, the extraction model, and literal vs conditional patterns.
+
+### Recovery Strategy
+When the user wants alerts to recover only when a condition is met, to never recover, or asks how recovery is detected, set \`recovery_strategy\` on \`set_query\`. Consult the [recovery-strategy reference](./references/recovery-strategy.md).
+
+### No-Data Strategy
+When the user asks what happens if data stops arriving (missing metrics, heartbeat, "keep the last status"), set \`no_data_strategy\` on \`set_query\`. Consult the [no-data-strategy reference](./references/no-data-strategy.md).
+
+### Notifications
+When the user asks for email, Slack, PagerDuty, or how rules send notifications, consult the [notifications-overview reference](./references/notifications-overview.md) (includes **Notifications Require Alert Kind**). Do not compose action policies from this skill — load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill after the rule is \`kind: alert\`.`,
     getInlineTools: () => [manageRuleTool(deps)],
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -171,7 +171,7 @@ After composing a complete **alert** rule (has name, query, schedule, and \`kind
 Do not offer notifications if the rule is still incomplete (missing name, query, or schedule).
 If the rule's kind is \`signal\`, follow **Notifications Require Alert Kind** in the [notifications-overview reference](./references/notifications-overview.md) before proceeding.
 
-If the user agrees (or asks for notifications directly), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill via \`filestore.read\` (path: \`skills/platform/alerting/${ACTION_POLICY_MANAGEMENT_SKILL_ID}/SKILL.md\`) and let that skill own the workflow + action policy setup (see [notifications-overview reference](./references/notifications-overview.md)). Do **not** compose action policies or notification workflows from this skill.
+If the user agrees, load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill via \`filestore.read\` (path: \`skills/platform/alerting/${ACTION_POLICY_MANAGEMENT_SKILL_ID}/SKILL.md\`). Do **not** compose action policies or notification workflows from this skill.
 
 ---
 
@@ -193,6 +193,6 @@ When the user wants alerts to recover only when a condition is met, to never rec
 When the user asks what happens if data stops arriving (missing metrics, heartbeat, "keep the last status"), set \`no_data_strategy\` on \`set_query\`. Consult the [no-data-strategy reference](./references/no-data-strategy.md).
 
 ### Notifications
-When the user asks for email, Slack, PagerDuty, or how rules send notifications, consult the [notifications-overview reference](./references/notifications-overview.md) (includes **Notifications Require Alert Kind**). Do not compose action policies from this skill — load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill after the rule is \`kind: alert\`.`,
+When the user asks for email, Slack, PagerDuty, or how rules send notifications, consult the [notifications-overview reference](./references/notifications-overview.md).`,
     getInlineTools: () => [manageRuleTool(deps)],
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
@@ -414,7 +414,9 @@ describe('schema_to_skill_docs', () => {
       expect(doc).toContain('Alerts (`kind: alert`)');
       expect(doc).toContain('Events (`kind: signal`)');
       expect(doc).toContain('**Explain the difference**');
-      expect(doc).toContain('If the rule is a **draft (in-memory)**: use `set_kind` to change it to `alert`');
+      expect(doc).toContain(
+        'If the rule is a **draft (in-memory)**: use `set_kind` to change it to `alert`'
+      );
       expect(doc).toContain('If the rule is **persisted**: `kind` is immutable after creation');
       expect(doc).toContain('existing Events (`kind: signal`) rule cannot be converted');
       expect(doc).toContain('After ensuring the rule is `kind: alert`');

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
@@ -26,6 +26,7 @@ import {
   getDescribedEnumValues,
   generateActionPolicyOperationsDoc,
   generateActionPolicyWorkflowPayloadDoc,
+  generateNotificationsOverviewDoc,
 } from './schema_to_skill_docs';
 
 /**
@@ -218,24 +219,6 @@ describe('schema_to_skill_docs', () => {
     it('matches the snapshot', () => {
       expect(generateRuleSchemaDoc()).toMatchSnapshot();
     });
-
-    it('includes key field names from the schema', () => {
-      const doc = generateRuleSchemaDoc();
-      expect(doc).toContain('`kind`');
-      expect(doc).toContain('`metadata`');
-      expect(doc).toContain('`schedule`');
-      expect(doc).toContain('`query`');
-      expect(doc).toContain('`recovery_strategy`');
-      expect(doc).toContain('`no_data_strategy`');
-      expect(doc).toContain('`state_transition`');
-    });
-
-    it('does not contain stale field names', () => {
-      const doc = generateRuleSchemaDoc();
-      expect(doc).not.toContain('consecutive_breaches');
-      expect(doc).not.toContain('evaluation');
-      expect(doc).not.toContain('recovery_policy');
-    });
   });
 
   describe('generateRuleOperationsDoc', () => {
@@ -412,6 +395,36 @@ describe('schema_to_skill_docs', () => {
     it('matches the reviewed skill-doc snapshot', () => {
       expect(generateRuleKindDoc()).toMatchSnapshot();
     });
+
+    it('uses product labels from RULE_KIND_LABELS', () => {
+      const doc = generateRuleKindDoc();
+      expect(doc).toContain('### Alerts (`kind: alert`)');
+      expect(doc).toContain('### Events (`kind: signal`)');
+      expect(doc).not.toContain('### Signal (`kind: signal`)');
+    });
+  });
+
+  describe('generateNotificationsOverviewDoc', () => {
+    it('matches the reviewed skill-doc snapshot', () => {
+      expect(generateNotificationsOverviewDoc()).toMatchSnapshot();
+    });
+
+    it('uses product labels and the two-step convert-then-notify flow', () => {
+      const doc = generateNotificationsOverviewDoc();
+      expect(doc).toContain('Alerts (`kind: alert`)');
+      expect(doc).toContain('Events (`kind: signal`)');
+      expect(doc).toContain('Use `set_kind` to change it to `alert`');
+      expect(doc).toContain('After ensuring the rule is `kind: alert`');
+      expect(doc).not.toContain('**Explain the difference**');
+      expect(doc).not.toContain('existing Event rule cannot be converted');
+    });
+
+    it('links sibling references without a ./references/ prefix', () => {
+      const doc = generateNotificationsOverviewDoc();
+      expect(doc).toContain('(./rule-kind.md)');
+      expect(doc).toContain('(./episode-lifecycle.md)');
+      expect(doc).not.toContain('./references/');
+    });
   });
 
   describe('generateEpisodeLifecycleDoc', () => {
@@ -420,21 +433,28 @@ describe('schema_to_skill_docs', () => {
     });
   });
 
-  describe('generateStateTransitionDoc', () => {
-    it('matches the reviewed skill-doc snapshot', () => {
-      expect(generateStateTransitionDoc()).toMatchSnapshot();
-    });
-  });
-
   describe('generateRecoveryStrategyDoc', () => {
     it('matches the reviewed skill-doc snapshot', () => {
       expect(generateRecoveryStrategyDoc()).toMatchSnapshot();
+    });
+
+    it('links sibling references without a ./references/ prefix', () => {
+      const doc = generateRecoveryStrategyDoc();
+      expect(doc).toContain('(./episode-lifecycle.md)');
+      expect(doc).toContain('(./rule-kind.md)');
+      expect(doc).not.toContain('./references/');
     });
   });
 
   describe('generateNoDataStrategyDoc', () => {
     it('matches the reviewed skill-doc snapshot', () => {
       expect(generateNoDataStrategyDoc()).toMatchSnapshot();
+    });
+
+    it('links sibling references without a ./references/ prefix', () => {
+      const doc = generateNoDataStrategyDoc();
+      expect(doc).toContain('(./rule-kind.md)');
+      expect(doc).not.toContain('./references/');
     });
   });
 
@@ -514,6 +534,7 @@ describe('schema_to_skill_docs', () => {
       ['generateEnumList (grouping modes from spec)', generateGroupingModesDoc],
       ['generateEnumList (throttle strategies from spec)', generateThrottleStrategiesDoc],
       ['generateRuleKindDoc from spec', generateRuleKindDoc],
+      ['generateNotificationsOverviewDoc from spec', generateNotificationsOverviewDoc],
       ['generateStateTransitionDoc field .describe()', generateStateTransitionDoc],
       [
         'generateActionPolicyWorkflowPayloadDoc workflow input definition',

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.test.ts
@@ -409,14 +409,15 @@ describe('schema_to_skill_docs', () => {
       expect(generateNotificationsOverviewDoc()).toMatchSnapshot();
     });
 
-    it('uses product labels and the two-step convert-then-notify flow', () => {
+    it('uses product labels and distinguishes draft vs persisted kind changes', () => {
       const doc = generateNotificationsOverviewDoc();
       expect(doc).toContain('Alerts (`kind: alert`)');
       expect(doc).toContain('Events (`kind: signal`)');
-      expect(doc).toContain('Use `set_kind` to change it to `alert`');
+      expect(doc).toContain('**Explain the difference**');
+      expect(doc).toContain('If the rule is a **draft (in-memory)**: use `set_kind` to change it to `alert`');
+      expect(doc).toContain('If the rule is **persisted**: `kind` is immutable after creation');
+      expect(doc).toContain('existing Events (`kind: signal`) rule cannot be converted');
       expect(doc).toContain('After ensuring the rule is `kind: alert`');
-      expect(doc).not.toContain('**Explain the difference**');
-      expect(doc).not.toContain('existing Event rule cannot be converted');
     });
 
     it('links sibling references without a ./references/ prefix', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from '@kbn/zod/v4';
+import { ACTION_POLICY_MANAGEMENT_SKILL_ID, RULE_KIND_LABELS } from '@kbn/alerting-v2-constants';
 import {
   createRuleDataBaseSchema,
   createActionPolicyDataSchema,
@@ -538,6 +539,17 @@ export const generateThrottleGroupingCompatibilityDoc = (): string => {
   return lines.join('\n');
 };
 
+/** Product-facing label for a rule kind (`Alerts` / `Events`). Throws if a kind has no UI label. */
+const getRuleKindProductLabel = (kind: string): string => {
+  const label = RULE_KIND_LABELS[kind as keyof typeof RULE_KIND_LABELS];
+  if (!label) {
+    throw new SchemaTranslationError(
+      `Missing product label for rule kind "${kind}". Add it to RULE_KIND_LABELS.`
+    );
+  }
+  return label;
+};
+
 /** Generates the Rule Kind section with heading, per-kind subsections, and immutability note. */
 export const generateRuleKindDoc = (): string => {
   const kinds = getDescribedEnumValues(ruleKindSchema, 'ruleKindSchema');
@@ -545,7 +557,7 @@ export const generateRuleKindDoc = (): string => {
   const transitionFields = formatEnumValuesList(getStateTransitionFields());
 
   const kindSections = kinds.flatMap(({ value, description }, i) => {
-    const heading = `### ${value.charAt(0).toUpperCase()}${value.slice(1)} (\`kind: ${value}\`)`;
+    const heading = `### ${getRuleKindProductLabel(value)} (\`kind: ${value}\`)`;
     const lines = [heading, description];
     if (value === 'alert') {
       lines.push(`Episode statuses: ${episodeStatuses}.`);
@@ -554,15 +566,44 @@ export const generateRuleKindDoc = (): string => {
     return i > 0 ? ['', ...lines] : lines;
   });
 
+  const alertLabel = getRuleKindProductLabel('alert');
+  const signalLabel = getRuleKindProductLabel('signal');
+
   return [
-    '## Rule Kind: Alert vs Signal',
+    `# Rule Kind: ${alertLabel} vs ${signalLabel}`,
     '',
-    'Rules declare a `kind` of `alert` or `signal`. This is the most important behavioral split in the system.',
+    `Rules declare a \`kind\` of \`alert\` (${alertLabel}) or \`signal\` (${signalLabel}). This is the most important behavioral split in the system.`,
     '',
     ...kindSections,
     '',
-    '### Immutability',
+    '## Immutability',
     '`kind` is **immutable on persisted rules** — it can only be set at creation time. The update API rejects changes to `kind`. For draft (in-memory) rules, `set_kind` can change it freely.',
+  ].join('\n');
+};
+
+/**
+ * Generates the notifications-overview reference: action policies, plus how to
+ * handle notification requests on Events (`kind: signal`) vs Alerts (`kind: alert`) rules.
+ */
+export const generateNotificationsOverviewDoc = (): string => {
+  const alertLabel = getRuleKindProductLabel('alert');
+  const signalLabel = getRuleKindProductLabel('signal');
+
+  return [
+    '# Notifications via Action Policies',
+    '',
+    'Notifications are not configured on the rule itself. Alert episodes are matched and dispatched by **action policies** — space-scoped saved objects that send matched episodes to workflow destinations.',
+    '',
+    `When the user needs notifications (email, Slack, PagerDuty, etc.), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill. That skill owns action policy CRUD, workflow destination wiring, and the default notification setup flow.`,
+    '',
+    '## Notifications Require Alert Kind',
+    '',
+    `Action policies only process ${alertLabel} (\`kind: alert\`). ${signalLabel} (\`kind: signal\`) do not participate in episode lifecycle or notification dispatch. See the [rule-kind reference](./rule-kind.md) and [episode-lifecycle reference](./episode-lifecycle.md).`,
+    '',
+    'When a user asks for notifications on a rule that is currently `kind: signal` (or when composing a new rule where the user wants notifications):',
+    '',
+    `1. Use \`set_kind\` to change it to \`alert\`, then load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill for notification setup.`,
+    `2. After ensuring the rule is \`kind: alert\`, load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill for notification setup.`,
   ].join('\n');
 };
 
@@ -603,7 +644,7 @@ export const generateEpisodeLifecycleDoc = (): string => {
   });
 
   return [
-    '## Episode Lifecycle',
+    '# Episode Lifecycle',
     '',
     'Episodes are the unit of alert state. Each unique group (by `group_hash`) has its own episode. Each episode has a status that reflects where it is in the lifecycle:',
     '',
@@ -613,12 +654,12 @@ export const generateEpisodeLifecycleDoc = (): string => {
   ].join('\n');
 };
 
-/** Generates the Alert Event Severity section with heading, valid values, and ES|QL patterns. */
+/** Generates standalone markdown for alert event severity: valid values and ES|QL patterns. */
 export const generateSeverityDoc = (): string => {
   const values = formatEnumValuesList(getSeverityValues());
 
   return [
-    '## Alert Event Severity',
+    '# Alert Event Severity',
     '',
     'Severity is a per-event property on alert events and episodes, not a rule-level field. It is extracted at execution time from a column named `severity` in the ES|QL breach query output.',
     '',
@@ -638,7 +679,7 @@ export const generateSeverityDoc = (): string => {
   ].join('\n');
 };
 
-/** Generates the No-Data Strategy section with heading, prose, and value table. */
+/** Generates standalone markdown for no-data strategy: values, wiring, and kind constraints. */
 export const generateNoDataStrategyDoc = (): string => {
   const table = generateEnumTable({
     header: ['Value', 'Behaviour'],
@@ -647,7 +688,7 @@ export const generateNoDataStrategyDoc = (): string => {
   });
 
   return [
-    '## No-Data Strategy',
+    '# No-Data Strategy',
     '',
     '`no_data_strategy` is a **top-level rule field** that controls behaviour when no data is present.',
     '',
@@ -656,12 +697,11 @@ export const generateNoDataStrategyDoc = (): string => {
     "When setting `no_data_strategy` to anything other than `'none'`, add a `no_data` block to the standalone query:",
     "`no_data: { query: 'FROM heartbeat-* | STATS count = COUNT(*) BY host.name | WHERE count >= 1' }`. For composed query format, the `base` query is used as the data query.",
     '',
-    'Signal rules cannot set `no_data_strategy`.',
-    'Refer to the [rule-schema reference](./references/rule-schema.md) for allowed values and constraints.',
+    'Signal rules cannot set `no_data_strategy` ([rule-kind reference](./rule-kind.md)).',
   ].join('\n');
 };
 
-/** Generates the Recovery Strategy section with heading, prose, and value list. */
+/** Generates standalone markdown for recovery strategy: values, wiring, and kind constraints. */
 export const generateRecoveryStrategyDoc = (): string => {
   const list = generateEnumList({
     schema: recoveryStrategySchema,
@@ -669,17 +709,15 @@ export const generateRecoveryStrategyDoc = (): string => {
   });
 
   return [
-    '## Recovery Strategy',
+    '# Recovery Strategy',
     '',
-    '`recovery_strategy` is a **top-level rule field** (not inside the query). It controls how episodes transition from active to recovering/inactive. Signal rules (`kind: signal`) cannot set `recovery_strategy`.',
+    '`recovery_strategy` is a **top-level rule field** (not inside the query). It controls how episodes transition from active to recovering/inactive (see [episode-lifecycle reference](./episode-lifecycle.md)). Signal rules (`kind: signal`) cannot set `recovery_strategy` ([rule-kind reference](./rule-kind.md)).',
     '',
     list,
     '',
     `When using \`recovery_strategy: '${recoveryStrategy.query}'\`, add a \`set_query\` operation that includes a \`recovery\` block alongside \`breach\`:`,
     "- **Composed**: `recovery: { segment: 'WHERE cpu < 0.5' }`",
     "- **Standalone**: `recovery: { query: 'FROM metrics-* | WHERE cpu < 0.5' }`",
-    '',
-    'Refer to the [rule-schema reference](./references/rule-schema.md) for allowed values and constraints.',
   ].join('\n');
 };
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/schema_to_skill_docs.ts
@@ -602,8 +602,10 @@ export const generateNotificationsOverviewDoc = (): string => {
     '',
     'When a user asks for notifications on a rule that is currently `kind: signal` (or when composing a new rule where the user wants notifications):',
     '',
-    `1. Use \`set_kind\` to change it to \`alert\`, then load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill for notification setup.`,
-    `2. After ensuring the rule is \`kind: alert\`, load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill for notification setup.`,
+    `1. **Explain the difference**: ${signalLabel} (\`kind: signal\`) rules are observation-only and do not trigger notifications. ${alertLabel} (\`kind: alert\`) track episode lifecycle and can dispatch to action policies.`,
+    `2. If the rule is a **draft (in-memory)**: use \`set_kind\` to change it to \`alert\`, then load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill for notification setup.`,
+    `3. If the rule is **persisted**: \`kind\` is immutable after creation. Inform the user that the existing ${signalLabel} (\`kind: signal\`) rule cannot be converted. Offer to create a new ${alertLabel} (\`kind: alert\`) rule with the same query and schedule, then set up notifications on the new rule.`,
+    `4. After ensuring the rule is \`kind: alert\`, load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill for notification setup.`,
   ].join('\n');
 };
 


### PR DESCRIPTION
## Summary
- Split the monolithic `concepts` `referencedContent` in the rule-management Agent Builder skill into topic-scoped references (`rule-kind`, `episode-lifecycle`, `alert-event-severity`, `recovery-strategy`, `no-data-strategy`, `notifications-overview`) so the agent can fetch only what it needs.
- Source those references from the schema-driven skill doc generators (`generateRuleKindDoc`, `generateNotificationsOverviewDoc`, etc.) and align rule-kind copy with the rule form (Alerts / Events).
- Wire Domain Knowledge and inline instruction links to the new refs.

Split from #284979 (rule-management skill only). Companion: #285741.

## Test plan
- [ ] Unit tests for `rule_management_skill` + `schema_to_skill_docs` pass
- [ ] Alerting V2 evals (add `evals:alerting-v2` + model labels when ready)