### PR TITLE
[Alerting v2] Switch to shared DateRangePicker wrapper

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/compose_discover_flyout.test.tsx
@@ -13,9 +13,10 @@ import { ESQLVariableType } from '@kbn/esql-types';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
-import { applicationServiceMock } from '@kbn/core/public/mocks';
+import { applicationServiceMock, coreMock } from '@kbn/core/public/mocks';
 import { lensPluginMock } from '@kbn/lens-plugin/public/mocks';
 import { uiActionsPluginMock } from '@kbn/ui-actions-plugin/public/mocks';
 import type { RuleFormServices } from '../../form/contexts/rule_form_context';
@@ -248,6 +249,8 @@ const createMockServices = (): RuleFormServices => ({
   dataViews: dataViewPluginMocks.createStartContract(),
   notifications: notificationServiceMock.createStartContract(),
   application: applicationServiceMock.createStartContract(),
+  uiSettings: uiSettingsServiceMock.createStartContract(),
+  featureFlags: coreMock.createStart().featureFlags,
   lens: lensPluginMock.createStartContract(),
   uiActions: uiActionsPluginMock.createStartContract(),
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.styles.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.styles.ts
@@ -13,11 +13,6 @@ const sandboxRootCss = css`
   flex-direction: column;
 `;
 
-const timeFieldSelectCss = css`
-  width: 200px;
-  min-width: 0;
-`;
-
 const loadingCenterCss = css`
   min-height: 200px;
 `;
@@ -79,7 +74,6 @@ export const useQuerySandboxStyles = ({ euiTheme }: UseEuiTheme) => {
     headerBlockCss,
     editorBodyCss,
     editorResizeHandleCss,
-    timeFieldSelectCss,
     loadingCenterCss,
     resultsSectionCss,
   };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.styles.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.styles.ts
@@ -13,6 +13,11 @@ const sandboxRootCss = css`
   flex-direction: column;
 `;
 
+const timeFieldSelectCss = css`
+  width: 200px;
+  min-width: 0;
+`;
+
 const loadingCenterCss = css`
   min-height: 200px;
 `;
@@ -74,6 +79,7 @@ export const useQuerySandboxStyles = ({ euiTheme }: UseEuiTheme) => {
     headerBlockCss,
     editorBodyCss,
     editorResizeHandleCss,
+    timeFieldSelectCss,
     loadingCenterCss,
     resultsSectionCss,
   };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.test.tsx
@@ -47,11 +47,16 @@ jest.mock('../../form/hooks/use_data_fields', () => ({
   }),
 }));
 
+jest.mock('@kbn/alerting-v2-browser-shared', () => ({
+  AlertingDateRangePicker: () => <div data-test-subj="querySandboxDatePicker" />,
+}));
+
 jest.mock('../../form/contexts/rule_form_context', () => ({
   useRuleFormServices: () => ({
     http: {},
     data: { search: { search: jest.fn() } },
     dataViews: {},
+    notifications: { toasts: { addDanger: jest.fn(), addWarning: jest.fn() } },
     lens: { EmbeddableComponent: () => null, stateHelperApi: jest.fn() },
   }),
 }));

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
@@ -148,6 +148,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
     headerBlockCss,
     editorBodyCss,
     editorResizeHandleCss,
+    timeFieldSelectCss,
     loadingCenterCss,
     resultsSectionCss,
   } = useQuerySandboxStyles(euiThemeContext);
@@ -358,7 +359,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
       </div>
 
       <EuiPanel hasBorder paddingSize="m" data-test-subj="querySandboxEditorPanel">
