### PR TITLE
[Streams] Un-skip Stream data quality scout UI tests

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/.meta/ui/standard.json
@@ -30,7 +30,7 @@
     {
       "id": "c0229d5f01d9765-673bfeac807f871",
       "title": "Stream data quality should show data quality metrics",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -39,14 +39,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 73,
-        "column": 25
+        "line": 94,
+        "column": 61
       }
     },
     {
       "id": "c0229d5f01d9765-ccd2761d79f84f2",
       "title": "Stream data quality date picker should show same time range as Streams Main page",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -55,14 +55,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 81,
-        "column": 7
+        "line": 102,
+        "column": 25
       }
     },
     {
       "id": "c0229d5f01d9765-690079b58151ce0",
       "title": "Stream data quality changing time range should also update date picker on Streams Main page",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -71,14 +71,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 98,
-        "column": 7
+        "line": 118,
+        "column": 13
       }
     },
     {
       "id": "c0229d5f01d9765-f71d78d4ae9a924",
       "title": "Stream data quality time range should persist after page refresh on Data Quality tab",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -87,14 +87,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 109,
-        "column": 13
+        "line": 129,
+        "column": 25
       }
     },
     {
       "id": "c0229d5f01d9765-4469d65a10929c8",
       "title": "Stream data quality time range should persist after page refresh on Retention tab",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -103,14 +103,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 122,
-        "column": 11
+        "line": 141,
+        "column": 7
       }
     },
     {
       "id": "c0229d5f01d9765-ee97b0d5664f74d",
       "title": "Stream data quality time range should be globally synced across all tabs",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -119,14 +119,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 148,
+        "line": 168,
         "column": 7
       }
     },
     {
       "id": "c0229d5f01d9765-4775d23430ce410",
       "title": "Stream data quality should toggle between degraded and failed docs quality issues charts",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -135,14 +135,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 165,
-        "column": 24
+        "line": 187,
+        "column": 13
       }
     },
     {
       "id": "c0229d5f01d9765-d433732b148e845",
       "title": "Stream data quality should show degraded fields table with data",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -151,14 +151,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 173,
-        "column": 9
+        "line": 195,
+        "column": 25
       }
     },
     {
       "id": "c0229d5f01d9765-dd8fbacadb48e67",
       "title": "Stream data quality should open and close degraded field flyout",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -167,14 +167,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 196,
+        "line": 210,
         "column": 24
       }
     },
     {
       "id": "c0229d5f01d9765-20b23641495bf7b",
       "title": "Stream data quality should navigate to Discover from degraded field flyout",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -183,14 +183,14 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 218,
-        "column": 66
+        "line": 226,
+        "column": 25
       }
     },
     {
       "id": "c0229d5f01d9765-27ee667d7063050",
       "title": "Stream data quality should edit failure store for wired streams",
-      "expectedStatus": "skipped",
+      "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
         "@cloud-stateful-classic",
@@ -199,8 +199,8 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 234,
-        "column": 13
+        "line": 237,
+        "column": 7
       }
     }
   ]

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/fixtures/data_quality_helpers.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/fixtures/data_quality_helpers.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { type ScoutPage } from '@kbn/scout';
+import { type Locator, type ScoutPage } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
+
+const FAILED_DOCS_ISSUE = 'Documents indexing failed';
 
 /**
  * Saves failure store changes in the shared failure store modal
@@ -16,4 +18,55 @@ export async function saveFailureStoreChanges(page: ScoutPage): Promise<void> {
   const saveButton = page.getByTestId('failureStoreModalSaveButton');
   await expect(saveButton).toBeEnabled();
   await saveButton.click();
+}
+
+export function getQualityIssueRow(table: Locator, issue: string): Locator {
+  return table.getByTestId('datasetQualityDetailsDegradedTableRow').filter({ hasText: issue });
+}
+
+/**
+ * Waits for the quality issues table to show the degraded field and the failed docs rows.
+ * Both are fetched independently and each response re-sorts the table, so interacting with a
+ * row before the two have landed can hit a row that has just been re-pointed at the other issue.
+ */
+export async function waitForQualityIssuesTable(
+  page: ScoutPage,
+  degradedField: string
+): Promise<Locator> {
+  const table = page.getByTestId('datasetQualityDetailsDegradedFieldTable');
+  await expect(table).toBeVisible();
+  await expect(getQualityIssueRow(table, degradedField)).toBeVisible();
+  await expect(getQualityIssueRow(table, FAILED_DOCS_ISSUE)).toBeVisible();
+  return table;
+}
+
+/**
+ * Expands the quality issue of a degraded field and returns its flyout.
+ */
+export async function openDegradedFieldFlyout(
+  page: ScoutPage,
+  degradedField: string
+): Promise<Locator> {
+  const table = await waitForQualityIssuesTable(page, degradedField);
+  await getQualityIssueRow(table, degradedField)
+    .getByTestId('datasetQualityDetailsQualityIssuesExpandButton')
+    .click();
+
+  const flyout = page.getByTestId('datasetQualityDetailsDegradedFieldFlyout');
+  await expect(flyout).toBeVisible();
+  return flyout;
+}
+
+/**
+ * Waits for the failed documents KPI card to hold a resolved value. The card renders a `--`
+ * placeholder while the data stream details load and is swapped for the "No failure store" card
+ * when the stream has no failure store, so it is only actionable once the details have loaded.
+ */
+export async function waitForFailedDocsCard(page: ScoutPage): Promise<Locator> {
+  const card = page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents');
+  await expect(card).toBeVisible();
+  await expect(
+    card.getByTestId('datasetQualityDetailsSummaryKpiValue-Failed documents')
+  ).not.toHaveText('--');
+  return card;
 }

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts
@@ -9,21 +9,28 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 import { test } from '../fixtures';
 import { generateLogsData } from '../fixtures/generators';
