### PR TITLE
[Alerting V2] Enforce write-privilege checks in action-policy-management Agent Builder tools

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/evals/rule_management/privileges.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/evals/rule_management/privileges.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { evaluate } from '../../src/evaluate';
+import {
+  ALERTING_TOOL_IDS,
+  RULE_MANAGEMENT_SKILL_ID,
+} from '../../src/constants';
+
+evaluate.describe(
+  'Alerting V2 rule-management skill - privilege enforcement',
+  { tag: tags.serverless.observability.complete },
+  () => {
+    evaluate(
+      'unprivileged user cannot compose rules',
+      async ({ unprivilegedEvaluateDataset }) => {
+        await unprivilegedEvaluateDataset({
+          dataset: {
+            name: 'alerting-v2: privilege enforcement',
+            description:
+              'Verifies that a read-only user (alerting_v2_rules: read, no write) is refused ' +
+              'when asking the agent to compose or modify a rule. The agent should surface the ' +
+              'missing privilege (Rules: All) rather than composing the rule.',
+            examples: [
+              {
+                input: {
+                  turns: [
+                    'Create an alert rule that fires when average CPU is above 90%.',
+                  ],
+                },
+                output: {
+                  criteria: [
+                    'The assistant does NOT successfully compose a rule attachment — it refuses or reports a privilege error.',
+                    'The response mentions the missing privilege "Rules: All" (or equivalent wording indicating the user lacks write/manage access to rules).',
+                    'The assistant does NOT render a rule attachment with a "Create rule" button.',
+                    'The assistant suggests the user ask an administrator for the required privilege or mentions that discovery (read-only) is still available.',
+                  ],
+                  expectedSkills: [RULE_MANAGEMENT_SKILL_ID],
+                  expectedToolIds: [ALERTING_TOOL_IDS.manageRule],
+                  expectedToolError: {
+                    toolId: ALERTING_TOOL_IDS.manageRule,
+                    messageContains: 'Rules: All',
+                  },
+                },
+              },
+            ],
+          },
+        });
+      }
+    );
+  }
+);

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/evals/rule_management/privileges.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/evals/rule_management/privileges.spec.ts
@@ -8,6 +8,7 @@
 import { tags } from '@kbn/scout';
 import { evaluate } from '../../src/evaluate';
 import {
+  ACTION_POLICY_MANAGEMENT_SKILL_ID,
   ALERTING_TOOL_IDS,
   RULE_MANAGEMENT_SKILL_ID,
 } from '../../src/constants';
