### PR TITLE
[Flaky Test Fixer] Fix syntax error in review reminder sweep

### DIFF
--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -180,11 +180,11 @@ module.exports = async function flakyFixReviewReminder({ github, context, core }
     repo,
     state: 'open',
     labels: LABEL,
-    state: 'open',
-    labels: LABEL,
     sort: 'created',
     direction: 'asc',
     per_page: 100,
+  });
+
   let pinged = 0;
   let considered = 0;
 


### PR DESCRIPTION
The [first run](https://github.com/elastic/kibana/actions/runs/32249503343) of the flaky fix review reminder (added in #285686) crashed with:

```
SyntaxError: Unexpected identifier 'pinged'
```

The cause here is accepting an AI code review suggestion right before merging. This PR fixes it.