### PR TITLE
[ResponseOps][Alerting] Heal UIAM API keys for rules that report failures without throwing

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.test.ts
@@ -14,7 +14,11 @@ import { ErrorWithReason } from '../../lib/error_with_reason';
 import { RuleExecutionStatusErrorReasons } from '../../types';
 import type { RawRule } from '../../types';
 import { ApiKeyType, type TaskRunnerContext } from '../types';
-import { isMissingUiamApiKeyRunError, repairUiamApiKey } from './repair_uiam_api_key';
+import {
+  isMissingUiamApiKeyLastRunError,
+  isMissingUiamApiKeyRunError,
+  repairUiamApiKey,
+} from './repair_uiam_api_key';
 
 const logger = loggingSystemMock.create().get() as jest.Mocked<Logger>;
 
@@ -130,6 +134,63 @@ describe('isMissingUiamApiKeyRunError()', () => {
     error.cause = error;
 
     expect(isMissingUiamApiKeyRunError(error)).toBe(false);
+  });
+});
+
+describe('isMissingUiamApiKeyLastRunError()', () => {
+  // Both messages are the text production actually records, taken from `siem.*` runs in
+  // production eu-west-1. Neither retains the structured Elasticsearch error, which is why these
+  // runs are matched on the message rather than through isMissingUiamApiKeyRunError().
+  const STRINGIFIED_RESPONSE_ERROR = [
+    'security_exception',
+    '\tCaused by:',
+    '\t\tsecurity_exception: failed to authenticate cloud API key: [0x28D520]',
+    '\tRoot causes:',
+    '\t\tsecurity_exception: failed to authenticate cloud API key: [0x28D520]',
+  ].join('\n');
+
+  const WRAPPED_BY_RULE_TYPE = `unable to fetch exception list items, message: "${STRINGIFIED_RESPONSE_ERROR}" full error: "ResponseError: ${STRINGIFIED_RESPONSE_ERROR}"`;
+
+  test('returns true for a stringified Elasticsearch error the rule type recorded as-is', () => {
+    expect(
+      isMissingUiamApiKeyLastRunError([{ message: STRINGIFIED_RESPONSE_ERROR, userError: false }])
+    ).toBe(true);
+  });
+
+  test('returns true when the rule type wrapped the error in its own message', () => {
+    expect(
+      isMissingUiamApiKeyLastRunError([{ message: WRAPPED_BY_RULE_TYPE, userError: false }])
+    ).toBe(true);
+  });
+
+  test('returns true when only one of several recorded errors reports the missing key', () => {
+    expect(
+      isMissingUiamApiKeyLastRunError([
+        { message: 'a different rule execution problem', userError: false },
+        { message: STRINGIFIED_RESPONSE_ERROR, userError: false },
+      ])
+    ).toBe(true);
+  });
+
+  test('requires the full Elasticsearch phrase, not just the code', () => {
+    // A detection rule searching for authentication failures can put the bare code into its own
+    // error text; re-granting a key off that would be wrong.
+    expect(
+      isMissingUiamApiKeyLastRunError([
+        { message: 'found 3 documents matching "0x28D520"', userError: false },
+      ])
+    ).toBe(false);
+  });
+
+  test('ignores errors the rule author is responsible for', () => {
+    expect(
+      isMissingUiamApiKeyLastRunError([{ message: STRINGIFIED_RESPONSE_ERROR, userError: true }])
+    ).toBe(false);
+  });
+
+  test('returns false for unrelated or absent run errors', () => {
+    expect(isMissingUiamApiKeyLastRunError([])).toBe(false);
+    expect(isMissingUiamApiKeyLastRunError([{ message: 'boom', userError: false }])).toBe(false);
   });
 });
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/repair_uiam_api_key.ts
@@ -10,6 +10,7 @@ import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { UIAM_LOGS_REPAIR_TAGS } from '../../constants';
 import { bulkMarkApiKeysForInvalidation } from '../../invalidate_pending_api_keys/bulk_mark_api_keys_for_invalidation';
 import { isErrorWithReason } from '../../lib/error_with_reason';
