### PR TITLE
[Agent Builder] Bound empty-response retries in non-structured answerAgent  (9.4)

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.test.ts
@@ -110,6 +110,18 @@ describe('createAgentGraph', () => {
     expect(result.errorCount).toBe(0);
   });
 
+  it('stops after two retries and surfaces emptyResponse for empty answers', async () => {
+    const { graph, researchInvoke, answerInvoke } = createTestGraph();
+    researchInvoke.mockResolvedValue(new AIMessage({ content: 'research complete' }));
+    answerInvoke.mockResolvedValue(new AIMessage({ content: '' }));
+
+    await expect(graph.invoke({ cycleLimit: 10 }, { recursionLimit: 20 })).rejects.toMatchObject({
+      meta: { errCode: AgentExecutionErrorCode.emptyResponse },
+    });
+    expect(researchInvoke).toHaveBeenCalledTimes(1);
+    expect(answerInvoke).toHaveBeenCalledTimes(3);
+  });
+
   it('stops after two retries and surfaces emptyResponse for empty structured answers', async () => {
     const { graph, researchInvoke, structuredInvoke } = createTestGraph({
       structuredOutput: true,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/graph.ts
@@ -211,7 +211,9 @@ export const createAgentGraph = ({
 
       return {
         answerActions: [action],
-        errorCount: 0,
+        // Successful inference calls can still produce recoverable error actions,
+        // which must count toward the retry limit.
+        errorCount: isAgentErrorAction(action) ? state.errorCount + 1 : 0,
       };
     } catch (error) {
       const executionError = convertError(error);


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/284734
Follow-up from the empty-response retry fix in https://github.com/elastic/kibana/pull/281616 (and backports https://github.com/elastic/kibana/pull/283186, https://github.com/elastic/kibana/pull/283194).

On 9.4, if the answering model returned an empty reply, Agent Builder could continue retrying and fail with a recursion error instead of a clear empty-response error.

Research and structured answering already count those empty replies toward a retry limit (initial attempt plus two retries). The plain-text answering path still reset the error counter every time, so the same hang could happen while writing the final answer.

This change counts empty answering-model responses the same way. After two retries, execution stops and surfaces emptyResponse.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



