### PR TITLE
[8.19] [CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -254,6 +254,8 @@ steps:
       - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
         label: 'Defend Workflows Cypress Tests on Serverless'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -255,6 +255,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/profiling_cypress.sh
     label: 'Profiling Cypress Tests'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -275,6 +277,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/apm_cypress.sh
     label: 'APM Cypress Tests'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -405,6 +405,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -423,6 +425,8 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -2,10 +2,12 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows_burn.sh
     label: '[Soft fail] Defend Workflows Cypress Tests, burning changed specs'
     key: defend-workflows-burn
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 125
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -2,10 +2,12 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
     key: defend-workflows
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 125
+      diskSizeGb: 130
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
@@ -5,13 +5,15 @@ steps:
       - label: "Cypress - DW - Running cypress:dw:qa:serverless:run"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows.sh cypress:dw:qa:serverless:run
         key: test_defend_workflows
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-standard-4
-          diskSizeGb: 125
+          diskSizeGb: 130
           preemptible: true
         timeout_in_minutes: 300
         parallelism: 5
@@ -86,6 +88,8 @@ steps:
       - label: "API - DW - Running edr_workflows:policy_response:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:policy_response:qa:serverless
         key: edr_workflows:policy_response:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -93,6 +97,7 @@ steps:
           enableNestedVirtualization: true
           machineType: n2-standard-4
           preemptible: true
+          diskSizeGb: 130
         timeout_in_minutes: 120
         retry:
           automatic:
@@ -102,6 +107,8 @@ steps:
       - label: "API - DW - Running edr_workflows:resolver:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:resolver:qa:serverless
         key: edr_workflows:resolver:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -109,6 +116,7 @@ steps:
           enableNestedVirtualization: true
           machineType: n2-standard-4
           preemptible: true
+          diskSizeGb: 130
         timeout_in_minutes: 120
         retry:
           automatic:
@@ -118,6 +126,8 @@ steps:
       - label: "API - DW - Running edr_workflows:response_actions:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:response_actions:qa:serverless
         key: edr_workflows:response_actions:qa:serverless
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -125,6 +135,7 @@ steps:
           enableNestedVirtualization: true
           machineType: n2-standard-4
           preemptible: true
+          diskSizeGb: 130
         timeout_in_minutes: 120
         retry:
           automatic:
@@ -137,6 +148,8 @@ steps:
       - label: "Osquery - Cypress - DW - Running cypress:qa:serverless:run"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows_osquery.sh cypress:qa:serverless:run
         key: test_osquery_defend_workflows
+        env:
+          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
@@ -2,6 +2,8 @@ steps:
   - command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows.sh cypress:dw:qa:serverless:run
     label: 'Cypress MKI - Defend Workflows'
     key: test_defend_workflows
+    env:
+      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -48,3 +48,11 @@ fi
 if [[ "$DISABLE_BOOTSTRAP_VALIDATION" != "true" ]]; then
   check_for_changed_files 'yarn kbn bootstrap'
 fi
+
+# Opt-in per job (via CLEAR_YARN_CACHE) to free disk space on disk-constrained agents
+if [[ "${CLEAR_YARN_CACHE:-}" ]]; then
+  echo "Clearing yarn cache at /opt/buildkite-agent/.cache/yar..."
+  rm -rf /opt/buildkite-agent/.cache/yarn
+  echo "Available disk space after clearing yarn cache:"
+  df -h . || echo "Failed to get disk space"
+fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)](https://github.com/elastic/kibana/pull/278876)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-07-17T09:13:34Z","message":"[CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)\n\n## Summary\n\nFree disk space on the disk-constrained Defend Workflows CI agents by\nclearing the global yarn cache after bootstrap.\n\n- Adds `CLEAR_YARN_CACHE: '1'` env to all Defend Workflows jobs across\nthe pipelines.\n- `.buildkite/scripts/bootstrap.sh` deletes\n`/opt/buildkite-agent/.cache/yarn` when `CLEAR_YARN_CACHE` is set, then\nprints available disk space (`df -h .`).\n\nOpt-in via the env var, so other jobs are unaffected.\n\n## Test plan\n\n- [x] Defend Workflows CI jobs log the cache clear + disk space and stay\ngreen.\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"e2fc6657be444a7aea8df4b3bfff3421c26c7039","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:version","v9.5.0","v9.4.4","v9.6.0","v9.4.5","v9.3.9"],"title":"[CI] Clear yarn cache on defend workflows agents post-bootstrap","number":278876,"url":"https://github.com/elastic/kibana/pull/278876","mergeCommit":{"message":"[CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)\n\n## Summary\n\nFree disk space on the disk-constrained Defend Workflows CI agents by\nclearing the global yarn cache after bootstrap.\n\n- Adds `CLEAR_YARN_CACHE: '1'` env to all Defend Workflows jobs across\nthe pipelines.\n- `.buildkite/scripts/bootstrap.sh` deletes\n`/opt/buildkite-agent/.cache/yarn` when `CLEAR_YARN_CACHE` is set, then\nprints available disk space (`df -h .`).\n\nOpt-in via the env var, so other jobs are unaffected.\n\n## Test plan\n\n- [x] Defend Workflows CI jobs log the cache clear + disk space and stay\ngreen.\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"e2fc6657be444a7aea8df4b3bfff3421c26c7039"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279139","number":279139,"state":"MERGED","mergeCommit":{"sha":"554b7e346dea39395b57b70d42cdd3e5e7249002","message":"[9.5] [CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876) (#279139)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[CI] Clear yarn cache on defend workflows agents post-bootstrap\n(#278876)](https://github.com/elastic/kibana/pull/278876)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}},{"branch":"9.4","label":"v9.4.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279447","number":279447,"state":"MERGED","mergeCommit":{"sha":"18fefe8d326dfd5180c5889e2bd11e01c617ee77","message":"[9.4] [CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876) (#279447)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[CI] Clear yarn cache on defend workflows agents post-bootstrap\n(#278876)](https://github.com/elastic/kibana/pull/278876)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/278876","number":278876,"mergeCommit":{"message":"[CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876)\n\n## Summary\n\nFree disk space on the disk-constrained Defend Workflows CI agents by\nclearing the global yarn cache after bootstrap.\n\n- Adds `CLEAR_YARN_CACHE: '1'` env to all Defend Workflows jobs across\nthe pipelines.\n- `.buildkite/scripts/bootstrap.sh` deletes\n`/opt/buildkite-agent/.cache/yarn` when `CLEAR_YARN_CACHE` is set, then\nprints available disk space (`df -h .`).\n\nOpt-in via the env var, so other jobs are unaffected.\n\n## Test plan\n\n- [x] Defend Workflows CI jobs log the cache clear + disk space and stay\ngreen.\n\nMade with [Cursor](https://cursor.com)\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"e2fc6657be444a7aea8df4b3bfff3421c26c7039"}},{"branch":"9.3","label":"v9.3.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/279450","number":279450,"state":"MERGED","mergeCommit":{"sha":"1c55b63091776f2534f1cb4b61d1ee6bba5e70fb","message":"[9.3] [CI] Clear yarn cache on defend workflows agents post-bootstrap (#278876) (#279450)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[CI] Clear yarn cache on defend workflows agents post-bootstrap\n(#278876)](https://github.com/elastic/kibana/pull/278876)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}}]}] BACKPORT-->