+import type { RuleResultServiceResults } from '../../monitoring/rule_result_service';
 import { API_KEY_PENDING_INVALIDATION_TYPE, RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
 import type { RawRule } from '../../types';
 import { getDecryptedRule } from '../rule_loader';
@@ -74,6 +75,34 @@ export const isMissingUiamApiKeyRunError = (error: unknown): boolean => {
 
   return false;
 };
+
+/**
+ * Elasticsearch's own wording for {@link UIAM_API_KEY_MISSING_CODE}, matched in full rather than by
+ * the bare code.
+ *
+ * A recorded run error carries nothing but a message: rule types that report a failed run instead of
+ * throwing flatten the Elasticsearch error into text, leaving no `statusCode` or
+ * `authentication_error_code` to test. Requiring the whole phrase keeps a re-grant from being
+ * triggered by a rule whose own error text happens to quote the code — a real possibility for
+ * detection rules that search for authentication failures.
+ */
+const UIAM_API_KEY_MISSING_MESSAGE = `failed to authenticate cloud API key: [${UIAM_API_KEY_MISSING_CODE}]`;
+
+/**
+ * Returns true when a rule reported a failed run because UIAM no longer knows the API key it
+ * authenticated with, for rule types that record the failure instead of throwing it — Security
+ * Solution's detection rules report through {@link RuleResultService}, so the run never reaches the
+ * task runner's catch and {@link isMissingUiamApiKeyRunError} never sees the error.
+ *
+ * `userError` errors are ignored: those are the rule author's to fix and do not describe a
+ * credential Kibana granted.
+ */
+export const isMissingUiamApiKeyLastRunError = (
+  errors: RuleResultServiceResults['errors']
+): boolean =>
+  errors.some(
+    ({ message, userError }) => !userError && message.includes(UIAM_API_KEY_MISSING_MESSAGE)
+  );
 
 /**
  * Re-grants a rule's unusable UIAM API key by converting its Elasticsearch API key into a fresh

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -107,6 +107,7 @@ import {
 } from './maintenance_windows/maintenance_windows_service.mock';
 import { ErrorWithType } from '../lib/error_with_type';
 import { eventLogClientMock } from '@kbn/event-log-plugin/server/mocks';
+import { repairUiamApiKey } from './lib/repair_uiam_api_key';
 
 const RULE_EXECUTION_UUID = '5f6aa57d-3e22-484e-bae8-cbed868f4d28';
 jest.mock('uuid', () => ({
@@ -119,6 +120,14 @@ jest.mock('../lib/wrap_scoped_cluster_client', () => ({
 
 jest.mock('../lib/alerting_event_logger/alerting_event_logger');
 jest.mock('../monitoring/rule_result_service');
+
+// The real detection helpers are kept so these tests exercise the actual matching; only the
+// side-effecting re-grant is stubbed.
+jest.mock('./lib/repair_uiam_api_key', () => ({
+  ...jest.requireActual('./lib/repair_uiam_api_key'),
+  repairUiamApiKey: jest.fn(),
+}));
+const mockRepairUiamApiKey = repairUiamApiKey as jest.MockedFunction<typeof repairUiamApiKey>;
 
 jest.mock('../rules_client/lib/get_alert_from_raw');
 const mockGetRuleFromRaw = getAlertFromRaw as jest.MockedFunction<typeof getAlertFromRaw>;
@@ -3520,6 +3529,77 @@ describe('Task Runner', () => {
         tags: ['rule-run-failed', 'framework-error'],
       }
     );
+  });
+
+  test('re-grants the UIAM API key when the rule type throws a missing key error', async () => {
+    mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
+
+    ruleType.executor.mockImplementation(async () => {
+      throw Object.assign(new Error('security_exception'), {
+        statusCode: 401,
+        body: {
+          error: {
+            type: 'security_exception',
+            caused_by: { authentication_error_code: '0x28D520' },
+          },
+        },
+      });
+    });
+
+    const taskRunner = createTaskRunner();
+
+    await taskRunner.run();
+
+    expect(mockRepairUiamApiKey).toHaveBeenCalledTimes(1);
+    expect(mockRepairUiamApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({ ruleId: '1', spaceId: 'default' })
+    );
+  });
+
+  test('re-grants the UIAM API key when a rule reports a missing key without throwing', async () => {
+    // Security Solution's detection rules record a failed run rather than throwing, so the error
+    // never reaches the catch in run() and only survives as the recorded message.
+    mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
+
+    const taskRunner = createTaskRunner();
+
+    ruleResultService.getLastRunResults.mockImplementation(() => ({
+      errors: [
+        {
+          message:
+            'unable to fetch exception list items, message: "security_exception\n\tCaused by:\n\t\tsecurity_exception: failed to authenticate cloud API key: [0x28D520]"',
+          userError: false,
+        },
+      ],
+      warnings: [],
+      outcomeMessage: '',
+    }));
+
+    await taskRunner.run();
+
+    expect(mockRepairUiamApiKey).toHaveBeenCalledTimes(1);
+    expect(mockRepairUiamApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({ ruleId: '1', spaceId: 'default' })
+    );
+  });
+
+  test('does not re-grant the UIAM API key for an unrelated reported failure', async () => {
+    mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
+
+    const taskRunner = createTaskRunner();
+
+    ruleResultService.getLastRunResults.mockImplementation(() => ({
+      errors: [{ message: 'an error occurred', userError: false }],
+      warnings: [],
+      outcomeMessage: '',
+    }));
+
+    await taskRunner.run();
+
+    expect(mockRepairUiamApiKey).not.toHaveBeenCalled();
   });
 
   test('returns user error if all the errors reported by getLastRunResults are user error', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -36,7 +36,7 @@ import type {
 import type { RawRuleSnoozedInstance } from '../saved_objects/schemas/raw_rule';
 import { RuleExecutionStatusErrorReasons } from '../types';
 import type { Result } from '../lib/result_type';
-import { asErr, asOk, isOk } from '../lib/result_type';
+import { asErr, asOk, isErr, isOk } from '../lib/result_type';
 import { taskInstanceToAlertTaskInstance } from './alert_task_instance';
 import {
   atomicRemoveSnoozedInstancesWithEs,
@@ -83,7 +83,11 @@ import {
 // helpers such as `withAlertingSpan`, so adding a module with heavy dependencies to it changes module
 // initialization order for every importer and closes an import cycle that leaves
 // `DEFAULT_APP_CATEGORIES` undefined in `alert_deletion_client`.
-import { isMissingUiamApiKeyRunError, repairUiamApiKey } from './lib/repair_uiam_api_key';
+import {
+  isMissingUiamApiKeyLastRunError,
+  isMissingUiamApiKeyRunError,
+  repairUiamApiKey,
+} from './lib/repair_uiam_api_key';
 import {
   ErrorWithType,
   isOutdatedTaskVersionError,
@@ -913,14 +917,21 @@ export class TaskRunner<
       runRuleResult = asErr(err);
       schedule = asErr(err);
       shouldDisableTask = err.reason === RuleExecutionStatusErrorReasons.Disabled;
+    }
 
-      // The rule's UIAM API key is unusable, so re-grant it now: the rule's next scheduled run then
-      // authenticates with a working credential instead of failing the same way indefinitely.
-      if (isMissingUiamApiKeyRunError(err)) {
-        await withAlertingSpan('alerting:repair-uiam-api-key', () =>
-          repairUiamApiKey({ context: this.context, logger: this.logger, ruleId, spaceId })
-        );
-      }
+    // The rule's UIAM API key is unusable, so re-grant it now: the rule's next scheduled run then
+    // authenticates with a working credential instead of failing the same way indefinitely.
+    //
+    // Both shapes a failed run can take have to be checked. A rule type that throws leaves the
+    // Elasticsearch error on `runRuleResult`, while one that reports a failed run without throwing
+    // never enters the catch above at all and only exposes the failure as a recorded run error.
+    if (
+      (isErr(runRuleResult) && isMissingUiamApiKeyRunError(runRuleResult.error)) ||
+      isMissingUiamApiKeyLastRunError(this.ruleResult.getLastRunResults().errors)
+    ) {
+      await withAlertingSpan('alerting:repair-uiam-api-key', () =>
+        repairUiamApiKey({ context: this.context, logger: this.logger, ruleId, spaceId })
+      );
     }
 
     await withAlertingSpan('alerting:process-run-results-and-update-rule', () =>


### PR DESCRIPTION
## Summary

Resolves a coverage gap in the UIAM API key self-heal added by #285222.

The re-grant is hooked into the `catch` around `runRule()` in the rule task runner, so it only fires when a rule type **throws**. Rule types that report a failed run *without* throwing never reach it. Security Solution's detection rules work this way: the rule type wrapper catches the error, records it through `RuleResultService.addLastRunError()`, and returns normally. The failure resurfaces later in `getTaskRunError()`, which builds a fresh `Error` from the joined message strings — so by then there is no `statusCode` or `authentication_error_code` left for `isMissingUiamApiKeyRunError()` to match, and the healer was never invoked in the first place.

The result is that these rules fail with `0x28D520` on every scheduled run indefinitely, exactly the situation #285222 was meant to end.

### Production evidence

A ~2.5h window in production eu-west-1, after all remaining `apiKeyType: "es"` pins were removed:

| Path | Failures | Re-grants |
|---|---|---|
| Rule types that throw (`es-query`, `apm.*`, `synthetics.*`, `custom_threshold`, `ml.anomaly_detection_alert`) | 36 | **36** |
| `siem.*` (`queryRule`, `newTermsRule`, `mlRule`, `eqlRule`) | 63 | **0** |

The first row is 1:1 across 13 projects, and the count plateaued — each rule was repaired once and stopped failing. The `siem.*` count kept climbing for the whole window, because nothing ever repaired those keys.

## What this changes

`isMissingUiamApiKeyLastRunError()` inspects the errors a rule *recorded* for its last run, and the task runner now checks it alongside the existing thrown-error path.

Because a recorded run error carries nothing but a message, this necessarily matches on text. Two things keep that narrow:

- It requires Elasticsearch's full phrase, `failed to authenticate cloud API key: [0x28D520]`, rather than the bare code. A detection rule that searches for authentication failures can legitimately have the code in its own error text, and that must not trigger a credential re-grant.
- It ignores errors flagged `userError`, which are the rule author's to fix and never describe a credential Kibana granted.

The existing re-grant call was also moved out of the `catch` so that both detection paths share a single call site. This keeps the ordering relative to `processRunResults()` unchanged and makes it impossible to re-grant twice in one run.

## Scope

This covers failures a rule *records*. It deliberately does not address errors that are never recorded at all — `fetchRuleExecutionSettings()` in Security Solution catches a `0x28D520` and returns defaults, so the run reports no failure and there is nothing for either predicate to inspect. That path accounted for a further 146 log entries in the same window and needs a separate fix; it is tracked in elastic/response-ops-team#704.

## Testing

- `isMissingUiamApiKeyLastRunError()` is covered against the verbatim message text produced by `siem.*` rules in production, in both shapes observed: the raw stringified `ResponseError`, and the variant the rule type wraps in its own message. Negative cases cover the bare code without the phrase, `userError` errors, and unrelated failures.
- Task runner tests now cover all three outcomes: a rule type that throws the error and heals, one that records it without throwing and heals, and one that records an unrelated failure and is left alone. The re-grant itself is mocked while both predicates run for real, so the wiring is exercised.

### Checklist

- [x] Unit tests updated and passing (`repair_uiam_api_key.test.ts`, `task_runner.test.ts`)
- [x] Typecheck and lint clean for the alerting plugin
