### PR TITLE
[8.19] [Lens] Fix flaky color mapping test by typing custom hex in one shot (#284794)

### DIFF
--- a/x-pack/platform/test/functional/apps/lens/group2/color_mapping_runtime_migrations.ts
+++ b/x-pack/platform/test/functional/apps/lens/group2/color_mapping_runtime_migrations.ts
@@ -346,7 +346,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await testSubjects.click('lns-colorMapping-colorPicker-tab-custom');
         await testSubjects.setValue('lns-colorMapping-colorPicker-custom-input', customColor, {
-          typeCharByChar: true,
           clearWithKeyboard: true,
         });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Lens] Fix flaky color mapping test by typing custom hex in one shot (#284794)](https://github.com/elastic/kibana/pull/284794)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kibana Machine","email":"42973632+kibanamachine@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-13T19:23:48Z","message":"[Lens] Fix flaky color mapping test by typing custom hex in one shot (#284794)\n\nFixes #274521\n\n### Summary\n\n- `should apply new mappings for xy charts` was flaky: at the failure\npoint the custom-color input held only `value=\"#0118\"` (expected\n`#0118d8`), so the swatch never reached the target color and\n`retry.waitFor('verify color is correct before continuing')` looped\nuntil it timed out.\n- Char-by-char typing (`typeCharByChar: true`) sends each keystroke as a\nseparate `sendKeys` with a ~100 ms gap, giving EUI's controlled hex\n`<input>` time to re-render between keystrokes and drop the trailing\ndigits.\n- This drops `typeCharByChar` so the whole hex string is sent in a\nsingle `sendKeys`, matching the proven one-shot pattern used for the\nsame EUI hex input in `_esql_view.ts`. The existing swatch\n`retry.waitFor` still gates on the color applying, so nothing else\nchanges.\n\n### Context\n\n- Follows the most recent [Failed Test Investigator\nanalysis](https://github.com/elastic/kibana/issues/274521#issuecomment-5274305572)\n(2026-08-13), which diagnosed the dropped trailing digits and proposed\ndropping `typeCharByChar`. An earlier analysis suggested wrapping the\ntyping in a `retry` to re-type on truncation; that was superseded\nbecause re-issuing a flaky interaction is a manual retry loop that masks\nthe interaction bug — this patch removes the race at its source instead.\n- Latest failure on `main` in [kibana-on-merge\n#106232](https://buildkite.com/elastic/kibana-on-merge/builds/106232#019ff859-caf3-40ab-b6a2-78d919f4e83d)\n(FTR `ftr_configs_97`); first reported from a `kibana-fips` daily build,\nsame signature.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n- ✅ Passed: `node scripts/eslint\nx-pack/platform/test/functional/apps/lens/group2/color_mapping_runtime_migrations.ts`\n\n#### Not verified locally\n\n- Type check (`node scripts/type_check --project\nx-pack/platform/test/tsconfig.json`) could not complete — the process\nwas OOM-killed building the full project references in this environment.\nThe change only removes an optional property (`typeCharByChar?`) from a\ntyped `SetValueOptions` object, so it cannot introduce a type error.\n- This is an FTR test requiring a live Elasticsearch + Kibana, so it\ncould not be run here; its behavior under CI parallel load was not\nexercised.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:all-open`. The patched file and the identical\n`setValue(..., { typeCharByChar: true, clearWithKeyboard: true })` block\nexist on every open release branch (`9.5`, `9.4`, `8.19`), so this\none-line removal applies unchanged on all of them.\n\n</details>\n\n> [!NOTE]\n> Share feedback in #kibana-qa. Mention `@copilot` to make quick\nchanges.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/31653843413) for\n#274521 · 287.6 AIC · ⌖ 40.8 AIC · ⊞ 8.7K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\nCo-authored-by: Claude Opus 4 (1M context) <noreply@anthropic.com>","sha":"421f5947957cae3367ed6125fb3f92c9bbc01635","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","flaky-test-fixer","flaky-fix-check:passed","v9.6.0"],"title":"[Lens] Fix flaky color mapping test by typing custom hex in one shot","number":284794,"url":"https://github.com/elastic/kibana/pull/284794","mergeCommit":{"message":"[Lens] Fix flaky color mapping test by typing custom hex in one shot (#284794)\n\nFixes #274521\n\n### Summary\n\n- `should apply new mappings for xy charts` was flaky: at the failure\npoint the custom-color input held only `value=\"#0118\"` (expected\n`#0118d8`), so the swatch never reached the target color and\n`retry.waitFor('verify color is correct before continuing')` looped\nuntil it timed out.\n- Char-by-char typing (`typeCharByChar: true`) sends each keystroke as a\nseparate `sendKeys` with a ~100 ms gap, giving EUI's controlled hex\n`<input>` time to re-render between keystrokes and drop the trailing\ndigits.\n- This drops `typeCharByChar` so the whole hex string is sent in a\nsingle `sendKeys`, matching the proven one-shot pattern used for the\nsame EUI hex input in `_esql_view.ts`. The existing swatch\n`retry.waitFor` still gates on the color applying, so nothing else\nchanges.\n\n### Context\n\n- Follows the most recent [Failed Test Investigator\nanalysis](https://github.com/elastic/kibana/issues/274521#issuecomment-5274305572)\n(2026-08-13), which diagnosed the dropped trailing digits and proposed\ndropping `typeCharByChar`. An earlier analysis suggested wrapping the\ntyping in a `retry` to re-type on truncation; that was superseded\nbecause re-issuing a flaky interaction is a manual retry loop that masks\nthe interaction bug — this patch removes the race at its source instead.\n- Latest failure on `main` in [kibana-on-merge\n#106232](https://buildkite.com/elastic/kibana-on-merge/builds/106232#019ff859-caf3-40ab-b6a2-78d919f4e83d)\n(FTR `ftr_configs_97`); first reported from a `kibana-fips` daily build,\nsame signature.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n- ✅ Passed: `node scripts/eslint\nx-pack/platform/test/functional/apps/lens/group2/color_mapping_runtime_migrations.ts`\n\n#### Not verified locally\n\n- Type check (`node scripts/type_check --project\nx-pack/platform/test/tsconfig.json`) could not complete — the process\nwas OOM-killed building the full project references in this environment.\nThe change only removes an optional property (`typeCharByChar?`) from a\ntyped `SetValueOptions` object, so it cannot introduce a type error.\n- This is an FTR test requiring a live Elasticsearch + Kibana, so it\ncould not be run here; its behavior under CI parallel load was not\nexercised.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:all-open`. The patched file and the identical\n`setValue(..., { typeCharByChar: true, clearWithKeyboard: true })` block\nexist on every open release branch (`9.5`, `9.4`, `8.19`), so this\none-line removal applies unchanged on all of them.\n\n</details>\n\n> [!NOTE]\n> Share feedback in #kibana-qa. Mention `@copilot` to make quick\nchanges.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/31653843413) for\n#274521 · 287.6 AIC · ⌖ 40.8 AIC · ⊞ 8.7K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\nCo-authored-by: Claude Opus 4 (1M context) <noreply@anthropic.com>","sha":"421f5947957cae3367ed6125fb3f92c9bbc01635"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284794","number":284794,"mergeCommit":{"message":"[Lens] Fix flaky color mapping test by typing custom hex in one shot (#284794)\n\nFixes #274521\n\n### Summary\n\n- `should apply new mappings for xy charts` was flaky: at the failure\npoint the custom-color input held only `value=\"#0118\"` (expected\n`#0118d8`), so the swatch never reached the target color and\n`retry.waitFor('verify color is correct before continuing')` looped\nuntil it timed out.\n- Char-by-char typing (`typeCharByChar: true`) sends each keystroke as a\nseparate `sendKeys` with a ~100 ms gap, giving EUI's controlled hex\n`<input>` time to re-render between keystrokes and drop the trailing\ndigits.\n- This drops `typeCharByChar` so the whole hex string is sent in a\nsingle `sendKeys`, matching the proven one-shot pattern used for the\nsame EUI hex input in `_esql_view.ts`. The existing swatch\n`retry.waitFor` still gates on the color applying, so nothing else\nchanges.\n\n### Context\n\n- Follows the most recent [Failed Test Investigator\nanalysis](https://github.com/elastic/kibana/issues/274521#issuecomment-5274305572)\n(2026-08-13), which diagnosed the dropped trailing digits and proposed\ndropping `typeCharByChar`. An earlier analysis suggested wrapping the\ntyping in a `retry` to re-type on truncation; that was superseded\nbecause re-issuing a flaky interaction is a manual retry loop that masks\nthe interaction bug — this patch removes the race at its source instead.\n- Latest failure on `main` in [kibana-on-merge\n#106232](https://buildkite.com/elastic/kibana-on-merge/builds/106232#019ff859-caf3-40ab-b6a2-78d919f4e83d)\n(FTR `ftr_configs_97`); first reported from a `kibana-fips` daily build,\nsame signature.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n- ✅ Passed: `node scripts/eslint\nx-pack/platform/test/functional/apps/lens/group2/color_mapping_runtime_migrations.ts`\n\n#### Not verified locally\n\n- Type check (`node scripts/type_check --project\nx-pack/platform/test/tsconfig.json`) could not complete — the process\nwas OOM-killed building the full project references in this environment.\nThe change only removes an optional property (`typeCharByChar?`) from a\ntyped `SetValueOptions` object, so it cannot introduce a type error.\n- This is an FTR test requiring a live Elasticsearch + Kibana, so it\ncould not be run here; its behavior under CI parallel load was not\nexercised.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:all-open`. The patched file and the identical\n`setValue(..., { typeCharByChar: true, clearWithKeyboard: true })` block\nexist on every open release branch (`9.5`, `9.4`, `8.19`), so this\none-line removal applies unchanged on all of them.\n\n</details>\n\n> [!NOTE]\n> Share feedback in #kibana-qa. Mention `@copilot` to make quick\nchanges.\n\n\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/31653843413) for\n#274521 · 287.6 AIC · ⌖ 40.8 AIC · ⊞ 8.7K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\nCo-authored-by: Claude Opus 4 (1M context) <noreply@anthropic.com>","sha":"421f5947957cae3367ed6125fb3f92c9bbc01635"}}]}] BACKPORT-->