### PR TITLE
[Synthetics] Optimize package policy reads

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/fleet/get_has_integration_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/fleet/get_has_integration_monitors.ts
@@ -16,6 +16,7 @@ export const getHasIntegrationMonitorsRoute: SyntheticsRestApiRouteFactory = () 
       kuery:
         'ingest-package-policies.package.name:synthetics and not ingest-package-policies.is_managed:true',
       perPage: 1,
+      fields: ['name'],
     });
     return {
       hasIntegrationMonitors: monitors.total > 0,

--- a/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_integration_health_api.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_integration_health_api.test.ts
@@ -857,6 +857,7 @@ describe('MonitorIntegrationHealthApi', () => {
       // Any other space that has monitors must be included so cross-space
       // package policies are discoverable.
       expect(args.additionalSpaceIds).toEqual(expect.arrayContaining(['space-two']));
+      expect(args.fields).toEqual(['name']);
 
       // The monitor's package policy was created in a different space, but the
       // wrapper finds it — so the location is reported as healthy.

--- a/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_integration_health_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/services/monitor_integration_health_api.ts
@@ -7,7 +7,6 @@
 
 import type { SavedObject } from '@kbn/core/server';
 import type { SavedObjectsClientContract } from '@kbn/core/server';
-import type { AgentPolicy, PackagePolicy } from '@kbn/fleet-plugin/common';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
 import {
   ConfigKey,
@@ -273,25 +272,26 @@ export class MonitorIntegrationHealthApi {
     allSpaces: Set<string>
   ) {
     if (expectedPackagePolicyIds.length === 0) {
-      return new Map<string, PackagePolicy>();
+      return new Map<string, { id: string }>();
     }
 
-    // The Synthetics wrapper builds a namespace-scoped saved-objects client
-    // per space and de-duplicates the results, so package policies created
-    // for monitors in any space are visible regardless of the caller's space.
+    // The Synthetics wrapper queries all relevant namespaces in one bulk read,
+    // so package policies created for monitors in any space are visible
+    // regardless of the caller's space.
     const packagePolicyService = new PackagePolicyService(this.server);
     const additionalSpaceIds = [...allSpaces].filter((space) => space !== this.spaceId);
     const existingPackagePolicies = await packagePolicyService.getByIds({
       spaceId: this.spaceId,
       packagePolicyIds: expectedPackagePolicyIds,
       additionalSpaceIds,
+      fields: ['name'],
     });
     return new Map((existingPackagePolicies ?? []).map((policy) => [policy.id, policy]));
   }
 
   private async getExistingAgentPoliciesMap(agentPolicyIds: string[], allSpaces: Set<string>) {
     if (agentPolicyIds.length === 0) {
-      return new Map<string, AgentPolicy>();
+      return new Map<string, { id: string }>();
     }
 
     // Agent policies can be scoped to a non-default space via space_ids. A plain
@@ -305,7 +305,7 @@ export class MonitorIntegrationHealthApi {
         this.server.fleet.agentPolicyService.getByIds(
           unsafeClient.asScopedToNamespace(space),
           agentPolicyIds,
-          { ignoreMissing: true, withPackagePolicies: false }
+          { ignoreMissing: true, withPackagePolicies: false, fields: ['name'] }
         )
       )
     );

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/clean_up_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/clean_up_task.ts
@@ -53,6 +53,7 @@ export const registerCleanUpTask = (
 
                 const { items } = await fleet.packagePolicyService.list(soClient, {
                   kuery: getFilterForTestNowRun(),
+                  fields: ['name', 'created_at'],
                 });
 
                 const allItems = items.map((item) => {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts
@@ -21,12 +21,17 @@ const makeServer = () => {
   const getUnsafeInternalClient = jest.fn(() => unsafeClient);
   const fleetBulkCreate = jest.fn().mockResolvedValue({ created: [], failed: [] });
   const fleetGetByIDs = jest.fn().mockResolvedValue([]);
+  const fleetDelete = jest.fn().mockResolvedValue([]);
   const getByIds = jest.fn();
 
   const server = {
     logger: loggerMock.create(),
     fleet: {
-      packagePolicyService: { bulkCreate: fleetBulkCreate, getByIDs: fleetGetByIDs },
+      packagePolicyService: {
+        bulkCreate: fleetBulkCreate,
+        getByIDs: fleetGetByIDs,
+        delete: fleetDelete,
+      },
       agentPolicyService: { getByIds },
     },
     coreStart: {
@@ -42,6 +47,7 @@ const makeServer = () => {
     getUnsafeInternalClient,
     fleetBulkCreate,
     fleetGetByIDs,
+    fleetDelete,
     getByIds,
   };
 };
@@ -140,6 +146,27 @@ describe('PackagePolicyService.getDefaultAndSpacePackagePolicies (via bulkCreate
 
     expect(getByIds).not.toHaveBeenCalled();
     expect(clientPassedToFleet(fleetBulkCreate)).toEqual({ __space: DEFAULT_SPACE_ID });
+  });
+});
+
+describe('PackagePolicyService.bulkDelete', () => {
+  it('still deletes an orphaned package policy whose policy_ids is an empty array', async () => {
+    const { server, fleetGetByIDs, fleetDelete, getByIds } = makeServer();
+    // No agent policy attached — Fleet normalizes this to policy_ids: [].
+    fleetGetByIDs.mockResolvedValue([{ id: 'orphaned-policy', name: 'orphaned', policy_ids: [] }]);
+    getByIds.mockResolvedValue([]);
+
+    await new PackagePolicyService(server).bulkDelete({
+      policyIdsToDelete: ['orphaned-policy'],
+      spaceId: 'naims',
+    });
+
+    expect(fleetDelete).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      ['orphaned-policy'],
+      expect.objectContaining({ force: true, asyncDeploy: true })
+    );
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts
@@ -17,14 +17,16 @@ import type { SyntheticsServerSetup } from '../../types';
 // scoped to so we can assert which space a package policy was written into.
 const makeServer = () => {
   const asScopedToNamespace = jest.fn((space: string) => ({ __space: space }));
-  const getUnsafeInternalClient = jest.fn(() => ({ asScopedToNamespace }));
+  const unsafeClient = { asScopedToNamespace };
+  const getUnsafeInternalClient = jest.fn(() => unsafeClient);
   const fleetBulkCreate = jest.fn().mockResolvedValue({ created: [], failed: [] });
+  const fleetGetByIDs = jest.fn().mockResolvedValue([]);
   const getByIds = jest.fn();
 
   const server = {
     logger: loggerMock.create(),
     fleet: {
-      packagePolicyService: { bulkCreate: fleetBulkCreate },
+      packagePolicyService: { bulkCreate: fleetBulkCreate, getByIDs: fleetGetByIDs },
       agentPolicyService: { getByIds },
     },
     coreStart: {
@@ -33,7 +35,15 @@ const makeServer = () => {
     },
   } as unknown as SyntheticsServerSetup;
 
-  return { server, asScopedToNamespace, fleetBulkCreate, getByIds };
+  return {
+    server,
+    unsafeClient,
+    asScopedToNamespace,
+    getUnsafeInternalClient,
+    fleetBulkCreate,
+    fleetGetByIDs,
+    getByIds,
+  };
 };
 
 const policy = (overrides: Partial<NewPackagePolicyWithId> = {}): NewPackagePolicyWithId =>
@@ -41,6 +51,28 @@ const policy = (overrides: Partial<NewPackagePolicyWithId> = {}): NewPackagePoli
 
 const agentPolicy = (spaceIds?: string[]): AgentPolicy =>
   ({ id: 'policyId', space_ids: spaceIds } as AgentPolicy);
+
+describe('PackagePolicyService.getByIds', () => {
+  it('uses one unscoped bulk get across unique spaces and forwards requested fields', async () => {
+    const { server, unsafeClient, asScopedToNamespace, getUnsafeInternalClient, fleetGetByIDs } =
+      makeServer();
+
+    await new PackagePolicyService(server).getByIds({
+      spaceId: 'space-one',
+      packagePolicyIds: ['policy-one', 'policy-two'],
+      additionalSpaceIds: ['space-two', 'space-one'],
+      fields: ['name', 'condition'],
+    });
+
+    expect(getUnsafeInternalClient).toHaveBeenCalledTimes(1);
+    expect(asScopedToNamespace).not.toHaveBeenCalled();
+    expect(fleetGetByIDs).toHaveBeenCalledWith(unsafeClient, ['policy-one', 'policy-two'], {
+      ignoreMissing: true,
+      spaceIds: ['space-one', DEFAULT_SPACE_ID, 'space-two'],
+      fields: ['name', 'condition'],
+    });
+  });
+});
 
 describe('PackagePolicyService.getDefaultAndSpacePackagePolicies (via bulkCreate)', () => {
   const clientPassedToFleet = (fleetBulkCreate: jest.Mock) => fleetBulkCreate.mock.calls[0][0];
@@ -55,6 +87,10 @@ describe('PackagePolicyService.getDefaultAndSpacePackagePolicies (via bulkCreate
     });
 
     expect(fleetBulkCreate).toHaveBeenCalledTimes(1);
+    expect(getByIds).toHaveBeenCalledWith(expect.anything(), ['policyId'], {
+      ignoreMissing: true,
+      fields: ['name'],
+    });
     expect(clientPassedToFleet(fleetBulkCreate)).toEqual({ __space: DEFAULT_SPACE_ID });
   });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.ts
@@ -6,12 +6,29 @@
  */
 
 import type { NewPackagePolicyWithId } from '@kbn/fleet-plugin/server/services/package_policy';
+import type { PartialPackagePolicy } from '@kbn/fleet-plugin/server';
 import type { PackagePolicy, UpdatePackagePolicyWithId } from '@kbn/fleet-plugin/common';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 import { uniqBy } from 'lodash';
 import type { SyntheticsServerSetup } from '../../types';
+
+interface GetByIdsOptions {
+  spaceId: string;
+  packagePolicyIds: string[];
+  /**
+   * Extra spaces to look in alongside `spaceId` (and the default space).
+   * Use this when callers need a cross-space view — e.g. the monitor health
+   * API, which reports on monitors that may live in any space.
+   */
+  additionalSpaceIds?: string[];
+}
+
+interface PackagePolicyWithAgentPolicyIds {
+  id?: string;
+  policy_ids?: string[];
+}
 
 export class PackagePolicyService {
   private readonly server: SyntheticsServerSetup;
@@ -54,33 +71,31 @@ export class PackagePolicyService {
     );
   }
 
+  async getByIds(options: GetByIdsOptions & { fields: string[] }): Promise<PartialPackagePolicy[]>;
+  async getByIds(options: GetByIdsOptions): Promise<PackagePolicy[]>;
   async getByIds({
     spaceId,
     packagePolicyIds,
     additionalSpaceIds,
-  }: {
-    spaceId: string;
-    packagePolicyIds: string[];
-    /**
-     * Extra spaces to look in alongside `spaceId` (and the default space).
-     * Use this when callers need a cross-space view — e.g. the monitor health
-     * API, which reports on monitors that may live in any space.
-     */
-    additionalSpaceIds?: string[];
-  }) {
+    fields,
+  }: GetByIdsOptions & { fields?: string[] }): Promise<PackagePolicy[] | PartialPackagePolicy[]> {
     // For legacy reasons, we always include the default space in addition to
     // the request's space (older package policies were created there).
-    const spaces = new Set<string>([spaceId, DEFAULT_SPACE_ID, ...(additionalSpaceIds ?? [])]);
-    const clients = [...spaces].map((space) => this.getSpaceSoClient(space));
+    const spaceIds = [...new Set([spaceId, DEFAULT_SPACE_ID, ...(additionalSpaceIds ?? [])])];
+    const soClient = this.server.coreStart.savedObjects.getUnsafeInternalClient();
 
-    const ids = await Promise.all(
-      clients.map((soClient) =>
-        this.server.fleet.packagePolicyService.getByIDs(soClient, packagePolicyIds, {
-          ignoreMissing: true,
-        })
-      )
-    );
-    return uniqBy(ids.flat(), 'id');
+    if (fields) {
+      return this.server.fleet.packagePolicyService.getByIDs(soClient, packagePolicyIds, {
+        ignoreMissing: true,
+        spaceIds,
+        fields,
+      });
+    }
+
+    return this.server.fleet.packagePolicyService.getByIDs(soClient, packagePolicyIds, {
+      ignoreMissing: true,
+      spaceIds,
+    });
   }
 
   /**
@@ -234,14 +249,18 @@ export class PackagePolicyService {
 
     const promises = (
       await this.getDefaultAndSpacePackagePolicies({
-        policies: await this.getByIds({ spaceId, packagePolicyIds: policyIdsToDelete }),
+        policies: await this.getByIds({
+          spaceId,
+          packagePolicyIds: policyIdsToDelete,
+          fields: ['name', 'policy_ids'],
+        }),
         spaceId,
       })
     ).map(({ client, policies }) =>
       this.server.fleet.packagePolicyService.delete(
         client,
         this.getInternalEsClient(),
-        policies.map((policy) => policy.id!),
+        policies.map((policy) => policy.id),
         {
           force: true,
           asyncDeploy: true,
@@ -255,7 +274,7 @@ export class PackagePolicyService {
 
   // The agent policies can be in the default space or the spaceId
   // This function returns the package policies that are in the spaceId and the default space and the correct saved objects client to fetch the package policies
-  private async getDefaultAndSpacePackagePolicies<T extends NewPackagePolicyWithId>({
+  private async getDefaultAndSpacePackagePolicies<T extends PackagePolicyWithAgentPolicyIds>({
     policies,
     spaceId,
   }: {
@@ -267,7 +286,7 @@ export class PackagePolicyService {
       policies: T[];
     }[]
   > {
-    const agentPolicyIds = new Set(policies.flatMap((pkgPolicy) => pkgPolicy.policy_ids));
+    const agentPolicyIds = new Set(policies.flatMap((pkgPolicy) => pkgPolicy.policy_ids ?? []));
     const defaultSpaceSoClient = this.getSpaceSoClient(DEFAULT_SPACE_ID);
     const spaceSoClient = this.getSpaceSoClient(spaceId);
     const clients = [spaceSoClient];
@@ -283,6 +302,7 @@ export class PackagePolicyService {
         clients.map((soClient) =>
           this.server.fleet.agentPolicyService.getByIds(soClient, [...agentPolicyIds], {
             ignoreMissing: true,
+            fields: ['name'],
           })
         )
       )

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.ts
@@ -313,8 +313,8 @@ export class PackagePolicyService {
     const spacePackagePolicies: T[] = [];
 
     for (const pkgPolicy of policies) {
-      if (pkgPolicy.policy_ids) {
-        pkgPolicy.policy_ids?.forEach((policyId) => {
+      if (pkgPolicy.policy_ids && pkgPolicy.policy_ids.length > 0) {
+        pkgPolicy.policy_ids.forEach((policyId) => {
           const agentPolicy = agentPolicyById.get(policyId);
           if (
             agentPolicy?.space_ids?.includes(spaceId) ||

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -690,6 +690,7 @@ export class SyntheticsPrivateLocation {
     const policies = await this.packagePolicyService.getByIds({
       spaceId,
       packagePolicyIds: Array.from(policyIdsToFetch),
+      fields: ['name', 'condition'],
     });
 
     return { policies, allSpaces };
@@ -713,6 +714,7 @@ export class SyntheticsPrivateLocation {
     const existingPolicies = await this.packagePolicyService.getByIds({
       spaceId,
       packagePolicyIds: Array.from(policyIdsToFetch),
+      fields: ['name'],
     });
 
     const policyIdsToDelete = new Set<string>();


### PR DESCRIPTION
## Summary

- query package policies across relevant spaces with one unscoped bulk get
- request only the package policy fields needed by monitor health, edit, delete, cleanup, and integration-presence paths
- project adjacent agent policy routing and health reads to their minimal fields
- keep diagnostics package-policy reads full-fidelity for troubleshooting

## Why

Synthetics currently fetches complete package policies, including inputs, streams, and vars, when operational paths only consume IDs, conditions, routing fields, or small metadata. It also repeats the package policy bulk read for each relevant space.

This uses the field projection support merged in #285848 to reduce saved object requests, response payload size, parsing, and memory while preserving the existing cross-space behavior. The diagnostics route intentionally continues returning complete package policies.

## Validation

- node scripts/jest x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/package_policy_service.test.ts x-pack/solutions/observability/plugins/synthetics/server/services/monitor_integration_health_api.test.ts
- node scripts/jest x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.test.ts
- node scripts/type_check --project x-pack/solutions/observability/plugins/synthetics/tsconfig.json
- node scripts/eslint --fix on all changed files
- node scripts/check.js --scope=local
- git diff --check

Addresses #285743