### PR TITLE
[DOCS] Add new alerting label to changelog.yml

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -95,7 +95,6 @@ pivot:
       - 'Feature:SharingURLs'
       - 'Feature:Reporting'
       - 'Team:Reporting Services'
-      - 'Feature:Alerting/v2'
       - 'Feature:AlertingV2'
     'Dashboards and visualizations':
       - 'Feature:Dashboard'

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -96,6 +96,7 @@ pivot:
       - 'Feature:Reporting'
       - 'Team:Reporting Services'
       - 'Feature:Alerting/v2'
+      - 'Feature:AlertingV2'
     'Dashboards and visualizations':
       - 'Feature:Dashboard'
       - 'Feature:Drilldowns'

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -95,6 +95,7 @@ pivot:
       - 'Feature:SharingURLs'
       - 'Feature:Reporting'
       - 'Team:Reporting Services'
+      - 'Feature:Alerting/v2'
     'Dashboards and visualizations':
       - 'Feature:Dashboard'
       - 'Feature:Drilldowns'


### PR DESCRIPTION
## Summary

Adds "Alerting v2" labels to the `docs/changelog.yml` file so that PRs will generate changelogs with the appropriate `areas`.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~
~~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
~~- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
~~- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

N/A