### PR TITLE
[RuleRegistry] Fix cross-space writes in bulkUpdateTags

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -82989,7 +82989,7 @@ components:
               enum:
                 - emit
               type: string
-            - description: Forces recovery when no data is present.
+            - description: Resolves the alert episode to inactive on the first no-data run.
               enum:
                 - recover
               type: string
@@ -83486,7 +83486,7 @@ components:
               enum:
                 - emit
               type: string
-            - description: Forces recovery when no data is present.
+            - description: Resolves the alert episode to inactive on the first no-data run.
               enum:
                 - recover
               type: string
@@ -83876,7 +83876,7 @@ components:
               enum:
                 - emit
               type: string
-            - description: Forces recovery when no data is present.
+            - description: Resolves the alert episode to inactive on the first no-data run.
               enum:
                 - recover
               type: string

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -96459,7 +96459,7 @@ components:
               enum:
                 - emit
               type: string
-            - description: Forces recovery when no data is present.
+            - description: Resolves the alert episode to inactive on the first no-data run.
               enum:
                 - recover
               type: string
@@ -96956,7 +96956,7 @@ components:
               enum:
                 - emit
               type: string
-            - description: Forces recovery when no data is present.
+            - description: Resolves the alert episode to inactive on the first no-data run.
               enum:
                 - recover
               type: string
@@ -97346,7 +97346,7 @@ components:
               enum:
                 - emit
               type: string
-            - description: Forces recovery when no data is present.
+            - description: Resolves the alert episode to inactive on the first no-data run.
               enum:
                 - recover
               type: string

--- a/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/alerts_client.test.ts
@@ -640,6 +640,24 @@ describe('AlertsClient', () => {
         expect(esClientMock.updateByQuery).toHaveBeenCalledTimes(1);
       });
 
