### PR TITLE
Added very basic cps scout api tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2738,6 +2738,8 @@ src/platform/plugins/shared/workflows_management/test/connector_workflows @elast
 /x-pack/platform/test/alerting_api_integration/security_and_spaces/group10/tests/alerting/gap @elastic/response-ops @elastic/security-detection-engineering
 /x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/gap @elastic/response-ops @elastic/security-detection-engineering
 /x-pack/platform/plugins/shared/alerting/server/rules_client/lib/change_tracking @elastic/security-detection-engineering
+x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/tests/detection_engine/ @elastic/security-detection-engineering
+x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/fixtures/cps_rule_helpers.ts @elastic/security-detection-engineering
 
 # Enterprise Search
 # search

--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/constants/detection_rules.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/constants/detection_rules.ts
@@ -16,6 +16,7 @@ export interface CustomQueryRule {
   type: 'query';
   query: string;
   from: string;
+  interval?: string;
   investigation_fields?: { field_names: string[] };
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/fixtures/cps_rule_helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/fixtures/cps_rule_helpers.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsClient, KbnClient } from '@kbn/scout-security';
+import { PUBLIC_HEADERS } from '.';
+
+export const RULE_INTERVAL = '1m';
+export const ALERT_WAIT_TIMEOUT = 180_000;
+/** Extra wait after the first in-scope alert so a same-run leak can show up. */
+export const ISOLATION_SETTLE_MS = 2_000;
+
+const DETECTION_ENGINE_RULES_URL = '/api/detection_engine/rules';
+const DETECTION_ENGINE_RULES_BULK_ACTION = '/api/detection_engine/rules/_bulk_action';
+const WAIT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_ALERT_SOURCE_FIELDS = ['host.name', 'kibana.alert.threshold_result.count'];
+
+export interface RuleAlertHit {
+  _source?: {
+    host?: { name?: string };
+    kibana?: { alert?: { threshold_result?: { count?: number } } };
+    ['kibana.alert.threshold_result']?: { count?: number };
+    ['kibana.alert.threshold_result.count']?: number;
+  };
+}
+
+export const alertsIndexForSpace = (spaceId = 'default'): string =>
+  `.alerts-security.alerts-${spaceId}`;
+
+const spaceBasePath = (spaceId?: string): string =>
+  spaceId !== undefined && spaceId !== 'default' ? `/s/${spaceId}` : '';
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * One event on a `logs-*` data stream. Serverless treats `logs-*` as
+ * data-stream-only, so we write with `op_type: create` and let ES create the stream.
+ */
+export const seedLogsEvent = async (
+  esClient: EsClient,
+  {
+    dataStream,
+    hostName,
+    eventAction,
+    runId,
+  }: {
+    dataStream: string;
+    hostName: string;
+    eventAction: string;
+    runId: string;
+  }
+): Promise<void> => {
+  await esClient.indices.deleteDataStream({ name: dataStream }, { ignore: [404] });
+  await esClient.bulk(
+    {
+      refresh: 'wait_for',
+      operations: [
+        { create: { _index: dataStream } },
+        {
+          '@timestamp': new Date(Date.now() - 5 * 60_000).toISOString(),
+          event: { id: `${runId}-${hostName}`, action: eventAction, kind: 'event' },
+          host: { name: hostName },
+        },
+      ],
+    },
+    { requestTimeout: 180_000 }
+  );
+};
+
+const hostNamesFromAlertHits = (hits: RuleAlertHit[]): Array<string | undefined> =>
+  hits.map((hit) => hit._source?.host?.name);
+
+export const thresholdCountFromAlertHit = (hit: RuleAlertHit): number | undefined => {
+  const nested = hit._source?.kibana?.alert?.threshold_result?.count;
+  if (typeof nested === 'number') {
+    return nested;
+  }
+  const dottedObject = hit._source?.['kibana.alert.threshold_result']?.count;
+  if (typeof dottedObject === 'number') {
+    return dottedObject;
+  }
+  const dottedCount = hit._source?.['kibana.alert.threshold_result.count'];
+  return typeof dottedCount === 'number' ? dottedCount : undefined;
+};
+
+const searchRuleAlerts = async ({
+  esClient,
+  ruleName,
+  spaceId,
+  sourceFields,
+}: {
+  esClient: EsClient;
+  ruleName: string;
+  spaceId: string;
+  sourceFields: string[];
+}): Promise<RuleAlertHit[]> => {
+  const index = alertsIndexForSpace(spaceId);
+  await esClient.indices.refresh({ index, ignore_unavailable: true });
+  const result = await esClient.search({
+    index,
+    ignore_unavailable: true,
+    query: { term: { 'kibana.alert.rule.name': ruleName } },
+    _source: sourceFields,
+    size: 10,
+  });
+  return result.hits.hits as RuleAlertHit[];
+};
+
+export const waitForRuleAlertHits = async ({
+  esClient,
+  ruleName,
+  minCount,
+  timeout = ALERT_WAIT_TIMEOUT,
+  spaceId = 'default',
+  sourceFields = DEFAULT_ALERT_SOURCE_FIELDS,
+  settleMs = 0,
+}: {
+  esClient: EsClient;
+  ruleName: string;
+  minCount: number;
+  timeout?: number;
+  spaceId?: string;
+  sourceFields?: string[];
+  settleMs?: number;
+}): Promise<RuleAlertHit[]> => {
+  const deadline = Date.now() + timeout;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const hits = await searchRuleAlerts({ esClient, ruleName, spaceId, sourceFields });
+      if (hits.length >= minCount) {
+        if (settleMs > 0) {
+          await sleep(settleMs);
+          return searchRuleAlerts({ esClient, ruleName, spaceId, sourceFields });
+        }
+        return hits;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+    await sleep(WAIT_POLL_INTERVAL_MS);
+  }
+
+  const lastErrorMsg = lastError instanceof Error ? lastError.message : String(lastError ?? '');
+  throw new Error(
+    `Timed out after ${timeout}ms waiting for >=${minCount} alert(s) for rule "${ruleName}" in space "${spaceId}"${
+      lastErrorMsg ? ` (last error: ${lastErrorMsg})` : ''
+    }`
+  );
+};
+
+export const waitForRuleAlertHosts = async (
+  opts: Parameters<typeof waitForRuleAlertHits>[0]
+): Promise<Array<string | undefined>> => hostNamesFromAlertHits(await waitForRuleAlertHits(opts));
+
+interface JsonApiClient {
+  post: (
+    url: string,
+    opts: { headers: Record<string, string>; responseType: 'json'; body: object }
+  ) => Promise<{ statusCode: number; body: unknown }>;
+}
+
+/**
+ * Creates a detection rule with a UIAM session cookie.
+ *
+ * Do not switch this to `requestAuth` API keys or Scout `kbnClient`. `cps_local`
+ * sets `xpack.alerting.rules.apiKeyType=uiam`. Alerting only grants an `essu_…`
+ * execution key when create carries UIAM credentials; basic auth / API keys skip
+ * grant and the rule searches origin only.
+ */
+export const createDetectionRuleWithUiam = async ({
+  apiClient,
+  cookieHeader,
+  body,
+  spaceId,
+}: {
+  apiClient: JsonApiClient;
+  cookieHeader: Record<string, string>;
+  body: object;
+  spaceId?: string;
+}): Promise<{ statusCode: number; body: unknown }> => {
+  return apiClient.post(`${spaceBasePath(spaceId)}${DETECTION_ENGINE_RULES_URL}`, {
+    headers: { ...PUBLIC_HEADERS, ...cookieHeader },
+    responseType: 'json',
+    body,
+  });
+};
+
+export const deleteAllDetectionRulesInSpace = async (
+  kbnClient: KbnClient,
+  spaceId?: string
+): Promise<void> => {
+  await kbnClient.request({
+    method: 'POST',
+    path: `${spaceBasePath(spaceId)}${DETECTION_ENGINE_RULES_BULK_ACTION}`,
+    body: {
+      query: '',
+      action: 'delete',
+    },
+  });
+};
+
+export const deleteAlertsInSpace = async (
+  esClient: EsClient,
+  spaceId = 'default'
+): Promise<void> => {
+  const index = alertsIndexForSpace(spaceId);
+  await esClient.indices.refresh({ index, ignore_unavailable: true });
+  await esClient.deleteByQuery({
+    index,
+    ignore_unavailable: true,
+    query: { match_all: {} },
+    conflicts: 'proceed',
+    scroll_size: 10000,
+    refresh: true,
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/fixtures/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/fixtures/index.ts
@@ -6,9 +6,38 @@
  */
 
 import { get } from 'lodash';
-import type { EsClient } from '@kbn/scout-security';
+import type { ApiServicesFixture, EsClient } from '@kbn/scout-security';
+import { apiTest as baseApiTest } from '@kbn/scout-security';
+import {
+  getDetectionAlertsApiService,
+  getDetectionRuleApiService,
+  type DetectionAlertsApiService,
+  type DetectionRuleApiService,
+} from '@kbn/scout-security/src/playwright/fixtures/worker/apis';
 import { ENTITY_LATEST, ENTITY_STORE_ROUTES, getEntitiesAlias } from '@kbn/entity-store/common';
 import { hashEuid } from '@kbn/entity-store/common/domain/euid';
+
+export type CpsApiServicesFixture = ApiServicesFixture & {
+  detectionRule: DetectionRuleApiService;
+  detectionAlerts: DetectionAlertsApiService;
+};
+
+export const apiTest = baseApiTest.extend<{}, { apiServices: CpsApiServicesFixture }>({
+  apiServices: [
+    async (
+      { apiServices, kbnClient, esClient, log },
+      use: (extendedApiServices: CpsApiServicesFixture) => Promise<void>
+    ) => {
+      const extendedApiServices: CpsApiServicesFixture = {
+        ...apiServices,
+        detectionRule: getDetectionRuleApiService({ kbnClient, log }),
+        detectionAlerts: getDetectionAlertsApiService({ esClient, log }),
+      };
+      await use(extendedApiServices);
+    },
+    { scope: 'worker' },
+  ],
+});
 
 const BASE_HEADERS = {
   'kbn-xsrf': 'some-xsrf-token',

--- a/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/tests/detection_engine/custom_query_rule_alerts.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/tests/detection_engine/custom_query_rule_alerts.spec.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { randomUUID } from 'crypto';
+import { tags, CUSTOM_QUERY_RULE } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { apiTest } from '../../fixtures';
+import {
+  ISOLATION_SETTLE_MS,
+  RULE_INTERVAL,
+  createDetectionRuleWithUiam,
+  deleteAlertsInSpace,
+  deleteAllDetectionRulesInSpace,
+  seedLogsEvent,
+  waitForRuleAlertHosts,
+} from '../../fixtures/cps_rule_helpers';
+
+/**
+ * Custom query rule execution under CPS space scope.
+ *
+ * Covers:
+ * - Default space NPRE `_alias:*`: alerts from origin AND linked source events.
+ * - Origin-only space (`_alias:_origin`): linked events must not alert.
+ * - Linked-only space (`_alias:linked_local_project`): origin events must not alert.
+ *
+ * Three tests, three claims, three scheduled rule runs. Detection rules cannot
+ * schedule faster than 1m, so this file is slow by design. Do not merge these
+ * into one test: a failure must identify which space scope broke (all-linked,
+ * origin-only, or linked-only).
+ *
+ * Do not replace the wait with rule preview. Preview uses a different ES client
+ * mix (including asInternalUser, which is origin-only). These tests cover
+ * scheduled execution: Task Manager, the rule's UIAM key, and projectRouting
+ * space.
+ *
+ * Rule create must use a UIAM session (SAML cookie), not `requestAuth` API keys
+ * or Scout `kbnClient`. `cps_local` sets `xpack.alerting.rules.apiKeyType=uiam`.
+ * Alerting only grants a UIAM execution key when the create request carries UIAM
+ * credentials (`essu_…`). API keys and `kbnClient` (basic auth) skip grant and
+ * the rule runs with a stock ES API key that cannot fan out.
+ *
+ * Does not cover: saved query / EQL / ES|QL / ML / new terms; CPS Kibana flag
+ * off; exceptions, filters, data views; alerts-table / signals search (pinned
+ * origin, a different pipeline); rule preview.
+ *
+ * Requires:
+ *   node scripts/scout start-server --arch serverless \
+ *     --domain security_complete --serverConfigSet cps_local
+ *
+ * Run on Docker Desktop or Linux, not Colima. Docker needs ≥ ~12–16 GB RAM or
+ * the linked ES node is OOM-killed (exit 137) and `localhost:9230` is unreachable.
+ */
+
+const SPACE_PROJECT_ROUTING_ORIGIN_ONLY = '_alias:_origin';
+/**
+ * Linked-only space NPRE. `_alias:linked_local_project` is the cps_local docker
+ * alias from GET /_remote/info. `@kbn/mock-idp-utils` (`_id:…`) cannot be imported
+ * from security_solution (group-crossing).
+ */
+const SPACE_PROJECT_ROUTING_LINKED_ONLY = '_alias:linked_local_project';
+
+apiTest.describe('CPS custom query rule alerts', { tag: tags.serverless.security.complete }, () => {
+  const runId = randomUUID().slice(0, 8);
+  const sourceIndex = `logs-scout-cps-query-${runId}`;
+  const eventAction = `scout-cps-custom-query-${runId}`;
+  const originHostName = `scout-cps-origin-host-${runId}`;
+  const linkedHostName = `scout-cps-linked-host-${runId}`;
+
+  let cookieHeader: Record<string, string>;
+
+  const customQueryBody = (name: string, ruleId: string) => ({
+    ...CUSTOM_QUERY_RULE,
+    name,
+    rule_id: ruleId,
+    query: `event.action: "${eventAction}"`,
+    interval: RULE_INTERVAL,
+    from: 'now-1h',
+  });
+
+  apiTest.beforeAll(async ({ apiServices, esClient, linkedProject, samlAuth }) => {
+    await apiServices.detectionRule.deleteAll();
+    await apiServices.detectionAlerts.deleteAll();
+
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    cookieHeader = credentials.cookieHeader;
+
+    await seedLogsEvent(esClient, {
+      dataStream: sourceIndex,
+      hostName: originHostName,
+      eventAction,
+      runId,
+    });
+    await seedLogsEvent(linkedProject.esClient, {
+      dataStream: sourceIndex,
+      hostName: linkedHostName,
+      eventAction,
+      runId,
+    });
+  });
+
+  apiTest.afterAll(async ({ apiServices, esClient, linkedProject }) => {
+    await apiServices.detectionRule.deleteAll();
+    await apiServices.detectionAlerts.deleteAll();
+    await esClient.indices.deleteDataStream({ name: sourceIndex }, { ignore: [404] });
+    await linkedProject.esClient.indices.deleteDataStream({ name: sourceIndex }, { ignore: [404] });
+  });
+
+  apiTest(
+    'generates alerts from origin and linked projects when space scope is all linked',
+    async ({ apiClient, esClient, kbnClient }) => {
+      apiTest.setTimeout(240_000);
+      const ruleName = `CPS custom query all-linked ${runId}`;
+      const ruleId = `cps-custom-query-all-${runId}`;
+
+      try {
+        const createResponse = await createDetectionRuleWithUiam({
+          apiClient,
+          cookieHeader,
+          body: customQueryBody(ruleName, ruleId),
+        });
+        expect(createResponse).toHaveStatusCode(200);
+        expect(createResponse.body).toMatchObject({ rule_id: ruleId });
+
+        const hostNames = await waitForRuleAlertHosts({
+          esClient,
+          ruleName,
+          minCount: 2,
+        });
+
+        expect(
+          hostNames,
+          'With space scope `_alias:*`, the rule must alert on matching events from origin and linked projects'
+        ).toStrictEqual(expect.arrayContaining([originHostName, linkedHostName]));
+      } finally {
+        await deleteAllDetectionRulesInSpace(kbnClient);
+        await deleteAlertsInSpace(esClient);
+      }
+    }
+  );
+
+  apiTest(
+    'does not alert on linked-project events when space scope is origin only',
+    async ({ apiClient, apiServices, esClient, kbnClient }) => {
+      apiTest.setTimeout(240_000);
+      const spaceId = `cps-cq-origin-${runId}`;
+      const ruleName = `CPS custom query origin-only ${runId}`;
+      const ruleId = `cps-custom-query-origin-${runId}`;
+
+      await apiServices.spaces.create({
+        id: spaceId,
+        name: spaceId,
+        projectRouting: SPACE_PROJECT_ROUTING_ORIGIN_ONLY,
+      });
+
+      try {
+        const createResponse = await createDetectionRuleWithUiam({
+          apiClient,
+          cookieHeader,
+          body: customQueryBody(ruleName, ruleId),
+          spaceId,
+        });
+        expect(createResponse).toHaveStatusCode(200);
+        expect(createResponse.body).toMatchObject({ rule_id: ruleId });
+
+        const hostNames = await waitForRuleAlertHosts({
+          esClient,
+          ruleName,
+          minCount: 1,
+          spaceId,
+          settleMs: ISOLATION_SETTLE_MS,
+        });
+
+        expect(
+          hostNames,
+          'With space scope `_alias:_origin`, a matching origin event must still alert'
+        ).toContain(originHostName);
+        expect(
+          hostNames,
+          'With space scope `_alias:_origin`, a matching linked-project event must not alert'
+        ).not.toContain(linkedHostName);
+      } finally {
+        await deleteAllDetectionRulesInSpace(kbnClient, spaceId);
+        await deleteAlertsInSpace(esClient, spaceId);
+        await apiServices.spaces.delete(spaceId);
+      }
+    }
+  );
+
+  apiTest(
+    'does not alert on origin events when space scope is the linked project only',
+    async ({ apiClient, apiServices, esClient, kbnClient }) => {
+      apiTest.setTimeout(240_000);
+      const spaceId = `cps-cq-linked-${runId}`;
+      const ruleName = `CPS custom query linked-only ${runId}`;
+      const ruleId = `cps-custom-query-linked-${runId}`;
+
+      await apiServices.spaces.create({
+        id: spaceId,
+        name: spaceId,
+        projectRouting: SPACE_PROJECT_ROUTING_LINKED_ONLY,
+      });
+
+      try {
+        const createResponse = await createDetectionRuleWithUiam({
+          apiClient,
+          cookieHeader,
+          body: customQueryBody(ruleName, ruleId),
+          spaceId,
+        });
+        expect(createResponse).toHaveStatusCode(200);
+        expect(createResponse.body).toMatchObject({ rule_id: ruleId });
+
+        const hostNames = await waitForRuleAlertHosts({
+          esClient,
+          ruleName,
+          minCount: 1,
+          spaceId,
+          settleMs: ISOLATION_SETTLE_MS,
+        });
+
+        expect(
+          hostNames,
+          'With linked-only space scope, a matching linked-project event must still alert'
+        ).toContain(linkedHostName);
+        expect(
+          hostNames,
+          'With linked-only space scope, a matching origin event must not alert'
+        ).not.toContain(originHostName);
+      } finally {
+        await deleteAllDetectionRulesInSpace(kbnClient, spaceId);
+        await deleteAlertsInSpace(esClient, spaceId);
+        await apiServices.spaces.delete(spaceId);
+      }
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/tests/detection_engine/threat_match_rule_alerts.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/tests/detection_engine/threat_match_rule_alerts.spec.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { randomUUID } from 'crypto';
+import { tags } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import type { EsClient } from '@kbn/scout-security';
+import { apiTest } from '../../fixtures';
+import {
+  RULE_INTERVAL,
+  createDetectionRuleWithUiam,
+  deleteAlertsInSpace,
+  deleteAllDetectionRulesInSpace,
+  seedLogsEvent,
+  waitForRuleAlertHosts,
+} from '../../fixtures/cps_rule_helpers';
+
+/**
+ * Threat-match rule execution under CPS all-linked scope.
+ *
+ * Claim: with default-space NPRE `_alias:*`, origin events correlate with
+ * indicators that exist only on the linked project.
+ *
+ * Does not cover: the reverse (linked events + origin indicators); field
+ * autocomplete (see the CPS threat-match UI field-dropdown spec); space-scope
+ * isolation (custom query spec).
+ *
+ * Wait for the scheduled run (1m minimum interval). Do not use rule preview —
+ * preview is a different ES client mix. This test covers Task Manager + the
+ * rule's UIAM key + `projectRouting: 'space'`.
+ *
+ * Requires:
+ *   node scripts/scout start-server --arch serverless \
+ *     --domain security_complete --serverConfigSet cps_local
+ *
+ * Run on Docker Desktop or Linux, not Colima.
+ */
+
+const seedIndicator = async (
+  esClient: EsClient,
+  { dataStream, hostName, runId }: { dataStream: string; hostName: string; runId: string }
+): Promise<void> => {
+  await esClient.indices.deleteDataStream({ name: dataStream }, { ignore: [404] });
+  await esClient.bulk(
+    {
+      refresh: 'wait_for',
+      operations: [
+        { create: { _index: dataStream } },
+        {
+          '@timestamp': new Date(Date.now() - 5 * 60_000).toISOString(),
+          event: { id: `${runId}-indicator-${hostName}`, kind: 'indicator' },
+          host: { name: hostName },
+        },
+      ],
+    },
+    { requestTimeout: 180_000 }
+  );
+};
+
+apiTest.describe('CPS threat match rule alerts', { tag: tags.serverless.security.complete }, () => {
+  apiTest.setTimeout(240_000);
+
+  const runId = randomUUID().slice(0, 8);
+  const eventsIndex = `logs-scout-cps-tm-events-${runId}`;
+  const threatIndex = `logs-scout-cps-tm-threat-${runId}`;
+  const eventAction = `scout-cps-tm-${runId}`;
+  const matchHostName = `scout-cps-tm-host-${runId}`;
+  const ruleName = `CPS threat match ${runId}`;
+  const ruleId = `cps-threat-match-${runId}`;
+
+  let cookieHeader: Record<string, string>;
+
+  apiTest.beforeAll(async ({ apiServices, esClient, linkedProject, samlAuth }) => {
+    await apiServices.detectionRule.deleteAll();
+    await apiServices.detectionAlerts.deleteAll();
+
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    cookieHeader = credentials.cookieHeader;
+
+    await seedLogsEvent(esClient, {
+      dataStream: eventsIndex,
+      hostName: matchHostName,
+      eventAction,
+      runId,
+    });
+    await seedIndicator(linkedProject.esClient, {
+      dataStream: threatIndex,
+      hostName: matchHostName,
+      runId,
+    });
+  });
+
+  apiTest.afterAll(async ({ kbnClient, esClient, linkedProject }) => {
+    await deleteAllDetectionRulesInSpace(kbnClient);
+    await deleteAlertsInSpace(esClient);
+    await esClient.indices.deleteDataStream({ name: eventsIndex }, { ignore: [404] });
+    await esClient.indices.deleteDataStream({ name: threatIndex }, { ignore: [404] });
+    await linkedProject.esClient.indices.deleteDataStream({ name: eventsIndex }, { ignore: [404] });
+    await linkedProject.esClient.indices.deleteDataStream({ name: threatIndex }, { ignore: [404] });
+  });
+
+  apiTest(
+    'correlates origin events with linked-project indicators',
+    async ({ apiClient, esClient, kbnClient }) => {
+      try {
+        const createResponse = await createDetectionRuleWithUiam({
+          apiClient,
+          cookieHeader,
+          body: {
+            enabled: true,
+            name: ruleName,
+            description: 'CPS threat match origin events with linked indicators',
+            risk_score: 1,
+            rule_id: ruleId,
+            severity: 'high',
+            type: 'threat_match',
+            language: 'kuery',
+            index: [eventsIndex],
+            query: `event.action: "${eventAction}"`,
+            threat_index: [threatIndex],
+            threat_query: 'event.kind: indicator',
+            threat_mapping: [
+              {
+                entries: [
+                  {
+                    field: 'host.name',
+                    value: 'host.name',
+                    type: 'mapping',
+                  },
+                ],
+              },
+            ],
+            interval: RULE_INTERVAL,
+            from: 'now-1h',
+          },
+        });
+        expect(createResponse).toHaveStatusCode(200);
+        expect(createResponse.body).toMatchObject({ rule_id: ruleId });
+
+        const hostNames = await waitForRuleAlertHosts({
+          esClient,
+          ruleName,
+          minCount: 1,
+        });
+
+        expect(
+          hostNames,
+          'Origin events must correlate with indicators that exist only on the linked project'
+        ).toContain(matchHostName);
+      } finally {
+        await deleteAllDetectionRulesInSpace(kbnClient);
+        await deleteAlertsInSpace(esClient);
+      }
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/tests/detection_engine/threshold_rule_alerts.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/tests/detection_engine/threshold_rule_alerts.spec.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { randomUUID } from 'crypto';
+import { tags } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { apiTest } from '../../fixtures';
+import {
+  RULE_INTERVAL,
+  createDetectionRuleWithUiam,
+  deleteAlertsInSpace,
+  deleteAllDetectionRulesInSpace,
+  seedLogsEvent,
+  thresholdCountFromAlertHit,
+  waitForRuleAlertHits,
+} from '../../fixtures/cps_rule_helpers';
+
+/**
+ * Threshold rule execution under CPS all-linked scope.
+ *
+ * Claim: with default-space NPRE `_alias:*`, a threshold of 2 with one matching
+ * event on origin and one on linked produces an alert (the aggregation spans
+ * projects).
+ *
+ * Wait for the scheduled run (1m minimum interval). Do not use rule preview —
+ * preview is a different ES client mix. This test covers Task Manager + the
+ * rule's UIAM key + `projectRouting: 'space'`.
+ *
+ * Does not cover: origin-only / linked-only isolation (custom query spec);
+ * query-rule per-document fan-out; signal-history / prior-alert leak; other
+ * rule types.
+ *
+ * Requires:
+ *   node scripts/scout start-server --arch serverless \
+ *     --domain security_complete --serverConfigSet cps_local
+ *
+ * Run on Docker Desktop or Linux, not Colima.
+ */
+
+apiTest.describe('CPS threshold rule alerts', { tag: tags.serverless.security.complete }, () => {
+  apiTest.setTimeout(240_000);
+
+  const runId = randomUUID().slice(0, 8);
+  const sourceIndex = `logs-scout-cps-threshold-${runId}`;
+  const eventAction = `scout-cps-threshold-${runId}`;
+  const originHostName = `scout-cps-threshold-origin-${runId}`;
+  const linkedHostName = `scout-cps-threshold-linked-${runId}`;
+  const ruleName = `CPS threshold ${runId}`;
+  const ruleId = `cps-threshold-${runId}`;
+
+  let cookieHeader: Record<string, string>;
+
+  apiTest.beforeAll(async ({ apiServices, esClient, linkedProject, samlAuth }) => {
+    await apiServices.detectionRule.deleteAll();
+    await apiServices.detectionAlerts.deleteAll();
+
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    cookieHeader = credentials.cookieHeader;
+
+    await seedLogsEvent(esClient, {
+      dataStream: sourceIndex,
+      hostName: originHostName,
+      eventAction,
+      runId,
+    });
+    await seedLogsEvent(linkedProject.esClient, {
+      dataStream: sourceIndex,
+      hostName: linkedHostName,
+      eventAction,
+      runId,
+    });
+  });
+
+  apiTest.afterAll(async ({ kbnClient, esClient, linkedProject }) => {
+    await deleteAllDetectionRulesInSpace(kbnClient);
+    await deleteAlertsInSpace(esClient);
+    await esClient.indices.deleteDataStream({ name: sourceIndex }, { ignore: [404] });
+    await linkedProject.esClient.indices.deleteDataStream({ name: sourceIndex }, { ignore: [404] });
+  });
+
+  apiTest(
+    'counts matching events across origin and linked projects',
+    async ({ apiClient, esClient, kbnClient }) => {
+      try {
+        const createResponse = await createDetectionRuleWithUiam({
+          apiClient,
+          cookieHeader,
+          body: {
+            index: ['logs-*'],
+            enabled: true,
+            name: ruleName,
+            description: 'CPS threshold across origin and linked',
+            risk_score: 1,
+            rule_id: ruleId,
+            severity: 'high',
+            type: 'threshold',
+            language: 'kuery',
+            query: `event.action: "${eventAction}"`,
+            interval: RULE_INTERVAL,
+            from: 'now-1h',
+            threshold: {
+              field: [],
+              value: 2,
+            },
+          },
+        });
+        expect(createResponse).toHaveStatusCode(200);
+        expect(createResponse.body).toMatchObject({ rule_id: ruleId });
+
+        const hits = await waitForRuleAlertHits({
+          esClient,
+          ruleName,
+          minCount: 1,
+        });
+        expect(hits[0]).toBeDefined();
+
+        expect(
+          thresholdCountFromAlertHit(hits[0]),
+          'With space scope `_alias:*`, one origin event and one linked event must meet threshold value 2'
+        ).toBe(2);
+      } finally {
+        await deleteAllDetectionRulesInSpace(kbnClient);
+        await deleteAlertsInSpace(esClient);
+      }
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Adds Scout API tests; these five tests cover the distinct claims (space scope, threshold aggregation, threat-intel second index), not a matrix of every rule type.

All specs live in `test/scout_cps_local/` (needs the `cps_local` stack: origin ES + linked ES). Rules are created with a UIAM cookie so Alerting grants an execution key that can fan out. Assertions read alert `_source` on origin ES (`host.name` / threshold count), not the alerts table or `signals/search` (pinned origin — a different pipeline).

### Custom query (`api/tests/detection_engine/custom_query_rule_alerts.spec.ts`)

Three separate scheduled runs on purpose (1m min interval; do not merge, do not use rule preview).

1. **All-linked (`_alias:*`)** — matching events on origin and linked both alert (`host.name` markers).
2. **Origin-only space (`_alias:_origin`)** — origin host alerts; linked host must not (both events seeded so a dead rule cannot pass).
3. **Linked-only space (`_alias:linked_local_project`)** — linked host alerts; origin host must not.

### Threshold (`api/tests/detection_engine/threshold_rule_alerts.spec.ts`)

Under `_alias:*`, threshold value `2` with one matching event per project produces an alert whose `kibana.alert.threshold_result.count` is `2` (the agg spans projects). Does not retest isolation.

### Threat match (`api/tests/detection_engine/threat_match_rule_alerts.spec.ts`)

Under `_alias:*`, origin events correlate with indicators that exist only on the linked project (second index / PIT). Does not retest the reverse direction or the existing field-dropdown UI spec.

### Not covered

Saved query, EQL, ES|QL, new terms, ML; CPS Kibana flag off; query/index/exception narrowing; isolation clones per rule type; alerts-table / `signals/search` NPRE; rule preview.

## How to test

From root, you can run:

```
 node scripts/playwright test --project local \
  --config x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/playwright.config.ts \
  x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/tests/detection_engine
  ```