-        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
           <EuiFlexItem grow={false}>
             <EuiToolTip
               content={i18n.translate(
@@ -381,7 +382,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
               </EuiButton>
             </EuiToolTip>
           </EuiFlexItem>
-          <EuiFlexItem grow={false} style={{ width: 200, minWidth: 0 }}>
+          <EuiFlexItem grow={false} css={timeFieldSelectCss}>
             <EuiSelect
               options={timeFieldOptions}
               value={currentTimeFieldIsOption ? timeField : ''}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox.tsx
@@ -17,7 +17,6 @@ import {
   EuiPanel,
   EuiSelect,
   EuiSpacer,
-  EuiSuperDatePicker,
   EuiTabs,
   EuiText,
   EuiToolTip,
@@ -28,6 +27,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { CodeEditor, ESQL_LANG_ID, type monaco } from '@kbn/code-editor';
+import { AlertingDateRangePicker } from '@kbn/alerting-v2-browser-shared';
 import { useRuleFormServices } from '../../form/contexts/rule_form_context';
 import { useQueryExecution } from './use_query_execution';
 import { ComposeDiscoverChart } from './compose_discover_chart';
@@ -148,7 +148,6 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
     headerBlockCss,
     editorBodyCss,
     editorResizeHandleCss,
-    timeFieldSelectCss,
     loadingCenterCss,
     resultsSectionCss,
   } = useQuerySandboxStyles(euiThemeContext);
@@ -163,6 +162,13 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
   const isReadOnly = !onQueryChange;
   const hasTabs = Boolean(tabProps?.tabs?.length);
   const skipTimeFieldResolution = timeFieldOptionsProp !== undefined;
+
+  const handleDateRangeChange = useCallback(
+    ({ from, to }: { from: string; to: string }) => {
+      onDateRangeChange({ dateStart: from, dateEnd: to });
+    },
+    [onDateRangeChange]
+  );
 
   const splitTabs = useMemo(() => {
     if (!tabProps?.tabs?.length) return [];
@@ -352,7 +358,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
       </div>
 
       <EuiPanel hasBorder paddingSize="m" data-test-subj="querySandboxEditorPanel">
-        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
           <EuiFlexItem grow={false}>
             <EuiToolTip
               content={i18n.translate(
@@ -375,7 +381,7 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
               </EuiButton>
             </EuiToolTip>
           </EuiFlexItem>
-          <EuiFlexItem grow={false} css={timeFieldSelectCss}>
+          <EuiFlexItem grow={false} style={{ width: 200, minWidth: 0 }}>
             <EuiSelect
               options={timeFieldOptions}
               value={currentTimeFieldIsOption ? timeField : ''}
@@ -396,15 +402,13 @@ export const QuerySandbox: React.FC<QuerySandboxProps> = ({
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiSuperDatePicker
-              start={dateRange.dateStart}
-              end={dateRange.dateEnd}
-              onTimeChange={({ start, end }) => {
-                onDateRangeChange({ dateStart: start, dateEnd: end });
-              }}
-              showUpdateButton={false}
-              compressed
+            <AlertingDateRangePicker
+              from={dateRange.dateStart}
+              to={dateRange.dateEnd}
+              onChange={handleDateRangeChange}
+              services={services}
               width="auto"
+              data-test-subj="querySandboxDatePicker"
             />
           </EuiFlexItem>
           {headerActions && <EuiFlexItem grow={false}>{headerActions}</EuiFlexItem>}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/compose_discover/query_sandbox_flyout.test.tsx
@@ -26,12 +26,17 @@ jest.mock('../../form/hooks/use_data_fields', () => ({
   useDataFields: () => ({ data: mockFieldMap, isLoading: false }),
 }));
 
+jest.mock('@kbn/alerting-v2-browser-shared', () => ({
+  AlertingDateRangePicker: () => <div data-test-subj="querySandboxDatePicker" />,
+}));
+
 jest.mock('../../form/contexts/rule_form_context', () => ({
   useRuleFormServices: () => ({
     http: {},
     data: { search: { search: jest.fn() } },
     dataViews: {},
     application: {},
+    notifications: { toasts: { addDanger: jest.fn(), addWarning: jest.fn() } },
   }),
 }));
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_context.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/contexts/rule_form_context.tsx
@@ -5,7 +5,13 @@
  * 2.0.
  */
 
-import type { ApplicationStart, HttpStart, NotificationsStart } from '@kbn/core/public';
+import type {
+  ApplicationStart,
+  FeatureFlagsStart,
+  HttpStart,
+  IUiSettingsClient,
+  NotificationsStart,
+} from '@kbn/core/public';
 import type { CPSPluginStart } from '@kbn/cps/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
@@ -21,6 +27,8 @@ export interface RuleFormServices {
   dataViews: DataViewsPublicPluginStart;
   notifications: NotificationsStart;
   application: ApplicationStart;
+  uiSettings: IUiSettingsClient;
+  featureFlags: FeatureFlagsStart;
   lens: LensPublicStart;
   uiActions?: UiActionsStart;
   dashboard?: DashboardStart;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/moon.yml
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/moon.yml
@@ -57,6 +57,7 @@ dependsOn:
   - '@kbn/dashboard-plugin'
   - '@kbn/cps-utils'
   - '@kbn/cps'
+  - '@kbn/core-ui-settings-browser-mocks'
 tags:
   - shared-browser
   - package

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/moon.yml
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/moon.yml
@@ -31,6 +31,7 @@ dependsOn:
   - '@kbn/es-query'
   - '@kbn/react-query'
   - '@kbn/search-types'
+  - '@kbn/alerting-v2-browser-shared'
   - '@kbn/alerting-v2-schemas'
   - '@kbn/alerting-v2-constants'
   - '@kbn/alerting-v2-utils'

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/test_utils.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/test_utils.tsx
@@ -11,9 +11,10 @@ import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
-import { applicationServiceMock } from '@kbn/core/public/mocks';
+import { applicationServiceMock, coreMock } from '@kbn/core/public/mocks';
 import { lensPluginMock } from '@kbn/lens-plugin/public/mocks';
 import { uiActionsPluginMock } from '@kbn/ui-actions-plugin/public/mocks';
 import type { DashboardStart } from '@kbn/dashboard-plugin/public';
@@ -63,6 +64,8 @@ export const createMockServices = (): RuleFormServices => ({
   dataViews: dataViewPluginMocks.createStartContract(),
   notifications: notificationServiceMock.createStartContract(),
   application: applicationServiceMock.createStartContract(),
+  uiSettings: uiSettingsServiceMock.createStartContract(),
+  featureFlags: coreMock.createStart().featureFlags,
   lens: lensPluginMock.createStartContract(),
   uiActions: uiActionsPluginMock.createStartContract(),
   dashboard: createMockDashboardStart(),

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/tsconfig.json
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/tsconfig.json
@@ -19,6 +19,7 @@
     "@kbn/es-query",
     "@kbn/react-query",
     "@kbn/search-types",
+    "@kbn/alerting-v2-browser-shared",
     "@kbn/alerting-v2-schemas",
     "@kbn/alerting-v2-constants",
     "@kbn/alerting-v2-utils",

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/tsconfig.json
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/tsconfig.json
@@ -44,6 +44,7 @@
     "@kbn/kibana-react-plugin",
     "@kbn/dashboard-plugin",
     "@kbn/cps-utils",
-    "@kbn/cps"
+    "@kbn/cps",
+    "@kbn/core-ui-settings-browser-mocks"
   ]
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/moon.yml
+++ b/x-pack/platform/plugins/shared/alerting_v2/moon.yml
@@ -80,6 +80,7 @@ dependsOn:
   - '@kbn/kql'
   - '@kbn/scout'
   - '@kbn/object-utils'
+  - '@kbn/alerting-v2-browser-shared'
   - '@kbn/alerting-v2-constants'
   - '@kbn/alerting-v2-common-queries'
   - '@kbn/alerting-v2-utils'

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/alert_timeline/alert_timeline_section.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/alert_timeline/alert_timeline_section.test.tsx
@@ -11,7 +11,6 @@ import { I18nProvider } from '@kbn/i18n-react';
 import { AlertTimelineSection } from './alert_timeline_section';
 
 const mockUseFetchRuleEvents = jest.fn();
-const mockTimeRange = { from: 'now-7d', to: 'now' };
 let capturedOnRefresh: (() => void) | undefined;
 
 jest.mock('../../../../hooks/use_fetch_rule_events', () => ({
@@ -19,7 +18,7 @@ jest.mock('../../../../hooks/use_fetch_rule_events', () => ({
 }));
 
 jest.mock('./use_alert_timeline_url_state', () => ({
-  useAlertTimelineUrlState: () => [mockTimeRange, jest.fn()],
+  useAlertTimelineUrlState: () => [{ from: 'now-7d', to: 'now' }, jest.fn()],
 }));
 
 jest.mock('../../../../utils/discover_href_for_episode', () => ({
@@ -85,8 +84,6 @@ describe('AlertTimelineSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
-    mockTimeRange.from = 'now-7d';
-    mockTimeRange.to = 'now';
     capturedOnRefresh = undefined;
     mockUseFetchRuleEvents.mockReturnValue(successResult);
   });
@@ -114,9 +111,9 @@ describe('AlertTimelineSection', () => {
     expect(screen.getByTestId('alertTimelineSectionError')).toBeInTheDocument();
   });
 
-  it('refetches when refresh leaves an absolute window unchanged', () => {
-    mockTimeRange.from = '2026-08-01T00:00:00.000Z';
-    mockTimeRange.to = '2026-08-08T00:00:00.000Z';
+  it('refetches when refresh is pressed', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
     renderSection();
 
     act(() => {
@@ -124,12 +121,6 @@ describe('AlertTimelineSection', () => {
     });
 
     expect(successResult.refetch).toHaveBeenCalledTimes(1);
-    const lastCall = mockUseFetchRuleEvents.mock.calls.at(-1)?.[0] as {
-      windowStartMs: number;
-      windowEndMs: number;
-    };
-    expect(lastCall.windowStartMs).toBe(Date.parse(mockTimeRange.from));
-    expect(lastCall.windowEndMs).toBe(Date.parse(mockTimeRange.to));
   });
 
   it('slides a relative window forward on refresh without calling refetch', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/alert_timeline/alert_timeline_section.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/alert_timeline/alert_timeline_section.test.tsx
@@ -6,18 +6,20 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { AlertTimelineSection } from './alert_timeline_section';
 
 const mockUseFetchRuleEvents = jest.fn();
+const mockTimeRange = { from: 'now-7d', to: 'now' };
+let capturedOnRefresh: (() => void) | undefined;
 
 jest.mock('../../../../hooks/use_fetch_rule_events', () => ({
   useFetchRuleEvents: (...args: unknown[]) => mockUseFetchRuleEvents(...args),
 }));
 
 jest.mock('./use_alert_timeline_url_state', () => ({
-  useAlertTimelineUrlState: () => [{ from: 'now-7d', to: 'now' }, jest.fn()],
+  useAlertTimelineUrlState: () => [mockTimeRange, jest.fn()],
 }));
 
 jest.mock('../../../../utils/discover_href_for_episode', () => ({
@@ -32,12 +34,26 @@ jest.mock('../../rule_context', () => ({
   }),
 }));
 
+jest.mock('@kbn/alerting-v2-browser-shared', () => ({
+  AlertingDateRangePicker: ({
+    onRefresh,
+    'data-test-subj': dataTestSubj,
+  }: {
+    onRefresh?: () => void;
+    'data-test-subj'?: string;
+  }) => {
+    capturedOnRefresh = onRefresh;
+    return <div data-test-subj={dataTestSubj} />;
+  },
+}));
+
 const mockServices: Record<string, unknown> = {
   data: {},
   share: {},
   application: { capabilities: {}, navigateToUrl: jest.fn() },
   uiSettings: { get: jest.fn(() => 'Browser') },
   http: { basePath: { prepend: (path: string) => path } },
+  notifications: { toasts: { addDanger: jest.fn(), addWarning: jest.fn() } },
 };
 
 jest.mock('@kbn/core-di-browser', () => ({
@@ -68,12 +84,17 @@ const renderSection = () =>
 describe('AlertTimelineSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
+    mockTimeRange.from = 'now-7d';
+    mockTimeRange.to = 'now';
+    capturedOnRefresh = undefined;
     mockUseFetchRuleEvents.mockReturnValue(successResult);
   });
 
   it('renders the section with an empty prompt when there are no episodes', () => {
     renderSection();
     expect(screen.getByTestId('ruleAlertTimelineSection')).toBeInTheDocument();
+    expect(screen.getByTestId('alertTimelineDatePicker')).toBeInTheDocument();
     expect(screen.getByTestId('alertTimelineSectionEmpty')).toBeInTheDocument();
   });
 
@@ -91,5 +112,44 @@ describe('AlertTimelineSection', () => {
     renderSection();
     expect(screen.getByTestId('ruleAlertTimelineSection')).toBeInTheDocument();
     expect(screen.getByTestId('alertTimelineSectionError')).toBeInTheDocument();
+  });
+
+  it('refetches when refresh leaves an absolute window unchanged', () => {
+    mockTimeRange.from = '2026-08-01T00:00:00.000Z';
+    mockTimeRange.to = '2026-08-08T00:00:00.000Z';
+    renderSection();
+
+    act(() => {
+      capturedOnRefresh?.();
+    });
+
+    expect(successResult.refetch).toHaveBeenCalledTimes(1);
+    const lastCall = mockUseFetchRuleEvents.mock.calls.at(-1)?.[0] as {
+      windowStartMs: number;
+      windowEndMs: number;
+    };
+    expect(lastCall.windowStartMs).toBe(Date.parse(mockTimeRange.from));
+    expect(lastCall.windowEndMs).toBe(Date.parse(mockTimeRange.to));
+  });
+
+  it('slides a relative window forward on refresh without calling refetch', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
+    renderSection();
+    mockUseFetchRuleEvents.mockClear();
+
+    jest.setSystemTime(new Date('2026-08-14T12:05:00.000Z'));
+    act(() => {
+      capturedOnRefresh?.();
+    });
+
+    expect(successResult.refetch).not.toHaveBeenCalled();
+    expect(mockUseFetchRuleEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        windowStartMs: Date.parse('2026-08-07T12:05:00.000Z'),
+        windowEndMs: Date.parse('2026-08-14T12:05:00.000Z'),
+      })
+    );
+    jest.useRealTimers();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/alert_timeline/alert_timeline_section.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/alert_timeline/alert_timeline_section.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -14,11 +14,9 @@ import {
   EuiLoadingChart,
   EuiPanel,
   EuiSpacer,
-  EuiSuperDatePicker,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import type { OnTimeChangeProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { getRootEsqlQuery } from '@kbn/alerting-v2-schemas';
 import { CoreStart, useService } from '@kbn/core-di-browser';
@@ -27,6 +25,7 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import { deriveAlertTimelineData } from '@kbn/alerting-v2-episodes-ui/alert_timeline';
 import { AlertTimelineLegend } from '@kbn/alerting-v2-episodes-ui/alert_timeline';
+import { AlertingDateRangePicker } from '@kbn/alerting-v2-browser-shared';
 import { useRule } from '../../rule_context';
 import { useFetchRuleEvents } from '../../../../hooks/use_fetch_rule_events';
 import { getDiscoverHrefForRuleQuery } from '../../../../utils/discover_href_for_episode';
@@ -35,7 +34,8 @@ import { AlertTimelineChart } from './alert_timeline_chart';
 import { AlertTimelineStatsRow } from './alert_timeline_stats_row';
 import { AlertTimelineViewAllButton } from './alert_timeline_view_all_button';
 import { useAlertTimelineUrlState } from './use_alert_timeline_url_state';
-import { DEFAULT_ACTIVITY_TIME_RANGE, resolveGteLte } from '../time_range';
+import { DEFAULT_ACTIVITY_TIME_RANGE } from '../time_range';
+import { useResolvedActivityWindow } from '../use_resolved_activity_window';
 
 export const AlertTimelineSection: React.FC = () => {
   const data = useService(PluginStart('data')) as DataPublicPluginStart;
@@ -43,35 +43,28 @@ export const AlertTimelineSection: React.FC = () => {
   const application = useService(CoreStart('application'));
   const uiSettings = useService(CoreStart('uiSettings'));
   const http = useService(CoreStart('http'));
+  const notifications = useService(CoreStart('notifications'));
+  const featureFlags = useService(CoreStart('featureFlags'));
   const rule = useRule();
   const groupingFields = rule.grouping?.fields;
   const hasGroupingFields = (groupingFields?.length ?? 0) > 0;
   const timeZone = uiSettings.get<string>('dateFormat:tz', 'Browser');
 
   const [timeRange, setTimeRange] = useAlertTimelineUrlState(DEFAULT_ACTIVITY_TIME_RANGE);
-  const [refreshTick, setRefreshTick] = useState(0);
-
-  const handleTimeChange = useCallback(
-    (next: OnTimeChangeProps) => {
-      setTimeRange({ from: next.start, to: next.end });
-    },
-    [setTimeRange]
+  const { windowStartMs, windowEndMs, applyRefresh } = useResolvedActivityWindow(
+    timeRange.from,
+    timeRange.to
   );
 
-  const handleRefresh = useCallback(() => setRefreshTick((n) => n + 1), []);
-
-  const { windowStartMs, windowEndMs } = useMemo(() => {
-    void refreshTick;
-    return resolveGteLte(timeRange.from, timeRange.to);
-  }, [timeRange.from, timeRange.to, refreshTick]);
-
-  const { phases, groupingValuesByHash, summary, isLoading, isError } = useFetchRuleEvents({
-    ruleId: rule.id,
-    windowStartMs,
-    windowEndMs,
-    groupingFields,
-    data,
-  });
+  const { phases, groupingValuesByHash, summary, isLoading, isError, refetch } = useFetchRuleEvents(
+    {
+      ruleId: rule.id,
+      windowStartMs,
+      windowEndMs,
+      groupingFields,
+      data,
+    }
+  );
 
   const timelineData = useMemo(
     () =>
@@ -141,16 +134,15 @@ export const AlertTimelineSection: React.FC = () => {
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSuperDatePicker
-            compressed
-            width="auto"
-            start={timeRange.from}
-            end={timeRange.to}
-            onTimeChange={handleTimeChange}
-            onRefresh={handleRefresh}
+          <AlertingDateRangePicker
+            from={timeRange.from}
+            to={timeRange.to}
+            onChange={setTimeRange}
+            services={{ data, notifications, http, application, uiSettings, featureFlags }}
+            onRefresh={() => applyRefresh(refetch)}
             isLoading={isLoading}
-            showUpdateButton="iconOnly"
-            updateButtonProps={{ fill: false }}
+            showTimeWindowButtons
+            width="auto"
             data-test-subj="alertTimelineDatePicker"
           />
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/signal_rule_overview.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/signal_rule_overview.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   EuiButtonEmpty,
   EuiEmptyPrompt,
@@ -14,15 +14,14 @@ import {
   EuiLoadingChart,
   EuiPanel,
   EuiSpacer,
-  EuiSuperDatePicker,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import type { OnTimeChangeProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
 import { getRootEsqlQuery } from '@kbn/alerting-v2-schemas';
 import { intervalToMs } from '@kbn/alerting-v2-episodes-ui/utils/histogram_utils';
+import { AlertingDateRangePicker } from '@kbn/alerting-v2-browser-shared';
 import { CoreStart, useService } from '@kbn/core-di-browser';
 import { PluginStart } from '@kbn/core-di';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
@@ -31,7 +30,8 @@ import { useRule } from '../rule_context';
 import { useFetchSignalFirings } from '../../../hooks/use_fetch_signal_firings';
 import { getDiscoverHrefForRuleQuery } from '../../../utils/discover_href_for_episode';
 import { useAlertTimelineUrlState } from './alert_timeline/use_alert_timeline_url_state';
-import { DEFAULT_ACTIVITY_TIME_RANGE, resolveGteLte } from './time_range';
+import { DEFAULT_ACTIVITY_TIME_RANGE } from './time_range';
+import { useResolvedActivityWindow } from './use_resolved_activity_window';
 import { StatsRow, type StatItem } from './stats_row';
 import { SignalFiringsChart } from './signal_activity/signal_firings_chart';
 import { deriveSignalFiringKpis } from './signal_activity/signal_firing_kpis';
@@ -48,15 +48,13 @@ export const SignalRuleOverview: React.FC = () => {
   const share = useService(PluginStart('share')) as SharePluginStart;
   const application = useService(CoreStart('application'));
   const uiSettings = useService(CoreStart('uiSettings'));
+  const notifications = useService(CoreStart('notifications'));
+  const http = useService(CoreStart('http'));
+  const featureFlags = useService(CoreStart('featureFlags'));
   const rule = useRule();
   const timeZone = uiSettings.get<string>('dateFormat:tz', 'Browser');
 
   const [timeRange, setTimeRange] = useAlertTimelineUrlState(DEFAULT_ACTIVITY_TIME_RANGE);
-
-  const handleTimeChange = useCallback(
-    (next: OnTimeChangeProps) => setTimeRange({ from: next.start, to: next.end }),
-    [setTimeRange]
-  );
 
   const onBrushRange = useCallback(
     (fromMs: number, toMs: number) =>
@@ -64,12 +62,11 @@ export const SignalRuleOverview: React.FC = () => {
     [setTimeRange]
   );
 
-  const [refreshTick, setRefreshTick] = useState(0);
-
-  const { windowStartMs: gteMs, windowEndMs: lteMs } = useMemo(() => {
-    void refreshTick;
-    return resolveGteLte(timeRange.from, timeRange.to);
-  }, [timeRange.from, timeRange.to, refreshTick]);
+  const {
+    windowStartMs: gteMs,
+    windowEndMs: lteMs,
+    applyRefresh,
+  } = useResolvedActivityWindow(timeRange.from, timeRange.to);
 
   const { buckets, interval, lastFiringMs, isLoading, isHistogramError, isSummaryError, refetch } =
     useFetchSignalFirings({
@@ -78,11 +75,6 @@ export const SignalRuleOverview: React.FC = () => {
       lteMs,
       data,
     });
-
-  const handleRefresh = useCallback(() => {
-    setRefreshTick((n) => n + 1);
-    refetch();
-  }, [refetch]);
 
   const intervalMs = useMemo(() => intervalToMs(interval), [interval]);
 
@@ -255,16 +247,15 @@ export const SignalRuleOverview: React.FC = () => {
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSuperDatePicker
-            compressed
-            width="auto"
-            start={timeRange.from}
-            end={timeRange.to}
-            onTimeChange={handleTimeChange}
-            onRefresh={handleRefresh}
+          <AlertingDateRangePicker
+            from={timeRange.from}
+            to={timeRange.to}
+            onChange={setTimeRange}
+            services={{ data, notifications, http, application, uiSettings, featureFlags }}
+            onRefresh={() => applyRefresh(refetch)}
             isLoading={isLoading}
-            showUpdateButton="iconOnly"
-            updateButtonProps={{ fill: false }}
+            showTimeWindowButtons
+            width="auto"
             data-test-subj="signalOverviewDatePicker"
           />
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/time_range.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/time_range.test.ts
@@ -5,16 +5,60 @@
  * 2.0.
  */
 
-import { resolveGteLte } from './time_range';
+import { DEFAULT_ACTIVITY_TIME_RANGE, resolveGteLte } from './time_range';
 
 const ABSOLUTE_FROM = '2026-08-01T00:00:00.000Z';
 const ABSOLUTE_TO = '2026-08-08T00:00:00.000Z';
+const NOW = '2026-08-14T12:00:00.000Z';
+/** ISO-shaped but out of range, e.g. a hand-edited time range in the URL. */
+const MALFORMED = '2026-13-45T00:00:00.000Z';
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 describe('resolveGteLte', () => {
   it('resolves absolute ISO bounds', () => {
     expect(resolveGteLte(ABSOLUTE_FROM, ABSOLUTE_TO)).toEqual({
       windowStartMs: Date.parse(ABSOLUTE_FROM),
       windowEndMs: Date.parse(ABSOLUTE_TO),
+    });
+  });
+
+  describe('against a pinned clock', () => {
+    const nowMs = Date.parse(NOW);
+    const fallbackWindow = { windowStartMs: nowMs - 7 * DAY_MS, windowEndMs: nowMs };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(NOW));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('resolves the default relative range', () => {
+      const { from, to } = DEFAULT_ACTIVITY_TIME_RANGE;
+      expect(resolveGteLte(from, to)).toEqual(fallbackWindow);
+    });
+
+    it('falls back to a 7-day window when datemath rejects both bounds outright', () => {
+      // Empty strings short-circuit datemath.parse to `undefined`.
+      expect(resolveGteLte('', '')).toEqual(fallbackWindow);
+    });
+
+    it('falls back to a 7-day window when both bounds parse to an invalid date', () => {
+      // An invalid moment yields NaN from `valueOf()` rather than `undefined`.
+      expect(resolveGteLte(MALFORMED, MALFORMED)).toEqual(fallbackWindow);
+    });
+
+    it('falls back per bound, keeping the parseable one', () => {
+      expect(resolveGteLte(MALFORMED, ABSOLUTE_TO)).toEqual({
+        windowStartMs: nowMs - 7 * DAY_MS,
+        windowEndMs: Date.parse(ABSOLUTE_TO),
+      });
+      expect(resolveGteLte(ABSOLUTE_FROM, MALFORMED)).toEqual({
+        windowStartMs: Date.parse(ABSOLUTE_FROM),
+        windowEndMs: nowMs,
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/time_range.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/time_range.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { resolveGteLte } from './time_range';
+
+const ABSOLUTE_FROM = '2026-08-01T00:00:00.000Z';
+const ABSOLUTE_TO = '2026-08-08T00:00:00.000Z';
+
+describe('resolveGteLte', () => {
+  it('resolves absolute ISO bounds', () => {
+    expect(resolveGteLte(ABSOLUTE_FROM, ABSOLUTE_TO)).toEqual({
+      windowStartMs: Date.parse(ABSOLUTE_FROM),
+      windowEndMs: Date.parse(ABSOLUTE_TO),
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/time_range.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/time_range.ts
@@ -7,20 +7,21 @@
 
 import datemath from '@kbn/datemath';
 
-const HOUR_MS = 60 * 60 * 1000;
-const DAY_MS = 24 * HOUR_MS;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** Default activity window shared by the alert and signal rule overviews. */
 export const DEFAULT_ACTIVITY_TIME_RANGE = { from: 'now-7d', to: 'now' };
+
+export interface ResolvedActivityWindow {
+  windowStartMs: number;
+  windowEndMs: number;
+}
 
 /**
  * Resolves a datemath time range to absolute epoch-ms bounds, falling back to a
  * 7-day window when either bound cannot be parsed.
  */
-export const resolveGteLte = (
-  from: string,
-  to: string
-): { windowStartMs: number; windowEndMs: number } => {
+export const resolveGteLte = (from: string, to: string): ResolvedActivityWindow => {
   const fromMs = datemath.parse(from)?.valueOf();
   const toMs = datemath.parse(to, { roundUp: true })?.valueOf();
   const now = Date.now();

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/use_resolved_activity_window.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/use_resolved_activity_window.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { resolveGteLte } from './time_range';
+import { resolveRefreshWindow, useResolvedActivityWindow } from './use_resolved_activity_window';
+
+const ABSOLUTE_FROM = '2026-08-01T00:00:00.000Z';
+const ABSOLUTE_TO = '2026-08-08T00:00:00.000Z';
+
+describe('resolveRefreshWindow', () => {
+  it('reports unchanged bounds for an absolute range so the caller can refetch', () => {
+    const current = resolveGteLte(ABSOLUTE_FROM, ABSOLUTE_TO);
+    const result = resolveRefreshWindow(ABSOLUTE_FROM, ABSOLUTE_TO, current);
+
+    expect(result.boundsChanged).toBe(false);
+    expect(result.next).toEqual(current);
+  });
+
+  it('reports changed bounds when a relative range slides forward', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
+    const current = resolveGteLte('now-7d', 'now');
+
+    jest.setSystemTime(new Date('2026-08-14T12:05:00.000Z'));
+    const result = resolveRefreshWindow('now-7d', 'now', current);
+
+    expect(result.boundsChanged).toBe(true);
+    expect(result.next.windowEndMs).toBe(Date.parse('2026-08-14T12:05:00.000Z'));
+    expect(result.next.windowStartMs).toBe(Date.parse('2026-08-07T12:05:00.000Z'));
+
+    jest.useRealTimers();
+  });
+});
+
+describe('useResolvedActivityWindow', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('refetches when refresh does not move the resolved bounds', () => {
+    const refetch = jest.fn();
+    const { result } = renderHook(() => useResolvedActivityWindow(ABSOLUTE_FROM, ABSOLUTE_TO));
+
+    act(() => {
+      result.current.applyRefresh(refetch);
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(result.current.windowStartMs).toBe(Date.parse(ABSOLUTE_FROM));
+    expect(result.current.windowEndMs).toBe(Date.parse(ABSOLUTE_TO));
+  });
+
+  it('applies new bounds and skips refetch when a relative range moves', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
+    const refetch = jest.fn();
+    const { result } = renderHook(() => useResolvedActivityWindow('now-7d', 'now'));
+
+    expect(result.current.windowEndMs).toBe(Date.parse('2026-08-14T12:00:00.000Z'));
+
+    jest.setSystemTime(new Date('2026-08-14T12:05:00.000Z'));
+    act(() => {
+      result.current.applyRefresh(refetch);
+    });
+
+    expect(refetch).not.toHaveBeenCalled();
+    expect(result.current.windowEndMs).toBe(Date.parse('2026-08-14T12:05:00.000Z'));
+    expect(result.current.windowStartMs).toBe(Date.parse('2026-08-07T12:05:00.000Z'));
+  });
+
+  it('re-resolves when the selected range changes', () => {
+    const { result, rerender } = renderHook(({ from, to }) => useResolvedActivityWindow(from, to), {
+      initialProps: { from: 'now-7d', to: 'now' },
+    });
+
+    rerender({ from: ABSOLUTE_FROM, to: ABSOLUTE_TO });
+
+    expect(result.current.windowStartMs).toBe(Date.parse(ABSOLUTE_FROM));
+    expect(result.current.windowEndMs).toBe(Date.parse(ABSOLUTE_TO));
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/use_resolved_activity_window.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/overview/use_resolved_activity_window.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useState } from 'react';
+import { resolveGteLte, type ResolvedActivityWindow } from './time_range';
+
+const boundsEqual = (a: ResolvedActivityWindow, b: ResolvedActivityWindow): boolean =>
+  a.windowStartMs === b.windowStartMs && a.windowEndMs === b.windowEndMs;
+
+/**
+ * Re-resolves `from`/`to` and reports whether the absolute window moved.
+ * Callers should apply `next` when `boundsChanged`, and refetch otherwise.
+ */
+export const resolveRefreshWindow = (
+  from: string,
+  to: string,
+  current: ResolvedActivityWindow
+): { next: ResolvedActivityWindow; boundsChanged: boolean } => {
+  const next = resolveGteLte(from, to);
+  return { next, boundsChanged: !boundsEqual(next, current) };
+};
+
+/**
+ * Keeps a resolved activity window in sync with the selected range and refresh.
+ * Relative ranges (`now-*`) get new bounds on refresh; absolute ranges refetch.
+ */
+export const useResolvedActivityWindow = (
+  from: string,
+  to: string
+): {
+  windowStartMs: number;
+  windowEndMs: number;
+  applyRefresh: (refetch: () => void) => void;
+} => {
+  const [input, setInput] = useState({ from, to });
+  const [resolved, setResolved] = useState(() => resolveGteLte(from, to));
+
+  if (from !== input.from || to !== input.to) {
+    setInput({ from, to });
+    setResolved(resolveGteLte(from, to));
+  }
+
+  const applyRefresh = useCallback(
+    (refetch: () => void) => {
+      const { next, boundsChanged } = resolveRefreshWindow(from, to, resolved);
+      if (boundsChanged) {
+        setResolved(next);
+        return;
+      }
+      refetch();
+    },
+    [from, to, resolved]
+  );
+
+  return { ...resolved, applyRefresh };
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_sidebar_preview_tab.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/sidebar/rule_sidebar_preview_tab.tsx
@@ -9,7 +9,12 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { CoreStart, useService } from '@kbn/core-di-browser';
 import { PluginStart } from '@kbn/core-di';
-import type { HttpStart, NotificationsStart, ApplicationStart } from '@kbn/core/public';
+import type {
+  HttpStart,
+  NotificationsStart,
+  ApplicationStart,
+  IUiSettingsClient,
+} from '@kbn/core/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
@@ -27,13 +32,15 @@ const RuleSidebarPreviewTabInner: React.FC = () => {
   const http = useService<HttpStart>(CoreStart('http'));
   const notifications = useService<NotificationsStart>(CoreStart('notifications'));
   const application = useService<ApplicationStart>(CoreStart('application'));
+  const uiSettings = useService<IUiSettingsClient>(CoreStart('uiSettings'));
+  const featureFlags = useService(CoreStart('featureFlags'));
   const data = useService<DataPublicPluginStart>(PluginStart('data'));
   const dataViews = useService<DataViewsPublicPluginStart>(PluginStart('dataViews'));
   const lens = useService<LensPublicStart>(PluginStart('lens'));
 
   const services = useMemo(
-    () => ({ http, notifications, application, data, dataViews, lens }),
-    [http, notifications, application, data, dataViews, lens]
+    () => ({ http, notifications, application, uiSettings, featureFlags, data, dataViews, lens }),
+    [http, notifications, application, uiSettings, featureFlags, data, dataViews, lens]
   );
 
   const [dateStart, setDateStart] = useState('now-15m');

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_options_flyout.test.tsx
@@ -13,7 +13,7 @@ import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
-import { applicationServiceMock, uiSettingsServiceMock } from '@kbn/core/public/mocks';
+import { applicationServiceMock, coreMock, uiSettingsServiceMock } from '@kbn/core/public/mocks';
 import { lensPluginMock } from '@kbn/lens-plugin/public/mocks';
 import { uiActionsPluginMock } from '@kbn/ui-actions-plugin/public/mocks';
 import { AGENT_BUILDER_APP_ID } from '@kbn/deeplinks-agent-builder';
@@ -47,6 +47,7 @@ const createMockServices = (): AlertingV2KibanaServices => {
     lens: lensPluginMock.createStartContract(),
     uiActions: uiActionsPluginMock.createStartContract(),
     uiSettings,
+    featureFlags: coreMock.createStart().featureFlags,
     expressions: {} as AlertingV2KibanaServices['expressions'],
     container: {} as AlertingV2KibanaServices['container'],
   };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_compose_discover_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_compose_discover_flyout.tsx
@@ -49,6 +49,8 @@ export const useComposeDiscoverFlyout = ({
   const http = useService(CoreStart('http'));
   const notifications = useService(CoreStart('notifications'));
   const application = useService(CoreStart('application'));
+  const uiSettings = useService(CoreStart('uiSettings'));
+  const featureFlags = useService(CoreStart('featureFlags'));
   const data = useService(PluginStart('data')) as DataPublicPluginStart;
   const dataViews = useService(PluginStart('dataViews')) as DataViewsPublicPluginStart;
   const lens = useService(PluginStart('lens')) as LensPublicStart;
@@ -77,12 +79,26 @@ export const useComposeDiscoverFlyout = ({
       dataViews,
       notifications,
       application,
+      uiSettings,
+      featureFlags,
       lens,
       uiActions,
       dashboard,
       cps,
     }),
-    [http, data, dataViews, notifications, application, lens, uiActions, dashboard, cps]
+    [
+      http,
+      data,
+      dataViews,
+      notifications,
+      application,
+      uiSettings,
+      featureFlags,
+      lens,
+      uiActions,
+      dashboard,
+      cps,
+    ]
   );
 
   const closeFlyout = useCallback(() => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -207,6 +207,7 @@ const pluginModule = new ContainerModule(({ bind }) => {
         notifications: coreStart.notifications,
         application: coreStart.application,
         uiSettings: coreStart.uiSettings,
+        featureFlags: coreStart.featureFlags,
         data: diContainer.get(PluginStart('data')) as DataPublicPluginStart,
         dataViews: diContainer.get(PluginStart('dataViews')) as DataViewsPublicPluginStart,
         lens: diContainer.get(PluginStart('lens')) as LensPublicStart,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/kibana_services.test.ts
@@ -10,7 +10,7 @@ import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
-import { applicationServiceMock, uiSettingsServiceMock } from '@kbn/core/public/mocks';
+import { applicationServiceMock, coreMock, uiSettingsServiceMock } from '@kbn/core/public/mocks';
 import { lensPluginMock } from '@kbn/lens-plugin/public/mocks';
 
 const createMockServices = (): AlertingV2KibanaServices => ({
@@ -23,6 +23,7 @@ const createMockServices = (): AlertingV2KibanaServices => ({
   expressions: {} as AlertingV2KibanaServices['expressions'],
   uiActions: {} as AlertingV2KibanaServices['uiActions'],
   uiSettings: uiSettingsServiceMock.createStartContract(),
+  featureFlags: coreMock.createStart().featureFlags,
   container: {} as AlertingV2KibanaServices['container'],
 });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_filter_bar.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_filter_bar.test.tsx
@@ -7,6 +7,8 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
+import { applicationServiceMock, coreMock } from '@kbn/core/public/mocks';
 import { createMockServices } from '@kbn/alerting-v2-episodes-ui/hooks/test_utils';
 import { useFetchEpisodeTagOptions } from '@kbn/alerting-v2-episodes-ui/hooks/use_fetch_episode_tag_options';
 import { useBulkGetProfiles } from '@kbn/alerting-v2-episodes-ui/hooks/use_bulk_get_profiles';
@@ -15,6 +17,12 @@ import { TestProviders } from '../../../test_utils/test_providers';
 import { EpisodesFilterBar } from './episodes_filter_bar';
 
 jest.mock('react-use/lib/useDebounce', () => jest.fn());
+
+jest.mock('@kbn/alerting-v2-browser-shared', () => ({
+  AlertingDateRangePicker: ({ 'data-test-subj': dataTestSubj }: { 'data-test-subj'?: string }) => (
+    <div data-test-subj={dataTestSubj} />
+  ),
+}));
 
 jest.mock('@kbn/alerting-v2-episodes-ui/hooks/use_fetch_episode_tag_options', () => ({
   useFetchEpisodeTagOptions: jest.fn(),
@@ -33,6 +41,7 @@ const mockFetchRulesSearch = jest.mocked(fetchRulesSearch);
 const mockUseBulkGetProfiles = jest.mocked(useBulkGetProfiles);
 
 const mockEpisodeServices = createMockServices();
+const mockNotifications = notificationServiceMock.createStartContract();
 
 const defaultProps = {
   filterState: { status: ['active'] },
@@ -45,6 +54,11 @@ const defaultProps = {
     http: mockEpisodeServices.http,
     expressions: mockEpisodeServices.expressions,
     spaces: mockEpisodeServices.spaces,
+    data: mockEpisodeServices.data,
+    notifications: mockNotifications,
+    application: applicationServiceMock.createStartContract(),
+    uiSettings: mockEpisodeServices.uiSettings,
+    featureFlags: coreMock.createStart().featureFlags,
   },
 };
 
@@ -78,5 +92,6 @@ describe('EpisodesFilterBar', () => {
     expect(screen.getByTestId('episodesFilterBar-rule-button')).toBeInTheDocument();
     expect(screen.getByTestId('episodesFilterBar-tags-button')).toBeInTheDocument();
     expect(screen.getByTestId('episodesFilterBar-assignee-button')).toBeInTheDocument();
+    expect(screen.getByTestId('episodesFilterBar-datePicker')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_filter_bar.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/alert_episodes_list_page/components/episodes_filter_bar.tsx
@@ -17,7 +17,6 @@ import {
   EuiFlexItem,
   EuiFilterGroup,
   EuiFieldSearch,
-  EuiSuperDatePicker,
   useEuiTheme,
 } from '@elastic/eui';
 import type { EpisodesFilterState } from '@kbn/alerting-v2-common-queries';
@@ -29,7 +28,15 @@ import { AlertEpisodesTagFilter } from '@kbn/alerting-v2-episodes-ui/components/
 import { AlertEpisodesAssigneeFilter } from '@kbn/alerting-v2-episodes-ui/components/filters/assignee_filter';
 import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import type { HttpStart } from '@kbn/core-http-browser';
+import type {
+  ApplicationStart,
+  FeatureFlagsStart,
+  IUiSettingsClient,
+  NotificationsStart,
+} from '@kbn/core/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
+import { AlertingDateRangePicker } from '@kbn/alerting-v2-browser-shared';
 import useDebounce from 'react-use/lib/useDebounce';
 import { css } from '@emotion/react';
 import * as i18n from '../translations';
@@ -43,7 +50,16 @@ export interface EpisodesFilterBarProps {
   assigneeUids: string[];
   onRefresh?: () => void;
   isLoading?: boolean;
-  services: { http: HttpStart; expressions: ExpressionsStart; spaces: SpacesPluginStart };
+  services: {
+    http: HttpStart;
+    expressions: ExpressionsStart;
+    spaces: SpacesPluginStart;
+    data: DataPublicPluginStart;
+    notifications: NotificationsStart;
+    application: ApplicationStart;
+    uiSettings: IUiSettingsClient;
+    featureFlags: FeatureFlagsStart;
+  };
 }
 
 export const EpisodesFilterBar = ({
@@ -115,7 +131,7 @@ export const EpisodesFilterBar = ({
   }, []);
 
   return (
-    <EuiFlexGroup alignItems="center" gutterSize="s" wrap>
+    <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
       <EuiFlexItem grow>
         <EuiFieldSearch
           fullWidth
@@ -131,9 +147,22 @@ export const EpisodesFilterBar = ({
           `}
         />
       </EuiFlexItem>
-
       <EuiFlexItem grow={false}>
-        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+        <EuiFlexGroup alignItems="center" gutterSize="s" wrap>
+          <EuiFlexItem grow={false}>
+            <AlertingDateRangePicker
+              from={timeRange.from}
+              to={timeRange.to}
+              onChange={onTimeChange}
+              services={services}
+              onRefresh={onRefresh}
+              isLoading={isLoading}
+              showTimeWindowButtons
+              width="auto"
+              data-test-subj="episodesFilterBar-datePicker"
+            />
+          </EuiFlexItem>
+
           <EuiFlexItem grow={false}>
             <EuiFilterGroup compressed>
               <AlertEpisodesStatusFilter
@@ -173,21 +202,6 @@ export const EpisodesFilterBar = ({
             </EuiFilterGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiSuperDatePicker
-          compressed
-          start={timeRange.from}
-          end={timeRange.to}
-          onTimeChange={({ start, end }) => onTimeChange({ from: start, to: end })}
-          onRefresh={onRefresh}
-          isLoading={isLoading}
-          showUpdateButton="iconOnly"
-          updateButtonProps={{
-            fill: false,
-          }}
-          width="auto"
-        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
@@ -78,6 +78,7 @@
     "@kbn/kql",
     "@kbn/scout",
     "@kbn/object-utils",
+    "@kbn/alerting-v2-browser-shared",
     "@kbn/alerting-v2-constants",
     "@kbn/alerting-v2-common-queries",
     "@kbn/alerting-v2-utils",


### PR DESCRIPTION
## Release Notes

Migrates date range pickers in alerting v2 to `@kbn/date-range-picker`

## Summary

Closes [elastic/rna-program#527](https://github.com/elastic/rna-program/issues/527)

Stacked on top of #285757. Migrates Alerting v2 surfaces off `EuiSuperDatePicker` onto the shared `AlertingDateRangePicker`, now imported from `@kbn/alerting-v2-browser-shared` (introduced in the base PR).

> Note: base branch is `rna-527-browser-shared-pkg` (PR #285757). Review that PR first; this PR's diff will collapse to just the consumer changes once the base merges. This replaces the original #280884.

### Consumers
- Episodes list filter bar
- Rule details -> Alert activity (`AlertTimelineSection`)
- Signal rule overview -> Rule events
- Compose Discover query sandbox

### Decisions
- **Shared wrapper lives in `@kbn/alerting-v2-browser-shared`** (per review feedback) so both rule-form and episode UI can consume it without a circular dependency.
- **Single `services` prop** — `{ data, notifications, http, application, uiSettings, featureFlags }`.
- **Feature-flag kill-switch** — respects `unifiedSearch.newDateRangePickerEnabled`; falls back to `EuiSuperDatePicker` when disabled.
- **`persistPresets` defaults to `true`** — shared user preset storage; consumers can opt out.
- **Episodes filter bar layout** — intentional two-row layout so the picker doesn't fight the search field for horizontal space.
- **Out of scope**
  - Active time-range URL/localStorage persistence -> [#280583](https://github.com/elastic/kibana/issues/280583)
  - Auto-refresh / picker settings persistence -> follow-up
  - Query sandbox layout polish -> [#280866](https://github.com/elastic/kibana/issues/280866)

## Test plan
- [ ] Episodes list: change range, use presets/recent, auto-refresh; confirm filters still work with the two-row layout
- [ ] Rule details (alert rule): Alert activity picker updates timeline; refresh control works
- [ ] Signal rule overview: Rule events picker + brush interaction still update the range
- [ ] Compose Discover query sandbox: picker updates preview range
- [ ] With `unifiedSearch.newDateRangePickerEnabled=false`, surfaces fall back to `EuiSuperDatePicker`
- [ ] Enter an invalid range -> picker shows invalid state; editing clears it
- [x] Unit tests: `query_sandbox.test.tsx`, `episodes_filter_bar.test.tsx`, `alert_timeline_section.test.tsx`

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- [x] New picker is still under active development (`@kbn/date-range-picker`); mitigated by the `unifiedSearch.newDateRangePickerEnabled` kill-switch and `EuiSuperDatePicker` fallback.

Made with [Cursor](https://cursor.com)