### PR TITLE
[Entity Store] Fix mapping conflict for host.cpu.usage

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/esql/cast.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/esql/cast.ts
@@ -59,11 +59,10 @@ export function castFieldByType(fieldName: string, mappingType?: string): string
     case 'float':
     case 'double':
     case 'half_float':
+    case 'scaled_float':
       return `TO_DOUBLE(${fieldName})`;
     case 'ip':
       return `TO_IP(${fieldName})`;
-    case 'scaled_float':
-      return fieldName;
     default:
       return `TO_STRING(${fieldName})`;
   }


### PR DESCRIPTION
## Summary

fixes mapping conflict between `float` and `scaled_float` by casting `TO_DOUBLE`: 

``` ... verification_exception: Found 1 problem
line 32:31: Cannot use field [host.cpu.usage] due to ambiguities being mapped ...
```


