### PR TITLE
ci: Backport `pick_test_group_run_order` changes to 8.19

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -4,6 +4,7 @@ env:
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build
+    key: pre_build
     timeout_in_minutes: 10
     agents:
       image: family/kibana-ubuntu-2404
@@ -51,7 +52,8 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  - wait
+  - wait: ~
+    depends_on: pre_build
 
   - command: .buildkite/scripts/steps/store_cache.sh
     label: Store Cache for build

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -14,6 +14,43 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
+  - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
+    label: 'Pick Test Group Run Order'
+    agents:
+      provider: k8s
+      image: docker.elastic.co/ci-agent-images/kibana/ci-minimal
+      imageUID: 1000
+    timeout_in_minutes: 15
+    env:
+      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
+      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
+      FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
+      FTR_CONFIGS_DEPS: 'build'
+      FTR_TEST_CHANNELS: ci-on-commit
+    plugins:
+      - sparse-checkout#v1.6.0:
+          no_cone: true
+          paths:
+            - '/.buildkite/'
+            - '/.node-version'
+            - '/package.json'
+            - '/tsconfig.base.json'
+            - '/versions.json'
+            - '**/jest.config.js'
+            - '**/jest.integration.config.js'
+            - '**/*.test.js'
+            - '**/*.test.mjs'
+            - '**/*.test.ts'
+            - '**/*.test.tsx'
+          cleanup_sparse_state: true
+          post_checkout:
+            unshallow: true
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
   - wait
 
   - command: .buildkite/scripts/steps/store_cache.sh
@@ -183,25 +220,6 @@ steps:
     depends_on:
       - build
       - public-api-docs
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
-    label: 'Pick Test Group Run Order'
-    agents:
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      provider: gcp
-      machineType: n2-standard-2
-      diskSizeGb: 120
-    timeout_in_minutes: 10
-    env:
-      JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
-      JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
-      FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
-      FTR_CONFIGS_DEPS: 'build'
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -121,14 +121,37 @@ steps:
     label: 'Pick Test Group Run Order'
     key: pick_test_group_run_order
     agents:
-      machineType: n2-standard-2
-      diskSizeGb: 120
-    timeout_in_minutes: 10
+      provider: k8s
+      image: docker.elastic.co/ci-agent-images/kibana/ci-minimal
+      imageUID: 1000
+    timeout_in_minutes: 15
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
       JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
       FTR_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/ftr_configs.sh'
       FTR_CONFIGS_DEPS: 'build'
+      FTR_TEST_CHANNELS: ci-on-commit
+    plugins:
+      - sparse-checkout#v1.6.0:
+          no_cone: true
+          paths:
+            - '/.buildkite/'
+            - '/.node-version'
+            - '/package.json'
+            - '/tsconfig.base.json'
+            - '/versions.json'
+            - '/kibana.jsonc'
+            - '**/kibana.jsonc'
+            - '**/tsconfig.json'
+            - '**/jest.config.js'
+            - '**/jest.integration.config.js'
+            - '**/*.test.js'
+            - '**/*.test.mjs'
+            - '**/*.test.ts'
+            - '**/*.test.tsx'
+          cleanup_sparse_state: true
+          post_checkout:
+            unshallow: true
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
+++ b/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
@@ -2,11 +2,7 @@
 
 set -euo pipefail
 
-# This step only runs a Node.js script to compute test group ordering;
-# it never needs the dev-mode shared webpack bundles (monaco, ui-shared-deps).
-export KBN_BOOTSTRAP_NO_PREBUILT=true
-
-source .buildkite/scripts/bootstrap.sh
+source .buildkite/scripts/common/util.sh
 
 echo '--- Pick Test Group Run Order'
 ts-node "$(dirname "${0}")/pick_test_group_run_order.ts"


### PR DESCRIPTION
Backport of the following PRs:

- https://github.com/elastic/kibana/pull/285019
- https://github.com/elastic/kibana/pull/285255

---

1. Don't run `yarn bootstrap` as a prerequisite. This allows shifting the step to run in parallel with any pre-build actions. The picker-step only needs `ts-node` to be available to be functional. This amortization functionally should save ~2 minutes (the runtime of `pre-build`) before unit tests can be run.
2. Run the picker-step with a sparse-checkout on a K8s image. The `node` script that gets run here doesn't need the full repository, so we can perform a sparse-checkout and run with a slimmer image, saving on start-up time.
3. Move the test-group wait before the picker so dynamically generated tests run in the same pipeline phase as the build and other validation jobs.