### PR TITLE
[CI] Clear yarn cache after every bootstrap

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -98,8 +98,6 @@ steps:
 
   - command: .buildkite/scripts/steps/artifacts/cloud.sh
     label: 'Cloud Deployment'
-    env:
-      CLEAR_YARN_CACHE: '1'
     soft_fail:
       - exit_status: 255
       - exit_status: -1
@@ -126,8 +124,6 @@ steps:
 
   - command: KIBANA_MEMORY_SIZE=8192 .buildkite/scripts/steps/artifacts/cloud.sh
     label: 'Cloud Deployment - 8GB Kibana Node'
-    env:
-      CLEAR_YARN_CACHE: '1'
     soft_fail:
       - exit_status: 255
       - exit_status: -1

--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -429,8 +429,6 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4
@@ -446,8 +444,6 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -276,8 +276,6 @@ steps:
       - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
         label: 'Defend Workflows Cypress Tests on Serverless'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -70,8 +70,6 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -90,8 +88,6 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/node_glibc_217.yml
+++ b/.buildkite/pipelines/node_glibc_217.yml
@@ -483,8 +483,6 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -503,8 +501,6 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/node_pointer_compression.yml
+++ b/.buildkite/pipelines/node_pointer_compression.yml
@@ -485,8 +485,6 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -505,8 +503,6 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -2,8 +2,6 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows_burn.sh
     label: '[Soft fail] Defend Workflows Cypress Tests, burning changed specs'
     key: defend-workflows-burn
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
@@ -22,8 +20,6 @@ steps:
     label: '[Soft fail] Defend Workflows Cypress Tests on Serverless, burning changed specs'
     key: defend-workflows-serverless-burn
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -2,8 +2,6 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
     key: defend-workflows
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4
@@ -25,8 +23,6 @@ steps:
     label: 'Defend Workflows Cypress Tests on Serverless'
     key: defend-workflows-serverless
     if: "build.env('GITHUB_PR_TARGET_BRANCH') == 'main'"
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       enableNestedVirtualization: true
       machineType: n2-highmem-4

--- a/.buildkite/pipelines/security_solution_on_merge.yml
+++ b/.buildkite/pipelines/security_solution_on_merge.yml
@@ -451,8 +451,6 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod
@@ -474,8 +472,6 @@ steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
     label: 'Defend Workflows Cypress Tests on Serverless'
     branches: main
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
@@ -5,8 +5,6 @@ steps:
       - label: "Cypress MKI - cypress:dw:qa:serverless:run"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows.sh cypress:dw:qa:serverless:run
         key: test_defend_workflows
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -25,8 +23,6 @@ steps:
       - label: "Cypress MKI - Osquery - cypress:qa:serverless:run"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows_osquery.sh cypress:qa:serverless:run
         key: test_osquery_defend_workflows
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -45,8 +41,6 @@ steps:
       - label: "API MKI - edr_workflows:artifacts:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:artifacts:qa:serverless
         key: edr_workflows:artifacts:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -65,8 +59,6 @@ steps:
       - label: "API MKI - edr_workflows:authentication:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:authentication:qa:serverless
         key: edr_workflows:authentication:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -85,8 +77,6 @@ steps:
       - label: "API MKI - edr_workflows:metadata:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:metadata:qa:serverless
         key: edr_workflows:metadata:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -105,8 +95,6 @@ steps:
       - label: "API MKI - edr_workflows:package:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:package:qa:serverless
         key: edr_workflows:package:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -125,8 +113,6 @@ steps:
       - label: "API MKI - edr_workflows:policy:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:policy:qa:serverless
         key: edr_workflows:policy:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -145,8 +131,6 @@ steps:
       - label: "API MKI - edr_workflows:resolver:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:resolver:qa:serverless
         key: edr_workflows:resolver:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -165,8 +149,6 @@ steps:
       - label: "API MKI - edr_workflows:response_actions:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:response_actions:qa:serverless
         key: edr_workflows:response_actions:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -185,8 +167,6 @@ steps:
       - label: "API MKI - edr_workflows:role_migrations:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:role_migrations:qa:serverless
         key: edr_workflows:role_migrations:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -205,8 +185,6 @@ steps:
       - label: "API MKI - edr_workflows:scripts_library:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:scripts_library:qa:serverless
         key: edr_workflows:scripts_library:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
@@ -225,8 +203,6 @@ steps:
       - label: "API MKI - edr_workflows:spaces:qa:serverless"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh edr_workflows:spaces:qa:serverless
         key: edr_workflows:spaces:qa:serverless
