### PR TITLE
[Fleet] Support package policy field projections

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/index.ts
@@ -38,10 +38,7 @@ export { AgentNotFoundError, FleetUnauthorizedError } from './errors';
 export { config } from './config';
 export type { FleetConfigType } from './config';
 
-export type {
-  PackagePolicyClient,
-  PartialPackagePolicy,
-} from './services/package_policy_service';
+export type { PackagePolicyClient, PartialPackagePolicy } from './services/package_policy_service';
 
 export { relativeDownloadUrlFromArtifact } from './services/artifacts/mappings';
 

--- a/x-pack/platform/plugins/shared/fleet/server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/index.ts
@@ -38,7 +38,10 @@ export { AgentNotFoundError, FleetUnauthorizedError } from './errors';
 export { config } from './config';
 export type { FleetConfigType } from './config';
 
-export type { PackagePolicyClient } from './services/package_policy_service';
+export type {
+  PackagePolicyClient,
+  PartialPackagePolicy,
+} from './services/package_policy_service';
 
 export { relativeDownloadUrlFromArtifact } from './services/artifacts/mappings';
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -2142,6 +2142,49 @@ describe('Package policy service', () => {
   });
 
   describe('getByIDs', () => {
+    it('should request only the specified package policy fields', async () => {
+      const soClient = createSavedObjectClientMock();
+      soClient.bulkGet.mockResolvedValueOnce({
+        saved_objects: [
+          {
+            id: 'test-package-policy',
+            version: 'WzEsMV0=',
+            attributes: {
+              condition: "'agent.id' == 'agent-1'",
+              policy_ids: ['agent-policy-1'],
+              revision: 2,
+            },
+            references: [],
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+          },
+        ],
+      });
+
+      const fields = ['condition', 'policy_ids', 'revision'];
+      const result = await packagePolicyService.getByIDs(soClient, ['test-package-policy'], {
+        fields,
+      });
+
+      expect(soClient.bulkGet).toHaveBeenCalledWith([
+        {
+          id: 'test-package-policy',
+          type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+          fields,
+          namespaces: undefined,
+        },
+      ]);
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'test-package-policy',
+          version: 'WzEsMV0=',
+          condition: "'agent.id' == 'agent-1'",
+          policy_ids: ['agent-policy-1'],
+          revision: 2,
+        }),
+      ]);
+      expect(result[0]).not.toHaveProperty('name');
+    });
+
     it('should call audit logger', async () => {
       const soClient = createSavedObjectClientMock();
       soClient.bulkGet.mockResolvedValueOnce({

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -199,6 +199,7 @@ import type {
   PackagePolicyClientListIdsOptions,
   PackagePolicyClientRollbackOptions,
   PackagePolicyService,
+  PartialPackagePolicy,
   RollbackResult,
   RunExternalCallbacksPackagePolicyArgument,
   RunExternalCallbacksPackagePolicyResponse,
@@ -1368,8 +1369,18 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
   public async getByIDs(
     soClient: SavedObjectsClientContract,
     ids: string[],
+    options?: Omit<PackagePolicyClientGetByIdsOptions, 'fields'>
+  ): Promise<PackagePolicy[]>;
+  public async getByIDs(
+    soClient: SavedObjectsClientContract,
+    ids: string[],
+    options: PackagePolicyClientGetByIdsOptions & { fields: string[] }
+  ): Promise<PartialPackagePolicy[]>;
+  public async getByIDs(
+    soClient: SavedObjectsClientContract,
+    ids: string[],
     options: PackagePolicyClientGetByIdsOptions = {}
-  ): Promise<PackagePolicy[]> {
+  ): Promise<PackagePolicy[] | PartialPackagePolicy[]> {
     const logger = this.getLogger('getByIDs');
     const savedObjectType = await getPackagePolicySavedObjectType();
     const isSpacesEnabled = await isSpaceAwarenessEnabled();
@@ -1388,13 +1399,14 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
         ids.map((id) => ({
           id,
           type: savedObjectType,
+          ...(options.fields ? { fields: options.fields } : {}),
           namespaces: isSpacesEnabled ? options.spaceIds : undefined,
         }))
       )
       .catch(catchAndSetErrorStackTrace.withMessage('bulkGet of package policies failed'));
 
     const packagePolicies = packagePolicySO.saved_objects
-      .map((so): PackagePolicy | null => {
+      .map((so): PartialPackagePolicy | null => {
         if (isSavedObjectErrorResult(so)) {
           if (options.ignoreMissing && so.error.statusCode === 404) {
             return null;
@@ -1409,7 +1421,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
 
         return mapPackagePolicySavedObjectToPackagePolicy(so);
       })
-      .filter((packagePolicy): packagePolicy is PackagePolicy => packagePolicy !== null);
+      .filter((packagePolicy): packagePolicy is PartialPackagePolicy => packagePolicy !== null);
 
     for (const packagePolicy of packagePolicies) {
       auditLoggingService.writeCustomSoAuditLog({

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy_service.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy_service.ts
@@ -162,8 +162,13 @@ export interface PackagePolicyClient {
   getByIDs(
     soClient: SavedObjectsClientContract,
     ids: string[],
-    options?: PackagePolicyClientGetByIdsOptions
+    options?: Omit<PackagePolicyClientGetByIdsOptions, 'fields'>
   ): Promise<PackagePolicy[]>;
+  getByIDs(
+    soClient: SavedObjectsClientContract,
+    ids: string[],
+    options: PackagePolicyClientGetByIdsOptions & { fields: string[] }
+  ): Promise<PartialPackagePolicy[]>;
 
   list(
     soClient: SavedObjectsClientContract,
@@ -335,8 +340,11 @@ export type PackagePolicyClientFetchAllItemsOptions = Pick<
 > &
   WithSpaceIdsOption;
 
+export type PartialPackagePolicy = Pick<PackagePolicy, 'id'> & Partial<PackagePolicy>;
+
 export interface PackagePolicyClientGetByIdsOptions extends WithSpaceIdsOption {
   ignoreMissing?: boolean;
+  fields?: string[];
 }
 
 export interface PackagePolicyClientDeleteOptions extends WithSpaceIdsOption {


### PR DESCRIPTION
## Summary

- allow `packagePolicyService.getByIDs()` callers to pass Saved Objects `fields`
- forward the requested projection to every package-policy `bulkGet` item
- use overloads so projected reads return `PartialPackagePolicy[]` while existing calls retain `PackagePolicy[]`
- preserve package-policy IDs and Saved Object metadata in projected results

## Why

Callers such as Synthetics sharding only need a small subset of package-policy attributes. The current API always retrieves complete package policies, including inputs, streams, variables, and compiled payloads. This adds the smallest reusable Fleet API needed to avoid that extra payload without introducing a condition-specific service.

This is the read-side prerequisite for a separate partial-update PR. It does not change Saved Object mappings, schemas, migrations, or existing full-read behavior.

## Validation

- `node scripts/jest x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts` (257 tests, 4 snapshots)
- `node scripts/type_check --project x-pack/platform/plugins/shared/fleet/tsconfig.json`
- `node scripts/eslint` on the changed Fleet files
- `node scripts/check.js --scope=local`
- `git diff --check`

Addresses #285743