### PR TITLE
[9.4] [Lens] Recover by-ref panels missing their `savedObjectRef` reference linking (#285476)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.test.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.test.ts
@@ -108,4 +108,40 @@ describe('getTransformOut', () => {
 
     expect(result.title).toEqual('Attributes title');
   });
+
+  describe('BWC: by-ref panels missing their savedObjectRef reference', () => {
+    // See https://github.com/elastic/kibana/issues/285475
+
+    it('returns ref_id from legacy savedObjectId when no savedObjectRef reference exists', () => {
+      const builder = new LensConfigBuilder(undefined, true);
+      const transformOut = getTransformOut(builder, transformDrilldownsOut, false);
+
+      const storedState: LensByValueSerializedState = {
+        // @ts-expect-error - testing legacy savedObjectId
+        savedObjectId: 'legacy-saved-object-id',
+      };
+
+      const result = transformOut(storedState, []) as { ref_id?: string };
+
+      expect(result.ref_id).toEqual('legacy-saved-object-id');
+    });
+
+    it('falls through to by-value when savedObjectId is present alongside attributes (hybrid state)', () => {
+      const builder = new LensConfigBuilder(undefined, true);
+      const transformOut = getTransformOut(builder, transformDrilldownsOut, true);
+
+      const storedState: LensByValueSerializedState = {
+        // @ts-expect-error - testing legacy savedObjectId
+        savedObjectId: 'legacy-saved-object-id',
+        attributes: simpleMetricAttributes,
+        references: [],
+      };
+
+      // Should not throw and should not return the savedObjectId as ref_id —
+      // the embedded attributes take precedence for hybrid panels.
+      const result = transformOut(storedState, []) as { ref_id?: string };
+
+      expect(result.ref_id).toBeUndefined();
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.ts
+++ b/x-pack/platform/plugins/shared/lens/common/transforms/transform_out.ts
@@ -33,6 +33,10 @@ export const getTransformOut = (
   isDashboardAppRequest: boolean
 ): LensTransformOut => {
   return function transformOut(storedState, panelReferences) {
+    // Capture savedObjectId prior to stripInheritedContext
+    const legacySavedObjectId =
+      'savedObjectId' in storedState ? storedState.savedObjectId : undefined;
+
     const transformsFlow = flow(
       transformTitlesOut<LensSerializedState>,
       transformTimeRangeOut<LensSerializedState>,
@@ -49,6 +53,11 @@ export const getTransformOut = (
         ...state,
         ref_id: savedObjectRef.id,
       } satisfies LensByRefTransformOutResult;
+    }
+
+    // Fallback to handle legacy SO with missing savedObjectRef reference
+    if (!attributes && legacySavedObjectId && typeof legacySavedObjectId === 'string') {
+      return { ...state, ref_id: legacySavedObjectId } satisfies LensByRefTransformOutResult;
     }
 
     const migratedAttributes = migrateAttributes(attributes);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Lens] Recover by-ref panels missing their `savedObjectRef` reference linking (#285476)](https://github.com/elastic/kibana/pull/285476)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2026-08-18T19:35:33Z","message":"[Lens] Recover by-ref panels missing their `savedObjectRef` reference linking (#285476)\n\n## Summary\n\nFixes #285475\n\nAdds a backward-compatibility fallback in `transformOut` so that Lens\nby-reference panels whose `savedObjectRef` entry is missing from the\ndashboard's `references` array are recovered rather than crashing with:\n\n```\nUnable to transform panel config. Error: Why are attributes undefined?\n```\n\n<details><summary>Test dashboard SO</summary>\n<p>\n\n```\n{\"attributes\":{\"fieldFormatMap\":\"{\\\"hour_of_day\\\":{}}\",\"name\":\"Kibana Sample Data Logs\",\"runtimeFieldMap\":\"{\\\"hour_of_day\\\":{\\\"type\\\":\\\"long\\\",\\\"script\\\":{\\\"source\\\":\\\"emit(doc['timestamp'].value.getHour());\\\"}}}\",\"timeFieldName\":\"timestamp\",\"title\":\"kibana_sample_data_logs\"},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2026-08-17T20:29:05.830Z\",\"created_by\":\"u_2895723599_cloud\",\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"managed\":false,\"references\":[],\"type\":\"index-pattern\",\"typeMigrationVersion\":\"7.11.0\",\"updated_at\":\"2026-08-17T20:29:05.830Z\",\"updated_by\":\"u_2895723599_cloud\",\"version\":\"WzksMV0=\"}\n{\"attributes\":{\"description\":\"\",\"state\":{\"adHocDataViews\":{},\"datasourceStates\":{\"formBased\":{\"layers\":{\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\":{\"columnOrder\":[\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\",\"5c1d533b-a0f5-4242-aa95-df17e2f98305\"],\"columns\":{\"5c1d533b-a0f5-4242-aa95-df17e2f98305\":{\"dataType\":\"number\",\"isBucketed\":false,\"label\":\"Count of records\",\"operationType\":\"count\",\"params\":{\"emptyAsNull\":true},\"sourceField\":\"___records___\"},\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\":{\"dataType\":\"date\",\"isBucketed\":true,\"label\":\"timestamp\",\"operationType\":\"date_histogram\",\"params\":{\"dropPartials\":false,\"includeEmptyRows\":true,\"interval\":\"auto\"},\"sourceField\":\"timestamp\"}},\"incompleteColumns\":{},\"sampling\":1}}},\"indexpattern\":{\"layers\":{}},\"textBased\":{\"layers\":{}}},\"filters\":[],\"internalReferences\":[],\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"visualization\":{\"axisTitlesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"fittingFunction\":\"Linear\",\"gridlinesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"labelsOrientation\":{\"x\":0,\"yLeft\":0,\"yRight\":0},\"layers\":[{\"accessors\":[\"5c1d533b-a0f5-4242-aa95-df17e2f98305\"],\"colorMapping\":{\"assignments\":[],\"colorMode\":{\"type\":\"categorical\"},\"paletteId\":\"default\",\"specialAssignments\":[{\"color\":{\"type\":\"loop\"},\"rules\":[{\"type\":\"other\"}],\"touched\":false}]},\"layerId\":\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"layerType\":\"data\",\"position\":\"top\",\"seriesType\":\"bar_stacked\",\"showGridlines\":false,\"xAccessor\":\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\"}],\"legend\":{\"isVisible\":true,\"position\":\"right\"},\"preferredSeriesType\":\"bar_stacked\",\"tickLabelsVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"valueLabels\":\"hide\"}},\"title\":\"Lens - by-ref\",\"visualizationType\":\"lnsXY\"},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2026-08-17T20:32:44.923Z\",\"created_by\":\"u_2895723599_cloud\",\"id\":\"e360f7d4-6ab8-4cae-9f34-ec39e1a9325e\",\"managed\":false,\"references\":[{\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"type\":\"index-pattern\"}],\"type\":\"lens\",\"typeMigrationVersion\":\"8.9.0\",\"updated_at\":\"2026-08-17T20:32:44.923Z\",\"updated_by\":\"u_2895723599_cloud\",\"version\":\"WzI4LDFd\"}\n{\"attributes\":{\"controlGroupInput\":{\"chainingSystem\":\"HIERARCHICAL\",\"controlStyle\":\"oneLine\",\"ignoreParentSettingsJSON\":\"{\\\"ignoreFilters\\\":false,\\\"ignoreQuery\\\":false,\\\"ignoreTimerange\\\":false,\\\"ignoreValidations\\\":false}\",\"panelsJSON\":\"{}\",\"showApplySelections\":false},\"description\":\"\",\"kibanaSavedObjectMeta\":{\"searchSourceJSON\":\"{\\\"filter\\\":[],\\\"query\\\":{\\\"query\\\":\\\"\\\",\\\"language\\\":\\\"kuery\\\"}}\"},\"optionsJSON\":\"{\\\"useMargins\\\":true,\\\"syncColors\\\":false,\\\"syncCursor\\\":true,\\\"syncTooltips\\\":false,\\\"hidePanelTitles\\\":false}\",\"panelsJSON\":\"[{\\\"type\\\": \\\"lens\\\", \\\"embeddableConfig\\\": {\\\"enhancements\\\": {\\\"dynamicActions\\\": {\\\"events\\\": []}}, \\\"title\\\": \\\"Lens - by-value\\\", \\\"syncColors\\\": false, \\\"syncCursor\\\": true, \\\"syncTooltips\\\": false, \\\"filters\\\": [], \\\"query\\\": {\\\"query\\\": \\\"\\\", \\\"language\\\": \\\"kuery\\\"}, \\\"attributes\\\": {\\\"title\\\": \\\"\\\", \\\"visualizationType\\\": \\\"lnsXY\\\", \\\"type\\\": \\\"lens\\\", \\\"references\\\": [{\\\"type\\\": \\\"index-pattern\\\", \\\"id\\\": \\\"90943e30-9a47-11e8-b64d-95841ca0b247\\\", \\\"name\\\": \\\"indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\\\"}], \\\"state\\\": {\\\"visualization\\\": {\\\"legend\\\": {\\\"isVisible\\\": true, \\\"position\\\": \\\"right\\\"}, \\\"valueLabels\\\": \\\"hide\\\", \\\"fittingFunction\\\": \\\"Linear\\\", \\\"axisTitlesVisibilitySettings\\\": {\\\"x\\\": true, \\\"yLeft\\\": true, \\\"yRight\\\": true}, \\\"tickLabelsVisibilitySettings\\\": {\\\"x\\\": true, \\\"yLeft\\\": true, \\\"yRight\\\": true}, \\\"labelsOrientation\\\": {\\\"x\\\": 0, \\\"yLeft\\\": 0, \\\"yRight\\\": 0}, \\\"gridlinesVisibilitySettings\\\": {\\\"x\\\": true, \\\"yLeft\\\": true, \\\"yRight\\\": true}, \\\"preferredSeriesType\\\": \\\"bar_stacked\\\", \\\"layers\\\": [{\\\"layerId\\\": \\\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\\\", \\\"accessors\\\": [\\\"5c1d533b-a0f5-4242-aa95-df17e2f98305\\\"], \\\"position\\\": \\\"top\\\", \\\"seriesType\\\": \\\"bar_stacked\\\", \\\"showGridlines\\\": false, \\\"layerType\\\": \\\"data\\\", \\\"colorMapping\\\": {\\\"assignments\\\": [], \\\"specialAssignments\\\": [{\\\"rules\\\": [{\\\"type\\\": \\\"other\\\"}], \\\"color\\\": {\\\"type\\\": \\\"loop\\\"}, \\\"touched\\\": false}], \\\"paletteId\\\": \\\"default\\\", \\\"colorMode\\\": {\\\"type\\\": \\\"categorical\\\"}}, \\\"xAccessor\\\": \\\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\\\"}]}, \\\"query\\\": {\\\"query\\\": \\\"\\\", \\\"language\\\": \\\"kuery\\\"}, \\\"filters\\\": [], \\\"datasourceStates\\\": {\\\"formBased\\\": {\\\"layers\\\": {\\\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\\\": {\\\"columns\\\": {\\\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\\\": {\\\"label\\\": \\\"timestamp\\\", \\\"dataType\\\": \\\"date\\\", \\\"operationType\\\": \\\"date_histogram\\\", \\\"sourceField\\\": \\\"timestamp\\\", \\\"isBucketed\\\": true, \\\"params\\\": {\\\"interval\\\": \\\"auto\\\", \\\"includeEmptyRows\\\": true, \\\"dropPartials\\\": false}}, \\\"5c1d533b-a0f5-4242-aa95-df17e2f98305\\\": {\\\"label\\\": \\\"Count of records\\\", \\\"dataType\\\": \\\"number\\\", \\\"operationType\\\": \\\"count\\\", \\\"isBucketed\\\": false, \\\"sourceField\\\": \\\"___records___\\\", \\\"params\\\": {\\\"emptyAsNull\\\": true}}}, \\\"columnOrder\\\": [\\\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\\\", \\\"5c1d533b-a0f5-4242-aa95-df17e2f98305\\\"], \\\"incompleteColumns\\\": {}, \\\"sampling\\\": 1}}}, \\\"indexpattern\\\": {\\\"layers\\\": {}}, \\\"textBased\\\": {\\\"layers\\\": {}}}, \\\"internalReferences\\\": [], \\\"adHocDataViews\\\": {}}}}, \\\"panelIndex\\\": \\\"0630620b-1ee4-4949-b8be-c519ffdb0e88\\\", \\\"gridData\\\": {\\\"i\\\": \\\"0630620b-1ee4-4949-b8be-c519ffdb0e88\\\", \\\"y\\\": 0, \\\"x\\\": 0, \\\"w\\\": 24, \\\"h\\\": 15}}, {\\\"type\\\": \\\"lens\\\", \\\"embeddableConfig\\\": {\\\"enhancements\\\": {\\\"dynamicActions\\\": {\\\"events\\\": []}}, \\\"syncColors\\\": false, \\\"syncCursor\\\": true, \\\"syncTooltips\\\": false, \\\"filters\\\": [], \\\"query\\\": {\\\"query\\\": \\\"\\\", \\\"language\\\": \\\"kuery\\\"}, \\\"savedObjectId\\\": \\\"e360f7d4-6ab8-4cae-9f34-ec39e1a9325e\\\"}, \\\"panelIndex\\\": \\\"6b2f81c6-08f8-4082-bbab-0d3fd9422b8d\\\", \\\"gridData\\\": {\\\"i\\\": \\\"6b2f81c6-08f8-4082-bbab-0d3fd9422b8d\\\", \\\"y\\\": 0, \\\"x\\\": 24, \\\"w\\\": 24, \\\"h\\\": 15}}]\",\"timeRestore\":false,\"title\":\"Test Dashboard\",\"version\":3},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2026-08-17T20:29:57.096Z\",\"created_by\":\"u_2895723599_cloud\",\"id\":\"125f6cc0-0d83-4605-ae61-5bc558af9423\",\"managed\":false,\"references\":[{\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"0630620b-1ee4-4949-b8be-c519ffdb0e88:indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"type\":\"index-pattern\"},{\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"6b2f81c6-08f8-4082-bbab-0d3fd9422b8d:indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"type\":\"index-pattern\"}],\"type\":\"dashboard\",\"typeMigrationVersion\":\"10.3.0\",\"updated_at\":\"2026-08-17T20:33:05.881Z\",\"updated_by\":\"u_2895723599_cloud\",\"version\":\"WzMwLDFd\"}\n{\"excludedObjects\":[],\"excludedObjectsCount\":0,\"exportedCount\":4,\"missingRefCount\":0,\"missingReferences\":[]}\n\n```\n\n</p>\n</details> \n\n### Before\n\n<img width=\"1606\" height=\"590\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a5dd6ff9-2bbe-454b-bb81-96a21b23a967\"\n/>\n\n### After\n\nCorrectly loads by-ref Lens panel with missing reference linking\n\n<img width=\"1605\" height=\"589\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ec5748ff-e6cd-4886-83be-5aa71d64c155\"\n/>\n\n\n## Background\n\n[#239029](https://github.com/elastic/kibana/pull/239029) moved Lens\nreference handling to the server. Before it, by-reference panels were\nidentified by `savedObjectId` in `embeddableConfig`. After it,\n`transformOut` detects them by looking for a `savedObjectRef` entry in\nthe dashboard's `references` array via `findLensReference`. No fallback\nwas added for panels where that reference is absent.\n\nFor dashboards created in 8.x this gap is benign as long as the\nreference exists. However some panels arrive in 9.x with no such\nreference at all — either because the reference was never stored (very\nold format), because a buggy save path lost it, or because it was\nfiltered out during an NDJSON import. These panels have only\n`savedObjectId` in their `embeddableConfig` as the sole by-reference\nsignal.\n\n[#255555](https://github.com/elastic/kibana/pull/255555) then removed\n`savedObjectId` from the `stripInheritedContext` allowlist (renaming it\nto `ref_id`), meaning `savedObjectId` is now **dropped** before\n`transformOut` can use it — eliminating the last available signal and\nmaking the crash inevitable.\n\n## What breaks\n\n`transformOut` calls `findLensReference(panelReferences)`. When it\nreturns `undefined`, execution falls into the by-value path and calls\n`migrateAttributes(attributes)`. A by-reference panel has no inline\n`attributes`, so `attributes` is `undefined` → throws. The dashboard\ncatches this and emits the `\"Unable to transform panel config\"` warning,\ndropping the panel from the response.\n\n## Fix\n\n**`transform_out.ts`**\n\n1. Read `savedObjectId` from `storedState` **before** `transformsFlow`\nruns, since `stripInheritedContext` will drop it.\n2. After `findLensReference` fails, if `attributes` is absent and\n`legacySavedObjectId` is present, return `{ ...state, ref_id:\nlegacySavedObjectId }` as a by-ref result.\n\nThe `!attributes` guard is critical: a panel with **both**\n`savedObjectId` **and** inline `attributes` is a corrupt hybrid (see\n#271318) and must fall through to the by-value path using its embedded\nattributes. This fix does not regress that behaviour.\n\nNote: checking `state.ref_id` as a further fallback is not needed —\n`transformIn` always strips `ref_id` from stored state and converts it\nto a `savedObjectRef` reference, so `ref_id` is never present in\n`panelsJSON`.\n\n## How recovery works end-to-end\n\n1. **Load:** `transformOut` returns `{ ref_id: \"<so-id>\" }`. The client\ncalls `attributeService.loadFromLibrary(ref_id)` to fetch the Lens saved\nobject directly — the panel renders correctly as long as the Lens SO\nexists.\n2. **Save (self-healing):** On the next dashboard save, `transformIn`\nsees `ref_id`, emits a proper `savedObjectRef` reference, and the\ndashboard stores `{panelIndex}:savedObjectRef` — the missing reference\nis created and the data is healed going forward.\n\n> **Note:** The fix only helps panels whose `panelsJSON` still contains\n`savedObjectId`. If the dashboard was opened and saved in 9.x after the\npanels started crashing (which drops them from the API response), the\npanel config is permanently gone from `panelsJSON` and the Lens SO must\nbe re-added manually from the library.\n\n## Related\n\n- #239029 — introduced the `savedObjectRef` requirement (root cause)\n- #255555 — removed `savedObjectId` from the `stripInheritedContext`\nallowlist, making pre-capture necessary\n- #271318 — hybrid `savedObjectId` + `attributes` corrupt state; the\n`!attributes` guard here prevents regressing that fix\n- #245569 — changed `transformOut` to receive separate `panelReferences`\n/ `containerReferences` (not related to this crash, confirmed)\n\n## Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release Note\n\nFixes a bug with by-reference Lens panels where references are missing\nin the dashboard SavedObject causing affected panels to be removed when\nloaded.","sha":"8c21adfae4ada67e8b973919fd67028ab5cf34a8","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Visualizations","Feature:Lens","backport:version","v9.6.0","v9.4.5","v9.5.2"],"title":"[Lens] Recover by-ref panels missing their `savedObjectRef` reference linking","number":285476,"url":"https://github.com/elastic/kibana/pull/285476","mergeCommit":{"message":"[Lens] Recover by-ref panels missing their `savedObjectRef` reference linking (#285476)\n\n## Summary\n\nFixes #285475\n\nAdds a backward-compatibility fallback in `transformOut` so that Lens\nby-reference panels whose `savedObjectRef` entry is missing from the\ndashboard's `references` array are recovered rather than crashing with:\n\n```\nUnable to transform panel config. Error: Why are attributes undefined?\n```\n\n<details><summary>Test dashboard SO</summary>\n<p>\n\n```\n{\"attributes\":{\"fieldFormatMap\":\"{\\\"hour_of_day\\\":{}}\",\"name\":\"Kibana Sample Data Logs\",\"runtimeFieldMap\":\"{\\\"hour_of_day\\\":{\\\"type\\\":\\\"long\\\",\\\"script\\\":{\\\"source\\\":\\\"emit(doc['timestamp'].value.getHour());\\\"}}}\",\"timeFieldName\":\"timestamp\",\"title\":\"kibana_sample_data_logs\"},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2026-08-17T20:29:05.830Z\",\"created_by\":\"u_2895723599_cloud\",\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"managed\":false,\"references\":[],\"type\":\"index-pattern\",\"typeMigrationVersion\":\"7.11.0\",\"updated_at\":\"2026-08-17T20:29:05.830Z\",\"updated_by\":\"u_2895723599_cloud\",\"version\":\"WzksMV0=\"}\n{\"attributes\":{\"description\":\"\",\"state\":{\"adHocDataViews\":{},\"datasourceStates\":{\"formBased\":{\"layers\":{\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\":{\"columnOrder\":[\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\",\"5c1d533b-a0f5-4242-aa95-df17e2f98305\"],\"columns\":{\"5c1d533b-a0f5-4242-aa95-df17e2f98305\":{\"dataType\":\"number\",\"isBucketed\":false,\"label\":\"Count of records\",\"operationType\":\"count\",\"params\":{\"emptyAsNull\":true},\"sourceField\":\"___records___\"},\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\":{\"dataType\":\"date\",\"isBucketed\":true,\"label\":\"timestamp\",\"operationType\":\"date_histogram\",\"params\":{\"dropPartials\":false,\"includeEmptyRows\":true,\"interval\":\"auto\"},\"sourceField\":\"timestamp\"}},\"incompleteColumns\":{},\"sampling\":1}}},\"indexpattern\":{\"layers\":{}},\"textBased\":{\"layers\":{}}},\"filters\":[],\"internalReferences\":[],\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"visualization\":{\"axisTitlesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"fittingFunction\":\"Linear\",\"gridlinesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"labelsOrientation\":{\"x\":0,\"yLeft\":0,\"yRight\":0},\"layers\":[{\"accessors\":[\"5c1d533b-a0f5-4242-aa95-df17e2f98305\"],\"colorMapping\":{\"assignments\":[],\"colorMode\":{\"type\":\"categorical\"},\"paletteId\":\"default\",\"specialAssignments\":[{\"color\":{\"type\":\"loop\"},\"rules\":[{\"type\":\"other\"}],\"touched\":false}]},\"layerId\":\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"layerType\":\"data\",\"position\":\"top\",\"seriesType\":\"bar_stacked\",\"showGridlines\":false,\"xAccessor\":\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\"}],\"legend\":{\"isVisible\":true,\"position\":\"right\"},\"preferredSeriesType\":\"bar_stacked\",\"tickLabelsVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"valueLabels\":\"hide\"}},\"title\":\"Lens - by-ref\",\"visualizationType\":\"lnsXY\"},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2026-08-17T20:32:44.923Z\",\"created_by\":\"u_2895723599_cloud\",\"id\":\"e360f7d4-6ab8-4cae-9f34-ec39e1a9325e\",\"managed\":false,\"references\":[{\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"type\":\"index-pattern\"}],\"type\":\"lens\",\"typeMigrationVersion\":\"8.9.0\",\"updated_at\":\"2026-08-17T20:32:44.923Z\",\"updated_by\":\"u_2895723599_cloud\",\"version\":\"WzI4LDFd\"}\n{\"attributes\":{\"controlGroupInput\":{\"chainingSystem\":\"HIERARCHICAL\",\"controlStyle\":\"oneLine\",\"ignoreParentSettingsJSON\":\"{\\\"ignoreFilters\\\":false,\\\"ignoreQuery\\\":false,\\\"ignoreTimerange\\\":false,\\\"ignoreValidations\\\":false}\",\"panelsJSON\":\"{}\",\"showApplySelections\":false},\"description\":\"\",\"kibanaSavedObjectMeta\":{\"searchSourceJSON\":\"{\\\"filter\\\":[],\\\"query\\\":{\\\"query\\\":\\\"\\\",\\\"language\\\":\\\"kuery\\\"}}\"},\"optionsJSON\":\"{\\\"useMargins\\\":true,\\\"syncColors\\\":false,\\\"syncCursor\\\":true,\\\"syncTooltips\\\":false,\\\"hidePanelTitles\\\":false}\",\"panelsJSON\":\"[{\\\"type\\\": \\\"lens\\\", \\\"embeddableConfig\\\": {\\\"enhancements\\\": {\\\"dynamicActions\\\": {\\\"events\\\": []}}, \\\"title\\\": \\\"Lens - by-value\\\", \\\"syncColors\\\": false, \\\"syncCursor\\\": true, \\\"syncTooltips\\\": false, \\\"filters\\\": [], \\\"query\\\": {\\\"query\\\": \\\"\\\", \\\"language\\\": \\\"kuery\\\"}, \\\"attributes\\\": {\\\"title\\\": \\\"\\\", \\\"visualizationType\\\": \\\"lnsXY\\\", \\\"type\\\": \\\"lens\\\", \\\"references\\\": [{\\\"type\\\": \\\"index-pattern\\\", \\\"id\\\": \\\"90943e30-9a47-11e8-b64d-95841ca0b247\\\", \\\"name\\\": \\\"indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\\\"}], \\\"state\\\": {\\\"visualization\\\": {\\\"legend\\\": {\\\"isVisible\\\": true, \\\"position\\\": \\\"right\\\"}, \\\"valueLabels\\\": \\\"hide\\\", \\\"fittingFunction\\\": \\\"Linear\\\", \\\"axisTitlesVisibilitySettings\\\": {\\\"x\\\": true, \\\"yLeft\\\": true, \\\"yRight\\\": true}, \\\"tickLabelsVisibilitySettings\\\": {\\\"x\\\": true, \\\"yLeft\\\": true, \\\"yRight\\\": true}, \\\"labelsOrientation\\\": {\\\"x\\\": 0, \\\"yLeft\\\": 0, \\\"yRight\\\": 0}, \\\"gridlinesVisibilitySettings\\\": {\\\"x\\\": true, \\\"yLeft\\\": true, \\\"yRight\\\": true}, \\\"preferredSeriesType\\\": \\\"bar_stacked\\\", \\\"layers\\\": [{\\\"layerId\\\": \\\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\\\", \\\"accessors\\\": [\\\"5c1d533b-a0f5-4242-aa95-df17e2f98305\\\"], \\\"position\\\": \\\"top\\\", \\\"seriesType\\\": \\\"bar_stacked\\\", \\\"showGridlines\\\": false, \\\"layerType\\\": \\\"data\\\", \\\"colorMapping\\\": {\\\"assignments\\\": [], \\\"specialAssignments\\\": [{\\\"rules\\\": [{\\\"type\\\": \\\"other\\\"}], \\\"color\\\": {\\\"type\\\": \\\"loop\\\"}, \\\"touched\\\": false}], \\\"paletteId\\\": \\\"default\\\", \\\"colorMode\\\": {\\\"type\\\": \\\"categorical\\\"}}, \\\"xAccessor\\\": \\\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\\\"}]}, \\\"query\\\": {\\\"query\\\": \\\"\\\", \\\"language\\\": \\\"kuery\\\"}, \\\"filters\\\": [], \\\"datasourceStates\\\": {\\\"formBased\\\": {\\\"layers\\\": {\\\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\\\": {\\\"columns\\\": {\\\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\\\": {\\\"label\\\": \\\"timestamp\\\", \\\"dataType\\\": \\\"date\\\", \\\"operationType\\\": \\\"date_histogram\\\", \\\"sourceField\\\": \\\"timestamp\\\", \\\"isBucketed\\\": true, \\\"params\\\": {\\\"interval\\\": \\\"auto\\\", \\\"includeEmptyRows\\\": true, \\\"dropPartials\\\": false}}, \\\"5c1d533b-a0f5-4242-aa95-df17e2f98305\\\": {\\\"label\\\": \\\"Count of records\\\", \\\"dataType\\\": \\\"number\\\", \\\"operationType\\\": \\\"count\\\", \\\"isBucketed\\\": false, \\\"sourceField\\\": \\\"___records___\\\", \\\"params\\\": {\\\"emptyAsNull\\\": true}}}, \\\"columnOrder\\\": [\\\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\\\", \\\"5c1d533b-a0f5-4242-aa95-df17e2f98305\\\"], \\\"incompleteColumns\\\": {}, \\\"sampling\\\": 1}}}, \\\"indexpattern\\\": {\\\"layers\\\": {}}, \\\"textBased\\\": {\\\"layers\\\": {}}}, \\\"internalReferences\\\": [], \\\"adHocDataViews\\\": {}}}}, \\\"panelIndex\\\": \\\"0630620b-1ee4-4949-b8be-c519ffdb0e88\\\", \\\"gridData\\\": {\\\"i\\\": \\\"0630620b-1ee4-4949-b8be-c519ffdb0e88\\\", \\\"y\\\": 0, \\\"x\\\": 0, \\\"w\\\": 24, \\\"h\\\": 15}}, {\\\"type\\\": \\\"lens\\\", \\\"embeddableConfig\\\": {\\\"enhancements\\\": {\\\"dynamicActions\\\": {\\\"events\\\": []}}, \\\"syncColors\\\": false, \\\"syncCursor\\\": true, \\\"syncTooltips\\\": false, \\\"filters\\\": [], \\\"query\\\": {\\\"query\\\": \\\"\\\", \\\"language\\\": \\\"kuery\\\"}, \\\"savedObjectId\\\": \\\"e360f7d4-6ab8-4cae-9f34-ec39e1a9325e\\\"}, \\\"panelIndex\\\": \\\"6b2f81c6-08f8-4082-bbab-0d3fd9422b8d\\\", \\\"gridData\\\": {\\\"i\\\": \\\"6b2f81c6-08f8-4082-bbab-0d3fd9422b8d\\\", \\\"y\\\": 0, \\\"x\\\": 24, \\\"w\\\": 24, \\\"h\\\": 15}}]\",\"timeRestore\":false,\"title\":\"Test Dashboard\",\"version\":3},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2026-08-17T20:29:57.096Z\",\"created_by\":\"u_2895723599_cloud\",\"id\":\"125f6cc0-0d83-4605-ae61-5bc558af9423\",\"managed\":false,\"references\":[{\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"0630620b-1ee4-4949-b8be-c519ffdb0e88:indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"type\":\"index-pattern\"},{\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"6b2f81c6-08f8-4082-bbab-0d3fd9422b8d:indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"type\":\"index-pattern\"}],\"type\":\"dashboard\",\"typeMigrationVersion\":\"10.3.0\",\"updated_at\":\"2026-08-17T20:33:05.881Z\",\"updated_by\":\"u_2895723599_cloud\",\"version\":\"WzMwLDFd\"}\n{\"excludedObjects\":[],\"excludedObjectsCount\":0,\"exportedCount\":4,\"missingRefCount\":0,\"missingReferences\":[]}\n\n```\n\n</p>\n</details> \n\n### Before\n\n<img width=\"1606\" height=\"590\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a5dd6ff9-2bbe-454b-bb81-96a21b23a967\"\n/>\n\n### After\n\nCorrectly loads by-ref Lens panel with missing reference linking\n\n<img width=\"1605\" height=\"589\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ec5748ff-e6cd-4886-83be-5aa71d64c155\"\n/>\n\n\n## Background\n\n[#239029](https://github.com/elastic/kibana/pull/239029) moved Lens\nreference handling to the server. Before it, by-reference panels were\nidentified by `savedObjectId` in `embeddableConfig`. After it,\n`transformOut` detects them by looking for a `savedObjectRef` entry in\nthe dashboard's `references` array via `findLensReference`. No fallback\nwas added for panels where that reference is absent.\n\nFor dashboards created in 8.x this gap is benign as long as the\nreference exists. However some panels arrive in 9.x with no such\nreference at all — either because the reference was never stored (very\nold format), because a buggy save path lost it, or because it was\nfiltered out during an NDJSON import. These panels have only\n`savedObjectId` in their `embeddableConfig` as the sole by-reference\nsignal.\n\n[#255555](https://github.com/elastic/kibana/pull/255555) then removed\n`savedObjectId` from the `stripInheritedContext` allowlist (renaming it\nto `ref_id`), meaning `savedObjectId` is now **dropped** before\n`transformOut` can use it — eliminating the last available signal and\nmaking the crash inevitable.\n\n## What breaks\n\n`transformOut` calls `findLensReference(panelReferences)`. When it\nreturns `undefined`, execution falls into the by-value path and calls\n`migrateAttributes(attributes)`. A by-reference panel has no inline\n`attributes`, so `attributes` is `undefined` → throws. The dashboard\ncatches this and emits the `\"Unable to transform panel config\"` warning,\ndropping the panel from the response.\n\n## Fix\n\n**`transform_out.ts`**\n\n1. Read `savedObjectId` from `storedState` **before** `transformsFlow`\nruns, since `stripInheritedContext` will drop it.\n2. After `findLensReference` fails, if `attributes` is absent and\n`legacySavedObjectId` is present, return `{ ...state, ref_id:\nlegacySavedObjectId }` as a by-ref result.\n\nThe `!attributes` guard is critical: a panel with **both**\n`savedObjectId` **and** inline `attributes` is a corrupt hybrid (see\n#271318) and must fall through to the by-value path using its embedded\nattributes. This fix does not regress that behaviour.\n\nNote: checking `state.ref_id` as a further fallback is not needed —\n`transformIn` always strips `ref_id` from stored state and converts it\nto a `savedObjectRef` reference, so `ref_id` is never present in\n`panelsJSON`.\n\n## How recovery works end-to-end\n\n1. **Load:** `transformOut` returns `{ ref_id: \"<so-id>\" }`. The client\ncalls `attributeService.loadFromLibrary(ref_id)` to fetch the Lens saved\nobject directly — the panel renders correctly as long as the Lens SO\nexists.\n2. **Save (self-healing):** On the next dashboard save, `transformIn`\nsees `ref_id`, emits a proper `savedObjectRef` reference, and the\ndashboard stores `{panelIndex}:savedObjectRef` — the missing reference\nis created and the data is healed going forward.\n\n> **Note:** The fix only helps panels whose `panelsJSON` still contains\n`savedObjectId`. If the dashboard was opened and saved in 9.x after the\npanels started crashing (which drops them from the API response), the\npanel config is permanently gone from `panelsJSON` and the Lens SO must\nbe re-added manually from the library.\n\n## Related\n\n- #239029 — introduced the `savedObjectRef` requirement (root cause)\n- #255555 — removed `savedObjectId` from the `stripInheritedContext`\nallowlist, making pre-capture necessary\n- #271318 — hybrid `savedObjectId` + `attributes` corrupt state; the\n`!attributes` guard here prevents regressing that fix\n- #245569 — changed `transformOut` to receive separate `panelReferences`\n/ `containerReferences` (not related to this crash, confirmed)\n\n## Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release Note\n\nFixes a bug with by-reference Lens panels where references are missing\nin the dashboard SavedObject causing affected panels to be removed when\nloaded.","sha":"8c21adfae4ada67e8b973919fd67028ab5cf34a8"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/285476","number":285476,"mergeCommit":{"message":"[Lens] Recover by-ref panels missing their `savedObjectRef` reference linking (#285476)\n\n## Summary\n\nFixes #285475\n\nAdds a backward-compatibility fallback in `transformOut` so that Lens\nby-reference panels whose `savedObjectRef` entry is missing from the\ndashboard's `references` array are recovered rather than crashing with:\n\n```\nUnable to transform panel config. Error: Why are attributes undefined?\n```\n\n<details><summary>Test dashboard SO</summary>\n<p>\n\n```\n{\"attributes\":{\"fieldFormatMap\":\"{\\\"hour_of_day\\\":{}}\",\"name\":\"Kibana Sample Data Logs\",\"runtimeFieldMap\":\"{\\\"hour_of_day\\\":{\\\"type\\\":\\\"long\\\",\\\"script\\\":{\\\"source\\\":\\\"emit(doc['timestamp'].value.getHour());\\\"}}}\",\"timeFieldName\":\"timestamp\",\"title\":\"kibana_sample_data_logs\"},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2026-08-17T20:29:05.830Z\",\"created_by\":\"u_2895723599_cloud\",\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"managed\":false,\"references\":[],\"type\":\"index-pattern\",\"typeMigrationVersion\":\"7.11.0\",\"updated_at\":\"2026-08-17T20:29:05.830Z\",\"updated_by\":\"u_2895723599_cloud\",\"version\":\"WzksMV0=\"}\n{\"attributes\":{\"description\":\"\",\"state\":{\"adHocDataViews\":{},\"datasourceStates\":{\"formBased\":{\"layers\":{\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\":{\"columnOrder\":[\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\",\"5c1d533b-a0f5-4242-aa95-df17e2f98305\"],\"columns\":{\"5c1d533b-a0f5-4242-aa95-df17e2f98305\":{\"dataType\":\"number\",\"isBucketed\":false,\"label\":\"Count of records\",\"operationType\":\"count\",\"params\":{\"emptyAsNull\":true},\"sourceField\":\"___records___\"},\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\":{\"dataType\":\"date\",\"isBucketed\":true,\"label\":\"timestamp\",\"operationType\":\"date_histogram\",\"params\":{\"dropPartials\":false,\"includeEmptyRows\":true,\"interval\":\"auto\"},\"sourceField\":\"timestamp\"}},\"incompleteColumns\":{},\"sampling\":1}}},\"indexpattern\":{\"layers\":{}},\"textBased\":{\"layers\":{}}},\"filters\":[],\"internalReferences\":[],\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"visualization\":{\"axisTitlesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"fittingFunction\":\"Linear\",\"gridlinesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"labelsOrientation\":{\"x\":0,\"yLeft\":0,\"yRight\":0},\"layers\":[{\"accessors\":[\"5c1d533b-a0f5-4242-aa95-df17e2f98305\"],\"colorMapping\":{\"assignments\":[],\"colorMode\":{\"type\":\"categorical\"},\"paletteId\":\"default\",\"specialAssignments\":[{\"color\":{\"type\":\"loop\"},\"rules\":[{\"type\":\"other\"}],\"touched\":false}]},\"layerId\":\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"layerType\":\"data\",\"position\":\"top\",\"seriesType\":\"bar_stacked\",\"showGridlines\":false,\"xAccessor\":\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\"}],\"legend\":{\"isVisible\":true,\"position\":\"right\"},\"preferredSeriesType\":\"bar_stacked\",\"tickLabelsVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"valueLabels\":\"hide\"}},\"title\":\"Lens - by-ref\",\"visualizationType\":\"lnsXY\"},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2026-08-17T20:32:44.923Z\",\"created_by\":\"u_2895723599_cloud\",\"id\":\"e360f7d4-6ab8-4cae-9f34-ec39e1a9325e\",\"managed\":false,\"references\":[{\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"type\":\"index-pattern\"}],\"type\":\"lens\",\"typeMigrationVersion\":\"8.9.0\",\"updated_at\":\"2026-08-17T20:32:44.923Z\",\"updated_by\":\"u_2895723599_cloud\",\"version\":\"WzI4LDFd\"}\n{\"attributes\":{\"controlGroupInput\":{\"chainingSystem\":\"HIERARCHICAL\",\"controlStyle\":\"oneLine\",\"ignoreParentSettingsJSON\":\"{\\\"ignoreFilters\\\":false,\\\"ignoreQuery\\\":false,\\\"ignoreTimerange\\\":false,\\\"ignoreValidations\\\":false}\",\"panelsJSON\":\"{}\",\"showApplySelections\":false},\"description\":\"\",\"kibanaSavedObjectMeta\":{\"searchSourceJSON\":\"{\\\"filter\\\":[],\\\"query\\\":{\\\"query\\\":\\\"\\\",\\\"language\\\":\\\"kuery\\\"}}\"},\"optionsJSON\":\"{\\\"useMargins\\\":true,\\\"syncColors\\\":false,\\\"syncCursor\\\":true,\\\"syncTooltips\\\":false,\\\"hidePanelTitles\\\":false}\",\"panelsJSON\":\"[{\\\"type\\\": \\\"lens\\\", \\\"embeddableConfig\\\": {\\\"enhancements\\\": {\\\"dynamicActions\\\": {\\\"events\\\": []}}, \\\"title\\\": \\\"Lens - by-value\\\", \\\"syncColors\\\": false, \\\"syncCursor\\\": true, \\\"syncTooltips\\\": false, \\\"filters\\\": [], \\\"query\\\": {\\\"query\\\": \\\"\\\", \\\"language\\\": \\\"kuery\\\"}, \\\"attributes\\\": {\\\"title\\\": \\\"\\\", \\\"visualizationType\\\": \\\"lnsXY\\\", \\\"type\\\": \\\"lens\\\", \\\"references\\\": [{\\\"type\\\": \\\"index-pattern\\\", \\\"id\\\": \\\"90943e30-9a47-11e8-b64d-95841ca0b247\\\", \\\"name\\\": \\\"indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\\\"}], \\\"state\\\": {\\\"visualization\\\": {\\\"legend\\\": {\\\"isVisible\\\": true, \\\"position\\\": \\\"right\\\"}, \\\"valueLabels\\\": \\\"hide\\\", \\\"fittingFunction\\\": \\\"Linear\\\", \\\"axisTitlesVisibilitySettings\\\": {\\\"x\\\": true, \\\"yLeft\\\": true, \\\"yRight\\\": true}, \\\"tickLabelsVisibilitySettings\\\": {\\\"x\\\": true, \\\"yLeft\\\": true, \\\"yRight\\\": true}, \\\"labelsOrientation\\\": {\\\"x\\\": 0, \\\"yLeft\\\": 0, \\\"yRight\\\": 0}, \\\"gridlinesVisibilitySettings\\\": {\\\"x\\\": true, \\\"yLeft\\\": true, \\\"yRight\\\": true}, \\\"preferredSeriesType\\\": \\\"bar_stacked\\\", \\\"layers\\\": [{\\\"layerId\\\": \\\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\\\", \\\"accessors\\\": [\\\"5c1d533b-a0f5-4242-aa95-df17e2f98305\\\"], \\\"position\\\": \\\"top\\\", \\\"seriesType\\\": \\\"bar_stacked\\\", \\\"showGridlines\\\": false, \\\"layerType\\\": \\\"data\\\", \\\"colorMapping\\\": {\\\"assignments\\\": [], \\\"specialAssignments\\\": [{\\\"rules\\\": [{\\\"type\\\": \\\"other\\\"}], \\\"color\\\": {\\\"type\\\": \\\"loop\\\"}, \\\"touched\\\": false}], \\\"paletteId\\\": \\\"default\\\", \\\"colorMode\\\": {\\\"type\\\": \\\"categorical\\\"}}, \\\"xAccessor\\\": \\\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\\\"}]}, \\\"query\\\": {\\\"query\\\": \\\"\\\", \\\"language\\\": \\\"kuery\\\"}, \\\"filters\\\": [], \\\"datasourceStates\\\": {\\\"formBased\\\": {\\\"layers\\\": {\\\"48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\\\": {\\\"columns\\\": {\\\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\\\": {\\\"label\\\": \\\"timestamp\\\", \\\"dataType\\\": \\\"date\\\", \\\"operationType\\\": \\\"date_histogram\\\", \\\"sourceField\\\": \\\"timestamp\\\", \\\"isBucketed\\\": true, \\\"params\\\": {\\\"interval\\\": \\\"auto\\\", \\\"includeEmptyRows\\\": true, \\\"dropPartials\\\": false}}, \\\"5c1d533b-a0f5-4242-aa95-df17e2f98305\\\": {\\\"label\\\": \\\"Count of records\\\", \\\"dataType\\\": \\\"number\\\", \\\"operationType\\\": \\\"count\\\", \\\"isBucketed\\\": false, \\\"sourceField\\\": \\\"___records___\\\", \\\"params\\\": {\\\"emptyAsNull\\\": true}}}, \\\"columnOrder\\\": [\\\"5dd72837-5cbb-484b-bc8e-dee61a2885dc\\\", \\\"5c1d533b-a0f5-4242-aa95-df17e2f98305\\\"], \\\"incompleteColumns\\\": {}, \\\"sampling\\\": 1}}}, \\\"indexpattern\\\": {\\\"layers\\\": {}}, \\\"textBased\\\": {\\\"layers\\\": {}}}, \\\"internalReferences\\\": [], \\\"adHocDataViews\\\": {}}}}, \\\"panelIndex\\\": \\\"0630620b-1ee4-4949-b8be-c519ffdb0e88\\\", \\\"gridData\\\": {\\\"i\\\": \\\"0630620b-1ee4-4949-b8be-c519ffdb0e88\\\", \\\"y\\\": 0, \\\"x\\\": 0, \\\"w\\\": 24, \\\"h\\\": 15}}, {\\\"type\\\": \\\"lens\\\", \\\"embeddableConfig\\\": {\\\"enhancements\\\": {\\\"dynamicActions\\\": {\\\"events\\\": []}}, \\\"syncColors\\\": false, \\\"syncCursor\\\": true, \\\"syncTooltips\\\": false, \\\"filters\\\": [], \\\"query\\\": {\\\"query\\\": \\\"\\\", \\\"language\\\": \\\"kuery\\\"}, \\\"savedObjectId\\\": \\\"e360f7d4-6ab8-4cae-9f34-ec39e1a9325e\\\"}, \\\"panelIndex\\\": \\\"6b2f81c6-08f8-4082-bbab-0d3fd9422b8d\\\", \\\"gridData\\\": {\\\"i\\\": \\\"6b2f81c6-08f8-4082-bbab-0d3fd9422b8d\\\", \\\"y\\\": 0, \\\"x\\\": 24, \\\"w\\\": 24, \\\"h\\\": 15}}]\",\"timeRestore\":false,\"title\":\"Test Dashboard\",\"version\":3},\"coreMigrationVersion\":\"8.8.0\",\"created_at\":\"2026-08-17T20:29:57.096Z\",\"created_by\":\"u_2895723599_cloud\",\"id\":\"125f6cc0-0d83-4605-ae61-5bc558af9423\",\"managed\":false,\"references\":[{\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"0630620b-1ee4-4949-b8be-c519ffdb0e88:indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"type\":\"index-pattern\"},{\"id\":\"90943e30-9a47-11e8-b64d-95841ca0b247\",\"name\":\"6b2f81c6-08f8-4082-bbab-0d3fd9422b8d:indexpattern-datasource-layer-48a0fff0-acea-42c3-8bf5-9c0a03a7ab34\",\"type\":\"index-pattern\"}],\"type\":\"dashboard\",\"typeMigrationVersion\":\"10.3.0\",\"updated_at\":\"2026-08-17T20:33:05.881Z\",\"updated_by\":\"u_2895723599_cloud\",\"version\":\"WzMwLDFd\"}\n{\"excludedObjects\":[],\"excludedObjectsCount\":0,\"exportedCount\":4,\"missingRefCount\":0,\"missingReferences\":[]}\n\n```\n\n</p>\n</details> \n\n### Before\n\n<img width=\"1606\" height=\"590\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a5dd6ff9-2bbe-454b-bb81-96a21b23a967\"\n/>\n\n### After\n\nCorrectly loads by-ref Lens panel with missing reference linking\n\n<img width=\"1605\" height=\"589\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ec5748ff-e6cd-4886-83be-5aa71d64c155\"\n/>\n\n\n## Background\n\n[#239029](https://github.com/elastic/kibana/pull/239029) moved Lens\nreference handling to the server. Before it, by-reference panels were\nidentified by `savedObjectId` in `embeddableConfig`. After it,\n`transformOut` detects them by looking for a `savedObjectRef` entry in\nthe dashboard's `references` array via `findLensReference`. No fallback\nwas added for panels where that reference is absent.\n\nFor dashboards created in 8.x this gap is benign as long as the\nreference exists. However some panels arrive in 9.x with no such\nreference at all — either because the reference was never stored (very\nold format), because a buggy save path lost it, or because it was\nfiltered out during an NDJSON import. These panels have only\n`savedObjectId` in their `embeddableConfig` as the sole by-reference\nsignal.\n\n[#255555](https://github.com/elastic/kibana/pull/255555) then removed\n`savedObjectId` from the `stripInheritedContext` allowlist (renaming it\nto `ref_id`), meaning `savedObjectId` is now **dropped** before\n`transformOut` can use it — eliminating the last available signal and\nmaking the crash inevitable.\n\n## What breaks\n\n`transformOut` calls `findLensReference(panelReferences)`. When it\nreturns `undefined`, execution falls into the by-value path and calls\n`migrateAttributes(attributes)`. A by-reference panel has no inline\n`attributes`, so `attributes` is `undefined` → throws. The dashboard\ncatches this and emits the `\"Unable to transform panel config\"` warning,\ndropping the panel from the response.\n\n## Fix\n\n**`transform_out.ts`**\n\n1. Read `savedObjectId` from `storedState` **before** `transformsFlow`\nruns, since `stripInheritedContext` will drop it.\n2. After `findLensReference` fails, if `attributes` is absent and\n`legacySavedObjectId` is present, return `{ ...state, ref_id:\nlegacySavedObjectId }` as a by-ref result.\n\nThe `!attributes` guard is critical: a panel with **both**\n`savedObjectId` **and** inline `attributes` is a corrupt hybrid (see\n#271318) and must fall through to the by-value path using its embedded\nattributes. This fix does not regress that behaviour.\n\nNote: checking `state.ref_id` as a further fallback is not needed —\n`transformIn` always strips `ref_id` from stored state and converts it\nto a `savedObjectRef` reference, so `ref_id` is never present in\n`panelsJSON`.\n\n## How recovery works end-to-end\n\n1. **Load:** `transformOut` returns `{ ref_id: \"<so-id>\" }`. The client\ncalls `attributeService.loadFromLibrary(ref_id)` to fetch the Lens saved\nobject directly — the panel renders correctly as long as the Lens SO\nexists.\n2. **Save (self-healing):** On the next dashboard save, `transformIn`\nsees `ref_id`, emits a proper `savedObjectRef` reference, and the\ndashboard stores `{panelIndex}:savedObjectRef` — the missing reference\nis created and the data is healed going forward.\n\n> **Note:** The fix only helps panels whose `panelsJSON` still contains\n`savedObjectId`. If the dashboard was opened and saved in 9.x after the\npanels started crashing (which drops them from the API response), the\npanel config is permanently gone from `panelsJSON` and the Lens SO must\nbe re-added manually from the library.\n\n## Related\n\n- #239029 — introduced the `savedObjectRef` requirement (root cause)\n- #255555 — removed `savedObjectId` from the `stripInheritedContext`\nallowlist, making pre-capture necessary\n- #271318 — hybrid `savedObjectId` + `attributes` corrupt state; the\n`!attributes` guard here prevents regressing that fix\n- #245569 — changed `transformOut` to receive separate `panelReferences`\n/ `containerReferences` (not related to this crash, confirmed)\n\n## Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release Note\n\nFixes a bug with by-reference Lens panels where references are missing\nin the dashboard SavedObject causing affected panels to be removed when\nloaded.","sha":"8c21adfae4ada67e8b973919fd67028ab5cf34a8"}},{"branch":"9.4","label":"v9.4.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/285831","number":285831,"state":"MERGED","mergeCommit":{"sha":"963abe952250d6ad3f7d8132a78674c6c74115e7","message":"[9.5] [Lens] Recover by-ref panels missing their `savedObjectRef` reference linking (#285476) (#285831)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Lens] Recover by-ref panels missing their `savedObjectRef` reference\nlinking (#285476)](https://github.com/elastic/kibana/pull/285476)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>"}}]}] BACKPORT-->