### PR TITLE
ci: Backport `pick_test_group_run_order` changes to 9.5

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-merge-queue.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-merge-queue.yml
@@ -21,7 +21,7 @@ spec:
       env:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-merge-queue-alerts'
         KIBANA_GITHUB_BUILD_COMMIT_STATUS_ENABLED: 'true'
-        GITHUB_COMMIT_STATUS_CONTEXT: buildkite/merge-queue
+        GITHUB_COMMIT_STATUS_CONTEXT: 'kibana-ci'
         SLACK_NOTIFICATIONS_SKIP_FOR_RETRIES: 'true'
       allow_rebuilds: true
       branch_configuration: gh-readonly-queue/* gh-readonly-queue/*/*

--- a/.buildkite/pipelines/merge_queue.yml
+++ b/.buildkite/pipelines/merge_queue.yml
@@ -1,6 +1,6 @@
 env:
   GITHUB_COMMIT_STATUS_ENABLED: 'true'
-  GITHUB_COMMIT_STATUS_CONTEXT: 'buildkite/merge-queue'
+  GITHUB_COMMIT_STATUS_CONTEXT: 'kibana-ci'
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build
@@ -103,31 +103,13 @@ steps:
         - exit_status: '-1'
           limit: 3
 
-  - command: .buildkite/scripts/steps/lint_with_oxlint.sh
-    label: 'Linting (with oxlint)'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n4-standard-4
-      diskType: hyperdisk-balanced
-      preemptible: true
-      spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-      diskSizeGb: 105
-    key: linting_with_oxlint
-    timeout_in_minutes: 60
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-
   - command: .buildkite/scripts/steps/typecheck/check_types.sh
     label: 'Check Types'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: c4-standard-8-lssd
+      machineType: n4-highcpu-32
       diskType: hyperdisk-balanced
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
@@ -138,40 +120,6 @@ steps:
       automatic:
         - exit_status: '-1'
           limit: 3
-
-  - command: .buildkite/scripts/steps/checks/capture_oas_snapshot.sh
-    label: 'Check OAS Snapshot'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2d-highmem-4
-      preemptible: true
-      spotZones: us-central1-b,us-central1-c,us-central1-f
-      diskSizeGb: 105
-    key: check_oas_snapshot
-    timeout_in_minutes: 60
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-
-  - command: .buildkite/scripts/steps/report_package_metrics.sh
-    label: Report Package Metrics
-    key: report_package_metrics
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-2
-      diskSizeGb: 105
-    timeout_in_minutes: 15
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-        - exit_status: '*'
-          limit: 1
 
   - command: .buildkite/scripts/steps/ci_stats_ready.sh
     label: Mark CI Stats as ready
@@ -184,14 +132,13 @@ steps:
     timeout_in_minutes: 10
     depends_on:
       - build
-      - report_package_metrics
     retry:
       automatic:
         - exit_status: '*'
           limit: 1
 
   # e2e suites (FTR, Scout, Cypress) intentionally do not run here; they run
-  # post-merge in kibana-on-merge. Only Jest unit/integration gate the queue.
+  # post-merge in kibana-on-merge. Only Jest unit tests gate the queue.
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
     label: 'Pick Test Group Run Order'
     agents:
@@ -203,8 +150,8 @@ steps:
     timeout_in_minutes: 15
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
-      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
-      LIMIT_CONFIG_TYPE: 'unit,integration'
+      JEST_UNIT_MAX_MINUTES: '15.0'
+      LIMIT_CONFIG_TYPE: 'unit'
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/merge_queue.yml
+++ b/.buildkite/pipelines/merge_queue.yml
@@ -4,6 +4,7 @@ env:
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build
+    key: pre_build
     timeout_in_minutes: 10
     agents:
       image: family/kibana-ubuntu-2404
@@ -15,8 +16,8 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  # e2e suites (FTR, Scout, Cypress) intentionally do not run here; they run
-  # post-merge in kibana-on-merge. Only Jest unit tests gate the queue.
+  # E2E suites (FTR, Scout, Cypress) intentionally do not run in the merge queue.
+  # Only Jest unit tests gate the queue.
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
     label: 'Pick Test Group Run Order'
     agents:
@@ -50,7 +51,8 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  - wait
+  - wait: ~
+    depends_on: pre_build
 
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
     label: Build Kibana Distribution

