### PR TITLE
[Agent Builder] Document instructions on using the MCP server with OAuth

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/README.md
+++ b/x-pack/platform/plugins/shared/agent_builder/README.md
@@ -253,61 +253,49 @@ Configure Claude Desktop by adding this to its configuration:
 
 ### Local OAuth setup (serverless only)
 
-MCP clients can authenticate with an OAuth 2.1 access token instead of an API key. Clients discover how to
-do so from the OAuth 2.0 Protected Resource Metadata that Kibana serves at
-`/.well-known/oauth-protected-resource`, which is populated from `xpack.security.mcp.oauth2.metadata`.
-That setting only exists in serverless, so this flow requires running Kibana in serverless mode.
+MCP clients can authenticate with an OAuth 2.1 access token instead of an API key. Clients discover how to do so from the OAuth 2.0 Protected Resource Metadata that Kibana serves at `/.well-known/oauth-protected-resource`, which is populated from `xpack.security.mcp.oauth2.metadata`. That setting only exists in serverless, so this flow needs a serverless Kibana pointed at an Elasticsearch that runs the UIAM OAuth authorization server.
 
-1. Start Elasticsearch with the UIAM OAuth container:
+1. Add the following to `config/kibana.dev.yml`, adjusting the URLs if you serve Kibana over HTTPS or on a different port:
 
-```bash
-yarn es serverless --projectType elasticsearch --uiam-oauth
-```
+   ```yaml
+   server.publicBaseUrl: http://localhost:5601
+   xpack.security.mcp.oauth2.metadata:
+     authorization_servers: [https://localhost:8444/oauth2]
+     resource: http://localhost:5601/api/agent_builder/mcp
+   ```
 
-`--uiam-oauth` defaults to `false` even though `--uiam` defaults to `true`, so it has to be passed
-explicitly. It starts an additional `uiam-oauth` container that serves the authorization server on
-`https://localhost:8444`, alongside the UIAM service itself on `https://localhost:8443`.
+   `server.publicBaseUrl` determines the resource metadata URL that Kibana advertises in the `WWW-Authenticate` header when an MCP request is rejected with a 401. Without it, Kibana falls back to the incoming request URL, which is not necessarily reachable by the client.
 
-2. Add the following to `config/kibana.dev.yml`, adjusting the URLs if you serve Kibana over HTTPS or on
-   a different port:
+   > **Note:** `xpack.security.mcp` is only accepted in serverless. While these keys are in `kibana.dev.yml`, a non-serverless Kibana refuses to start with `[config validation of [xpack.security].mcp]: a value wasn't expected to be present`, so comment them out before going back to `yarn start`.
 
-```yaml
-server.publicBaseUrl: http://localhost:5601
-xpack.security.mcp.oauth2.metadata:
-  authorization_servers: [https://localhost:8444/oauth2]
-  resource: http://localhost:5601/api/agent_builder/mcp
-```
+2. Start Elasticsearch with the UIAM OAuth authorization server by passing `--uiam-oauth`. For example:
 
-`server.publicBaseUrl` determines the resource metadata URL that Kibana advertises in the
-`WWW-Authenticate` header when an MCP request is rejected with a 401. Without it, Kibana falls back to the
-incoming request URL, which is not necessarily reachable by the client.
+   ```bash
+   yarn es serverless --projectType elasticsearch --uiam-oauth
+   ```
 
-3. Start Kibana in serverless mode:
+   That flag defaults to `false` even though `--uiam` defaults to `true`, so it has to be passed explicitly. It starts an additional `uiam-oauth` container that serves the authorization server on `https://localhost:8444`, alongside the UIAM service itself on `https://localhost:8443`. Leave UIAM itself enabled: the MCP client management UI used in step 4 is hidden when it is off.
 
-```bash
-yarn serverless-es
-```
+3. Run Kibana in serverless mode, for example:
 
