### PR TITLE
[9.5] [Alerting V2] Add maxResponseSize guardrail for ES|QL query responses (#284893)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/config.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/config.ts
@@ -25,10 +25,26 @@ const MAX_MINIMUM_SCHEDULE_INTERVAL = '30d';
 
 /** Default and highest value of `xpack.alerting_v2.rules.run.alerts.max`. */
 const MAX_ALERTS_PER_RUN = 10000;
+/** Default cap on the ES response body size for non-streaming rule queries (50 MB). */
+const DEFAULT_MAX_QUERY_RESPONSE_SIZE_BYTES = 50 * 1024 * 1024;
 
 const rulesRunSchema = schema.object({
   alerts: schema.object({
     max: schema.number({ defaultValue: MAX_ALERTS_PER_RUN, min: 1, max: MAX_ALERTS_PER_RUN }),
+  }),
+  timeout: schema.maybe(schema.string({ validate: validateDuration })),
+  query: schema.object({
+    /**
+     * Maximum allowed Elasticsearch response body size (in bytes) for
+     * non-streaming rule queries (recovery, data-presence). Queries whose
+     * response exceeds this limit are aborted and the execution is attributed
+     * to the rule owner so they can narrow the query or raise the limit.
+     * Defaults to 50 MB.
+     */
+    maxResponseSize: schema.number({
+      defaultValue: DEFAULT_MAX_QUERY_RESPONSE_SIZE_BYTES,
+      min: 1024,
+    }),
   }),
 });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/detect_data_presence.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/detect_data_presence.test.ts
@@ -162,6 +162,24 @@ describe('detectDataPresence', () => {
     expect(getErrorSource(error as Error)).toBe(TaskErrorSource.USER);
   });
 
+  it('surfaces content-length-exceeded errors as TaskErrorSource.USER', async () => {
+    const { queryService, scopedEsClient } = setup();
+
+    scopedEsClient.esql.query.mockRejectedValue(
+      new errors.RequestAbortedError('Response size exceeded the limit (content length: 52428800)')
+    );
+
+    const error = await detectDataPresence({
+      queryService,
+      rule: buildRule(),
+      input: createRuleExecutionInput(),
+      logger: loggerService,
+    }).catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(getErrorSource(error as Error)).toBe(TaskErrorSource.USER);
+  });
+
   it('does not classify ES|QL 5xx errors as user errors (server-side, retryable)', async () => {
     const { queryService, scopedEsClient } = setup();
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/detect_data_presence.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/detect_data_presence.ts
@@ -6,6 +6,7 @@
  */
 
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
+import { isMaximumResponseSizeExceededError } from '@kbn/es-errors';
 import { stableStringify } from '@kbn/std';
 import { getNoDataEsqlQuery } from '@kbn/alerting-v2-schemas';
 import { isEsqlUserError } from '../errors/esql_user_error';
@@ -31,11 +32,13 @@ export const detectDataPresence = async ({
   rule,
   input,
   logger,
+  maxResponseSize,
 }: {
   queryService: QueryServiceContract;
   rule: RuleResponse;
   input: RuleExecutionInput;
   logger: LoggerServiceContract;
+  maxResponseSize?: number;
 }): Promise<Set<string>> => {
   const noDataQuery = getNoDataEsqlQuery(rule.query, rule.no_data_strategy);
 
@@ -67,11 +70,12 @@ export const detectDataPresence = async ({
       filter: queryPayload.filter,
       params: queryPayload.params,
       abortSignal: input.executionContext.signal,
+      maxResponseSize,
     });
 
     return collectGroupHashesFromRows({ rule, rows, input });
   } catch (error) {
-    if (isEsqlUserError(error)) {
+    if (isMaximumResponseSizeExceededError(error) || isEsqlUserError(error)) {
       throw createTaskRunError(error as Error, TaskErrorSource.USER);
     }
     throw error;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execute_recovery_query.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execute_recovery_query.test.ts
@@ -150,6 +150,27 @@ describe('executeRecoveryQuery', () => {
     expect(getErrorSource(error as Error)).toBe(TaskErrorSource.USER);
   });
 
+  it('marks content-length-exceeded recovery query errors as TaskErrorSource.USER', async () => {
+    const { queryService, scopedEsClient } = setup();
+
+    scopedEsClient.esql.query.mockRejectedValue(
+      new errors.RequestAbortedError('Response size exceeded the limit (content length: 52428800)')
+    );
+
+    const error = await executeRecoveryQuery({
+      queryService,
+      logger: loggerService,
+      rule: createRuleResponse({ kind: 'alert', recovery_strategy: 'query' }),
+      effectiveQuery: 'FROM logs-*',
+      input: createRuleExecutionInput(),
+      activeGroupHashes: toActive(['hash-1']),
+      breachedGroupHashes: new Set(),
+    }).catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(getErrorSource(error as Error)).toBe(TaskErrorSource.USER);
+  });
+
   it('does not mark ResponseError(503) recovery query errors as TaskErrorSource.USER', async () => {
     const { queryService, scopedEsClient } = setup();
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execute_recovery_query.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/execute_recovery_query.ts
@@ -7,6 +7,7 @@
 
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import { stableStringify } from '@kbn/std';
+import { isMaximumResponseSizeExceededError } from '@kbn/es-errors';
 import { isEsqlUserError } from '../errors/esql_user_error';
 import type { RuleExecutionInput } from './types';
 import { buildQueryRecoveryAlertEvents } from './build_alert_events';
@@ -33,6 +34,7 @@ export const executeRecoveryQuery = async ({
   input,
   activeGroupHashes,
   breachedGroupHashes,
+  maxResponseSize,
 }: {
   queryService: QueryServiceContract;
   logger: LoggerServiceContract;
@@ -41,6 +43,7 @@ export const executeRecoveryQuery = async ({
   input: RuleExecutionInput;
   activeGroupHashes: ActiveAlertGroupHash[];
   breachedGroupHashes: ReadonlySet<string>;
+  maxResponseSize?: number;
 }): Promise<AlertEvent[]> => {
   const lookbackWindow = rule.schedule.lookback ?? rule.schedule.every;
 
@@ -67,6 +70,7 @@ export const executeRecoveryQuery = async ({
       filter: queryPayload.filter,
       params: queryPayload.params,
       abortSignal: input.executionContext.signal,
+      maxResponseSize,
     });
 
     return buildQueryRecoveryAlertEvents({
@@ -80,7 +84,7 @@ export const executeRecoveryQuery = async ({
       scheduledTimestamp: input.scheduledAt,
     });
   } catch (error) {
-    if (isEsqlUserError(error)) {
+    if (isMaximumResponseSizeExceededError(error) || isEsqlUserError(error)) {
       throw createTaskRunError(error as Error, TaskErrorSource.USER);
     }
     throw error;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/classify_absent_groups_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/classify_absent_groups_step.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { coreMock } from '@kbn/core/server/mocks';
 import {
   collectStreamResults,
   createPipelineStream,
@@ -20,7 +21,21 @@ import { buildGroupHash } from '../build_alert_events';
 import type { AlertEvent } from '../../../resources/datastreams/alert_events';
 import type { PipelineStateStream } from '../types';
 import type { RuleResponse } from '../../rules_client';
+import type { PluginConfig } from '../../../config';
 import { ClassifyAbsentGroupsStep } from './classify_absent_groups_step';
+
+const createPluginConfigAccessor = () => {
+  const config: PluginConfig = {
+    enabled: true,
+    invalidateApiKeysTask: { interval: '5m', removalDelay: '1h' },
+    rules: {
+      minimumScheduleInterval: '1m',
+      maxScheduledPerMinute: 400,
+      run: { alerts: { max: 10000 }, query: { maxResponseSize: 50 * 1024 * 1024 } },
+    },
+  };
+  return coreMock.createPluginInitializerContext<PluginConfig>(config).config;
+};
 
 const hashFor = (host: string): string =>
   buildGroupHash({
@@ -38,7 +53,8 @@ describe('ClassifyAbsentGroupsStep', () => {
     const step = new ClassifyAbsentGroupsStep(
       loggerService,
       internal.queryService,
-      scoped.queryService
+      scoped.queryService,
+      createPluginConfigAccessor()
     );
     return { step, internalEsClient: internal.mockEsClient, scopedEsClient: scoped.mockEsClient };
   }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/classify_absent_groups_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/classify_absent_groups_step.ts
@@ -7,6 +7,9 @@
 
 import { inject, injectable } from 'inversify';
 import { getNoDataEsqlQuery, getRecoverEsqlQuery } from '@kbn/alerting-v2-schemas';
+import { PluginInitializer } from '@kbn/core-di-server';
+import type { PluginInitializerContext } from '@kbn/core/server';
+import type { PluginConfig } from '../../../config';
 import type { PipelineStateStream, RuleExecutionStep, RulePipelineState } from '../types';
 import {
   buildContinuedBreachAlertEvents,
@@ -61,12 +64,19 @@ import type { AlertEvent } from '../../../resources/datastreams/alert_events';
 export class ClassifyAbsentGroupsStep implements RuleExecutionStep {
   public readonly name = 'classify_absent_groups';
 
+  private readonly maxQueryResponseSize: number;
+
   constructor(
     @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract,
     @inject(QueryServiceInternalToken) private readonly internalQueryService: QueryServiceContract,
     @inject(QueryServiceScopedSpaceRoutingToken)
-    private readonly scopedQueryService: QueryServiceContract
-  ) {}
+    private readonly scopedQueryService: QueryServiceContract,
+    @inject(PluginInitializer('config'))
+    pluginConfigAccessor: PluginInitializerContext<PluginConfig>['config']
+  ) {
+    this.maxQueryResponseSize =
+      pluginConfigAccessor.get<PluginConfig>().rules.run.query.maxResponseSize;
+  }
 
   public executeStream(streamState: PipelineStateStream): PipelineStateStream {
     return forwardThenFinalize(streamState, {
@@ -133,6 +143,7 @@ export class ClassifyAbsentGroupsStep implements RuleExecutionStep {
           rule,
           input,
           logger: this.logger,
+          maxResponseSize: this.maxQueryResponseSize,
         })
       : undefined;
 
@@ -187,6 +198,7 @@ export class ClassifyAbsentGroupsStep implements RuleExecutionStep {
         input,
         activeGroupHashes: activeGroups,
         breachedGroupHashes,
+        maxResponseSize: this.maxQueryResponseSize,
       });
     }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/execute_rule_query_step.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/execute_rule_query_step.test.ts
@@ -36,7 +36,7 @@ const createPluginConfigAccessor = (maxAlertsPerRun = DEFAULT_MAX_ALERTS_PER_RUN
     rules: {
       minimumScheduleInterval: '1m',
       maxScheduledPerMinute: 400,
-      run: { alerts: { max: maxAlertsPerRun } },
+      run: { alerts: { max: maxAlertsPerRun }, query: { maxResponseSize: 50 * 1024 * 1024 } },
     },
   };
 
@@ -188,6 +188,26 @@ describe('ExecuteRuleQueryStep', () => {
     mockHelpersEsqlToArrowReader(
       mockEsClient,
       jest.fn().mockRejectedValue(new errors.ResponseError({ statusCode: 400 } as DiagnosticResult))
+    );
+
+    const state = createRulePipelineState({ rule: createRuleResponse() });
+
+    const error = await getStepError(step, state);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(getErrorSource(error!)).toBe(TaskErrorSource.USER);
+  });
+
+  it('marks content-length-exceeded errors as TaskErrorSource.USER', async () => {
+    mockHelpersEsqlToArrowReader(
+      mockEsClient,
+      jest
+        .fn()
+        .mockRejectedValue(
+          new errors.RequestAbortedError(
+            'Response size exceeded the limit (content length: 52428800)'
+          )
+        )
     );
 
     const state = createRulePipelineState({ rule: createRuleResponse() });

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/execute_rule_query_step.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rule_executor/steps/execute_rule_query_step.ts
@@ -9,6 +9,7 @@ import { inject, injectable } from 'inversify';
 import { getBreachEsqlQuery } from '@kbn/alerting-v2-schemas';
 import { appendLimitToQuery } from '@kbn/esql-utils';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
+import { isMaximumResponseSizeExceededError } from '@kbn/es-errors';
 import { PluginInitializer } from '@kbn/core-di-server';
 import type { PluginInitializerContext } from '@kbn/core/server';
 import { isEsqlUserError } from '../../errors/esql_user_error';
@@ -28,6 +29,7 @@ export class ExecuteRuleQueryStep implements RuleExecutionStep {
   public readonly name = 'execute_rule_query';
 
   private readonly maxAlertsPerRun: number;
+  private readonly maxQueryResponseSize: number;
 
   constructor(
     @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract,
@@ -36,7 +38,9 @@ export class ExecuteRuleQueryStep implements RuleExecutionStep {
     @inject(PluginInitializer('config'))
     pluginConfigAccessor: PluginInitializerContext<PluginConfig>['config']
   ) {
-    this.maxAlertsPerRun = pluginConfigAccessor.get<PluginConfig>().rules.run.alerts.max;
+    const config = pluginConfigAccessor.get<PluginConfig>();
+    this.maxAlertsPerRun = config.rules.run.alerts.max;
+    this.maxQueryResponseSize = config.rules.run.query.maxResponseSize;
   }
 
   public executeStream(streamState: PipelineStateStream): PipelineStateStream {
@@ -72,6 +76,7 @@ export class ExecuteRuleQueryStep implements RuleExecutionStep {
           filter: queryPayload.filter,
           params: queryPayload.params,
           abortSignal: input.executionContext.signal,
+          maxResponseSize: step.maxQueryResponseSize,
         });
 
         let yielded = false;
@@ -91,7 +96,7 @@ export class ExecuteRuleQueryStep implements RuleExecutionStep {
           };
         }
       } catch (error) {
-        if (isEsqlUserError(error)) {
+        if (isMaximumResponseSizeExceededError(error) || isEsqlUserError(error)) {
           throw createTaskRunError(error as Error, TaskErrorSource.USER);
         }
         throw error;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/rules_client/rules_client.test.ts
@@ -121,6 +121,7 @@ describe('RulesClient', () => {
       rules: {
         minimumScheduleInterval: '1m',
         maxScheduledPerMinute: 400,
+        run: { alerts: { max: 10000 }, query: { maxResponseSize: 50 * 1024 * 1024 } },
         ...rulesConfigOverrides,
       },
     } as PluginConfig;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.ts
@@ -19,6 +19,8 @@ export interface ExecuteQueryParams {
   filter?: EsqlQueryRequest['filter'];
   params?: EsqlQueryRequest['params'];
   abortSignal?: AbortSignal;
+  /** Maximum allowed response body size in bytes. Passed to the ES transport. */
+  maxResponseSize?: number;
 }
 
 export interface QueryServiceContract {
@@ -41,6 +43,7 @@ export class QueryService implements QueryServiceContract {
     filter,
     params,
     abortSignal,
+    maxResponseSize,
   }: ExecuteQueryParams): Promise<EsqlQueryResponse> {
     this.logger.debug({
       message: () => `QueryService: Executing query - ${JSON.stringify({ query, filter, params })}`,
@@ -54,7 +57,7 @@ export class QueryService implements QueryServiceContract {
           filter,
           params,
         },
-        { signal: abortSignal }
+        { signal: abortSignal, ...(maxResponseSize !== undefined ? { maxResponseSize } : {}) }
       );
 
       this.logger.debug({
@@ -83,6 +86,7 @@ export class QueryService implements QueryServiceContract {
     filter,
     params,
     abortSignal,
+    maxResponseSize,
   }: ExecuteQueryParams): AsyncIterable<T[]> {
     const context = createExecutionContext(abortSignal ?? new AbortController().signal);
 
@@ -95,6 +99,9 @@ export class QueryService implements QueryServiceContract {
     try {
       context.throwIfAborted();
 
+      // Note: Arrow streaming uses chunked transfer encoding so the transport's
+      // maxResponseSize guard (which checks Content-Length) will not fire.
+      // The per-run alerts.max row limit acts as the primary guardrail here.
       reader = await this.esClient.helpers
         .esql(
           {
@@ -103,7 +110,7 @@ export class QueryService implements QueryServiceContract {
             filter,
             params,
           },
-          { signal: context.signal }
+          { signal: context.signal, ...(maxResponseSize !== undefined ? { maxResponseSize } : {}) }
         )
         .toArrowReader();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
- [[Alerting V2] Add maxResponseSize guardrail for ES|QL query responses (#284893)](https://github.com/elastic/kibana/pull/284893)

> This backport was generated by the failed backport resolver agent. Please review it carefully before merging.

<!--BACKPORT [{"sourcePullRequest":{"number":284893,"url":"https://github.com/elastic/kibana/pull/284893","title":"[Alerting V2] Add maxResponseSize guardrail for ES|QL query responses"},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"sourceCommit":{"sha":"24a06840218c1b190b58105ee0a65ea0a0cb28fc"}}] BACKPORT-->