### PR TITLE
[Developer Examples] Escape ICU braces in workflows example step docs i18n

### DIFF
--- a/examples/workflows_extensions_example/common/step_types/durable_poll_step.ts
+++ b/examples/workflows_extensions_example/common/step_types/durable_poll_step.ts
@@ -55,7 +55,7 @@ export const durablePollStepCommonDefinition: CommonStepDefinition<
   documentation: {
     details: i18n.translate('workflowsExtensionsExample.durablePollStep.documentation.details', {
       defaultMessage:
-        'Demonstrates the durable **start + poll** pattern: `start` submits work and returns `{ state }`; `poll` wakes on `policy` until `{ output }`. In production, `start` would call an HTTP API or task queue and `poll` would read job status from Elasticsearch or an upstream service. Authoring guide: `src/platform/plugins/shared/workflows_extensions/dev_docs/STEPS.md` — **Durable start/poll custom steps** (`createPollServerStepDefinition`).',
+        "Demonstrates the durable **start + poll** pattern: `start` submits work and returns `'{' state '}'`; `poll` wakes on `policy` until `'{' output '}'`. In production, `start` would call an HTTP API or task queue and `poll` would read job status from Elasticsearch or an upstream service. Authoring guide: `src/platform/plugins/shared/workflows_extensions/dev_docs/STEPS.md` — **Durable start/poll custom steps** (`createPollServerStepDefinition`).",
     }),
     examples: [
       `## Async export (demo)

--- a/examples/workflows_extensions_example/common/step_types/poll_only_job_step.ts
+++ b/examples/workflows_extensions_example/common/step_types/poll_only_job_step.ts
@@ -55,7 +55,7 @@ export const pollOnlyJobStepCommonDefinition: CommonStepDefinition<
   documentation: {
     details: i18n.translate('workflowsExtensionsExample.pollOnlyJobStep.documentation.details', {
       defaultMessage:
-        'Demonstrates the **poll-only** pattern: no `start` — the job id is already in `input` (from a connector, trigger payload, or an earlier step). `poll` runs immediately and on `policy` until `{ output }`. In production, each poll would call something like `GET /_transform/{jobId}/_stats` or your vendor export status API. Contrast with `example.durablePollDemo`, which uses `start` + `poll` when this step must submit work itself. Authoring guide: `src/platform/plugins/shared/workflows_extensions/dev_docs/STEPS.md` — **Poll-only variant**.',
+        "Demonstrates the **poll-only** pattern: no `start` — the job id is already in `input` (from a connector, trigger payload, or an earlier step). `poll` runs immediately and on `policy` until `'{' output '}'`. In production, each poll would call something like `GET /_transform/'{jobId}'/_stats` or your vendor export status API. Contrast with `example.durablePollDemo`, which uses `start` + `poll` when this step must submit work itself. Authoring guide: `src/platform/plugins/shared/workflows_extensions/dev_docs/STEPS.md` — **Poll-only variant**.",
     }),
     examples: [
       `## Wait for transform started elsewhere


### PR DESCRIPTION
## Summary

Fixes `FORMAT_ERROR` / `MissingValueError` logged at server startup with `--run-examples`. The `documentation.details` i18n messages of the `example.durablePollDemo` and `example.pollOnlyJobDemo` example step types contained unescaped `{ state }`, `{ output }`, and `{jobId}`, which ICU MessageFormat parsed as variables. Braces are now escaped with ICU single-quote syntax (`'{'`/`'}'`), rendering literally in the workflow YAML editor hover docs.

Likely introduced in #270913.

The logged error:

```
Error: [@formatjs/intl Error FORMAT_ERROR] Error formatting default message for:
 "workflowsExtensionsExample.durablePollStep.documentation.details", rendering default message verbatim
 MessageID: workflowsExtensionsExample.durablePollStep.documentation.details
 Default Message: Demonstrates the durable start + poll pattern: start submits work and returns { state }; poll
 wakes on policy until { output }. In production, start would call an HTTP API or task queue and poll would read
 job status from Elasticsearch or an upstream service. Authoring guide:
 src/platform/plugins/shared/workflows_extensions/dev_docs/STEPS.md — Durable start/poll custom steps
 (createPollServerStepDefinition).
 Description: undefined

 Locale: en
```

Fixed escaped tooltip text:

<img width="2150" height="722" alt="CleanShot 2026-08-19 at 13 19 22@2x" src="https://github.com/user-attachments/assets/2c42537d-8014-40c4-92d5-dd78944f8a3a" />

### Checklist

- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.