### PR TITLE
Deprecate legacy Kibana route header APIs

### DIFF
--- a/src/core/packages/chrome/app-header/README.md
+++ b/src/core/packages/chrome/app-header/README.md
@@ -35,6 +35,17 @@ with other hooks. Most apps should use `ChromeAppHeaderRegistration`.
 Use `chrome.next.appHeader.set` only when a React adapter is not practical. It is the imperative
 primitive behind the React APIs.
 
+## Migrating route headers
+
+Use `AppHeader` instead of `EuiPageHeader`, `EuiPageTemplate.Header`, or
+`KibanaPageTemplate.Header` for top-level application route headers. `EuiPageHeader` and
+`EuiPageTemplate.Header` remain appropriate for nested content and other UI that is not the route
+header. `KibanaPageTemplate.Header` and the `KibanaPageTemplate` `pageHeader` prop are deprecated;
+do not add new consumers.
+
+See the [AppHeader migration guide](https://github.com/elastic/kibana/issues/283673) for migration
+steps, examples, and tracking.
+
 ## Back navigation
 
 Pass the destination as `back`. Kibana handles same-origin `href` values as SPA navigation, so an
@@ -47,8 +58,9 @@ Pass the destination as `back`. Kibana handles same-origin `href` values as SPA 
 Use the object form when the back button needs a destination label or click behavior that differs
 from following `href`. If the handler replaces navigation, call `event.preventDefault()`.
 
-If a page already owns an in-page back (for example `EuiPageHeader` breadcrumbs or a custom back
-control) and would also get a Chrome Next compatibility back from breadcrumbs, mount:
+As a temporary compatibility fix, if an unmigrated page already owns an in-page back (for example
+`EuiPageHeader` breadcrumbs or a custom back control) and would also get a Chrome Next compatibility
+back from breadcrumbs, mount:
 
 ```tsx
 <>

--- a/src/platform/packages/shared/shared-ux/page/kibana_template/impl/src/page_template.tsx
+++ b/src/platform/packages/shared/shared-ux/page/kibana_template/impl/src/page_template.tsx
@@ -69,6 +69,10 @@ export const _KibanaPageTemplate: FC<KibanaPageTemplateProps> = ({
  */
 export const KibanaPageTemplate = Object.assign(_KibanaPageTemplate, {
   Sidebar: EuiPageTemplate.Sidebar,
+  /**
+   * @deprecated For top-level application route headers, use `AppHeader` from
+   * `@kbn/app-header`. For non-route content, use `EuiPageTemplate.Header` directly.
+   */
   Header: EuiPageTemplate.Header,
   Section: EuiPageTemplate.Section,
   BottomBar: EuiPageTemplate.BottomBar,

--- a/src/platform/packages/shared/shared-ux/page/kibana_template/types/index.ts
+++ b/src/platform/packages/shared/shared-ux/page/kibana_template/types/index.ts
@@ -42,9 +42,14 @@ export type KibanaPageTemplateProps = EuiPageTemplateProps & {
    */
   noDataConfig?: NoDataConfig;
   /**
-   * BWC Props from old EUI template
+   * @deprecated For top-level application route headers, use `AppHeader` from
+   * `@kbn/app-header`. For empty states, render `EuiEmptyPrompt` directly or use
+   * `noDataConfig`.
    */
   pageHeader?: EuiPageHeaderProps;
+  /**
+   * BWC Props from old EUI template
+   */
   pageSideBar?: ReactNode;
   pageSideBarProps?: EuiPageSidebarProps;
 };


### PR DESCRIPTION
Part of #283673

## Summary

Deprecates Kibana's legacy page-template header entry points so new route headers use `AppHeader`. EUI page headers remain available for nested and non-route content, and the AppHeader documentation now makes that boundary and the temporary fallback behavior explicit.