-        env:
-          CLEAR_YARN_CACHE: '1'
         agents:
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
@@ -2,8 +2,6 @@ steps:
   - command: .buildkite/scripts/pipelines/security_solution_quality_gate/edr_workflows/mki_security_solution_defend_workflows.sh cypress:dw:qa:serverless:run
     label: 'Cypress MKI - Defend Workflows'
     key: test_defend_workflows
-    env:
-      CLEAR_YARN_CACHE: '1'
     agents:
       image: family/kibana-ubuntu-2404
       imageProject: elastic-images-prod

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -53,9 +53,12 @@ if [[ "$DISABLE_BOOTSTRAP_VALIDATION" != "true" ]]; then
 fi
 
 # Yarn cache is only needed during install. Drop it afterwards to reclaim disk.
-echo "--- Clearing yarn cache"
-echo 'Removing /opt/buildkite-agent/.cache/yarn' && rm -rf /opt/buildkite-agent/.cache/yarn
-echo 'Removing /opt/buildkite-agent/.yarn-local-mirror' && rm -rf /opt/buildkite-agent/.yarn-local-mirror
-echo 'Removing ./.yarn-local-mirror' && rm -rf ./.yarn-local-mirror
-echo "Available disk space after clearing yarn cache:"
-df -h . || echo "Failed to get disk space"
+# Build steps that still run package installs afterwards can opt out with KEEP_INSTALL_CACHE=1.
+if [[ -z "${KEEP_INSTALL_CACHE:-}" ]]; then
+  echo "--- Clearing yarn cache"
+  echo 'Removing /opt/buildkite-agent/.cache/yarn' && rm -rf /opt/buildkite-agent/.cache/yarn
+  echo 'Removing /opt/buildkite-agent/.yarn-local-mirror' && rm -rf /opt/buildkite-agent/.yarn-local-mirror
+  echo 'Removing ./.yarn-local-mirror' && rm -rf ./.yarn-local-mirror
+  echo "Available disk space after clearing yarn cache:"
+  df -h . || echo "Failed to get disk space"
+fi

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -54,6 +54,8 @@ fi
 
 # Yarn cache is only needed during install. Drop it afterwards to reclaim disk.
 echo "--- Clearing yarn cache"
-rm -rf /opt/buildkite-agent/.cache/yarn
+echo 'Removing /opt/buildkite-agent/.cache/yarn' && rm -rf /opt/buildkite-agent/.cache/yarn
+echo 'Removing /opt/buildkite-agent/.yarn-local-mirror' && rm -rf /opt/buildkite-agent/.yarn-local-mirror
+echo 'Removing ./.yarn-local-mirror' && rm -rf ./.yarn-local-mirror
 echo "Available disk space after clearing yarn cache:"
 df -h . || echo "Failed to get disk space"

--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -52,10 +52,8 @@ if [[ "$DISABLE_BOOTSTRAP_VALIDATION" != "true" ]]; then
   check_for_changed_files 'yarn kbn bootstrap'
 fi
 
-# Opt-in per job (via CLEAR_YARN_CACHE) to free disk space on disk-constrained agents
-if [[ "${CLEAR_YARN_CACHE:-}" ]]; then
-  echo "Clearing yarn cache at /opt/buildkite-agent/.cache/yar..."
-  rm -rf /opt/buildkite-agent/.cache/yarn
-  echo "Available disk space after clearing yarn cache:"
-  df -h . || echo "Failed to get disk space"
-fi
+# Yarn cache is only needed during install. Drop it afterwards to reclaim disk.
+echo "--- Clearing yarn cache"
+rm -rf /opt/buildkite-agent/.cache/yarn
+echo "Available disk space after clearing yarn cache:"
+df -h . || echo "Failed to get disk space"

--- a/.buildkite/scripts/steps/build_kibana.sh
+++ b/.buildkite/scripts/steps/build_kibana.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # Skip building shared webpack bundles during bootstrap because
 # node scripts/build rebuilds them in production mode with --dist
 export KBN_BOOTSTRAP_NO_PREBUILT=true
+export KEEP_INSTALL_CACHE=1
 
 source .buildkite/scripts/common/util.sh
 

--- a/.buildkite/scripts/steps/on_merge_build_and_metrics.sh
+++ b/.buildkite/scripts/steps/on_merge_build_and_metrics.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # node scripts/build rebuilds shared webpack bundles in production mode,
 # so skip the dev-mode pre-build during bootstrap.
 export KBN_BOOTSTRAP_NO_PREBUILT=true
+export KEEP_INSTALL_CACHE=1
 
 .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/build_kibana.sh


### PR DESCRIPTION
## Summary
Some cypress tests are reaching the disk limits, let's try to grab some easy free estate, and remove the unnecessary yarn cache after bootstrap is done.

It adds ~4-5 seconds per bootstrap run, and it frees up ~ 7GB (on current VMs). 

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->