-4. Register an OAuth client from **Agents > Tools > Manage all tools > Manage MCP > Manage MCP clients
-   (OAuth) > Add MCP client**. The dialog shown after creation has the client ID and MCP server URL that
-   your client needs. Redirect URIs are client-specific, and the authorization server accepts any
-   localhost port but matches the path exactly, so refer to
-   [Create an OAuth client in Elastic Agent Builder](https://www.elastic.co/docs/deploy-manage/app-connections/create-oauth-client)
-   for the value your client expects.
+   ```bash
+   yarn serverless-es
+   ```
+
+4. Register an OAuth client from **Agents > Tools > Manage all tools > Manage MCP > Manage MCP clients (OAuth) > Add MCP client**. The dialog shown after creation has the client ID and MCP server URL that your client needs. Redirect URIs are client-specific, and the authorization server accepts any localhost port but matches the path exactly, so refer to [Create an OAuth client in Elastic Agent Builder](https://www.elastic.co/docs/deploy-manage/app-connections/create-oauth-client) for the value your client expects.
+
+5. Configure your MCP client with that client ID and server URL, then complete the browser-based authorization. [Connect an MCP host to Elastic Agent Builder](https://www.elastic.co/docs/deploy-manage/app-connections/connect-mcp-host) covers the setup for Claude Code and Claude Desktop.
 
 #### Troubleshooting
 
-Node-based clients may reject the self-signed certificate that the OAuth container serves on
-`https://localhost:8444` and fail during the token exchange. If you hit a certificate error, point Node at
-the Kibana development CA in the shell that runs the client:
+Node-based clients may reject the self-signed certificate that the OAuth container serves on `https://localhost:8444` and fail during the token exchange. If you hit a certificate error, point Node at the Kibana development CA in the shell that runs the client:
 
 ```bash
 # Run from the Kibana root, in the same shell as your MCP client
 export NODE_EXTRA_CA_CERTS="$(pwd)/src/platform/packages/shared/kbn-dev-utils/certs/ca.crt"
 ```
 
-Whether this is needed depends on the client: some ship their own trust store, and others ignore the
-variable entirely.
+Whether this is needed depends on the client: some ship their own trust store, and others ignore the variable entirely.
 
 ## A2A Server
 

--- a/x-pack/platform/plugins/shared/agent_builder/README.md
+++ b/x-pack/platform/plugins/shared/agent_builder/README.md
@@ -251,6 +251,64 @@ Configure Claude Desktop by adding this to its configuration:
 }
 ```
 
+### Local OAuth setup (serverless only)
+
+MCP clients can authenticate with an OAuth 2.1 access token instead of an API key. Clients discover how to
+do so from the OAuth 2.0 Protected Resource Metadata that Kibana serves at
+`/.well-known/oauth-protected-resource`, which is populated from `xpack.security.mcp.oauth2.metadata`.
+That setting only exists in serverless, so this flow requires running Kibana in serverless mode.
+
+1. Start Elasticsearch with the UIAM OAuth container:
+
+```bash
+yarn es serverless --projectType elasticsearch --uiam-oauth
+```
+
+`--uiam-oauth` defaults to `false` even though `--uiam` defaults to `true`, so it has to be passed
+explicitly. It starts an additional `uiam-oauth` container that serves the authorization server on
+`https://localhost:8444`, alongside the UIAM service itself on `https://localhost:8443`.
+
+2. Add the following to `config/kibana.dev.yml`, adjusting the URLs if you serve Kibana over HTTPS or on
+   a different port:
+
+```yaml
+server.publicBaseUrl: http://localhost:5601
+xpack.security.mcp.oauth2.metadata:
+  authorization_servers: [https://localhost:8444/oauth2]
+  resource: http://localhost:5601/api/agent_builder/mcp
+```
+
+`server.publicBaseUrl` determines the resource metadata URL that Kibana advertises in the
+`WWW-Authenticate` header when an MCP request is rejected with a 401. Without it, Kibana falls back to the
+incoming request URL, which is not necessarily reachable by the client.
+
+3. Start Kibana in serverless mode:
+
+```bash
+yarn serverless-es
+```
+
+4. Register an OAuth client from **Agents > Tools > Manage all tools > Manage MCP > Manage MCP clients
+   (OAuth) > Add MCP client**. The dialog shown after creation has the client ID and MCP server URL that
+   your client needs. Redirect URIs are client-specific, and the authorization server accepts any
+   localhost port but matches the path exactly, so refer to
+   [Create an OAuth client in Elastic Agent Builder](https://www.elastic.co/docs/deploy-manage/app-connections/create-oauth-client)
+   for the value your client expects.
+
+#### Troubleshooting
+
+Node-based clients may reject the self-signed certificate that the OAuth container serves on
+`https://localhost:8444` and fail during the token exchange. If you hit a certificate error, point Node at
+the Kibana development CA in the shell that runs the client:
+
+```bash
+# Run from the Kibana root, in the same shell as your MCP client
+export NODE_EXTRA_CA_CERTS="$(pwd)/src/platform/packages/shared/kbn-dev-utils/certs/ca.crt"
+```
+
+Whether this is needed depends on the client: some ship their own trust store, and others ignore the
+variable entirely.
+
 ## A2A Server
 
 The A2A (Agent-to-Agent) server provides a standardized interface for external A2A clients to communicate with agentBuilder agents, enabling agent-to-agent collaboration following the A2A protocol specification.


### PR DESCRIPTION
## Summary

Documents how to run the Agent Builder MCP server with OAuth locally in serverless mode.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
