### PR TITLE
[Index Management] Wait for Synthetic _source to be present

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/index_templates/index_templates_tab_source_field.spec.ts
+++ b/x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/index_templates/index_templates_tab_source_field.spec.ts
@@ -40,6 +40,11 @@ test.describe('Index templates tab - source field', { tag: tags.stateful.classic
     // Navigate to Mappings > Advanced options and disable _source
     await page.testSubj.locator('formWizardStep-3').click();
     await page.testSubj.locator('advancedOptionsTab').click();
+
+    // The form defaults `_source` to synthetic once the synthetic source status request resolves,
+    // discarding any option selected before that. Wait for it, or the selection below is lost.
+    await expect(page.testSubj.locator('sourceValueField')).toContainText('Synthetic _source');
+
     await page.testSubj.locator('sourceValueField').click();
     await page.testSubj.locator('disabledSourceFieldOption').click();
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/284422

## Summary
- Fix the Scout test `can not disable synthetic source in an index template with logsdb index mode`.
- The mappings editor applies a synthetic `_source` default once `GET /api/index_management/synthetic_source` resolves, resetting the form and discarding anything selected before that. When the request was slow, the test's "Disabled _source" selection was dropped, the template saved successfully and `saveTemplateError` never appeared.
- The test now waits for that default to be applied before opening the dropdown, so the selection sticks regardless of request latency.
- Test-side fix only. The underlying product behavior (a user's selection can be silently reverted) is tracked in https://github.com/elastic/kibana/issues/285739.

### Test plan
- Automated: no new tests; updated the existing spec. Run with:
  `node scripts/scout run-tests --arch stateful --domain classic --testFiles x-pack/platform/plugins/shared/index_management/test/scout/ui/tests/index_templates/index_templates_tab_source_field.spec.ts`