-import { saveFailureStoreChanges } from '../fixtures/data_quality_helpers';
+import {
+  getQualityIssueRow,
+  openDegradedFieldFlyout,
+  saveFailureStoreChanges,
+  waitForFailedDocsCard,
+  waitForQualityIssuesTable,
+} from '../fixtures/data_quality_helpers';
 
 const TEST_STREAM = 'logs-nginx-default';
+const FORKED_STREAM = 'logs.otel.nginx';
+const DEGRADED_FIELD = 'log.level';
 
-// Failing: See https://github.com/elastic/kibana/issues/267204
-test.describe.skip(
+test.describe(
   'Stream data quality',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
-    test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+    test.beforeAll(async ({ apiServices, esClient, logsSynthtraceEsClient }) => {
       const currentTime = Date.now();
       const generateLogs = generateLogsData(logsSynthtraceEsClient);
 
       // Create a test stream with routing rules first
-      await apiServices.streams.forkStream('logs.otel', 'logs.otel.nginx', {
+      await apiServices.streams.forkStream('logs.otel', FORKED_STREAM, {
         field: 'service.name',
         eq: 'nginx',
       });
@@ -46,17 +53,26 @@ test.describe.skip(
         isMalformed: true,
       });
 
-      // Add a processor that always fails to create failed docs
-      await apiServices.streams.updateStreamProcessors(TEST_STREAM, {
-        steps: [
-          {
-            action: 'rename',
-            from: 'non_existent_field',
-            to: 'renamed_field',
-            ignore_missing: false,
-            override: false,
+      // Add a processor that always fails to create failed docs, and enable the failure store so
+      // those docs are stored instead of dropped: classic streams inherit it from the index
+      // template, which enables it on stateful but not on serverless
+      const { stream } = await apiServices.streams.getStreamDefinition(TEST_STREAM);
+      await apiServices.streams.updateStream(TEST_STREAM, {
+        ingest: {
+          ...stream.ingest,
+          processing: {
+            steps: [
+              {
+                action: 'rename',
+                from: 'non_existent_field',
+                to: 'renamed_field',
+                ignore_missing: false,
+                override: false,
+              },
+            ],
           },
-        ],
+          failure_store: { lifecycle: { enabled: {} } },
+        },
       });
 
       // Add 1 failed doc
@@ -66,6 +82,29 @@ test.describe.skip(
         endTime: new Date(currentTime).toISOString(),
         docsPerMinute: 1,
       });
+
+      // The failure store is a separate index that the synthtrace refresh doesn't cover and that
+      // refreshes on its own interval (30s on serverless), so refresh it until the failed document
+      // is searchable for the UI
+      const failureStoreIndex = `${TEST_STREAM}::failures`;
+      await expect
+        .poll(
+          async () => {
+            await esClient.indices.refresh({
+              index: failureStoreIndex,
+              allow_no_indices: true,
+              ignore_unavailable: true,
+            });
+            const { count } = await esClient.count({
+              index: failureStoreIndex,
+              allow_no_indices: true,
+              ignore_unavailable: true,
+            });
+            return count;
+          },
+          { timeout: 60_000 }
+        )
+        .toBeGreaterThan(0);
     });
 
     test.beforeEach(async ({ browserAuth, pageObjects }) => {
@@ -74,8 +113,9 @@ test.describe.skip(
     });
 
     test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-      // Clear existing rules
-      await apiServices.streams.clearStreamChildren('logs.otel');
+      // Delete only the fork this suite created, so unrelated children of the shared
+      // `logs.otel` root are left untouched
+      await apiServices.streams.deleteStream(FORKED_STREAM);
       // Clean up the test stream
       await apiServices.streams.deleteStream(TEST_STREAM);
       // Clean up synthetic logs
@@ -87,12 +127,10 @@ test.describe.skip(
       await expect(
         page.getByTestId('datasetQualityDetailsSummaryKpiCard-Degraded documents')
       ).toBeVisible();
-      await expect(
-        page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents')
-      ).toBeVisible();
+      const failedDocsCard = await waitForFailedDocsCard(page);
 
-      // Edit failure store button should not be visible for wired streams
-      await page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents').click();
+      // Edit failure store button should be visible for wired streams
+      await failedDocsCard.click();
       await expect(page.getByTestId('datasetQualityDetailsEditFailureStore')).toBeVisible();
 
       // Quality issues table should be visible
@@ -104,6 +142,7 @@ test.describe.skip(
     }) => {
       // Go to Main page
       await pageObjects.streams.gotoStreamMainPage();
+      await pageObjects.streams.expectStreamsTableVisible();
       const mainTimeRange = {
         from: 'Sep 20, 2023 @ 00:00:00.000',
         to: 'Sep 20, 2023 @ 00:30:00.000',
@@ -112,7 +151,7 @@ test.describe.skip(
       await pageObjects.datePicker.setAbsoluteRange(mainTimeRange);
 
       // Go to Data Quality tab
-      await pageObjects.streams.clickStreamNameLink('logs.otel.nginx');
+      await pageObjects.streams.clickStreamNameLink(FORKED_STREAM);
       await pageObjects.streams.clickDataQualityTab();
       await pageObjects.streams.verifyDatePickerTimeRange(mainTimeRange);
     });
@@ -200,7 +239,7 @@ test.describe.skip(
       await pageObjects.streams.verifyDatePickerTimeRange(timeRange);
 
       // Navigate to a different stream and verify time persists
-      await pageObjects.streams.clickStreamNameLink('logs.otel.nginx');
+      await pageObjects.streams.clickStreamNameLink(FORKED_STREAM);
       await pageObjects.streams.clickDataQualityTab();
       await pageObjects.streams.verifyDatePickerTimeRange(timeRange);
     });
@@ -212,13 +251,14 @@ test.describe.skip(
       await expect(page.getByTestId('datasetQualityDetailsLinkToDiscover')).toBeVisible();
 
       // Click to show failed docs chart
-      await page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents').click();
+      const failedDocsCard = await waitForFailedDocsCard(page);
+      await failedDocsCard.click();
+      await expect(failedDocsCard).toHaveAttribute('aria-pressed', 'true');
     });
 
     test('should show degraded fields table with data', async ({ page }) => {
       // Quality issues table should be visible
-      const degradedFieldTable = page.getByTestId('datasetQualityDetailsDegradedFieldTable');
-      await expect(degradedFieldTable).toBeVisible();
+      const degradedFieldTable = await waitForQualityIssuesTable(page, DEGRADED_FIELD);
 
       // Should show table headers (scope to the table to avoid ambiguity)
       await expect(degradedFieldTable.getByRole('columnheader', { name: 'Field' })).toBeVisible();
@@ -231,58 +271,33 @@ test.describe.skip(
       ).toBeVisible();
 
       // Verify there is at least one degraded field row
-      const degradedFieldRows = degradedFieldTable.locator('tbody tr');
+      const degradedFieldRows = degradedFieldTable.getByTestId(
+        'datasetQualityDetailsDegradedTableRow'
+      );
       expect(await degradedFieldRows.count()).toBeGreaterThan(0);
 
       // Verify the log.level field is present (from malformed data)
-      await expect(
-        degradedFieldTable.getByRole('row').filter({ hasText: 'log.level' })
-      ).toBeVisible();
+      await expect(getQualityIssueRow(degradedFieldTable, DEGRADED_FIELD)).toBeVisible();
     });
 
     test('should open and close degraded field flyout', async ({ page, pageObjects }) => {
-      // Wait for degraded fields table to be visible
-      const degradedFieldTable = page.getByTestId('datasetQualityDetailsDegradedFieldTable');
-      await expect(degradedFieldTable).toBeVisible();
-
-      // Get the row for log.level field (which we created as malformed)
-      const logLevelRow = degradedFieldTable.getByRole('row').filter({ hasText: 'log.level' });
-      await expect(logLevelRow).toBeVisible();
-
-      // Click on the expand button for log.level
-      await logLevelRow.locator('button[aria-label="Expand"]').click();
-
-      // Flyout should be visible
-      await expect(page.getByTestId('datasetQualityDetailsDegradedFieldFlyout')).toBeVisible();
+      // Expand the row of the log.level field (which we created as malformed)
+      const flyout = await openDegradedFieldFlyout(page, DEGRADED_FIELD);
 
       // Verify flyout shows the field name
-      await expect(page.getByTestId('datasetQualityDetailsDegradedFieldFlyout')).toContainText(
-        'log.level'
-      );
+      await expect(flyout).toContainText(DEGRADED_FIELD);
 
       // Close the flyout
       await pageObjects.streams.closeFlyout();
 
       // Flyout should be hidden
-      await expect(page.getByTestId('datasetQualityDetailsDegradedFieldFlyout')).toBeHidden();
+      await expect(flyout).toBeHidden();
     });
 
     test('should navigate to Discover from degraded field flyout', async ({ page }) => {
-      // Wait for degraded fields table to be visible
-      const degradedFieldTable = page.getByTestId('datasetQualityDetailsDegradedFieldTable');
-      await expect(degradedFieldTable).toBeVisible();
-
-      // Get the row for log.level field (which we created as malformed)
-      const logLevelRow = degradedFieldTable.getByRole('row').filter({ hasText: 'log.level' });
-      await expect(logLevelRow).toBeVisible();
-
-      // Click on the expand button for log.level
-      await logLevelRow.locator('button[aria-label="Expand"]').click();
-
-      // Flyout should be visible and show the degraded field name
-      const flyout = page.getByTestId('datasetQualityDetailsDegradedFieldFlyout');
-      await expect(flyout).toBeVisible();
-      await expect(flyout).toContainText('log.level');
+      // Expand the row of the log.level field (which we created as malformed)
+      const flyout = await openDegradedFieldFlyout(page, DEGRADED_FIELD);
+      await expect(flyout).toContainText(DEGRADED_FIELD);
 
       // Click the link to Discover in the flyout
       await page.getByTestId('datasetQualityDetailsDegradedFieldFlyoutTitleLinkToDiscover').click();
@@ -294,7 +309,8 @@ test.describe.skip(
 
     test('should edit failure store for wired streams', async ({ page }) => {
       // Open failed documents panel
-      await page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents').click();
+      const failedDocsCard = await waitForFailedDocsCard(page);
+      await failedDocsCard.click();
 
       // Click the edit button to open the failure store modal
       await page.getByTestId('datasetQualityDetailsEditFailureStore').click();


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/248951
Closes https://github.com/elastic/kibana/issues/267064

## Summary

Un-skips the `Stream data quality` Scout suite (skipped under #267204) and fixes the races behind its failures.

- The quality issues table is filled by two independent requests (degraded fields and failed docs) and re-sorted on each response. Because the table rows have no stable React keys, the expand button the test had resolved could end up belonging to the other row by the time the click landed, opening the failed docs flyout instead of the `log.level` one. Tests now wait for both rows before interacting, and click the button by its own `data-test-subj`.
- The `Failed documents` KPI card is only actionable once the data stream details have loaded (it shows a `--` placeholder meanwhile, and is replaced by the `No failure store` card otherwise), so clicks on it now wait for a resolved value.
- `beforeAll` waits for the failed document to be searchable in the failure store, which the synthtrace refresh does not cover.
- Teardown deletes only the fork this suite creates instead of clearing every child of the shared `logs.otel` root, which is what hit the streams lock with a `409`.

The date picker timeouts in #267064 were diagnosed as CI environment failures (Kibana's app shell never loaded); this adds a readiness wait on the Streams table, and the shared date picker page object has since been reworked.

### Test plan

Local, stateful classic — 3 consecutive green runs (13/13 each):

```bash
node scripts/scout start-server --arch stateful --domain classic
node scripts/playwright test --config x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts --project local --grep @local-stateful-classic
```

Local, serverless observability complete — 3 consecutive green runs (13/13 each):
```bash
node scripts/scout start-server --arch serverless --domain observability_complete
node scripts/playwright test --config x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts --project local --grep @local-serverless-observability_complete
```

Flaky test runner: `/flaky scoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts:30`

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->