+      it('should scope the updateByQuery to the current space', async () => {
+        await alertsClient.bulkUpdateTags({
+          alertIds: ['alert-1', 'alert-2'],
+          index: '.alerts-security.alerts-default',
+          add: ['urgent'],
+        });
+
+        const query = esClientMock.updateByQuery.mock.calls[0][0].query;
+        expect(query).toEqual({
+          bool: {
+            filter: [
+              { ids: { values: ['alert-1', 'alert-2'] } },
+              { terms: { 'kibana.space_ids': ['space-1', '*'] } },
+            ],
+          },
+        });
+      });
+
       it('should construct the query and aggs correctly when getting the rule type ids and consumers', async () => {
         await alertsClient.bulkUpdateTags({
           alertIds: ['alert-1', 'alert-2'],
@@ -808,54 +826,68 @@ describe('AlertsClient', () => {
             "bool": Object {
               "filter": Array [
                 Object {
-                  "multi_match": Object {
-                    "lenient": true,
-                    "query": "some-query",
-                    "type": "best_fields",
+                  "bool": Object {
+                    "filter": Array [
+                      Object {
+                        "multi_match": Object {
+                          "lenient": true,
+                          "query": "some-query",
+                          "type": "best_fields",
+                        },
+                      },
+                      Object {
+                        "arguments": Array [
+                          Object {
+                            "arguments": Array [
+                              Object {
+                                "isQuoted": false,
+                                "type": "literal",
+                                "value": "alert.attributes.alertTypeId",
+                              },
+                              Object {
+                                "isQuoted": false,
+                                "type": "literal",
+                                "value": "test-rule-type-1",
+                              },
+                            ],
+                            "function": "is",
+                            "type": "function",
+                          },
+                          Object {
+                            "arguments": Array [
+                              Object {
+                                "isQuoted": false,
+                                "type": "literal",
+                                "value": "alert.attributes.consumer",
+                              },
+                              Object {
+                                "isQuoted": false,
+                                "type": "literal",
+                                "value": "foo",
+                              },
+                            ],
+                            "function": "is",
+                            "type": "function",
+                          },
+                        ],
+                        "function": "and",
+                        "type": "function",
+                      },
+                    ],
+                    "must": Array [],
+                    "must_not": Array [],
+                    "should": Array [],
                   },
                 },
                 Object {
-                  "arguments": Array [
-                    Object {
-                      "arguments": Array [
-                        Object {
-                          "isQuoted": false,
-                          "type": "literal",
-                          "value": "alert.attributes.alertTypeId",
-                        },
-                        Object {
-                          "isQuoted": false,
-                          "type": "literal",
-                          "value": "test-rule-type-1",
-                        },
-                      ],
-                      "function": "is",
-                      "type": "function",
-                    },
-                    Object {
-                      "arguments": Array [
-                        Object {
-                          "isQuoted": false,
-                          "type": "literal",
-                          "value": "alert.attributes.consumer",
-                        },
-                        Object {
-                          "isQuoted": false,
-                          "type": "literal",
-                          "value": "foo",
-                        },
-                      ],
-                      "function": "is",
-                      "type": "function",
-                    },
-                  ],
-                  "function": "and",
-                  "type": "function",
+                  "terms": Object {
+                    "kibana.space_ids": Array [
+                      "space-1",
+                      "*",
+                    ],
+                  },
                 },
               ],
-              "must": Array [],
-              "must_not": Array [],
-              "should": Array [],
             },
           }
         `);

--- a/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/alerts_client.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/alerts_client.ts
@@ -973,8 +973,12 @@ export class AlertsClient {
       index,
     });
 
+    const spacesFilter = getSpacesFilter(this.spaceId);
+    const idsQuery: estypes.QueryDslQueryContainer = { ids: { values: alertIds } };
+    const updateQuery = spacesFilter ? { bool: { filter: [idsQuery, spacesFilter] } } : idsQuery;
+
     const bulkUpdateResponse = await this.esClient.updateByQuery({
-      query: { ids: { values: alertIds } },
+      query: updateQuery,
       index,
       script,
       refresh: true,
@@ -997,12 +1001,14 @@ export class AlertsClient {
         WriteOperations.Update
       )) as Filter;
 
-      const finalQuery = buildEsQuery(
+      const spacesFilter = getSpacesFilter(this.spaceId);
+      const baseQuery = buildEsQuery(
         undefined,
         { query, language: 'kuery' },
         [authzFilter],
         config
       );
+      const finalQuery = spacesFilter ? { bool: { filter: [baseQuery, spacesFilter] } } : baseQuery;
 
       const auditEvent = alertAuditEvent({
         action: operationAlertAuditActionMap[WriteOperations.Update],


### PR DESCRIPTION
## Summary

Fixes two cross-space write bugs introduced in #241883 (`bulkUpdateTags` on `AlertsClient`).

### Bug 1 — ID path: spaces filter missing from the write

The authorization check in `getAuthorizedRuleTypeIdsConsumersPairs` correctly applied `getSpacesFilter` when aggregating `(ruleTypeId, consumer)` pairs. But the actual `updateByQuery` used only `{ ids: { values: alertIds } }` with no spaces filter — meaning alert IDs from another space could be updated once the auth check passed on in-space alerts.

**Fix:** AND `getSpacesFilter(this.spaceId)` into the `updateByQuery` query alongside the ids filter.

### Bug 2 — Query path: no spaces filter at all

`bulkUpdateTagsByQuery` built its ES query from `authzFilter` (rule type + consumer) only. There was no `getSpacesFilter` call, so a KQL query would match and update alerts across all spaces the caller is authorized for — not just the current space.

**Fix:** Wrap the `buildEsQuery` result in an outer `bool.filter` that also includes `getSpacesFilter(this.spaceId)`, matching the pattern used by `buildEsQueryWithAuthz` elsewhere in the file.

### Tests

- Added a test for the ID path asserting that `updateByQuery` is called with the spaces filter in the query.
- Updated the existing inline snapshot for the query path to reflect the new outer `bool.filter` wrapper.

## Checklist

- [x] Unit tests pass
- [x] TypeScript type check passes
- [x] ESLint clean

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->