### PR TITLE
fix(fleet): require superuser to rotate the Fleet message signing key pair

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/message_signing_service/handlers.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/message_signing_service/handlers.test.ts
@@ -11,10 +11,18 @@ import type { KibanaRequest } from '@kbn/core/server';
 
 import { createAppContextStartContractMock, xpackMocks } from '../../mocks';
 import { appContextService } from '../../services';
+import { checkSuperuser } from '../../services/security';
 import type { FleetRequestHandlerContext } from '../../types';
 import { withDefaultErrorHandler } from '../../services/security/fleet_router';
 
 import { rotateKeyPairHandler } from './handlers';
+
+jest.mock('../../services/security', () => ({
+  ...jest.requireActual('../../services/security'),
+  checkSuperuser: jest.fn(),
+}));
+
+const mockCheckSuperuser = checkSuperuser as jest.MockedFunction<typeof checkSuperuser>;
 
 const rotateKeyPairHandlerWithErrorHandler = withDefaultErrorHandler(rotateKeyPairHandler);
 
@@ -40,11 +48,27 @@ describe('FleetMessageSigningServiceHandler', () => {
     response = httpServerMock.createResponseFactory();
     // prevents `Logger not set.` and other appContext errors
     appContextService.start(createAppContextStartContractMock());
+    mockCheckSuperuser.mockReturnValue(true);
   });
 
   afterEach(async () => {
     jest.clearAllMocks();
     appContextService.stop();
+  });
+
+  it('POST /message_signing_service/rotate_key_pair returns 403 when caller is not superuser', async () => {
+    mockCheckSuperuser.mockReturnValue(false);
+
+    await rotateKeyPairHandlerWithErrorHandler(
+      coreMock.createCustomRequestHandlerContext(context),
+      request,
+      response
+    );
+
+    expect(response.forbidden).toHaveBeenCalledWith({
+      body: { message: 'Rotating the key pair requires superuser privileges.' },
+    });
+    expect(response.ok).not.toHaveBeenCalled();
   });
 
   it(`POST /message_signing_service/rotate_key_pair?acknowledge=true fails with an 500 with "acknowledge=true" when no messaging service`, async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/message_signing_service/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/message_signing_service/handlers.ts
@@ -10,13 +10,20 @@ import type { TypeOf } from '@kbn/config-schema';
 import type { FleetRequestHandler } from '../../types';
 
 import { appContextService } from '../../services';
+import { checkSuperuser } from '../../services/security';
 import type { RotateKeyPairSchema } from '../../types/rest_spec/message_signing_service';
 
 export const rotateKeyPairHandler: FleetRequestHandler<
   undefined,
   TypeOf<typeof RotateKeyPairSchema.query>,
   undefined
-> = async (_, __, response) => {
+> = async (context, request, response) => {
+  if (!checkSuperuser(request)) {
+    return response.forbidden({
+      body: { message: 'Rotating the key pair requires superuser privileges.' },
+    });
+  }
+
   const logger = appContextService.getLogger();
   const messageSigningService = appContextService.getMessageSigningService();
   if (!messageSigningService) {


### PR DESCRIPTION
## Summary

The `POST /api/fleet/message_signing_service/rotate_key_pair` endpoint now requires superuser privileges. Rotating the key pair is an irreversible, fleet-wide operation — every enrolled Elastic Agent must be re-enrolled afterward. The handler previously relied solely on Kibana RBAC, with no additional check in the handler itself.

## Changes

- `routes/message_signing_service/handlers.ts` — adds `checkSuperuser(request)` guard; returns `403 Forbidden` with a clear message if the caller is not superuser
- `routes/message_signing_service/handlers.test.ts` — mocks `checkSuperuser`, adds a 403 test case

## Backport

`backport:all-open`

## Test plan

- [ ] `node scripts/jest --config x-pack/platform/plugins/shared/fleet/server/jest.config.js x-pack/platform/plugins/shared/fleet/server/routes/message_signing_service/handlers.test.ts`
- [ ] Confirm a user with only Fleet admin privileges (no superuser) receives `403` on `POST /api/fleet/message_signing_service/rotate_key_pair?acknowledge=true`
- [ ] Confirm a superuser can still rotate the key pair successfully

Note: the superuser check will include `system_indices_superuser` when https://github.com/elastic/kibana/pull/285918/changes#diff-f082bddaa222b304e6c7aaffac65acb0deb4b8ac0b0ef25a6f4f2eca32f9b7c0 is merged

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->