--- a/.buildkite/pipelines/merge_queue.yml
+++ b/.buildkite/pipelines/merge_queue.yml
@@ -14,6 +14,42 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
+  # e2e suites (FTR, Scout, Cypress) intentionally do not run here; they run
+  # post-merge in kibana-on-merge. Only Jest unit tests gate the queue.
+  - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
+    label: 'Pick Test Group Run Order'
+    agents:
+      provider: k8s
+      image: docker.elastic.co/ci-agent-images/kibana/ci-minimal
+      imageUID: 1000
+    timeout_in_minutes: 15
+    env:
+      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_UNIT_MAX_MINUTES: '15.0'
+      LIMIT_CONFIG_TYPE: 'unit'
+    plugins:
+      - sparse-checkout#v1.6.0:
+          no_cone: true
+          paths:
+            - '/.buildkite/'
+            - '/.node-version'
+            - '/package.json'
+            - '/tsconfig.base.json'
+            - '/versions.json'
+            - '**/jest.config.js'
+            - '**/*.test.js'
+            - '**/*.test.mjs'
+            - '**/*.test.ts'
+            - '**/*.test.tsx'
+          cleanup_sparse_state: true
+          post_checkout:
+            unshallow: true
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
   - wait
 
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
@@ -132,26 +168,6 @@ steps:
     timeout_in_minutes: 10
     depends_on:
       - build
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
-  # e2e suites (FTR, Scout, Cypress) intentionally do not run here; they run
-  # post-merge in kibana-on-merge. Only Jest unit tests gate the queue.
-  - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
-    label: 'Pick Test Group Run Order'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-2
-      diskSizeGb: 105
-    timeout_in_minutes: 15
-    env:
-      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
-      JEST_UNIT_MAX_MINUTES: '15.0'
-      LIMIT_CONFIG_TYPE: 'unit'
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -14,6 +14,43 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
+  - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
+    label: 'Pick Test Group Run Order'
+    agents:
+      provider: k8s
+      image: docker.elastic.co/ci-agent-images/kibana/ci-minimal
+      imageUID: 1000
+    timeout_in_minutes: 15
+    env:
+      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
+      FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
+      FTR_CONFIGS_DEPS: 'build'
+      FTR_TEST_CHANNELS: ci-on-commit
+    plugins:
+      - sparse-checkout#v1.6.0:
+          no_cone: true
+          paths:
+            - '/.buildkite/'
+            - '/.node-version'
+            - '/package.json'
+            - '/tsconfig.base.json'
+            - '/versions.json'
+            - '**/jest.config.js'
+            - '**/jest.integration.config.js'
+            - '**/*.test.js'
+            - '**/*.test.mjs'
+            - '**/*.test.ts'
+            - '**/*.test.tsx'
+          cleanup_sparse_state: true
+          post_checkout:
+            unshallow: true
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
   - wait
 
   - command: .buildkite/scripts/steps/store_cache.sh
@@ -218,25 +255,6 @@ steps:
     depends_on:
       - build
       - report_package_metrics
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
-    label: 'Pick Test Group Run Order'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-2
-      diskSizeGb: 130
-    timeout_in_minutes: 15
-    env:
-      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
-      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
-      FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
-      FTR_CONFIGS_DEPS: 'build'
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -4,6 +4,7 @@ env:
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build
+    key: pre_build
     timeout_in_minutes: 10
     agents:
       image: family/kibana-ubuntu-2404
@@ -51,7 +52,8 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  - wait
+  - wait: ~
+    depends_on: pre_build
 
   - command: .buildkite/scripts/steps/store_cache.sh
     label: Store Cache for build

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -159,14 +159,37 @@ steps:
     label: 'Pick Test Group Run Order'
     key: pick_test_group_run_order
     agents:
-      machineType: n2-standard-2
-      diskSizeGb: 130
+      provider: k8s
+      image: docker.elastic.co/ci-agent-images/kibana/ci-minimal
+      imageUID: 1000
     timeout_in_minutes: 15
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
       JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
       FTR_CONFIGS_DEPS: 'build'
+      FTR_TEST_CHANNELS: ci-on-commit
+    plugins:
+      - sparse-checkout#v1.6.0:
+          no_cone: true
+          paths:
+            - '/.buildkite/'
+            - '/.node-version'
+            - '/package.json'
+            - '/tsconfig.base.json'
+            - '/versions.json'
+            - '/kibana.jsonc'
+            - '**/kibana.jsonc'
+            - '**/tsconfig.json'
+            - '**/jest.config.js'
+            - '**/jest.integration.config.js'
+            - '**/*.test.js'
+            - '**/*.test.mjs'
+            - '**/*.test.ts'
+            - '**/*.test.tsx'
+          cleanup_sparse_state: true
+          post_checkout:
+            unshallow: true
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
+++ b/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
@@ -2,11 +2,7 @@
 
 set -euo pipefail
 
-# This step only runs a Node.js script to compute test group ordering;
-# it never needs the dev-mode shared webpack bundles (monaco, ui-shared-deps).
-export KBN_BOOTSTRAP_NO_PREBUILT=true
-
-source .buildkite/scripts/bootstrap.sh
+source .buildkite/scripts/common/util.sh
 
 echo '--- Pick Test Group Run Order'
 ts-node "$(dirname "${0}")/pick_test_group_run_order.ts"


### PR DESCRIPTION
Backport of the following PRs:

- https://github.com/elastic/kibana/pull/283221
- https://github.com/elastic/kibana/pull/285019
- https://github.com/elastic/kibana/pull/285255

---

1. Streamline the merge-queue pipeline by removing unnecessary checks.
2. Don't run `yarn bootstrap` as a prerequisite. This allows shifting the step to run in parallel with any pre-build actions. The picker-step only needs `ts-node` to be available to be functional. This amortization functionally should save ~2 minutes (the runtime of `pre-build`) before unit tests can be run.
3. Run the picker-step with a sparse-checkout on a K8s image. The `node` script that gets run here doesn't need the full repository, so we can perform a sparse-checkout and run with a slimmer image, saving on start-up time.
4. Move the test-group wait before the picker so dynamically generated tests run in the same pipeline phase as the build and other validation jobs.