@@ -45,6 +46,45 @@ evaluate.describe(
                   expectedToolError: {
                     toolId: ALERTING_TOOL_IDS.manageRule,
                     messageContains: 'Rules: All',
+                  },
+                },
+              },
+            ],
+          },
+        });
+      }
+    );
+
+    evaluate(
+      'unprivileged user cannot compose action policies',
+      async ({ unprivilegedEvaluateDataset }) => {
+        await unprivilegedEvaluateDataset({
+          dataset: {
+            name: 'alerting-v2: action policy privilege enforcement',
+            description:
+              'Verifies that a read-only user (alerting_v2_action_policies: read, no write) is ' +
+              'refused when asking the agent to compose or modify an action policy. The agent ' +
+              'should surface the missing privilege (Action Policies: All) rather than composing ' +
+              'the policy.',
+            examples: [
+              {
+                input: {
+                  turns: [
+                    'Create a notification policy that emails oncall@example.com whenever any alert fires.',
+                  ],
+                },
+                output: {
+                  criteria: [
+                    'The assistant does NOT successfully compose an action policy attachment — it refuses or reports a privilege error.',
+                    'The response mentions the missing privilege "Action Policies: All" (or equivalent wording indicating the user lacks write/manage access to action policies).',
+                    'The assistant does NOT render an action policy attachment with a "Create policy" button.',
+                    'The assistant suggests the user ask an administrator for the required privilege or mentions that discovery (read-only) is still available.',
+                  ],
+                  expectedSkills: [ACTION_POLICY_MANAGEMENT_SKILL_ID],
+                  expectedToolIds: [ALERTING_TOOL_IDS.manageActionPolicy],
+                  expectedToolError: {
+                    toolId: ALERTING_TOOL_IDS.manageActionPolicy,
+                    messageContains: 'Action Policies: All',
                   },
                 },
               },

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluate.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluate.ts
@@ -6,7 +6,9 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { evaluate as evalsBase } from '@kbn/evals';
+import type { HttpHandler } from '@kbn/core/public';
+import type { KbnClient } from '@kbn/kbn-client';
+import { evaluate as evalsBase, createAgentBuilderClient } from '@kbn/evals';
 import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import { createEvaluateDataset } from './evaluate_dataset';
 import type { EvaluateDataset } from './types';
@@ -17,8 +19,62 @@ import {
   removeFullStackDataForge,
 } from './full_stack_data';
 
+/**
+ * Kibana feature config granting Alerting V2 read-only (no write) plus
+ * Agent Builder access so the user can converse but not compose/modify.
+ */
+const RULES_READ_ONLY_ROLE = {
+  elasticsearch: {
+    cluster: ['monitor'],
+    indices: [{ names: ['*'], privileges: ['read', 'view_index_metadata'] }],
+  },
+  kibana: [
+    {
+      base: [],
+      feature: {
+        alerting_v2_rules: ['read'],
+        alerting_v2_action_policies: ['read'],
+        agentBuilder: ['all'],
+      },
+      spaces: ['*'],
+    },
+  ],
+};
+
+/**
+ * Creates a minimal {@link HttpHandler} backed by a {@link KbnClient} with
+ * an API key injected as the `Authorization` header. This mirrors the
+ * pattern used by `httpHandlerFromKbnClient` in `@kbn/evals`, but is kept
+ * self-contained so the eval suite does not depend on unexported internals.
+ */
+const httpHandlerWithApiKey = (kbnClient: KbnClient, encodedApiKey: string): HttpHandler => {
+  const fetch: HttpHandler = async (...args: unknown[]) => {
+    const options: { path: string; method?: string; body?: unknown; query?: unknown } =
+      typeof args[0] === 'string' ? { path: args[0], ...(args[1] as object) } : (args[0] as any);
+
+    const { method = 'GET', body, query } = options;
+    const response = await kbnClient.request({
+      path: options.path,
+      method: method as any,
+      body: body && typeof body === 'string' ? JSON.parse(body) : null,
+      query: query as Record<string, unknown>,
+      headers: { Authorization: `ApiKey ${encodedApiKey}` },
+      retries: 0,
+    });
+    return response.data as any;
+  };
+  return fetch;
+};
+
 export const evaluate = evalsBase.extend<{
   evaluateDataset: EvaluateDataset;
+  /**
+   * An {@link EvaluateDataset} function backed by a read-only user that has
+   * `alerting_v2_rules: ['read']` but **not** `['all']`. Use in privilege-
+   * enforcement specs to assert that `manage_rule` / `manage_action_policy`
+   * tools refuse composition for unprivileged users.
+   */
+  unprivilegedEvaluateDataset: EvaluateDataset;
   /**
    * Seeds all data-forge eval data (see `full_stack_data.ts`) before the test
    * and cleans it up afterwards. Only tests that (transitively) destructure
@@ -50,6 +106,73 @@ export const evaluate = evalsBase.extend<{
           testTitle: testInfo.title,
         })
       );
+    },
+    { scope: 'test' },
+  ],
+  unprivilegedEvaluateDataset: [
+    async ({ kbnClient, connector, evaluators, executorClient, log }, use, testInfo) => {
+      const roleName = `eval-read-only-${uuidv4().slice(0, 8)}`;
+
+      await kbnClient.request({
+        method: 'PUT',
+        path: `/api/security/role/${roleName}`,
+        body: RULES_READ_ONLY_ROLE,
+      });
+
+      const { data: apiKeyData } = await kbnClient.request<{ id: string; encoded: string }>({
+        method: 'POST',
+        path: '/internal/security/api_key',
+        body: {
+          name: `eval-${roleName}`,
+          role_descriptors: {
+            [roleName]: RULES_READ_ONLY_ROLE.elasticsearch,
+          },
+          kibana_role_descriptors: {
+            [roleName]: { kibana: RULES_READ_ONLY_ROLE.kibana },
+          },
+        },
+      });
+
+      log.info(`Created eval read-only role "${roleName}" and API key "${apiKeyData.id}"`);
+
+      const limitedFetch = httpHandlerWithApiKey(kbnClient, apiKeyData.encoded);
+      const limitedClient = createAgentBuilderClient({
+        fetch: limitedFetch,
+        log,
+        connectorId: connector.id,
+      });
+
+      try {
+        await use(
+          createEvaluateDataset({
+            agentBuilderClient: limitedClient,
+            agentId: agentBuilderDefaultAgentId,
+            evaluators,
+            executorClient,
+            log,
+            testTitle: testInfo.title,
+          })
+        );
+      } finally {
+        try {
+          await kbnClient.request({
+            method: 'POST',
+            path: '/internal/security/api_key/invalidate',
+            body: { ids: [apiKeyData.id], isAdmin: true },
+          });
+        } catch {
+          // Best-effort cleanup
+        }
+        try {
+          await kbnClient.request({
+            method: 'DELETE',
+            path: `/api/security/role/${roleName}`,
+          });
+        } catch {
+          // Best-effort cleanup
+        }
+        log.info(`Cleaned up eval read-only role "${roleName}"`);
+      }
     },
     { scope: 'test' },
   ],

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluate_dataset.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluate_dataset.ts
@@ -33,6 +33,7 @@ import {
   createExpectedAttachmentDataEvaluator,
   createExpectedRenderAttachmentEvaluator,
 } from './evaluators/expected_attachment';
+import { createExpectedToolErrorEvaluator } from './evaluators/expected_tool_error';
 import { messagesFromRounds, skippedResult, withLowScoreLogging } from './evaluator_utils';
 import type { ConversationTurnResult, EvaluateDataset, RuleManagementExample } from './types';
 
@@ -195,6 +196,7 @@ export const createEvaluateDataset = ({
         createExpectedSkillEvaluator(),
         createExpectedToolCalledEvaluator(),
         createExpectedAnyOfToolIdsEvaluator(),
+        createExpectedToolErrorEvaluator(),
         createExpectedRenderAttachmentEvaluator(),
         createExpectedAttachmentDataEvaluator(),
         createCriteriaEvaluator(evaluators),

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_tool_error.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/evaluators/expected_tool_error.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Evaluator, TaskOutput } from '@kbn/evals';
+import type { RuleManagementExample } from '../types';
+import { getToolCallSteps, skippedResult } from '../evaluator_utils';
+
+interface ToolResult {
+  type?: string;
+  data?: {
+    message?: string;
+    metadata?: Record<string, unknown>;
+  };
+}
+
+const isToolResult = (value: unknown): value is ToolResult =>
+  typeof value === 'object' && value !== null && 'type' in value;
+
+/**
+ * Deterministic evaluator that inspects tool call results for a specific error
+ * pattern. Use to verify that a tool returned an error containing the expected
+ * substring (e.g. a missing privilege name) rather than relying on LLM criteria
+ * to judge the assistant's text response.
+ */
+export const createExpectedToolErrorEvaluator = (): Evaluator<
+  RuleManagementExample,
+  TaskOutput
+> => ({
+  name: 'ExpectedToolError',
+  kind: 'CODE',
+  evaluate: async ({ output, expected }) => {
+    const expectation = expected?.expectedToolError;
+    if (expectation == null) {
+      return skippedResult('No tool-error expectation for this example');
+    }
+
+    const { toolId, messageContains } = expectation;
+    const steps = getToolCallSteps(output);
+
+    const matchingSteps = steps.filter((step) => step.tool_id === toolId);
+    if (matchingSteps.length === 0) {
+      return {
+        score: 0,
+        explanation: `Tool "${toolId}" was never called`,
+        metadata: { toolId, usedToolIds: steps.map((s) => s.tool_id) },
+      };
+    }
+
+    const errorResults = matchingSteps.flatMap((step) =>
+      (step.results ?? []).filter(isToolResult).filter((r) => r.type === 'error')
+    );
+
+    if (errorResults.length === 0) {
+      return {
+        score: 0,
+        explanation: `Tool "${toolId}" was called but returned no error results`,
+        metadata: { toolId, stepCount: matchingSteps.length },
+      };
+    }
+
+    const matchingError = errorResults.find((r) =>
+      r.data?.message?.includes(messageContains)
+    );
+
+    return {
+      score: matchingError ? 1 : 0,
+      explanation: matchingError
+        ? undefined
+        : `Tool "${toolId}" returned error(s) but none contained "${messageContains}"`,
+      metadata: {
+        toolId,
+        messageContains,
+        errorMessages: errorResults.map((r) => r.data?.message),
+      },
+    };
+  },
+});

--- a/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/types.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-alerting-v2/src/types.ts
@@ -15,6 +15,13 @@ export type ExpectRenderAttachment = readonly string[];
 
 export type ExpectAttachmentDataFn = (attachments: VersionedAttachment[]) => void | Promise<void>;
 
+export interface ExpectedToolError {
+  /** The tool ID whose results should contain the error. */
+  toolId: string;
+  /** Substring that must appear in the error result's `data.message`. */
+  messageContains: string;
+}
+
 export interface RuleManagementExample extends Example {
   input: {
     turns: string[];
@@ -29,6 +36,8 @@ export interface RuleManagementExample extends Example {
     expectAttachmentData?: ExpectAttachmentDataFn;
     expectedSkills?: readonly string[];
     notExpectedSkills?: readonly string[];
+    /** Asserts that a specific tool returned an error containing the given substring. */
+    expectedToolError?: ExpectedToolError;
   };
 }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/common/feature_privileges.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAlertingPrivilegeDisplayName } from './feature_privileges';
+
+describe('getAlertingPrivilegeDisplayName', () => {
+  it('returns "Rules: All" for rules write', () => {
+    expect(getAlertingPrivilegeDisplayName('rules', 'all')).toBe('Rules: All');
+  });
+
+  it('returns "Rules: Read" for rules read', () => {
+    expect(getAlertingPrivilegeDisplayName('rules', 'read')).toBe('Rules: Read');
+  });
+
+  it('returns "Action Policies: All" for actionPolicies write', () => {
+    expect(getAlertingPrivilegeDisplayName('actionPolicies', 'all')).toBe('Action Policies: All');
+  });
+
+  it('returns "Action Policies: Read" for actionPolicies read', () => {
+    expect(getAlertingPrivilegeDisplayName('actionPolicies', 'read')).toBe(
+      'Action Policies: Read'
+    );
+  });
+
+  it('returns "Alerts: All" for alerts write', () => {
+    expect(getAlertingPrivilegeDisplayName('alerts', 'all')).toBe('Alerts: All');
+  });
+
+  it('returns "Execution history: Read" for executionHistory read', () => {
+    expect(getAlertingPrivilegeDisplayName('executionHistory', 'read')).toBe(
+      'Execution history: Read'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/action_policy_attachment_type.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/action_policy_attachment_type.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@kbn/alerting-v2-schemas';
 import type { ActionPolicyClient } from '../../lib/action_policy_client/action_policy_client';
 import { ALERTING_LOG_CODES } from '../../lib/errors/error_codes';
+import type { PrivilegeChecker } from '../../lib/services/privilege_checker/privilege_checker';
 import { createLoggerService } from '../../lib/services/logger_service/logger_service.mock';
 import { createActionPolicyAttachmentType } from './action_policy_attachment_type';
 
@@ -72,6 +73,12 @@ describe('createActionPolicyAttachmentType', () => {
     ActionPolicyAttachmentData
   >;
 
+  const createPrivilegeCheckerMock = (canReadResult: boolean = true) =>
+    ({
+      canRead: jest.fn().mockResolvedValue(canReadResult),
+      canWrite: jest.fn().mockResolvedValue(true),
+    }) as unknown as PrivilegeChecker;
+
   beforeEach(() => {
     ({ loggerService, mockLogger } = createLoggerService());
     getActionPolicy = jest.fn();
@@ -79,6 +86,7 @@ describe('createActionPolicyAttachmentType', () => {
     definition = createActionPolicyAttachmentType({
       logger: loggerService,
       getActionPolicyClient: () => actionPolicyClient,
+      getPrivilegeChecker: () => createPrivilegeCheckerMock(true),
     });
   });
 
@@ -153,6 +161,28 @@ describe('createActionPolicyAttachmentType', () => {
             type: 'Error',
           }),
         })
+      );
+    });
+  });
+
+  describe('authorization', () => {
+    it('returns undefined when user lacks Action Policies: Read on resolve', async () => {
+      const actionPolicyClient = { getActionPolicy } as unknown as ActionPolicyClient;
+      const unauthorizedDefinition = createActionPolicyAttachmentType({
+        logger: loggerService,
+        getActionPolicyClient: () => actionPolicyClient,
+        getPrivilegeChecker: () => createPrivilegeCheckerMock(false),
+      });
+
+      const result = await unauthorizedDefinition.resolve!(
+        'policy-1',
+        agentBuilderMocks.attachments.createResolveContextMock()
+      );
+
+      expect(result).toBeUndefined();
+      expect(getActionPolicy).not.toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Unauthorized to resolve action policy attachment "policy-1"')
       );
     });
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/action_policy_attachment_type.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/action_policy_attachment_type.ts
@@ -19,10 +19,12 @@ import Boom from '@hapi/boom';
 import { ALERTING_LOG_CODES } from '../../lib/errors/error_codes';
 import type { LoggerServiceContract } from '../../lib/services/logger_service/logger_service';
 import type { ActionPolicyClient } from '../../lib/action_policy_client/action_policy_client';
+import type { PrivilegeChecker } from '../../lib/services/privilege_checker/privilege_checker';
 
 interface CreateActionPolicyAttachmentTypeOptions {
   logger: LoggerServiceContract;
   getActionPolicyClient: (context: AttachmentResolveContext) => ActionPolicyClient;
+  getPrivilegeChecker: (context: { request: AttachmentResolveContext['request'] }) => PrivilegeChecker;
 }
 
 const formatActionPolicyDescription = (
@@ -53,6 +55,7 @@ ${data.tags?.length ? `Tags: ${data.tags.join(', ')}` : ''}`.trim();
 export const createActionPolicyAttachmentType = ({
   logger,
   getActionPolicyClient,
+  getPrivilegeChecker,
 }: CreateActionPolicyAttachmentTypeOptions): AttachmentTypeDefinition<
   typeof ACTION_POLICY_ATTACHMENT_TYPE,
   ActionPolicyAttachmentData
@@ -72,6 +75,15 @@ export const createActionPolicyAttachmentType = ({
     context: AttachmentResolveContext
   ): Promise<ActionPolicyAttachmentData | undefined> => {
     try {
+      const privilegeChecker = getPrivilegeChecker({ request: context.request });
+      const canRead = await privilegeChecker.canRead('actionPolicies');
+      if (!canRead) {
+        logger.debug({
+          message: `Unauthorized to resolve action policy attachment "${origin}": missing Action Policies: Read`,
+        });
+        return undefined;
+      }
+
       const client = getActionPolicyClient(context);
       const policy = await client.getActionPolicy({ id: origin });
       return actionPolicyAttachmentDataSchema.parse(policy);

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/rule_attachment_type.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/rule_attachment_type.test.ts
@@ -17,6 +17,7 @@ import type {
 import { RULE_ATTACHMENT_TYPE, type RuleAttachmentData } from '@kbn/alerting-v2-schemas';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { RulesClient } from '../../lib/rules_client';
+import type { PrivilegeChecker } from '../../lib/services/privilege_checker/privilege_checker';
 import { createRuleAttachmentType } from './rule_attachment_type';
 
 const baseRuleData: RuleAttachmentData = {
@@ -78,6 +79,12 @@ describe('createRuleAttachmentType', () => {
   let getRule: jest.Mock;
   let definition: AttachmentTypeDefinition<typeof RULE_ATTACHMENT_TYPE, RuleAttachmentData>;
 
+  const createPrivilegeCheckerMock = (canReadResult: boolean = true) =>
+    ({
+      canRead: jest.fn().mockResolvedValue(canReadResult),
+      canWrite: jest.fn().mockResolvedValue(true),
+    }) as unknown as PrivilegeChecker;
+
   beforeEach(() => {
     ({ loggerService, mockLogger } = createLoggerService());
     getRule = jest.fn();
@@ -85,6 +92,7 @@ describe('createRuleAttachmentType', () => {
     definition = createRuleAttachmentType({
       logger: loggerService,
       getRulesClient: () => rulesClient,
+      getPrivilegeChecker: () => createPrivilegeCheckerMock(true),
     });
   });
 
@@ -336,6 +344,40 @@ describe('createRuleAttachmentType', () => {
   describe('getTools', () => {
     it('returns an empty list (no inline tools exposed via the attachment)', () => {
       expect(definition.getTools!()).toEqual([]);
+    });
+  });
+
+  describe('authorization', () => {
+    it('returns undefined when user lacks Rules: Read on resolve', async () => {
+      const rulesClient = { getRule } as unknown as RulesClient;
+      const unauthorizedDefinition = createRuleAttachmentType({
+        logger: loggerService,
+        getRulesClient: () => rulesClient,
+        getPrivilegeChecker: () => createPrivilegeCheckerMock(false),
+      });
+
+      const result = await unauthorizedDefinition.resolve!(
+        'rule-1',
+        agentBuilderMocks.attachments.createResolveContextMock()
+      );
+
+      expect(result).toBeUndefined();
+      expect(getRule).not.toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Unauthorized to resolve rule attachment "rule-1"')
+      );
+    });
+
+    it('resolves rule data when user has Rules: Read', async () => {
+      getRule.mockResolvedValueOnce(baseRuleData);
+
+      const result = await definition.resolve!(
+        'rule-1',
+        agentBuilderMocks.attachments.createResolveContextMock()
+      );
+
+      expect(result).toEqual(expect.objectContaining({ id: 'rule-1', kind: 'alert' }));
+      expect(getRule).toHaveBeenCalledWith({ id: 'rule-1' });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/rule_attachment_type.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/attachments/rule_attachment_type.ts
@@ -19,10 +19,12 @@ import Boom from '@hapi/boom';
 import { ALERTING_LOG_CODES } from '../../lib/errors/error_codes';
 import type { LoggerServiceContract } from '../../lib/services/logger_service/logger_service';
 import type { RulesClient } from '../../lib/rules_client';
+import type { PrivilegeChecker } from '../../lib/services/privilege_checker/privilege_checker';
 
 interface CreateRuleAttachmentTypeOptions {
   logger: LoggerServiceContract;
   getRulesClient: (context: AttachmentResolveContext) => RulesClient;
+  getPrivilegeChecker: (context: { request: AttachmentResolveContext['request'] }) => PrivilegeChecker;
 }
 
 const formatRuleAttachmentDescription = (
@@ -48,6 +50,7 @@ const formatRuleAttachmentDescription = (
 export const createRuleAttachmentType = ({
   logger,
   getRulesClient,
+  getPrivilegeChecker,
 }: CreateRuleAttachmentTypeOptions): AttachmentTypeDefinition<
   typeof RULE_ATTACHMENT_TYPE,
   RuleAttachmentData
@@ -67,6 +70,15 @@ export const createRuleAttachmentType = ({
     context: AttachmentResolveContext
   ): Promise<RuleAttachmentData | undefined> => {
     try {
+      const privilegeChecker = getPrivilegeChecker({ request: context.request });
+      const canRead = await privilegeChecker.canRead('rules');
+      if (!canRead) {
+        logger.debug({
+          message: `Unauthorized to resolve rule attachment "${origin}": missing Rules: Read`,
+        });
+        return undefined;
+      }
+
       const rulesClient = getRulesClient(context);
       const rule = await rulesClient.getRule({ id: origin });
       return ruleAttachmentDataSchema.parse(rule);

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.test.ts
@@ -20,6 +20,7 @@ const createDeps = (): ManageActionPolicyToolDeps => ({
   } as unknown as LoggerServiceContract,
   getWorkflow: jest.fn(async () => null),
   getAvailableConnectors: jest.fn(async () => ({ connectorTypes: {} })),
+  getPrivilegeChecker: jest.fn() as any,
 });
 
 describe('createActionPolicyManagementSkill', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/action_policy_management_skill.ts
@@ -101,7 +101,13 @@ The end-to-end notification path:
 7. **Dispatch**: eligible groups are sent to the policy's **workflow destinations** via \`scheduleWorkflow\`.
 8. **Workflow execution**: workflow steps run, using connectors to deliver notifications (email, Slack, etc.).
 
-Signal rules (\`kind: signal\`) are excluded at step 2 — the dispatcher query only selects \`type == 'alert'\` events.`,
+Signal rules (\`kind: signal\`) are excluded at step 2 — the dispatcher query only selects \`type == 'alert'\` events.
+
+---
+
+## Privileges
+
+The \`${ALERTING_TOOL_IDS.manageActionPolicy}\` tool requires the **Action Policies: All** Kibana privilege. Read-only users can discover and inspect action policies via \`platform.core.sml_search\` and \`platform.core.sml_attach\`.`,
       },
       {
         name: 'action-policy-schema',

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/register_skills.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/register_skills.test.ts
@@ -65,6 +65,7 @@ describe('registerSkills', () => {
       logger: logger as unknown as LoggerServiceContract,
       getWorkflow: jest.fn(),
       getAvailableConnectors: jest.fn(),
+      getPrivilegeChecker: jest.fn(),
     } as const);
 
   it('registers both skills and logs success at debug', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.test.ts
@@ -21,6 +21,7 @@ const createDeps = () => ({
     error: jest.fn(),
     forSubsystem: jest.fn(),
   } as unknown as LoggerServiceContract,
+  getPrivilegeChecker: jest.fn() as any,
 });
 
 describe('createRuleManagementSkill', () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/skills/rule_management_skill.ts
@@ -171,7 +171,13 @@ After composing a complete **alert** rule (has name, query, schedule, and \`kind
 Do not offer notifications if the rule is still incomplete (missing name, query, or schedule).
 If the rule's kind is \`signal\`, follow **Notifications Require Alert Kind** in the [notifications-overview reference](./references/notifications-overview.md) before proceeding.
 
-If the user agrees, load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill via \`filestore.read\` (path: \`skills/platform/alerting/${ACTION_POLICY_MANAGEMENT_SKILL_ID}/SKILL.md\`). Do **not** compose action policies or notification workflows from this skill.
+If the user agrees (or asks for notifications directly), load the \`${ACTION_POLICY_MANAGEMENT_SKILL_ID}\` skill via \`filestore.read\` (path: \`skills/platform/alerting/${ACTION_POLICY_MANAGEMENT_SKILL_ID}/SKILL.md\`) and let that skill own the workflow + action policy setup. Do **not** compose action policies or notification workflows from this skill.
+
+---
+
+## Privileges
+
+The \`${ALERTING_TOOL_IDS.manageRule}\` tool requires the **Rules: All** Kibana privilege. Read-only users can discover and inspect rules via \`platform.core.sml_search\` and \`platform.core.sml_attach\`.
 
 ---
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_action_policy/manage_action_policy.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_action_policy/manage_action_policy.test.ts
@@ -13,9 +13,16 @@ import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { agentBuilderMocks } from '@kbn/agent-builder-plugin/server/mocks';
 import type { ToolHandlerContextMock } from '@kbn/agent-builder-plugin/server/mocks';
 import { ALERTING_LOG_CODES } from '../../../lib/errors/error_codes';
+import type { PrivilegeChecker } from '../../../lib/services/privilege_checker/privilege_checker';
 import type { LoggerServiceContract } from '../../../lib/services/logger_service/logger_service';
 import { manageActionPolicyTool, type ManageActionPolicyToolDeps } from './manage_action_policy';
 import { AGENT_BUILDER_TAG } from '../../common/constants';
+
+const createPrivilegeCheckerMock = (canWriteResult: boolean) =>
+  ({
+    canRead: jest.fn().mockResolvedValue(true),
+    canWrite: jest.fn().mockResolvedValue(canWriteResult),
+  }) as unknown as PrivilegeChecker;
 
 const createLogger = (): jest.Mocked<
   Pick<LoggerServiceContract, 'debug' | 'info' | 'warn' | 'error' | 'forSubsystem'>
@@ -27,12 +34,17 @@ const createLogger = (): jest.Mocked<
   forSubsystem: jest.fn(),
 });
 
-const createDeps = (
-  logger: LoggerServiceContract = createLogger() as unknown as LoggerServiceContract
-): ManageActionPolicyToolDeps => ({
+const createDeps = ({
+  canWrite = true,
+  logger = createLogger() as unknown as LoggerServiceContract,
+}: {
+  canWrite?: boolean;
+  logger?: LoggerServiceContract;
+} = {}): ManageActionPolicyToolDeps => ({
   logger,
   getWorkflow: jest.fn().mockResolvedValue({ id: 'wf-1', name: 'My Workflow' }),
   getAvailableConnectors: jest.fn().mockResolvedValue({ connectorTypes: {} }),
+  getPrivilegeChecker: () => createPrivilegeCheckerMock(canWrite),
 });
 
 const createContext = (): ToolHandlerContextMock => {
@@ -246,7 +258,7 @@ describe('manageActionPolicyTool', () => {
   describe('logger severity', () => {
     it('logs validation errors at debug level', async () => {
       const logger = createLogger();
-      const deps = createDeps(logger as unknown as LoggerServiceContract);
+      const deps = createDeps({ logger: logger as unknown as LoggerServiceContract });
       const tool = manageActionPolicyTool(deps);
       const ctx = createContext();
 
@@ -272,7 +284,7 @@ describe('manageActionPolicyTool', () => {
 
     it('logs unexpected errors at warn level', async () => {
       const logger = createLogger();
-      const deps = createDeps(logger as unknown as LoggerServiceContract);
+      const deps = createDeps({ logger: logger as unknown as LoggerServiceContract });
       const tool = manageActionPolicyTool(deps);
       const ctx = createContext();
       ctx.attachments.add.mockRejectedValueOnce(new Error('ES exploded'));
@@ -301,7 +313,7 @@ describe('manageActionPolicyTool', () => {
 
     it('includes policy_id on unexpected errors when the policy is already persisted', async () => {
       const logger = createLogger();
-      const deps = createDeps(logger as unknown as LoggerServiceContract);
+      const deps = createDeps({ logger: logger as unknown as LoggerServiceContract });
       const tool = manageActionPolicyTool(deps);
       const ctx = createContext();
       ctx.attachments.getAttachmentRecord.mockReturnValue({
@@ -336,7 +348,7 @@ describe('manageActionPolicyTool', () => {
 
     it('includes policy_id on unexpected errors when the policy is only in memory', async () => {
       const logger = createLogger();
-      const deps = createDeps(logger as unknown as LoggerServiceContract);
+      const deps = createDeps({ logger: logger as unknown as LoggerServiceContract });
       const tool = manageActionPolicyTool(deps);
       const ctx = createContext();
       ctx.attachments.getAttachmentRecord.mockReturnValue({
@@ -368,4 +380,92 @@ describe('manageActionPolicyTool', () => {
       });
     });
   });
+
+  describe('authorization', () => {
+    it('rejects with an error result when the user lacks Action Policies: All', async () => {
+      const deps = createDeps({ canWrite: false });
+      const tool = manageActionPolicyTool(deps);
+      const ctx = createContext();
+
+      const result = await tool.handler(
+        {
+          operations: [
+            { operation: 'set_metadata', name: 'Should Fail' },
+            {
+              operation: 'set_destinations',
+              destinations: [{ type: 'workflow', id: 'wf-1' }],
+            },
+          ],
+        },
+        ctx
+      );
+
+      const { results } = result as {
+        results: Array<{
+          type: string;
+          data: { message: string; metadata?: { missingPrivileges?: string[] } };
+        }>;
+      };
+      expect(results[0].type).toBe(ToolResultType.error);
+      expect(results[0].data.message).toContain('Action Policies: All');
+      expect(results[0].data.message).toContain('Unauthorized');
+      expect(results[0].data.metadata?.missingPrivileges).toEqual(['Action Policies: All']);
+      expect(ctx.attachments.add).not.toHaveBeenCalled();
+      expect(ctx.attachments.update).not.toHaveBeenCalled();
+    });
+
+    it('does not execute operations or external lookups when unauthorized', async () => {
+      const deps = createDeps({ canWrite: false });
+      const tool = manageActionPolicyTool(deps);
+      const ctx = createContext();
+
+      await tool.handler(
+        {
+          operations: [
+            { operation: 'set_metadata', name: 'Should Not Execute' },
+            {
+              operation: 'set_destinations',
+              destinations: [{ type: 'workflow', id: 'wf-1' }],
+            },
+          ],
+        },
+        ctx
+      );
+
+      expect(deps.getWorkflow).not.toHaveBeenCalled();
+      expect(deps.getAvailableConnectors).not.toHaveBeenCalled();
+      expect(ctx.attachments.getAttachmentRecord).not.toHaveBeenCalled();
+    });
+
+    it('resolves the PrivilegeChecker with the handler request', async () => {
+      const checkerMock = createPrivilegeCheckerMock(true);
+      const getPrivilegeChecker = jest.fn().mockReturnValue(checkerMock);
+      const deps: ManageActionPolicyToolDeps = {
+        logger: createLogger() as unknown as LoggerServiceContract,
+        getWorkflow: jest.fn().mockResolvedValue({ id: 'wf-1', name: 'My Workflow' }),
+        getAvailableConnectors: jest.fn().mockResolvedValue({ connectorTypes: {} }),
+        getPrivilegeChecker,
+      };
+      const tool = manageActionPolicyTool(deps);
+      const ctx = createContext();
+
+      await tool.handler(
+        {
+          operations: [
+            { operation: 'set_metadata', name: 'Privilege Check Test' },
+            {
+              operation: 'set_destinations',
+              destinations: [{ type: 'workflow', id: 'wf-1' }],
+            },
+          ],
+        },
+        ctx
+      );
+
+      expect(getPrivilegeChecker).toHaveBeenCalledWith({ request: ctx.request });
+      expect(checkerMock.canWrite).toHaveBeenCalledWith('actionPolicies');
+      expect(ctx.attachments.add).toHaveBeenCalledTimes(1);
+    });
+  });
 });
+

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_action_policy/manage_action_policy.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_action_policy/manage_action_policy.ts
@@ -11,9 +11,12 @@ import { ToolType } from '@kbn/agent-builder-common';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { getToolResultId } from '@kbn/agent-builder-server';
 import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
+import type { KibanaRequest } from '@kbn/core-http-server';
 import { ALERTING_TOOL_IDS } from '@kbn/alerting-v2-constants';
 import type { ActionPolicyAttachmentData } from '@kbn/alerting-v2-schemas';
 import { ACTION_POLICY_ATTACHMENT_TYPE } from '@kbn/alerting-v2-schemas';
+import { getAlertingPrivilegeDisplayName } from '../../../../common/feature_privileges';
+import type { PrivilegeChecker } from '../../../lib/services/privilege_checker/privilege_checker';
 import {
   actionPolicyOperationSchema,
   executeActionPolicyOperations,
@@ -38,16 +41,18 @@ export interface ManageActionPolicyToolDeps {
   getWorkflow: (id: string, spaceId: string) => Promise<{ id: string; name?: string } | null>;
   getAvailableConnectors: (
     spaceId: string,
-    request: import('@kbn/core/server').KibanaRequest
+    request: KibanaRequest
   ) => Promise<{
     connectorTypes: Record<string, { instances: Array<{ id: string; name: string }> }>;
   }>;
+  getPrivilegeChecker: (context: { request: KibanaRequest }) => PrivilegeChecker;
 }
 
 export const manageActionPolicyTool = ({
   logger,
   getWorkflow,
   getAvailableConnectors,
+  getPrivilegeChecker,
 }: ManageActionPolicyToolDeps): BuiltinSkillBoundedTool<typeof manageActionPolicySchema> => ({
   id: ALERTING_TOOL_IDS.manageActionPolicy,
   type: ToolType.builtin,
@@ -69,6 +74,23 @@ Use operations[] to:
     { actionPolicyAttachmentId: previousAttachmentId, operations },
     { attachments, spaceId, request }
   ) => {
+    const privilegeChecker = getPrivilegeChecker({ request });
+    const privilegeDisplayName = getAlertingPrivilegeDisplayName('actionPolicies', 'all');
+    const authorized = await privilegeChecker.canWrite('actionPolicies');
+    if (!authorized) {
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Unauthorized to compose or modify Alerting V2 action policies. Missing Kibana privilege: ${privilegeDisplayName}. Ask an administrator to grant this privilege, or continue with discovery-only if you only have Action Policies: Read.`,
+              metadata: { missingPrivileges: [privilegeDisplayName] },
+            },
+          },
+        ],
+      };
+    }
+
     let policyId: string | undefined;
     try {
       const currentAttachment = previousAttachmentId

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/manage_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/manage_rule.test.ts
@@ -13,6 +13,7 @@ import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { agentBuilderMocks } from '@kbn/agent-builder-plugin/server/mocks';
 import type { ToolHandlerContextMock } from '@kbn/agent-builder-plugin/server/mocks';
 import { ALERTING_LOG_CODES } from '../../../lib/errors/error_codes';
+import type { PrivilegeChecker } from '../../../lib/services/privilege_checker/privilege_checker';
 import type { LoggerServiceContract } from '../../../lib/services/logger_service/logger_service';
 import { manageRuleTool } from './manage_rule';
 import { AGENT_BUILDER_TAG } from '../../common/constants';
@@ -23,11 +24,14 @@ const getEsqlQueryMock = (ctx: ToolHandlerContextMock) =>
 const getFieldCapsMock = (ctx: ToolHandlerContextMock) =>
   ctx.esClient.asCurrentUser.fieldCaps as unknown as jest.Mock;
 
-// set_query resolves the rule's time field from the source index via fieldCaps.
-// Default to an index that exposes @timestamp so query-based operations don't
-// fail time-field resolution.
 const mockResolvableTimeField = (ctx: ToolHandlerContextMock) =>
   getFieldCapsMock(ctx).mockResolvedValueOnce({ fields: { '@timestamp': { date: {} } } });
+
+const createPrivilegeCheckerMock = (canWriteResult: boolean) =>
+  ({
+    canRead: jest.fn().mockResolvedValue(true),
+    canWrite: jest.fn().mockResolvedValue(canWriteResult),
+  }) as unknown as PrivilegeChecker;
 
 const createContext = (): ToolHandlerContextMock => {
   const ctx = agentBuilderMocks.tools.createHandlerContext();
@@ -58,7 +62,10 @@ describe('manageRuleTool', () => {
 
   beforeEach(() => {
     logger = createLogger();
-    tool = manageRuleTool({ logger: logger as unknown as LoggerServiceContract });
+    tool = manageRuleTool({
+      logger: logger as unknown as LoggerServiceContract,
+      getPrivilegeChecker: () => createPrivilegeCheckerMock(true),
+    });
   });
 
   describe('handler', () => {
@@ -391,4 +398,96 @@ describe('manageRuleTool', () => {
       });
     });
   });
+
+  describe('authorization', () => {
+    it('rejects with an error result when the user lacks Rules: All', async () => {
+      const unauthorizedTool = manageRuleTool({
+        logger: logger as unknown as LoggerServiceContract,
+        getPrivilegeChecker: () => createPrivilegeCheckerMock(false),
+      });
+      const ctx = createContext();
+
+      const result = await unauthorizedTool.handler(
+        { operations: [{ operation: 'set_metadata', name: 'Should Fail' }] },
+        ctx
+      );
+
+      const { results } = result as {
+        results: Array<{
+          type: string;
+          data: { message: string; metadata?: { missingPrivileges?: string[] } };
+        }>;
+      };
+      expect(results[0].type).toBe(ToolResultType.error);
+      expect(results[0].data.message).toContain('Rules: All');
+      expect(results[0].data.message).toContain('Unauthorized');
+      expect(results[0].data.metadata?.missingPrivileges).toEqual(['Rules: All']);
+      expect(ctx.attachments.add).not.toHaveBeenCalled();
+      expect(ctx.attachments.update).not.toHaveBeenCalled();
+    });
+
+    it('does not execute operations or ES queries when unauthorized', async () => {
+      const unauthorizedTool = manageRuleTool({
+        logger: logger as unknown as LoggerServiceContract,
+        getPrivilegeChecker: () => createPrivilegeCheckerMock(false),
+      });
+      const ctx = createContext();
+
+      await unauthorizedTool.handler(
+        {
+          operations: [
+            { operation: 'set_metadata', name: 'Should Not Execute' },
+            {
+              operation: 'set_query',
+              query: {
+                format: 'standalone',
+                breach: { query: 'FROM metrics-* | STATS AVG(cpu) BY host.name' },
+              },
+            },
+          ],
+        },
+        ctx
+      );
+
+      expect(getEsqlQueryMock(ctx)).not.toHaveBeenCalled();
+      expect(getFieldCapsMock(ctx)).not.toHaveBeenCalled();
+      expect(ctx.attachments.getAttachmentRecord).not.toHaveBeenCalled();
+    });
+
+    it('resolves the PrivilegeChecker with the handler request', async () => {
+      const checkerMock = createPrivilegeCheckerMock(true);
+      const getPrivilegeChecker = jest.fn().mockReturnValue(checkerMock);
+      const authorizedTool = manageRuleTool({
+        logger: logger as unknown as LoggerServiceContract,
+        getPrivilegeChecker,
+      });
+      const ctx = createContext();
+      getEsqlQueryMock(ctx).mockResolvedValueOnce({
+        columns: [{ name: 'host.name', type: 'keyword' }],
+        values: [],
+      });
+      mockResolvableTimeField(ctx);
+
+      await authorizedTool.handler(
+        {
+          operations: [
+            { operation: 'set_metadata', name: 'Privilege Check Test' },
+            {
+              operation: 'set_query',
+              query: {
+                format: 'standalone',
+                breach: { query: 'FROM metrics-* | STATS AVG(cpu) BY host.name' },
+              },
+            },
+          ],
+        },
+        ctx
+      );
+
+      expect(getPrivilegeChecker).toHaveBeenCalledWith({ request: ctx.request });
+      expect(checkerMock.canWrite).toHaveBeenCalledWith('rules');
+      expect(ctx.attachments.add).toHaveBeenCalledTimes(1);
+    });
+  });
 });
+

--- a/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/manage_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/agent_builder/tools/manage_rule/manage_rule.ts
@@ -11,9 +11,12 @@ import { ToolType } from '@kbn/agent-builder-common';
 import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 import { getToolResultId } from '@kbn/agent-builder-server';
 import type { BuiltinSkillBoundedTool } from '@kbn/agent-builder-server/skills';
+import type { KibanaRequest } from '@kbn/core-http-server';
 import { ALERTING_TOOL_IDS } from '@kbn/alerting-v2-constants';
 import type { RuleAttachmentData } from '@kbn/alerting-v2-schemas';
 import { RULE_ATTACHMENT_TYPE, getBreachEsqlQuery } from '@kbn/alerting-v2-schemas';
+import { getAlertingPrivilegeDisplayName } from '../../../../common/feature_privileges';
+import type { PrivilegeChecker } from '../../../lib/services/privilege_checker/privilege_checker';
 import {
   ruleOperationSchema,
   executeRuleOperations,
@@ -34,10 +37,12 @@ const manageRuleSchema = z.object({
 
 export interface ManageRuleToolDeps {
   logger: LoggerServiceContract;
+  getPrivilegeChecker: (context: { request: KibanaRequest }) => PrivilegeChecker;
 }
 
 export const manageRuleTool = ({
   logger,
+  getPrivilegeChecker,
 }: ManageRuleToolDeps): BuiltinSkillBoundedTool<typeof manageRuleSchema> => ({
   id: ALERTING_TOOL_IDS.manageRule,
   type: ToolType.builtin,
@@ -64,8 +69,25 @@ Use operations[] to:
   schema: manageRuleSchema,
   handler: async (
     { ruleAttachmentId: previousAttachmentId, operations },
-    { attachments, esClient, spaceId }
+    { attachments, esClient, request, spaceId }
   ) => {
+    const privilegeChecker = getPrivilegeChecker({ request });
+    const privilegeDisplayName = getAlertingPrivilegeDisplayName('rules', 'all');
+    const authorized = await privilegeChecker.canWrite('rules');
+    if (!authorized) {
+      return {
+        results: [
+          {
+            type: ToolResultType.error,
+            data: {
+              message: `Unauthorized to compose or modify Alerting V2 rules. Missing Kibana privilege: ${privilegeDisplayName}. Ask an administrator to grant this privilege, or continue with discovery-only if you only have Rules: Read.`,
+              metadata: { missingPrivileges: [privilegeDisplayName] },
+            },
+          },
+        ],
+      };
+    }
+
     let ruleId: string | undefined;
     try {
       const currentAttachment = previousAttachmentId

--- a/x-pack/platform/plugins/shared/alerting_v2/server/integration_tests/README.md
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/integration_tests/README.md
@@ -1,0 +1,25 @@
+# Non-HTTP Integration Tests for Alerting V2
+
+## Context
+
+From [PR #282447](https://github.com/elastic/kibana/pull/282447#issuecomment-5199601012) (Jason Rhodes):
+
+> The plumbing is all in place but there aren't a lot of examples of doing it.
+
+Components like `EpisodesClient` and `PrivilegeChecker` are not exposed via HTTP routes, so they can't be tested with supertest. Instead, we can run ES and Kibana inside a Jest integration test and invoke plugin internals directly.
+
+## References
+
+- **Existing example** — Security Solution's `receiver.test.ts` runs ES + Kibana in a Jest test without supertest or browser interactions:
+  https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/integration_tests/receiver.test.ts
+
+- **Cross-plugin sketch** — Jason's gist showing how the spy system could work across plugin boundaries:
+  https://gist.github.com/jasonrhodes/8ad58e5e80dca2658ad119da6e031cbd
+
+## Next Steps
+
+- Build shared utils so this pattern is easy to adopt across Alerting V2.
+- Candidate components for non-HTTP integration tests:
+  - `EpisodesClient` — space isolation, single-episode reads
+  - `PrivilegeChecker` — privilege checks at the correct space scope
+  - `RulesClient` / `ActionPolicyClient` — CRUD with real saved objects

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.test.ts
@@ -224,6 +224,7 @@ describe('bindAgentBuilder', () => {
           logger: expect.anything(),
           getWorkflow: expect.any(Function),
           getAvailableConnectors: expect.any(Function),
+          getPrivilegeChecker: expect.any(Function),
         })
       );
     });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -61,6 +61,8 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
       createRuleAttachmentType({
         logger: loggerService.forSubsystem('agentBuilder'),
         getRulesClient: (context) => resolveRequestScoped(injection, context.request, RulesClient),
+        getPrivilegeChecker: (context) =>
+          resolveRequestScoped(injection, context.request, PrivilegeChecker),
       }) as AttachmentTypeDefinition,
     [LoggerServiceToken, CoreStart('injection')]
   );
@@ -147,10 +149,13 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
 
     const workflowsManagementApi = container.get(WorkflowsManagementApiToken);
     const agentBuilderLogger = container.get(LoggerServiceToken).forSubsystem('agentBuilder');
+    const injection = container.get(CoreStart('injection'));
     registerSkills(agentBuilder, {
       logger: agentBuilderLogger,
       getWorkflow: (id, sid) => workflowsManagementApi.getWorkflow(id, sid),
       getAvailableConnectors: (sid, req) => workflowsManagementApi.getAvailableConnectors(sid, req),
+      getPrivilegeChecker: (context) =>
+        resolveRequestScoped(injection, context.request, PrivilegeChecker),
     });
   });
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_agent_builder.ts
@@ -72,6 +72,8 @@ export function bindAgentBuilder({ bind }: ContainerModuleLoadOptions) {
         logger: loggerService.forSubsystem('agentBuilder'),
         getActionPolicyClient: (context) =>
           resolveRequestScoped(injection, context.request, ActionPolicyClient),
+        getPrivilegeChecker: (context) =>
+          resolveRequestScoped(injection, context.request, PrivilegeChecker),
       }) as AttachmentTypeDefinition,
     [LoggerServiceToken, CoreStart('injection')]
   );


### PR DESCRIPTION
## Summary
Closes #275441

Split from #282871. **Stacked on #285865** (rule management). Merge #285865 first, then rebase this branch.

Adds write-privilege gates to the `manage_action_policy` Agent Builder tool so only users with **Action Policies: All** can compose or modify action-policy attachments. Action-policy attachment resolve requires **Action Policies: Read**.

- **Tool handler gate** — `manage_action_policy` checks `PrivilegeChecker.canWrite('actionPolicies')` at handler entry. On failure, returns `ToolResultType.error` with `"Action Policies: All"`.
- **Attachment resolve** — action-policy attachment resolve returns `undefined` when the user lacks Action Policies: Read.
- **Skill docs** — Privileges section on the action-policy-management skill.
- **Eval** — unprivileged user cannot compose action policies (`privileges.spec.ts`).

### Review this PR
Because the head branch lives on a fork, GitHub cannot use #285865 as the base ref. Files changed vs `main` therefore includes #285865.

**Action-policy-only diff:** https://github.com/dominiqueclarke/kibana/compare/feature/privilege-checks-rule-management...feature/privilege-checks-action-policy-management

## Test plan
- [x] `manage_action_policy.test.ts` — unauthorized, no-side-effects, PrivilegeChecker request wiring
- [x] `action_policy_attachment_type.test.ts` — resolve returns undefined without Action Policies: Read
- [x] `action_policy_management_skill.test.ts` — deps include `getPrivilegeChecker`
- [ ] `privileges.spec.ts` action-policy eval (requires live stack with Agent Builder)


Made with [Cursor](https://cursor.com)