### PR TITLE
[Agent Builder] Agent-access hints and conversation-sharing Scout API tests

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder/moon.yml
@@ -146,6 +146,7 @@ dependsOn:
   - '@kbn/storybook'
   - '@kbn/context-engine-plugin'
   - '@kbn/ui-callout'
+  - '@kbn/core-user-profile-common'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/access_principals.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/access_principals.test.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  AgentAccessControlMode,
+  AgentAccessControlRole,
+  createAgentNotFoundError,
+  type AgentDefinition,
+} from '@kbn/agent-builder-common';
+import { type IRouter, kibanaResponseFactory } from '@kbn/core/server';
+import { httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import type { UserProfile } from '@kbn/core-user-profile-common';
+import type { RouteDependencies } from '../types';
+import { registerAccessPrincipalsRoutes } from './access_principals';
+
+const profiles = [
+  { uid: 'owner-id', enabled: true, data: {}, user: { username: 'owner' } },
+  { uid: 'member-id', enabled: true, data: {}, user: { username: 'member' } },
+  { uid: 'other-id', enabled: true, data: {}, user: { username: 'other' } },
+] satisfies UserProfile[];
+
+const agentWithAccessMode = (
+  accessMode: AgentAccessControlMode,
+  entries: NonNullable<AgentDefinition['access_control']>['entries'] = []
+) => ({
+  created_by: { id: 'owner-id', username: 'owner' },
+  access_control: { access_mode: accessMode, entries },
+});
+
+describe('registerAccessPrincipalsRoutes', () => {
+  const routePath = '/internal/agent_builder/_suggest_user_profiles';
+  let routeHandler: (ctx: any, req: any, res: any) => Promise<any>;
+  let suggestProfiles: jest.Mock;
+  let getAgent: jest.Mock;
+
+  const createContext = () => ({
+    licensing: Promise.resolve({
+      license: { status: 'active', hasAtLeast: jest.fn().mockReturnValue(true) },
+    }),
+    agentBuilder: Promise.resolve({
+      spaces: { getSpaceId: jest.fn().mockReturnValue('default') },
+    }),
+  });
+
+  const createRequest = (body: { name: string; agent_id?: string }) =>
+    httpServerMock.createKibanaRequest({ method: 'post', path: routePath, body });
+
+  beforeEach(() => {
+    suggestProfiles = jest.fn().mockResolvedValue(profiles);
+    getAgent = jest.fn();
+    const handlers: Record<string, (ctx: any, req: any, res: any) => Promise<any>> = {};
+    const router = {
+      post: jest
+        .fn()
+        .mockImplementation(
+          (config: { path: string }, handler: (ctx: any, req: any, res: any) => Promise<any>) => {
+            handlers[config.path] = handler;
+          }
+        ),
+    } as unknown as IRouter;
+
+    registerAccessPrincipalsRoutes({
+      router,
+      logger: loggingSystemMock.createLogger(),
+      coreSetup: {
+        getStartServices: jest.fn().mockResolvedValue([
+          {},
+          {
+            security: {
+              userProfiles: { suggest: suggestProfiles },
+              authz: { actions: { login: 'login' } },
+            },
+          },
+        ]),
+      },
+      getInternalServices: () => ({
+        agents: { getRegistry: jest.fn().mockResolvedValue({ get: getAgent }) },
+      }),
+    } as unknown as RouteDependencies);
+
+    routeHandler = handlers[routePath];
+  });
+
+  it('preserves the user profile response when agent_id is absent', async () => {
+    const response = await routeHandler(
+      createContext(),
+      createRequest({ name: 'owner' }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(profiles);
+    expect(getAgent).not.toHaveBeenCalled();
+  });
+
+  it('preserves suggestions when the caller cannot read the selected agent', async () => {
+    getAgent.mockRejectedValue(createAgentNotFoundError({ agentId: 'hidden-agent' }));
+
+    const response = await routeHandler(
+      createContext(),
+      createRequest({ name: 'owner', agent_id: 'hidden-agent' }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(profiles);
+  });
+
+  it.each([AgentAccessControlMode.Public, AgentAccessControlMode.Shared])(
+    'marks every suggested user as having access to a %s agent',
+    async (accessMode) => {
+      getAgent.mockResolvedValue(agentWithAccessMode(accessMode));
+
+      const response = await routeHandler(
+        createContext(),
+        createRequest({ name: 'owner', agent_id: 'agent-id' }),
+        kibanaResponseFactory
+      );
+
+      expect(response.payload).toEqual(
+        profiles.map((profile) => ({ ...profile, has_agent_access: true }))
+      );
+    }
+  );
+
+  it('marks only the owner and explicitly granted users for a private agent', async () => {
+    getAgent.mockResolvedValue(
+      agentWithAccessMode(AgentAccessControlMode.Private, [
+        { type: 'user', name: 'member', role: AgentAccessControlRole.User },
+      ])
+    );
+
+    const response = await routeHandler(
+      createContext(),
+      createRequest({ name: 'owner', agent_id: 'agent-id' }),
+      kibanaResponseFactory
+    );
+
+    expect(response.payload).toEqual([
+      { ...profiles[0], has_agent_access: true },
+      { ...profiles[1], has_agent_access: true },
+      { ...profiles[2], has_agent_access: false },
+    ]);
+  });
+
+  it('recognizes a legacy owner recorded without a stable id', async () => {
+    getAgent.mockResolvedValue({
+      created_by: { username: 'owner' },
+      access_control: { access_mode: AgentAccessControlMode.Private, entries: [] },
+    });
+
+    const response = await routeHandler(
+      createContext(),
+      createRequest({ name: 'owner', agent_id: 'agent-id' }),
+      kibanaResponseFactory
+    );
+
+    expect(response.payload[0].has_agent_access).toBe(true);
+    expect(response.payload[1].has_agent_access).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/access_principals.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/access_principals.ts
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
+import { isAgentNotFoundError } from '@kbn/agent-builder-common';
 import { schema } from '@kbn/config-schema';
 import type { RouteDependencies } from '../types';
 import { getHandlerWrapper } from '../wrap_handler';
 import { AGENTS_WRITE_SECURITY } from '../route_security';
+import type { InternalAgentDefinition } from '../../services/agents/agent_registry';
+import { hasAgentUseAccess } from '../../services/agents/access_control';
 
 /**
  * Picker endpoints for the access flyout.
@@ -18,7 +21,12 @@ import { AGENTS_WRITE_SECURITY } from '../route_security';
  * `manage_security` is tracked separately; role grants will land in V2 once that
  * change is in.
  */
-export function registerAccessPrincipalsRoutes({ router, logger, coreSetup }: RouteDependencies) {
+export function registerAccessPrincipalsRoutes({
+  router,
+  logger,
+  coreSetup,
+  getInternalServices,
+}: RouteDependencies) {
   const wrapHandler = getHandlerWrapper({ logger });
 
   // Suggest user profiles (browser calls coreStart.userProfile.suggest pointing here).
@@ -31,6 +39,7 @@ export function registerAccessPrincipalsRoutes({ router, logger, coreSetup }: Ro
           name: schema.string({ minLength: 0, maxLength: 256 }),
           size: schema.maybe(schema.number({ min: 1, max: 100 })),
           dataPath: schema.maybe(schema.string()),
+          agent_id: schema.maybe(schema.string({ maxLength: 256 })),
         }),
       },
       options: { access: 'internal' },
@@ -53,7 +62,34 @@ export function registerAccessPrincipalsRoutes({ router, logger, coreSetup }: Ro
         },
       });
 
-      return response.ok({ body: profiles });
+      const { agent_id: agentId } = request.body;
+      if (!agentId) {
+        return response.ok({ body: profiles });
+      }
+
+      const { agents } = getInternalServices();
+      let agent: InternalAgentDefinition;
+      try {
+        const registry = await agents.getRegistry({ request });
+        agent = await registry.get(agentId);
+      } catch (error) {
+        if (isAgentNotFoundError(error)) {
+          return response.ok({ body: profiles });
+        }
+        throw error;
+      }
+
+      return response.ok({
+        body: profiles.map((profile) => ({
+          ...profile,
+          has_agent_access: hasAgentUseAccess({
+            accessControl: agent.access_control,
+            owner: agent.created_by,
+            currentUser: { id: profile.uid, username: profile.user.username },
+            isAdmin: false,
+          }),
+        })),
+      });
     })
   );
 }

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/conversations_access_control_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/conversations_access_control_api.spec.ts
@@ -8,6 +8,7 @@
 import { randomUUID } from 'crypto';
 import {
   AgentAccessControlMode,
+  AgentAccessControlRole,
   CONVERSATION_ACCESS_CONTROL_MAX_ENTRIES,
   ConversationAccessControlMode,
   ConversationAccessControlRole,
@@ -27,6 +28,7 @@ import type {
 } from '../../../../common/http_api/conversations';
 import { setupAgentDirectAnswer } from '../../../scout_agent_builder_shared/lib/proxy_scenario';
 import { internalApiPath, publicApiPath } from '../../../../common/constants';
+import type { AuthedApiClient } from '../../../scout_agent_builder_shared/lib/authed_api_client';
 import { apiTest } from '../fixtures';
 import {
   CHAT_CONVERSATIONS_INDEX,
@@ -101,6 +103,11 @@ apiTest.describe(
       username: `${ACCESS_CONTROL_TEST_PREFIX}-bob-${testRunId}`,
       password: 'bob-password',
     };
+    const eve = {
+      roleName: `${ACCESS_CONTROL_TEST_PREFIX}-eve-role-${testRunId}`,
+      username: `${ACCESS_CONTROL_TEST_PREFIX}-eve-${testRunId}`,
+      password: 'eve-password',
+    };
     // No Agent Builder privileges. Used to assert route-level privilege gates.
     const noAccess = {
       roleName: `${ACCESS_CONTROL_TEST_PREFIX}-no-access-role-${testRunId}`,
@@ -108,7 +115,7 @@ apiTest.describe(
       password: 'no-access-password',
     };
 
-    const allPrincipals = [alice, bob, noAccess];
+    const allPrincipals = [alice, bob, eve, noAccess];
 
     let adminCookie: Record<string, string>;
     let llmProxy: LlmProxy;
@@ -176,7 +183,7 @@ apiTest.describe(
 
       connectorId = await createConnectorForSpace(kbnClient, llmProxy);
 
-      for (const { roleName } of [alice, bob]) {
+      for (const { roleName } of [alice, bob, eve]) {
         await kbnClient.request({
           method: 'PUT',
           path: `/api/security/role/${encodeURIComponent(roleName)}`,
@@ -298,6 +305,23 @@ apiTest.describe(
         {
           headers: headersFor(user),
           body: { access_control: { access_mode: accessMode } },
+          responseType: 'json',
+        }
+      );
+      expect(response).toHaveStatusCode(200);
+    };
+
+    const setAgentAccessControlAs = async (
+      apiClient: AuthedApiClient,
+      user: { username: string; password: string },
+      agentId: string,
+      entries: Array<{ type: 'user'; name: string; role: AgentAccessControlRole }>
+    ) => {
+      const response = await apiClient.put(
+        `${accessControlApiBase}/agents/${encodeURIComponent(agentId)}/access_control`,
+        {
+          headers: headersFor(user),
+          body: { entries },
           responseType: 'json',
         }
       );
@@ -1073,6 +1097,157 @@ apiTest.describe(
         });
       }
     );
+
+    apiTest(
+      'a conversation member needs access to its private backing agent',
+      async ({ apiClient }) => {
+        const sharedAgentId = `${ACCESS_CONTROL_TEST_PREFIX}-member-id-agent-${testRunId.slice(
+          0,
+          8
+        )}`;
+        await createAgentAs(
+          apiClient,
+          alice,
+          mockAgent(sharedAgentId, AgentAccessControlMode.Shared)
+        );
+        const bobConversation = await createConversationAs({
+          apiClient,
+          user: bob,
+          agentId: sharedAgentId,
+          input: 'Bob stable id probe',
+          title: 'Bob Stable Id Probe',
+        });
+        const bobId = await resolveStableUserId(apiClient, bob, bobConversation.conversation_id);
+
+        const privateAgentId = `${ACCESS_CONTROL_TEST_PREFIX}-private-member-agent-${testRunId.slice(
+          0,
+          8
+        )}`;
+        await createAgentAs(
+          apiClient,
+          alice,
+          mockAgent(privateAgentId, AgentAccessControlMode.Private)
+        );
+        const aliceConversation = await createConversationAs({
+          apiClient,
+          user: alice,
+          agentId: privateAgentId,
+          input: 'Private agent sharing test',
+          title: 'Private Agent Sharing Test',
+        });
+        const conversationId = aliceConversation.conversation_id;
+
+        await setAccessControlAs(apiClient, alice, conversationId, {
+          access_mode: ConversationAccessControlMode.Private,
+          entries: [{ type: 'user', id: bobId, role: ConversationAccessControlRole.Member }],
+        });
+
+        await apiTest.step(
+          'Bob cannot access the shared conversation before agent access',
+          async () => {
+            expect(await getConversationAs(apiClient, bob, conversationId)).toHaveStatusCode(404);
+            expect(await listConversationIdsAs(apiClient, bob)).not.toContain(conversationId);
+
+            const continueResponse = await apiClient.post(`${accessControlApiBase}/converse`, {
+              headers: headersFor(bob),
+              body: {
+                agent_id: privateAgentId,
+                conversation_id: conversationId,
+                input: 'Bob private-agent follow-up',
+                connector_id: connectorId,
+                _execution_mode: 'local',
+              },
+              responseType: 'json',
+            });
+            expect(continueResponse).toHaveStatusCode(404);
+          }
+        );
+
+        await apiTest.step('Bob gains access after the private agent is shared', async () => {
+          await setAgentAccessControlAs(apiClient, alice, privateAgentId, [
+            { type: 'user', name: bob.username, role: AgentAccessControlRole.User },
+          ]);
+
+          expect(await getConversationAs(apiClient, bob, conversationId)).toHaveStatusCode(200);
+          expect(await listConversationIdsAs(apiClient, bob)).toContain(conversationId);
+
+          await setupAgentDirectAnswer({
+            proxy: llmProxy,
+            response: 'Response to: Bob private-agent follow-up',
+            continueConversation: true,
+          });
+          const continueResponse = await apiClient.post(`${accessControlApiBase}/converse`, {
+            headers: headersFor(bob),
+            body: {
+              agent_id: privateAgentId,
+              conversation_id: conversationId,
+              input: 'Bob private-agent follow-up',
+              connector_id: connectorId,
+              _execution_mode: 'local',
+            },
+            responseType: 'json',
+          });
+          expect(continueResponse).toHaveStatusCode(200);
+          await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+        });
+      }
+    );
+
+    apiTest('user suggestions report access to the selected agent', async ({ apiClient }) => {
+      const publicAgentId = `${ACCESS_CONTROL_TEST_PREFIX}-suggest-public-${testRunId.slice(0, 8)}`;
+      const sharedAgentId = `${ACCESS_CONTROL_TEST_PREFIX}-suggest-shared-${testRunId.slice(0, 8)}`;
+      const privateAgentId = `${ACCESS_CONTROL_TEST_PREFIX}-suggest-private-${testRunId.slice(
+        0,
+        8
+      )}`;
+      await createAgentAs(
+        apiClient,
+        alice,
+        mockAgent(publicAgentId, AgentAccessControlMode.Public)
+      );
+      await createAgentAs(
+        apiClient,
+        alice,
+        mockAgent(sharedAgentId, AgentAccessControlMode.Shared)
+      );
+      await createAgentAs(
+        apiClient,
+        alice,
+        mockAgent(privateAgentId, AgentAccessControlMode.Private)
+      );
+      await setAgentAccessControlAs(apiClient, alice, privateAgentId, [
+        { type: 'user', name: bob.username, role: AgentAccessControlRole.User },
+      ]);
+
+      const suggest = async (agentId: string, username: string) => {
+        const response = await apiClient.post(
+          `${accessControlInternalBase}/_suggest_user_profiles`,
+          {
+            headers: headersFor(alice),
+            body: { name: username, agent_id: agentId },
+            responseType: 'json',
+          }
+        );
+        expect(response).toHaveStatusCode(200);
+        const profile = (
+          response.body as Array<{
+            user: { username: string };
+            has_agent_access?: boolean;
+          }>
+        ).find(({ user }) => user.username === username);
+        expect(profile).toBeDefined();
+        if (!profile) {
+          throw new Error(`Expected a suggested profile for ${username}`);
+        }
+        return profile;
+      };
+
+      expect((await suggest(publicAgentId, eve.username)).has_agent_access).toBe(true);
+      expect((await suggest(sharedAgentId, eve.username)).has_agent_access).toBe(true);
+      expect((await suggest(privateAgentId, alice.username)).has_agent_access).toBe(true);
+      expect((await suggest(privateAgentId, bob.username)).has_agent_access).toBe(true);
+      expect((await suggest(privateAgentId, eve.username)).has_agent_access).toBe(false);
+    });
 
     // ── cluster admin management ────────────────────────────────────────────
 

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/conversations_access_control_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/conversations_access_control_api.spec.ts
@@ -1215,6 +1215,27 @@ apiTest.describe(
         alice,
         mockAgent(privateAgentId, AgentAccessControlMode.Private)
       );
+      await createConversationAs({
+        apiClient,
+        user: alice,
+        agentId: publicAgentId,
+        input: 'Alice user profile probe',
+        title: 'Alice User Profile Probe',
+      });
+      await createConversationAs({
+        apiClient,
+        user: bob,
+        agentId: publicAgentId,
+        input: 'Bob user profile probe',
+        title: 'Bob User Profile Probe',
+      });
+      await createConversationAs({
+        apiClient,
+        user: eve,
+        agentId: publicAgentId,
+        input: 'Eve user profile probe',
+        title: 'Eve User Profile Probe',
+      });
       await setAgentAccessControlAs(apiClient, alice, privateAgentId, [
         { type: 'user', name: bob.username, role: AgentAccessControlRole.User },
       ]);

--- a/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
@@ -145,5 +145,6 @@
     "@kbn/storybook",
     "@kbn/context-engine-plugin",
     "@kbn/ui-callout",
+    "@kbn/core-user-profile-common",
   ]
 }


### PR DESCRIPTION
## Summary

Closes #283226
Closes #283227

- add agent-access hints to internal user-profile suggestions
- cover private backing-agent access and suggestion hints in Scout API tests
- add route-level coverage for omitted, unreadable, public/shared, and private agents

## Manual test

Set `KIBANA_URL`, `ELASTIC_API_KEY`, and `AGENT_ID` for an agent the caller can read.

```sh
curl -sS -X POST "$KIBANA_URL/internal/agent_builder/_suggest_user_profiles" \
  -H "Authorization: ApiKey $ELASTIC_API_KEY" \
  -H "kbn-xsrf: true" \
  -H "elastic-api-version: 2023-10-31" \
  -H "Content-Type: application/json" \
  --data "{\"name\": \"<username>\", \"agent_id\": \"$AGENT_ID\"}"
```

The matching profile includes `has_agent_access`. It is `true` for public/shared agents and for a private agent owner or explicitly granted user; it is `false` for other users.

```sh
curl -sS -X POST "$KIBANA_URL/internal/agent_builder/_suggest_user_profiles" \
  -H "Authorization: ApiKey $ELASTIC_API_KEY" \
  -H "kbn-xsrf: true" \
  -H "elastic-api-version: 2023-10-31" \
  -H "Content-Type: application/json" \
  --data "{\"name\": \"<username>\"}"
```

Without `agent_id`, the response retains the existing user-profile shape and omits `has_agent_access`.