### PR TITLE
[9.5] [Alerting V2][ResponseOps] Fix validation for the update API (#283775)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.test.ts
@@ -442,6 +442,61 @@ describe('executeRuleOperations', () => {
     });
   });
 
+  describe('set_query no_data cross-field validation', () => {
+    it('throws when a no_data block is present but no_data_strategy is not set', async () => {
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'standalone',
+            breach: { query: 'FROM metrics-* | WHERE cpu > 0.9' },
+            no_data: { query: 'FROM heartbeat-* | STATS COUNT(*) BY host.name' },
+          },
+        },
+      ];
+
+      await expect(executeRuleOperations({}, ops)).rejects.toThrow(
+        'query.no_data is only allowed when no_data_strategy is set to a non-"none" value'
+      );
+    });
+
+    it('throws when a no_data_strategy is set but no no_data block is provided (standalone)', async () => {
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'standalone',
+            breach: { query: 'FROM metrics-* | WHERE cpu > 0.9' },
+          },
+          no_data_strategy: 'last_known_status',
+        },
+      ];
+
+      const promise = executeRuleOperations({}, ops);
+      await expect(promise).rejects.toThrow('requires a no_data block in the query');
+      await expect(executeRuleOperations({}, ops)).rejects.toBeInstanceOf(
+        RuleOperationValidationError
+      );
+    });
+
+    it('passes when no_data_strategy is set and a no_data block is provided', async () => {
+      const ops: RuleOperation[] = [
+        {
+          operation: 'set_query',
+          query: {
+            format: 'standalone',
+            breach: { query: 'FROM metrics-* | WHERE cpu > 0.9' },
+            no_data: { query: 'FROM heartbeat-* | STATS COUNT(*) BY host.name' },
+          },
+          no_data_strategy: 'last_known_status',
+        },
+      ];
+
+      const result = await executeRuleOperations({}, ops);
+      expect(result.data.no_data_strategy).toBe('last_known_status');
+    });
+  });
+
   describe('set_grouping with column validation', () => {
     it('accepts grouping fields that exist in query columns', async () => {
       const esClient = createMockEsClient();

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/operations.ts
@@ -25,6 +25,8 @@ import {
   isSignalQueryBreachOnly,
   isRecoveryQueryConsistentWithStrategy,
   isRecoveryQueryProvidedForStrategy,
+  isNoDataQueryConsistentWithStrategy,
+  isNoDataQueryProvidedForStrategy,
 } from '@kbn/alerting-v2-schemas';
 import { buildRulePayload } from '../../../../common/agent_builder/rule_mappers';
 import { AGENT_BUILDER_TAG } from '../../common/constants';
@@ -241,6 +243,17 @@ export const executeRuleOperations = async (
           throw new RuleOperationValidationError(
             'recovery_strategy "query" requires a recovery block in the query ' +
               '(recovery: { segment } for composed, recovery: { query } for standalone).'
+          );
+        }
+        if (!isNoDataQueryConsistentWithStrategy(next)) {
+          throw new RuleOperationValidationError(
+            'query.no_data is only allowed when no_data_strategy is set to a non-"none" value.'
+          );
+        }
+        if (!isNoDataQueryProvidedForStrategy(next)) {
+          throw new RuleOperationValidationError(
+            'no_data_strategy (other than "none") requires a no_data block in the query ' +
+              'for standalone-format rules.'
           );
         }
         break;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/README.md
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/README.md
@@ -58,6 +58,7 @@ backwards compatible. Renaming or removing a code is a breaking change.
 | `INVALID_RULE_DATA`           | 400    | The submitted body fails the domain-level schema check               | `{ context, errors }` (tree-shaped errors) |
 | `INVALID_STATE_TRANSITION`    | 400    | `state_transition` is incompatible with the rule's `kind`            | `{ rule_id, kind, transition }`            |
 | `INVALID_SIGNAL_RULE`               | 400    | An update would leave a signal rule in an invalid shape | `{ rule_id, rule_kind }`               |
+| `INVALID_RULE_QUERY_CONFIG`         | 400    | An update would desynchronize a `recovery_strategy`/`no_data_strategy` from its `query.recovery`/`query.no_data` block              | `{ rule_id }`                              |
 | `INVALID_BULK_PARAMS`         | 400    | Bulk operation combines `ids` with `filter` / `search` / `match_all` | `{ params }`                               |
 | `IMMUTABLE_FIELDS_CHANGED`    | 400    | PUT (upsert) request changes a field flagged as immutable            | `{ fields }`                               |
 | `INVALID_FILTER_FIELD`        | 400    | The `filter` references a field that is not in the allow-list        | `{ field, allowed_fields }`                |

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/errors/error_codes.ts
@@ -37,6 +37,11 @@ export const ALERTING_V2_ERROR_CODES = {
   INVALID_BULK_PARAMS: 'INVALID_BULK_PARAMS',
   /** A signal rule's merged shape violates signal constraints. */
   INVALID_SIGNAL_RULE: 'INVALID_SIGNAL_RULE',
+  /**
+   * A rule's merged shape has a recovery/no-data query block that is
+   * inconsistent with its `recovery_strategy`/`no_data_strategy`.
+   */
+  INVALID_RULE_QUERY_CONFIG: 'INVALID_RULE_QUERY_CONFIG',
   /** PUT body changed a field flagged as immutable. */
   IMMUTABLE_FIELDS_CHANGED: 'IMMUTABLE_FIELDS_CHANGED',
   /** Filter expression referenced an unknown field. */

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -549,6 +549,128 @@ describe('RulesClient', () => {
       expect(mockSavedObjectsClient.update).toHaveBeenCalled();
     });
 
+    it('throws 400 when clearing recovery_strategy leaves a stale query.recovery block', async () => {
+      const client = createClient();
+
+      const existingAttributes: RuleSavedObjectAttributes = {
+        ...baseSoAttrs,
+        kind: 'alert',
+        recovery_strategy: 'query',
+        query: {
+          format: 'standalone',
+          breach: { query: 'FROM logs-* | LIMIT 1' },
+          recovery: { query: 'FROM logs-* | LIMIT 2' },
+        },
+      };
+
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-stale-recovery',
+        attributes: existingAttributes,
+        version: 'WzEsMV0=',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-stale-recovery',
+          data: { recovery_strategy: null },
+        })
+      ).rejects.toMatchObject({
+        output: { statusCode: 400 },
+        message: 'query.recovery is only allowed when recovery_strategy is "query".',
+      });
+
+      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 when setting recovery_strategy "query" without a query.recovery block', async () => {
+      const client = createClient();
+
+      const existingAttributes: RuleSavedObjectAttributes = {
+        ...baseSoAttrs,
+        kind: 'alert',
+      };
+
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-missing-recovery',
+        attributes: existingAttributes,
+        version: 'WzEsMV0=',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-missing-recovery',
+          data: { recovery_strategy: 'query' },
+        })
+      ).rejects.toMatchObject({
+        output: { statusCode: 400 },
+        message: 'query.recovery is required when recovery_strategy is "query".',
+      });
+
+      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 when clearing no_data_strategy leaves a stale query.no_data block', async () => {
+      const client = createClient();
+
+      const existingAttributes: RuleSavedObjectAttributes = {
+        ...baseSoAttrs,
+        kind: 'alert',
+        no_data_strategy: 'last_known_status',
+        query: {
+          format: 'standalone',
+          breach: { query: 'FROM logs-* | LIMIT 1' },
+          no_data: { query: 'FROM logs-* | STATS c = COUNT(*) | WHERE c == 0' },
+        },
+      };
+
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-stale-no-data',
+        attributes: existingAttributes,
+        version: 'WzEsMV0=',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-stale-no-data',
+          data: { no_data_strategy: null },
+        })
+      ).rejects.toMatchObject({
+        output: { statusCode: 400 },
+        message:
+          'query.no_data is only allowed when no_data_strategy is set to a non-"none" value.',
+      });
+
+      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 when setting a no_data_strategy without a query.no_data block (standalone)', async () => {
+      const client = createClient();
+
+      const existingAttributes: RuleSavedObjectAttributes = {
+        ...baseSoAttrs,
+        kind: 'alert',
+      };
+
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-missing-no-data',
+        attributes: existingAttributes,
+        version: 'WzEsMV0=',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-missing-no-data',
+          data: { no_data_strategy: 'last_known_status' },
+        })
+      ).rejects.toMatchObject({
+        output: { statusCode: 400 },
+        message:
+          'query.no_data is required when no_data_strategy is not "none" for standalone-format rules.',
+      });
+
+      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+    });
+
     it('allows setting state_transition to null on a signal rule (removing it)', async () => {
       const client = createClient();
 
@@ -2608,6 +2730,28 @@ describe('RulesClient', () => {
         data: {
           code: 'INVALID_SIGNAL_RULE',
           details: { rule_id: 'rule-id-signal-z', rule_kind: 'signal' },
+        },
+      });
+    });
+
+    it('attaches INVALID_RULE_QUERY_CONFIG code when an update desynchronizes a strategy and its query block', async () => {
+      const client = createClient();
+      rulesSavedObjectService.get.mockResolvedValueOnce({
+        id: 'rule-id-query-config',
+        attributes: { ...baseSoAttrs, kind: 'alert' },
+        version: 'v1',
+      });
+
+      await expect(
+        client.updateRule({
+          id: 'rule-id-query-config',
+          data: { recovery_strategy: 'query' },
+        })
+      ).rejects.toMatchObject({
+        output: { statusCode: 400 },
+        data: {
+          code: 'INVALID_RULE_QUERY_CONFIG',
+          details: { rule_id: 'rule-id-query-config' },
         },
       });
     });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -563,10 +563,12 @@ describe('RulesClient', () => {
         },
       };
 
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-stale-recovery',
         attributes: existingAttributes,
         version: 'WzEsMV0=',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(
@@ -579,7 +581,7 @@ describe('RulesClient', () => {
         message: 'query.recovery is only allowed when recovery_strategy is "query".',
       });
 
-      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+      expect(mockSavedObjectsClient.update).not.toHaveBeenCalled();
     });
 
     it('throws 400 when setting recovery_strategy "query" without a query.recovery block', async () => {
@@ -590,10 +592,12 @@ describe('RulesClient', () => {
         kind: 'alert',
       };
 
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-missing-recovery',
         attributes: existingAttributes,
         version: 'WzEsMV0=',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(
@@ -606,7 +610,7 @@ describe('RulesClient', () => {
         message: 'query.recovery is required when recovery_strategy is "query".',
       });
 
-      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+      expect(mockSavedObjectsClient.update).not.toHaveBeenCalled();
     });
 
     it('throws 400 when clearing no_data_strategy leaves a stale query.no_data block', async () => {
@@ -623,10 +627,12 @@ describe('RulesClient', () => {
         },
       };
 
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-stale-no-data',
         attributes: existingAttributes,
         version: 'WzEsMV0=',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(
@@ -640,7 +646,7 @@ describe('RulesClient', () => {
           'query.no_data is only allowed when no_data_strategy is set to a non-"none" value.',
       });
 
-      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+      expect(mockSavedObjectsClient.update).not.toHaveBeenCalled();
     });
 
     it('throws 400 when setting a no_data_strategy without a query.no_data block (standalone)', async () => {
@@ -651,10 +657,12 @@ describe('RulesClient', () => {
         kind: 'alert',
       };
 
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-missing-no-data',
         attributes: existingAttributes,
         version: 'WzEsMV0=',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(
@@ -668,7 +676,7 @@ describe('RulesClient', () => {
           'query.no_data is required when no_data_strategy is not "none" for standalone-format rules.',
       });
 
-      expect(rulesSavedObjectService.update).not.toHaveBeenCalled();
+      expect(mockSavedObjectsClient.update).not.toHaveBeenCalled();
     });
 
     it('allows setting state_transition to null on a signal rule (removing it)', async () => {
@@ -2736,10 +2744,12 @@ describe('RulesClient', () => {
 
     it('attaches INVALID_RULE_QUERY_CONFIG code when an update desynchronizes a strategy and its query block', async () => {
       const client = createClient();
-      rulesSavedObjectService.get.mockResolvedValueOnce({
+      mockSavedObjectsClient.get.mockResolvedValueOnce({
         id: 'rule-id-query-config',
         attributes: { ...baseSoAttrs, kind: 'alert' },
         version: 'v1',
+        type: RULE_SAVED_OBJECT_TYPE,
+        references: [],
       });
 
       await expect(

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.ts
@@ -9,8 +9,6 @@ import Boom from '@hapi/boom';
 import {
   BULK_FILTER_MAX_RULES,
   createRuleDataSchema,
-  isSignalQueryBreachOnly,
-  isSignalUsingStandaloneFormat,
   isStateTransitionAllowed,
   updateRuleDataSchema,
 } from '@kbn/alerting-v2-schemas';
@@ -64,6 +62,7 @@ import type {
 } from './types';
 import {
   assertImmutableUnchanged,
+  validateMergedRuleAttributes,
   buildUpdateRuleAttributes,
   transformCreateRuleBodyToRuleSoAttributes,
   transformRuleSoAttributesToRuleApiResponse,
@@ -366,18 +365,7 @@ export class RulesClient {
       updatedAt: nowIso,
     });
 
-    if (!isSignalUsingStandaloneFormat(nextAttrs)) {
-      throw Boom.badRequest('kind "signal" requires query.format "standalone".', {
-        code: ALERTING_V2_ERROR_CODES.INVALID_SIGNAL_RULE,
-        details: { rule_id: id, rule_kind: existingAttrs.kind },
-      });
-    }
-    if (!isSignalQueryBreachOnly(nextAttrs)) {
-      throw Boom.badRequest('Signal rules cannot set recovery_strategy or no_data_strategy.', {
-        code: ALERTING_V2_ERROR_CODES.INVALID_SIGNAL_RULE,
-        details: { rule_id: id, rule_kind: existingAttrs.kind },
-      });
-    }
+    validateMergedRuleAttributes(id, nextAttrs);
 
     await this.validateSchedule({
       updatedEvery: nextAttrs.schedule.every,

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.test.ts
@@ -12,6 +12,7 @@ import {
   transformRuleSoAttributesToRuleApiResponse,
   buildUpdateRuleAttributes,
   assertImmutableUnchanged,
+  validateMergedRuleAttributes,
   pickImmutable,
 } from './utils';
 
@@ -328,6 +329,215 @@ describe('utils', () => {
           },
         })
       );
+    });
+  });
+
+  describe('validateMergedRuleAttributes', () => {
+    it('does not throw for a valid alert rule', () => {
+      const attrs = createRuleSoAttributes({ kind: 'alert' });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).not.toThrow();
+    });
+
+    it('does not throw for a valid signal rule (standalone, breach-only)', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'signal',
+        recovery_strategy: undefined,
+        query: { format: 'standalone', breach: { query: 'FROM logs-* | LIMIT 1' } },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).not.toThrow();
+    });
+
+    it('throws INVALID_SIGNAL_RULE (400) when a signal rule uses a composed query', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'signal',
+        recovery_strategy: undefined,
+        query: {
+          format: 'composed',
+          base: 'FROM logs-*',
+          breach: { segment: 'WHERE error' },
+        },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).toThrow(
+        expect.objectContaining({
+          isBoom: true,
+          output: expect.objectContaining({ statusCode: 400 }),
+          message: 'kind "signal" requires query.format "standalone".',
+          data: {
+            code: 'INVALID_SIGNAL_RULE',
+            details: { rule_id: 'rule-1', rule_kind: 'signal' },
+          },
+        })
+      );
+    });
+
+    it('throws INVALID_SIGNAL_RULE when a signal rule sets a recovery_strategy', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'signal',
+        recovery_strategy: 'no_breach',
+        query: { format: 'standalone', breach: { query: 'FROM logs-* | LIMIT 1' } },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).toThrow(
+        expect.objectContaining({
+          message: 'Signal rules cannot set recovery_strategy or no_data_strategy.',
+          data: {
+            code: 'INVALID_SIGNAL_RULE',
+            details: { rule_id: 'rule-1', rule_kind: 'signal' },
+          },
+        })
+      );
+    });
+
+    it('throws INVALID_SIGNAL_RULE when a signal rule sets a no_data_strategy', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'signal',
+        recovery_strategy: undefined,
+        no_data_strategy: 'last_known_status',
+        query: {
+          format: 'standalone',
+          breach: { query: 'FROM logs-* | LIMIT 1' },
+          no_data: { query: 'FROM logs-* | STATS c = COUNT(*) | WHERE c == 0' },
+        },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).toThrow(
+        expect.objectContaining({
+          data: {
+            code: 'INVALID_SIGNAL_RULE',
+            details: { rule_id: 'rule-1', rule_kind: 'signal' },
+          },
+        })
+      );
+    });
+
+    it('throws INVALID_RULE_QUERY_CONFIG (400) when a query.recovery block has no "query" strategy', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'alert',
+        recovery_strategy: 'no_breach',
+        query: {
+          format: 'standalone',
+          breach: { query: 'FROM logs-* | LIMIT 1' },
+          recovery: { query: 'FROM logs-* | LIMIT 2' },
+        },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).toThrow(
+        expect.objectContaining({
+          isBoom: true,
+          output: expect.objectContaining({ statusCode: 400 }),
+          message: 'query.recovery is only allowed when recovery_strategy is "query".',
+          data: { code: 'INVALID_RULE_QUERY_CONFIG', details: { rule_id: 'rule-1' } },
+        })
+      );
+    });
+
+    it('throws INVALID_RULE_QUERY_CONFIG when a composed query.recovery segment has no "query" strategy', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'alert',
+        recovery_strategy: 'no_breach',
+        query: {
+          format: 'composed',
+          base: 'FROM logs-*',
+          breach: { segment: 'WHERE error' },
+          recovery: { segment: 'WHERE NOT error' },
+        },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).toThrow(
+        expect.objectContaining({
+          isBoom: true,
+          output: expect.objectContaining({ statusCode: 400 }),
+          message: 'query.recovery is only allowed when recovery_strategy is "query".',
+          data: { code: 'INVALID_RULE_QUERY_CONFIG', details: { rule_id: 'rule-1' } },
+        })
+      );
+    });
+
+    it('throws INVALID_RULE_QUERY_CONFIG when recovery_strategy "query" has no recovery block', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'alert',
+        recovery_strategy: 'query',
+        query: { format: 'standalone', breach: { query: 'FROM logs-* | LIMIT 1' } },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).toThrow(
+        expect.objectContaining({
+          message: 'query.recovery is required when recovery_strategy is "query".',
+          data: { code: 'INVALID_RULE_QUERY_CONFIG', details: { rule_id: 'rule-1' } },
+        })
+      );
+    });
+
+    it('throws INVALID_RULE_QUERY_CONFIG when a composed rule sets recovery_strategy "query" with no recovery segment', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'alert',
+        recovery_strategy: 'query',
+        query: {
+          format: 'composed',
+          base: 'FROM logs-*',
+          breach: { segment: 'WHERE error' },
+        },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).toThrow(
+        expect.objectContaining({
+          message: 'query.recovery is required when recovery_strategy is "query".',
+          data: { code: 'INVALID_RULE_QUERY_CONFIG', details: { rule_id: 'rule-1' } },
+        })
+      );
+    });
+
+    it('throws INVALID_RULE_QUERY_CONFIG when a query.no_data block has no strategy', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'alert',
+        no_data_strategy: undefined,
+        query: {
+          format: 'standalone',
+          breach: { query: 'FROM logs-* | LIMIT 1' },
+          no_data: { query: 'FROM logs-* | STATS c = COUNT(*) | WHERE c == 0' },
+        },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).toThrow(
+        expect.objectContaining({
+          message:
+            'query.no_data is only allowed when no_data_strategy is set to a non-"none" value.',
+          data: { code: 'INVALID_RULE_QUERY_CONFIG', details: { rule_id: 'rule-1' } },
+        })
+      );
+    });
+
+    it('throws INVALID_RULE_QUERY_CONFIG when a no_data_strategy has no no_data block (standalone)', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'alert',
+        no_data_strategy: 'last_known_status',
+        query: { format: 'standalone', breach: { query: 'FROM logs-* | LIMIT 1' } },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).toThrow(
+        expect.objectContaining({
+          message:
+            'query.no_data is required when no_data_strategy is not "none" for standalone-format rules.',
+          data: { code: 'INVALID_RULE_QUERY_CONFIG', details: { rule_id: 'rule-1' } },
+        })
+      );
+    });
+
+    it('does not require a no_data block for a composed-format rule (base query is the data-presence query)', () => {
+      const attrs = createRuleSoAttributes({
+        kind: 'alert',
+        no_data_strategy: 'last_known_status',
+        query: {
+          format: 'composed',
+          base: 'FROM logs-*',
+          breach: { segment: 'WHERE error' },
+        },
+      });
+
+      expect(() => validateMergedRuleAttributes('rule-1', attrs)).not.toThrow();
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
@@ -22,7 +22,6 @@ import {
   isSignalQueryBreachOnly,
   isSignalUsingStandaloneFormat,
 } from '@kbn/alerting-v2-schemas';
-import { TaskStatus } from '@kbn/task-manager-plugin/server';
 
 import { type RuleSavedObjectAttributes } from '../../saved_objects';
 import { ALERTING_V2_ERROR_CODES } from '../errors/error_codes';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
@@ -7,8 +7,22 @@
 
 import Boom from '@hapi/boom';
 import { isEqual } from 'lodash';
-import type { CreateRuleData, UpdateRuleData, RuleResponse } from '@kbn/alerting-v2-schemas';
-import { IMMUTABLE_RULE_FIELDS, type ImmutableRuleField } from '@kbn/alerting-v2-schemas';
+import type {
+  CreateRuleData,
+  UpdateRuleData,
+  RuleResponse,
+  ImmutableRuleField,
+} from '@kbn/alerting-v2-schemas';
+import {
+  IMMUTABLE_RULE_FIELDS,
+  isNoDataQueryConsistentWithStrategy,
+  isNoDataQueryProvidedForStrategy,
+  isRecoveryQueryConsistentWithStrategy,
+  isRecoveryQueryProvidedForStrategy,
+  isSignalQueryBreachOnly,
+  isSignalUsingStandaloneFormat,
+} from '@kbn/alerting-v2-schemas';
+import { TaskStatus } from '@kbn/task-manager-plugin/server';
 
 import { type RuleSavedObjectAttributes } from '../../saved_objects';
 import { ALERTING_V2_ERROR_CODES } from '../errors/error_codes';
@@ -203,6 +217,73 @@ export function buildUpdateRuleAttributes(
     // can leak through if someone adds a new immutable field to the registry.
     ...pickImmutable(existingAttrs),
   };
+}
+
+/**
+ * Re-checks the create schema's cross-field invariants against the merged
+ * update attributes (the update body alone can't, since `kind` is immutable and
+ * `query`/strategy fields update independently). Throws on the first violation.
+ *
+ * Excludes the `state_transition`/`kind` invariant, which `RulesClient`
+ * validates against the update body directly.
+ */
+export function validateMergedRuleAttributes(
+  ruleId: string,
+  attrs: RuleSavedObjectAttributes
+): void {
+  const invariants: Array<{
+    valid: boolean;
+    message: string;
+    code: string;
+    details: Record<string, unknown>;
+  }> = [
+    {
+      valid: isSignalUsingStandaloneFormat(attrs),
+      message: 'kind "signal" requires query.format "standalone".',
+      code: ALERTING_ERROR_CODES.INVALID_SIGNAL_RULE,
+      details: { rule_id: ruleId, rule_kind: attrs.kind },
+    },
+    {
+      valid: isSignalQueryBreachOnly(attrs),
+      message: 'Signal rules cannot set recovery_strategy or no_data_strategy.',
+      code: ALERTING_ERROR_CODES.INVALID_SIGNAL_RULE,
+      details: { rule_id: ruleId, rule_kind: attrs.kind },
+    },
+    {
+      valid: isRecoveryQueryConsistentWithStrategy(attrs),
+      message: 'query.recovery is only allowed when recovery_strategy is "query".',
+      code: ALERTING_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
+      details: { rule_id: ruleId },
+    },
+    {
+      valid: isRecoveryQueryProvidedForStrategy(attrs),
+      message: 'query.recovery is required when recovery_strategy is "query".',
+      code: ALERTING_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
+      details: { rule_id: ruleId },
+    },
+    {
+      valid: isNoDataQueryConsistentWithStrategy(attrs),
+      message: 'query.no_data is only allowed when no_data_strategy is set to a non-"none" value.',
+      code: ALERTING_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
+      details: { rule_id: ruleId },
+    },
+    {
+      valid: isNoDataQueryProvidedForStrategy(attrs),
+      message:
+        'query.no_data is required when no_data_strategy is not "none" for standalone-format rules.',
+      code: ALERTING_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
+      details: { rule_id: ruleId },
+    },
+  ];
+
+  for (const invariant of invariants) {
+    if (!invariant.valid) {
+      throw Boom.badRequest(invariant.message, {
+        code: invariant.code,
+        details: invariant.details,
+      });
+    }
+  }
 }
 
 /**

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/utils.ts
@@ -22,7 +22,6 @@ import {
   isSignalQueryBreachOnly,
   isSignalUsingStandaloneFormat,
 } from '@kbn/alerting-v2-schemas';
-import { TaskStatus } from '@kbn/task-manager-plugin/server';
 
 import { type RuleSavedObjectAttributes } from '../../saved_objects';
 import { ALERTING_V2_ERROR_CODES } from '../errors/error_codes';
@@ -240,38 +239,38 @@ export function validateMergedRuleAttributes(
     {
       valid: isSignalUsingStandaloneFormat(attrs),
       message: 'kind "signal" requires query.format "standalone".',
-      code: ALERTING_ERROR_CODES.INVALID_SIGNAL_RULE,
+      code: ALERTING_V2_ERROR_CODES.INVALID_SIGNAL_RULE,
       details: { rule_id: ruleId, rule_kind: attrs.kind },
     },
     {
       valid: isSignalQueryBreachOnly(attrs),
       message: 'Signal rules cannot set recovery_strategy or no_data_strategy.',
-      code: ALERTING_ERROR_CODES.INVALID_SIGNAL_RULE,
+      code: ALERTING_V2_ERROR_CODES.INVALID_SIGNAL_RULE,
       details: { rule_id: ruleId, rule_kind: attrs.kind },
     },
     {
       valid: isRecoveryQueryConsistentWithStrategy(attrs),
       message: 'query.recovery is only allowed when recovery_strategy is "query".',
-      code: ALERTING_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
+      code: ALERTING_V2_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
       details: { rule_id: ruleId },
     },
     {
       valid: isRecoveryQueryProvidedForStrategy(attrs),
       message: 'query.recovery is required when recovery_strategy is "query".',
-      code: ALERTING_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
+      code: ALERTING_V2_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
       details: { rule_id: ruleId },
     },
     {
       valid: isNoDataQueryConsistentWithStrategy(attrs),
       message: 'query.no_data is only allowed when no_data_strategy is set to a non-"none" value.',
-      code: ALERTING_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
+      code: ALERTING_V2_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
       details: { rule_id: ruleId },
     },
     {
       valid: isNoDataQueryProvidedForStrategy(attrs),
       message:
         'query.no_data is required when no_data_strategy is not "none" for standalone-format rules.',
-      code: ALERTING_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
+      code: ALERTING_V2_ERROR_CODES.INVALID_RULE_QUERY_CONFIG,
       details: { rule_id: ruleId },
     },
   ];

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/update_rule.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/routes/rules/update_rule.spec.ts
@@ -482,6 +482,85 @@ apiTest.describe('Update rule API', { tag: '@local-stateful-classic' }, () => {
   );
 
   apiTest(
+    'validation: should reject recovery_strategy "query" without a recovery block',
+    async ({ apiClient, apiServices }) => {
+      const created = await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({ metadata: { name: 'recovery-strategy-no-block' } })
+      );
+      const response = await apiClient.patch(getRuleUrl(created.id), {
+        headers: writerHeaders,
+        body: { recovery_strategy: 'query' },
+      });
+      expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_RULE_QUERY_CONFIG');
+    }
+  );
+
+  apiTest(
+    'validation: should reject a composed rule setting recovery_strategy "query" without a recovery segment',
+    async ({ apiClient, apiServices }) => {
+      const created = await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({
+          metadata: { name: 'composed-recovery-no-segment' },
+          query: {
+            format: 'composed',
+            base: 'FROM logs-* | STATS count = COUNT(*) BY host.name',
+            breach: { segment: 'WHERE count >= 10' },
+          },
+        })
+      );
+      const response = await apiClient.patch(getRuleUrl(created.id), {
+        headers: writerHeaders,
+        body: { recovery_strategy: 'query' },
+      });
+      expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_RULE_QUERY_CONFIG');
+    }
+  );
+
+  apiTest(
+    'validation: should reject clearing recovery_strategy while a composed recovery segment remains',
+    async ({ apiClient, apiServices }) => {
+      const created = await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({
+          metadata: { name: 'composed-recovery-stale-segment' },
+          recovery_strategy: 'query',
+          query: {
+            format: 'composed',
+            base: 'FROM logs-* | STATS count = COUNT(*) BY host.name',
+            breach: { segment: 'WHERE count >= 10' },
+            recovery: { segment: 'WHERE count < 5' },
+          },
+        })
+      );
+      const response = await apiClient.patch(getRuleUrl(created.id), {
+        headers: writerHeaders,
+        body: { recovery_strategy: 'no_breach' },
+      });
+      expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_RULE_QUERY_CONFIG');
+      // The rejected update must not have persisted: the strategy stays "query".
+      const stored = await apiServices.alertingV2.rules.get(created.id);
+      expect(stored.recovery_strategy).toBe('query');
+    }
+  );
+
+  apiTest(
+    'validation: should reject a no_data_strategy without a no_data block (standalone)',
+    async ({ apiClient, apiServices }) => {
+      const created = await apiServices.alertingV2.rules.create(
+        buildCreateRuleData({ metadata: { name: 'no-data-strategy-no-block' } })
+      );
+      const response = await apiClient.patch(getRuleUrl(created.id), {
+        headers: writerHeaders,
+        body: { no_data_strategy: 'last_known_status' },
+      });
+      expect(response).toHaveStatusCode(400);
+      expect(response.body.code).toBe('INVALID_RULE_QUERY_CONFIG');
+    }
+  );
+
+  apiTest(
     'authorization: should return 200 for a user with full alerting_v2 privileges',
     async ({ apiClient, apiServices }) => {
       const created = await apiServices.alertingV2.rules.create(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Alerting V2][ResponseOps] Fix validation for the update API (#283775)](https://github.com/elastic/kibana/pull/283775)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-17T21:00:21Z","message":"[Alerting V2][ResponseOps] Fix validation for the update API (#283775)\n\nFollow on from https://github.com/elastic/kibana/pull/283754\n\n## Summary\n\nThis PR fixes the validation on the update API so it matches the create\nAPI.\n\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n### To verify\n\n1. Start Kibana and enabled alertingV2\n2. Go to dev tools and create the rules rules\n```console\nPUT kbn:/api/alerting/v2/rules/mv-signal\n{\n  \"kind\": \"signal\",\n  \"metadata\": { \"name\": \"MV signal\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"query\": { \"format\": \"standalone\", \"breach\": { \"query\": \"FROM logs-* | LIMIT 1\" } }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-alert-standalone\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV standalone alert\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"query\": { \"format\": \"standalone\", \"breach\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c > 0\" } }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-alert-composed\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV composed alert\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"query\": { \"format\": \"composed\", \"base\": \"FROM logs-*\", \"breach\": { \"segment\": \"WHERE error\" } }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-recovery-standalone\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV recovery standalone\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"recovery_strategy\": \"query\",\n  \"query\": {\n    \"format\": \"standalone\",\n    \"breach\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c > 0\" },\n    \"recovery\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c == 0\" }\n  }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-recovery-composed\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV recovery composed\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"recovery_strategy\": \"query\",\n  \"query\": {\n    \"format\": \"composed\",\n    \"base\": \"FROM logs-*\",\n    \"breach\": { \"segment\": \"WHERE error\" },\n    \"recovery\": { \"segment\": \"WHERE NOT error\" }\n  }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-nodata-standalone\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV no_data standalone\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"no_data_strategy\": \"last_known_status\",\n  \"query\": {\n    \"format\": \"standalone\",\n    \"breach\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c > 0\" },\n    \"no_data\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c == 0\" }\n  }\n}\n```\n\n3. Verify that signal rules stay standalone + breach-only \n\n```console\n// 1a. signal -> composed query\nPATCH kbn:/api/alerting/v2/rules/mv-signal\n{ \"query\": { \"format\": \"composed\", \"base\": \"FROM logs-*\", \"breach\": { \"segment\": \"WHERE error\" } } }\n\n// 1b. signal gains a recovery_strategy\nPATCH kbn:/api/alerting/v2/rules/mv-signal\n{ \"recovery_strategy\": \"no_breach\" }\n\n// 1c. signal gains a no_data_strategy\nPATCH kbn:/api/alerting/v2/rules/mv-signal\n{ \"no_data_strategy\": \"last_known_status\" }\n```\n\n4. Verify that a recovery query only allowed when `recovery_strategy:\n\"query\"`\n```console\n// 2a. standalone - stale recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-recovery-standalone\n{ \"recovery_strategy\": \"no_breach\" }\n\n// 2b. composed - stale recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-recovery-composed\n{ \"recovery_strategy\": \"no_breach\" }\n```\n\n5. Verify that`recovery_strategy: \"query\"` requires a recovery block\n\n```console\n// 3a. standalone - set \"query\" strategy, no recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-alert-standalone\n{ \"recovery_strategy\": \"query\" }\n\n// 3b. composed - set \"query\" strategy, no recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-alert-composed\n{ \"recovery_strategy\": \"query\" }\n```\n\n6. Verify that no data query is only allowed when `no_data_strategy !=\n\"none\"`\n\n```console\n// 4a. standalone - clear the strategy but leave the stale no_data block\nPATCH kbn:/api/alerting/v2/rules/mv-nodata-standalone\n{ \"no_data_strategy\": \"none\" }\n```\n\n7. Verify that`no_data_strategy` requires a no data block for standalone\nformat\n\n```console\n// 5a. standalone - strategy set, no block  ->  400 INVALID_RULE_QUERY_CONFIG\nPATCH kbn:/api/alerting/v2/rules/mv-alert-standalone\n{ \"no_data_strategy\": \"last_known_status\" }\n\n// 5b. composed - strategy set, no block  ->  200 (base is the data-presence query)\nPATCH kbn:/api/alerting/v2/rules/mv-alert-composed\n{ \"no_data_strategy\": \"last_known_status\" }\n```","sha":"d90aab48e81b91b4ed5b3a9a5eb40559c52a93c1","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","reviewer:scout","v9.6.0","v9.5.2"],"title":"[Alerting V2][ResponseOps] Fix validation for the update API","number":283775,"url":"https://github.com/elastic/kibana/pull/283775","mergeCommit":{"message":"[Alerting V2][ResponseOps] Fix validation for the update API (#283775)\n\nFollow on from https://github.com/elastic/kibana/pull/283754\n\n## Summary\n\nThis PR fixes the validation on the update API so it matches the create\nAPI.\n\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n### To verify\n\n1. Start Kibana and enabled alertingV2\n2. Go to dev tools and create the rules rules\n```console\nPUT kbn:/api/alerting/v2/rules/mv-signal\n{\n  \"kind\": \"signal\",\n  \"metadata\": { \"name\": \"MV signal\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"query\": { \"format\": \"standalone\", \"breach\": { \"query\": \"FROM logs-* | LIMIT 1\" } }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-alert-standalone\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV standalone alert\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"query\": { \"format\": \"standalone\", \"breach\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c > 0\" } }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-alert-composed\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV composed alert\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"query\": { \"format\": \"composed\", \"base\": \"FROM logs-*\", \"breach\": { \"segment\": \"WHERE error\" } }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-recovery-standalone\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV recovery standalone\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"recovery_strategy\": \"query\",\n  \"query\": {\n    \"format\": \"standalone\",\n    \"breach\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c > 0\" },\n    \"recovery\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c == 0\" }\n  }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-recovery-composed\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV recovery composed\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"recovery_strategy\": \"query\",\n  \"query\": {\n    \"format\": \"composed\",\n    \"base\": \"FROM logs-*\",\n    \"breach\": { \"segment\": \"WHERE error\" },\n    \"recovery\": { \"segment\": \"WHERE NOT error\" }\n  }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-nodata-standalone\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV no_data standalone\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"no_data_strategy\": \"last_known_status\",\n  \"query\": {\n    \"format\": \"standalone\",\n    \"breach\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c > 0\" },\n    \"no_data\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c == 0\" }\n  }\n}\n```\n\n3. Verify that signal rules stay standalone + breach-only \n\n```console\n// 1a. signal -> composed query\nPATCH kbn:/api/alerting/v2/rules/mv-signal\n{ \"query\": { \"format\": \"composed\", \"base\": \"FROM logs-*\", \"breach\": { \"segment\": \"WHERE error\" } } }\n\n// 1b. signal gains a recovery_strategy\nPATCH kbn:/api/alerting/v2/rules/mv-signal\n{ \"recovery_strategy\": \"no_breach\" }\n\n// 1c. signal gains a no_data_strategy\nPATCH kbn:/api/alerting/v2/rules/mv-signal\n{ \"no_data_strategy\": \"last_known_status\" }\n```\n\n4. Verify that a recovery query only allowed when `recovery_strategy:\n\"query\"`\n```console\n// 2a. standalone - stale recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-recovery-standalone\n{ \"recovery_strategy\": \"no_breach\" }\n\n// 2b. composed - stale recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-recovery-composed\n{ \"recovery_strategy\": \"no_breach\" }\n```\n\n5. Verify that`recovery_strategy: \"query\"` requires a recovery block\n\n```console\n// 3a. standalone - set \"query\" strategy, no recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-alert-standalone\n{ \"recovery_strategy\": \"query\" }\n\n// 3b. composed - set \"query\" strategy, no recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-alert-composed\n{ \"recovery_strategy\": \"query\" }\n```\n\n6. Verify that no data query is only allowed when `no_data_strategy !=\n\"none\"`\n\n```console\n// 4a. standalone - clear the strategy but leave the stale no_data block\nPATCH kbn:/api/alerting/v2/rules/mv-nodata-standalone\n{ \"no_data_strategy\": \"none\" }\n```\n\n7. Verify that`no_data_strategy` requires a no data block for standalone\nformat\n\n```console\n// 5a. standalone - strategy set, no block  ->  400 INVALID_RULE_QUERY_CONFIG\nPATCH kbn:/api/alerting/v2/rules/mv-alert-standalone\n{ \"no_data_strategy\": \"last_known_status\" }\n\n// 5b. composed - strategy set, no block  ->  200 (base is the data-presence query)\nPATCH kbn:/api/alerting/v2/rules/mv-alert-composed\n{ \"no_data_strategy\": \"last_known_status\" }\n```","sha":"d90aab48e81b91b4ed5b3a9a5eb40559c52a93c1"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283775","number":283775,"mergeCommit":{"message":"[Alerting V2][ResponseOps] Fix validation for the update API (#283775)\n\nFollow on from https://github.com/elastic/kibana/pull/283754\n\n## Summary\n\nThis PR fixes the validation on the update API so it matches the create\nAPI.\n\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n### To verify\n\n1. Start Kibana and enabled alertingV2\n2. Go to dev tools and create the rules rules\n```console\nPUT kbn:/api/alerting/v2/rules/mv-signal\n{\n  \"kind\": \"signal\",\n  \"metadata\": { \"name\": \"MV signal\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"query\": { \"format\": \"standalone\", \"breach\": { \"query\": \"FROM logs-* | LIMIT 1\" } }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-alert-standalone\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV standalone alert\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"query\": { \"format\": \"standalone\", \"breach\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c > 0\" } }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-alert-composed\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV composed alert\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"query\": { \"format\": \"composed\", \"base\": \"FROM logs-*\", \"breach\": { \"segment\": \"WHERE error\" } }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-recovery-standalone\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV recovery standalone\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"recovery_strategy\": \"query\",\n  \"query\": {\n    \"format\": \"standalone\",\n    \"breach\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c > 0\" },\n    \"recovery\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c == 0\" }\n  }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-recovery-composed\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV recovery composed\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"recovery_strategy\": \"query\",\n  \"query\": {\n    \"format\": \"composed\",\n    \"base\": \"FROM logs-*\",\n    \"breach\": { \"segment\": \"WHERE error\" },\n    \"recovery\": { \"segment\": \"WHERE NOT error\" }\n  }\n}\n\nPUT kbn:/api/alerting/v2/rules/mv-nodata-standalone\n{\n  \"kind\": \"alert\",\n  \"metadata\": { \"name\": \"MV no_data standalone\" },\n  \"time_field\": \"@timestamp\",\n  \"schedule\": { \"every\": \"5m\" },\n  \"no_data_strategy\": \"last_known_status\",\n  \"query\": {\n    \"format\": \"standalone\",\n    \"breach\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c > 0\" },\n    \"no_data\": { \"query\": \"FROM logs-* | STATS c = COUNT(*) | WHERE c == 0\" }\n  }\n}\n```\n\n3. Verify that signal rules stay standalone + breach-only \n\n```console\n// 1a. signal -> composed query\nPATCH kbn:/api/alerting/v2/rules/mv-signal\n{ \"query\": { \"format\": \"composed\", \"base\": \"FROM logs-*\", \"breach\": { \"segment\": \"WHERE error\" } } }\n\n// 1b. signal gains a recovery_strategy\nPATCH kbn:/api/alerting/v2/rules/mv-signal\n{ \"recovery_strategy\": \"no_breach\" }\n\n// 1c. signal gains a no_data_strategy\nPATCH kbn:/api/alerting/v2/rules/mv-signal\n{ \"no_data_strategy\": \"last_known_status\" }\n```\n\n4. Verify that a recovery query only allowed when `recovery_strategy:\n\"query\"`\n```console\n// 2a. standalone - stale recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-recovery-standalone\n{ \"recovery_strategy\": \"no_breach\" }\n\n// 2b. composed - stale recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-recovery-composed\n{ \"recovery_strategy\": \"no_breach\" }\n```\n\n5. Verify that`recovery_strategy: \"query\"` requires a recovery block\n\n```console\n// 3a. standalone - set \"query\" strategy, no recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-alert-standalone\n{ \"recovery_strategy\": \"query\" }\n\n// 3b. composed - set \"query\" strategy, no recovery block\nPATCH kbn:/api/alerting/v2/rules/mv-alert-composed\n{ \"recovery_strategy\": \"query\" }\n```\n\n6. Verify that no data query is only allowed when `no_data_strategy !=\n\"none\"`\n\n```console\n// 4a. standalone - clear the strategy but leave the stale no_data block\nPATCH kbn:/api/alerting/v2/rules/mv-nodata-standalone\n{ \"no_data_strategy\": \"none\" }\n```\n\n7. Verify that`no_data_strategy` requires a no data block for standalone\nformat\n\n```console\n// 5a. standalone - strategy set, no block  ->  400 INVALID_RULE_QUERY_CONFIG\nPATCH kbn:/api/alerting/v2/rules/mv-alert-standalone\n{ \"no_data_strategy\": \"last_known_status\" }\n\n// 5b. composed - strategy set, no block  ->  200 (base is the data-presence query)\nPATCH kbn:/api/alerting/v2/rules/mv-alert-composed\n{ \"no_data_strategy\": \"last_known_status\" }\n```","sha":"d90aab48e81b91b4ed5b3a9a5eb40559c52a93c1"}},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->