### PR TITLE
[One Workflow] Inline visual preview for workflow.yaml attachments in AB chat

### DIFF
--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/index.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/index.ts
@@ -11,6 +11,7 @@ export {
   WorkflowGraphCanvasWithoutProvider,
   type WorkflowGraphCanvasProps,
 } from './workflow_graph_canvas';
+export { WorkflowGraphPreview, type WorkflowGraphPreviewProps } from './workflow_graph_preview';
 export type { RenderStepIcon } from './workflow_graph_actions_context';
 export { ReactFlowProvider } from '@xyflow/react';
 export {

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/use_workflow_layout.ts
@@ -51,6 +51,10 @@ interface UseWorkflowLayoutParams {
   stepExecutions?: WorkflowStepExecutionDto[];
   /** Dagre rank direction: `'TB'` (default) or `'LR'`. */
   direction?: LayoutDirection;
+  /** Override the default rank separation (arrow length in layout direction). */
+  rankSep?: number;
+  /** Override the default node separation (gap between siblings in a rank). */
+  nodeSep?: number;
   onPerfMark?: (name: 'transform_ms' | 'layout_ms', ms: number) => void;
   onLayoutFailed?: (reason: string) => void;
 }
@@ -72,6 +76,8 @@ export function useWorkflowLayout({
   transformed: transformedProp,
   stepExecutions,
   direction = 'TB',
+  rankSep,
+  nodeSep,
   onPerfMark,
   onLayoutFailed,
 }: UseWorkflowLayoutParams): UseWorkflowLayoutResult {
@@ -93,7 +99,7 @@ export function useWorkflowLayout({
     if (!workflow) return { nodes: [], edges: [] };
     try {
       const t1 = performance.now();
-      const snap = computeWorkflowLayout(transformed, { direction });
+      const snap = computeWorkflowLayout(transformed, { direction, nodeSep, rankSep });
       onPerfMark?.('layout_ms', performance.now() - t1);
       return snap;
     } catch (err) {
@@ -106,7 +112,7 @@ export function useWorkflowLayout({
     // fingerprint because both are computed from the same `workflow`/
     // `transformedProp` on the same render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topologyFingerprint, direction, onLayoutFailed, onPerfMark]);
+  }, [topologyFingerprint, direction, nodeSep, rankSep, onLayoutFailed, onPerfMark]);
 
   const stepExecutionMap = useMemo(() => {
     if (!stepExecutions) return null;

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_canvas.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_canvas.tsx
@@ -233,6 +233,10 @@ export interface WorkflowGraphCanvasProps {
   readonly renderStepIcon?: RenderStepIcon;
   /** Dagre rank direction (default `'TB'`). */
   readonly direction?: LayoutDirection;
+  /** Override dagre rank separation (arrow length in layout direction). */
+  readonly rankSep?: number;
+  /** Override dagre node separation (gap between siblings in a rank). */
+  readonly nodeSep?: number;
   /**
    * When true the viewport is fitted to show all nodes on init, overriding the
    * default centre-on-top behaviour.
@@ -278,6 +282,12 @@ export interface WorkflowGraphCanvasProps {
    * `defaultViewport` on the next mount.
    */
   readonly onViewportChange?: (viewport: Viewport) => void;
+  /**
+   * Static preview mode: icon-only nodes, no interaction, no invalid-YAML
+   * callout, autofit. Used by `WorkflowGraphPreview` to render a compact
+   * non-interactive snapshot (e.g. inline attachment previews).
+   */
+  readonly previewMode?: boolean;
 }
 
 function WorkflowGraphCanvasInner(props: WorkflowGraphCanvasProps) {
@@ -297,16 +307,27 @@ function WorkflowGraphCanvasInner(props: WorkflowGraphCanvasProps) {
     canRunSteps,
     renderStepIcon,
     direction = 'TB',
-    fitView: fitViewProp = false,
+    rankSep,
+    nodeSep,
+    previewMode = false,
+    fitView: fitViewPropRaw = false,
     fitViewOptions: fitViewOptionsProp,
-    showMinimap = true,
+    showMinimap: showMinimapProp,
     showZoomControls = false,
-    showBackground = true,
+    showBackground: showBackgroundProp,
     edgeZIndex = -1,
     onReady,
     defaultViewport,
     onViewportChange,
   } = props;
+
+  const fitViewProp = previewMode ? true : fitViewPropRaw;
+  const showMinimap = showMinimapProp ?? !previewMode;
+  const showBackground = showBackgroundProp ?? !previewMode;
+  const resolvedFitViewOptions = useMemo(
+    () => fitViewOptionsProp ?? { padding: 0.08, minZoom: 0.2, maxZoom: 2 },
+    [fitViewOptionsProp]
+  );
 
   const defaultEdgeOptions = useMemo(
     () => ({ type: 'workflowEdge', zIndex: edgeZIndex }),
@@ -334,6 +355,8 @@ function WorkflowGraphCanvasInner(props: WorkflowGraphCanvasProps) {
     transformed,
     stepExecutions,
     direction,
+    rankSep,
+    nodeSep,
     onPerfMark,
     onLayoutFailed,
   });
@@ -350,11 +373,17 @@ function WorkflowGraphCanvasInner(props: WorkflowGraphCanvasProps) {
     });
   }, [nodes.length, onPerfMark]);
 
-  // Decorate nodes with selection state — without rebuilding identity for non-changed ones
+  // Decorate nodes with selection state and preview flag — without rebuilding
+  // identity for non-changed ones. In preview mode every node also gets
+  // `data.preview: true`, which triggers the icon-only compact render inside
+  // `WorkflowGraphNode`.
   const decoratedNodes = useMemo(() => {
-    if (!selectedStepId) return nodes;
-    return nodes.map((n) => (n.id === selectedStepId ? { ...n, selected: true } : n));
-  }, [nodes, selectedStepId]);
+    if (!previewMode && !selectedStepId) return nodes;
+    return nodes.map((n) => {
+      const next = previewMode ? { ...n, data: { ...n.data, preview: true } } : n;
+      return n.id === selectedStepId ? { ...next, selected: true } : next;
+    });
+  }, [nodes, selectedStepId, previewMode]);
 
   const handleNodeClick = useCallback(
     (_evt: React.MouseEvent, node: { id: string; data: Record<string, unknown> }) => {
@@ -579,7 +608,7 @@ function WorkflowGraphCanvasInner(props: WorkflowGraphCanvasProps) {
     [euiTheme.colors.danger, euiTheme.colors.accent, euiTheme.colors.primary]
   );
 
-  const dimmed = !isYamlValid;
+  const dimmed = !isYamlValid && !previewMode;
 
   return (
     <WorkflowGraphActionsContext.Provider value={actions}>
@@ -644,11 +673,11 @@ function WorkflowGraphCanvasInner(props: WorkflowGraphCanvasProps) {
               colorMode={colorMode}
               onInit={handleInit}
               fitView={fitViewProp}
-              fitViewOptions={fitViewProp ? fitViewOptionsProp : undefined}
+              fitViewOptions={fitViewProp ? resolvedFitViewOptions : undefined}
               defaultViewport={defaultViewport}
               onMoveEnd={handleMoveEnd}
-              onNodeClick={handleNodeClick}
-              onPaneClick={handlePaneClick}
+              onNodeClick={previewMode ? undefined : handleNodeClick}
+              onPaneClick={previewMode ? undefined : handlePaneClick}
               nodesDraggable={false}
               nodesConnectable={false}
               // Prevent React Flow from boosting a selected node's z-index above
@@ -658,13 +687,13 @@ function WorkflowGraphCanvasInner(props: WorkflowGraphCanvasProps) {
               // through the body.
               elevateNodesOnSelect={false}
               elevateEdgesOnSelect={false}
-              elementsSelectable
-              panOnScroll
-              panOnDrag
+              elementsSelectable={!previewMode}
+              panOnScroll={!previewMode}
+              panOnDrag={!previewMode}
               zoomOnScroll={false}
-              zoomOnPinch={true}
+              zoomOnPinch={!previewMode}
               zoomOnDoubleClick={false}
-              translateExtent={translateExtent}
+              translateExtent={previewMode ? undefined : translateExtent}
               minZoom={0.1}
             >
               {showBackground && (

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_node.test.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_node.test.tsx
@@ -192,11 +192,17 @@ describe('WorkflowGraphNode', () => {
     expect(node.getAttribute('aria-label')).toContain(ExecutionStatus.FAILED);
   });
 
-  it('renders a compact preview without the step label text', () => {
-    const { queryByTitle } = renderNode({ label: 'hidden-label', preview: true });
-    // In preview mode the outer div is an aria-label'd div, not a role=button,
-    // and there is no label text rendered as a <span>.
-    expect(queryByTitle('hidden-label')).toBeNull();
+  it('renders a dense preview with the step name and step type', () => {
+    const { getByTitle, getByText } = renderNode({
+      label: 'my-step',
+      stepType: 'http',
+      preview: true,
+    });
+    // Preview mode shows both the step name (with a title attribute for truncation
+    // tooltips) and the step-type subtitle.
+    expect(getByTitle('my-step')).not.toBeNull();
+    expect(getByText('my-step')).not.toBeNull();
+    expect(getByText('http')).not.toBeNull();
   });
 });
 

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_node.test.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_node.test.tsx
@@ -198,10 +198,10 @@ describe('WorkflowGraphNode', () => {
       stepType: 'http',
       preview: true,
     });
-    // Preview mode shows both the step name (with a title attribute for truncation
-    // tooltips) and the step-type subtitle.
-    expect(getByTitle('my-step')).not.toBeNull();
-    expect(getByText('my-step')).not.toBeNull();
+    // Preview mode shows both the humanized step name (with a title attribute
+    // for truncation tooltips) and the raw step-type subtitle.
+    expect(getByTitle('My Step')).not.toBeNull();
+    expect(getByText('My Step')).not.toBeNull();
     expect(getByText('http')).not.toBeNull();
   });
 });

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_node.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_node.tsx
@@ -275,7 +275,8 @@ function NodeStepIcon({
   );
 }
 
-// Compact preview card — icon-only, used in the workflow-list hover popover.
+// Dense preview card — icon, step name and step-type subtitle. Used by the
+// inline attachment preview and the workflow-list hover popover.
 function NodePreviewCard({
   stepType,
   label,
@@ -283,6 +284,7 @@ function NodePreviewCard({
   isTriggerNode,
   iconType,
   palette,
+  stepLabelColor,
   triggerIconColor,
   renderStepIcon,
   targetHandlePos,
@@ -294,11 +296,13 @@ function NodePreviewCard({
   isTriggerNode: boolean;
   iconType: ReturnType<typeof getStepIconType>;
   palette: NodePalette;
+  stepLabelColor: string;
   triggerIconColor: string;
   renderStepIcon?: RenderStepIcon;
   targetHandlePos: Position;
   sourceHandlePos: Position;
 }) {
+  const { euiTheme } = useEuiTheme();
   return (
     <>
       {!isTrigger && <Handle type="target" position={targetHandlePos} style={{ opacity: 0 }} />}
@@ -307,23 +311,78 @@ function NodePreviewCard({
         css={{
           width: '100%',
           height: '100%',
-          background: palette.iconAreaBg,
+          background: euiTheme.colors.backgroundBasePlain,
           border: `1px solid ${palette.outerBorder}`,
           borderRadius: 6,
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center',
+          gap: 10,
+          padding: 8,
+          overflow: 'hidden',
         }}
       >
-        <NodeStepIcon
-          iconType={iconType}
-          iconColor={palette.iconColor}
-          forceTriggerPinkFill={isTriggerNode}
-          triggerIconColor={triggerIconColor}
-          renderStepIcon={renderStepIcon}
-          stepType={stepType}
-          isTrigger={isTrigger ?? false}
-        />
+        <div
+          css={{
+            flex: '0 0 auto',
+            width: 32,
+            height: 32,
+            background: palette.iconAreaBg,
+            border: `1px solid ${palette.innerBoxBorder}`,
+            borderRadius: 6,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <NodeStepIcon
+            iconType={iconType}
+            iconColor={palette.iconColor}
+            forceTriggerPinkFill={isTriggerNode}
+            triggerIconColor={triggerIconColor}
+            renderStepIcon={renderStepIcon}
+            stepType={stepType}
+            isTrigger={isTrigger ?? false}
+          />
+        </div>
+        <div
+          css={{
+            flex: '1 1 auto',
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          <span
+            css={{
+              fontFamily: euiTheme.font.family,
+              fontSize: 12,
+              fontWeight: 500,
+              lineHeight: '16px',
+              color: stepLabelColor,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+            title={label}
+          >
+            {label}
+          </span>
+          <span
+            css={{
+              fontFamily: euiTheme.font.familyCode ?? euiTheme.font.family,
+              fontSize: 11,
+              lineHeight: '14px',
+              color: euiTheme.colors.textSubdued,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+            title={stepType}
+          >
+            {stepType}
+          </span>
+        </div>
       </div>
       <Handle type="source" position={sourceHandlePos} style={{ opacity: 0 }} />
     </>
@@ -493,8 +552,9 @@ function WorkflowGraphNodeInner(node: NodeProps<Node<WorkflowGraphNodeData>>) {
     !isTrigger &&
     !colors.hasStatusIcon;
 
-  // Compact icon-only render for the workflow-list hover preview. All hooks
-  // above are still called every render, so the early return is safe.
+  // Dense preview render for inline attachment previews: icon + step name +
+  // step-type subtitle. No interaction, no retry badge, no run button. All
+  // hooks above are still called every render, so the early return is safe.
   if (preview) {
     return (
       <NodePreviewCard
@@ -504,6 +564,7 @@ function WorkflowGraphNodeInner(node: NodeProps<Node<WorkflowGraphNodeData>>) {
         isTriggerNode={isTriggerNode}
         iconType={iconType}
         palette={colors.palette}
+        stepLabelColor={colors.stepLabelColor}
         triggerIconColor={colors.triggerIconColor}
         renderStepIcon={renderStepIcon}
         targetHandlePos={targetHandlePos}

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_preview.stories.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_preview.stories.tsx
@@ -1,0 +1,310 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { parse as parseYaml } from 'yaml';
+import type { LayoutDirection, WorkflowYaml } from '@kbn/workflows';
+import { WorkflowGraphPreview } from './workflow_graph_preview';
+
+// --- YAML fixtures ---------------------------------------------------------
+//
+// Real-world-ish workflow shapes. Kept as YAML strings so the stories exercise
+// the same parse path the attachment renderer uses (bad YAML → callout, valid
+// YAML → graph, over-threshold → placeholder).
+
+const YAML_ROBUST_DAILY_EXPORT = `
+version: "1"
+name: Robust Daily Export
+enabled: true
+triggers:
+  - type: scheduled
+    with:
+      every: 24h
+steps:
+  - name: query_yesterday
+    type: elasticsearch.esql.query
+    with:
+      query: FROM logs-* | WHERE @timestamp >= NOW() - 2 days | LIMIT 10000
+  - name: export_to_archive
+    type: http
+    with:
+      url: https://archive.example.com/ingest
+      method: POST
+  - name: log_success
+    type: console
+    with:
+      message: Daily export completed successfully.
+`;
+
+const YAML_NATIONAL_PARKS = `
+version: "1"
+name: 🏔️ National Parks Demo
+enabled: true
+consts:
+  indexName: national-parks
+triggers:
+  - type: manual
+steps:
+  - name: get_index
+    type: elasticsearch.indices.exists
+    with:
+      index: "{{ consts.indexName }}"
+  - name: check_if_index_exists
+    type: if
+    condition: 'steps.get_index.output : true'
+    steps:
+      - name: index_already_exists
+        type: console
+        with:
+          message: index already exists
+      - name: delete_index
+        type: elasticsearch.indices.delete
+        with:
+          index: "{{ consts.indexName }}"
+    else:
+      - name: no_index_found
+        type: console
+        with:
+          message: index not found
+  - name: create_parks_index
+    type: elasticsearch.indices.create
+    with:
+      index: "{{ consts.indexName }}"
+  - name: bulk_index_park_data
+    type: elasticsearch.bulk
+    with:
+      index: "{{ consts.indexName }}"
+  - name: search_park_data
+    type: elasticsearch.search
+    with:
+      index: "{{ consts.indexName }}"
+  - name: log_results
+    type: console
+    with:
+      message: results
+  - name: loop_over_results
+    type: foreach
+    foreach: "{{ steps.search_park_data.output.hits.hits | json }}"
+    steps:
+      - name: process_item
+        type: console
+        with:
+          message: "{{ foreach.item._source.name }}"
+`;
+
+const YAML_ALERT_TRIAGE = `
+version: "1"
+name: 🔒 Attack Discovery Triage
+enabled: true
+triggers:
+  - type: alert
+steps:
+  - name: enrich_alert
+    type: elasticsearch.esql.query
+    with:
+      query: FROM alerts-* | WHERE alert.id == "{{ event.id }}"
+  - name: fetch_iocs
+    type: http
+    with:
+      url: https://ti.example.com/lookup
+    on-failure:
+      retry:
+        max-attempts: 3
+  - name: check_severity
+    type: if
+    condition: 'steps.enrich_alert.output.severity == "high"'
+    steps:
+      - name: isolate_host
+        type: http
+        with:
+          url: https://edr.example.com/isolate
+      - name: notify_soc
+        type: slack.postMessage
+        with:
+          channel: "#soc-alerts"
+    else:
+      - name: log_low_severity
+        type: console
+        with:
+          message: low severity alert
+  - name: create_case
+    type: cases.createCase
+    with:
+      title: "Auto triage"
+  - name: for_each_ioc
+    type: foreach
+    foreach: "{{ steps.fetch_iocs.output.iocs }}"
+    steps:
+      - name: query_vt
+        type: http
+        with:
+          url: https://virustotal.example.com/lookup
+      - name: attach_to_case
+        type: cases.addComment
+        with:
+          case_id: "{{ steps.create_case.output.case.id }}"
+  - name: page_oncall
+    type: pagerduty
+    with:
+      severity: critical
+`;
+
+const YAML_INVALID = `
+version: "1"
+name: broken
+steps:
+  - name: this: is: not: valid: [{
+`;
+
+// Build a workflow with N steps to exercise the "too large" placeholder.
+const buildLargeYaml = (n: number) => {
+  const stepBlocks = Array.from(
+    { length: n },
+    (_, i) => `
+  - name: step_${i + 1}
+    type: console
+    with:
+      message: step ${i + 1}
+`
+  ).join('');
+  return `
+version: "1"
+name: 🧨 ${n}-step workflow
+enabled: true
+triggers:
+  - type: manual
+steps:${stepBlocks}
+`;
+};
+
+const YAML_TOO_LARGE = buildLargeYaml(20);
+
+// --- Story harness ---------------------------------------------------------
+
+interface StoryArgs {
+  yaml: string;
+  height: number;
+  direction: LayoutDirection;
+  rankSep: number;
+  nodeSep: number;
+  nodeWidth: number;
+  nodeHeight: number;
+  maxSteps: number;
+}
+
+const StoryFrame = ({ yaml, ...rest }: StoryArgs) => {
+  let workflow: WorkflowYaml | null = null;
+  try {
+    const parsed = parseYaml(yaml);
+    if (parsed && typeof parsed === 'object') {
+      workflow = parsed as WorkflowYaml;
+    }
+  } catch {
+    workflow = null;
+  }
+
+  return (
+    <EuiPanel paddingSize="none" hasBorder style={{ width: 768, overflow: 'hidden' }}>
+      <EuiPanel paddingSize="m" color="subdued" hasBorder={false} hasShadow={false}>
+        <EuiText size="s">
+          <strong>{workflow?.name ?? 'Invalid YAML'}</strong>
+        </EuiText>
+      </EuiPanel>
+      {workflow ? (
+        <WorkflowGraphPreview workflow={workflow} {...rest} />
+      ) : (
+        <EuiPanel paddingSize="m" color="warning">
+          <EuiText size="s">
+            {
+              'YAML failed to parse. The real attachment renderer falls back to an EuiCallOut here; the story only exercises the graph path.'
+            }
+          </EuiText>
+        </EuiPanel>
+      )}
+      <EuiSpacer size="s" />
+    </EuiPanel>
+  );
+};
+
+const meta: Meta<typeof StoryFrame> = {
+  title: 'WorkflowGraphPreview',
+  component: StoryFrame,
+  args: {
+    height: 220,
+    direction: 'LR',
+    rankSep: 32,
+    nodeSep: 24,
+    nodeWidth: 200,
+    nodeHeight: 56,
+    maxSteps: 11,
+  },
+  argTypes: {
+    yaml: { control: 'text' },
+    height: { control: { type: 'number', min: 120, max: 640, step: 10 } },
+    direction: { control: { type: 'radio' }, options: ['LR', 'TB'] },
+    rankSep: { control: { type: 'number', min: 0, max: 200, step: 4 } },
+    nodeSep: { control: { type: 'number', min: 0, max: 200, step: 4 } },
+    nodeWidth: { control: { type: 'number', min: 100, max: 400, step: 10 } },
+    nodeHeight: { control: { type: 'number', min: 32, max: 200, step: 4 } },
+    maxSteps: { control: { type: 'number', min: 1, max: 200, step: 1 } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StoryFrame>;
+
+// --- Stories ---------------------------------------------------------------
+
+export const LinearThreeSteps: Story = {
+  name: 'Linear · 3 steps + scheduled trigger',
+  args: { yaml: YAML_ROBUST_DAILY_EXPORT },
+};
+
+export const IfElsePlusForeach: Story = {
+  name: 'Control flow · if/else + foreach (national parks)',
+  args: { yaml: YAML_NATIONAL_PARKS, height: 320 },
+};
+
+export const AlertTriageWithNested: Story = {
+  name: 'Complex · alert triage w/ nested foreach + retry',
+  args: { yaml: YAML_ALERT_TRIAGE, height: 340 },
+};
+
+export const HorizontalDefault: Story = {
+  name: 'Layout · horizontal (default)',
+  args: { yaml: YAML_ALERT_TRIAGE, height: 300, direction: 'LR' },
+};
+
+export const VerticalLayout: Story = {
+  name: 'Layout · vertical (TB)',
+  args: { yaml: YAML_ALERT_TRIAGE, height: 480, direction: 'TB' },
+};
+
+export const TightSpacing: Story = {
+  name: 'Density · very tight rankSep/nodeSep',
+  args: { yaml: YAML_ALERT_TRIAGE, height: 300, rankSep: 12, nodeSep: 12 },
+};
+
+export const OverThreshold: Story = {
+  name: 'Placeholder · workflow exceeds maxSteps',
+  args: { yaml: YAML_TOO_LARGE },
+};
+
+export const OverThresholdRaised: Story = {
+  name: 'Placeholder · same workflow with maxSteps raised to 30',
+  args: { yaml: YAML_TOO_LARGE, maxSteps: 30, height: 400, direction: 'TB' },
+};
+
+export const InvalidYaml: Story = {
+  name: 'Error · unparseable YAML (renderer would show a callout)',
+  args: { yaml: YAML_INVALID },
+};

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_preview.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_graph_preview.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiIcon, EuiText } from '@elastic/eui';
+import { ReactFlowProvider } from '@xyflow/react';
+import React, { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import type { LayoutDirection, TransformResult, WorkflowYaml } from '@kbn/workflows';
+import { collectAllSteps, transformWorkflowToGraph } from '@kbn/workflows';
+import type { RenderStepIcon } from './workflow_graph_actions_context';
+import { WorkflowGraphCanvasWithoutProvider } from './workflow_graph_canvas';
+
+export interface WorkflowGraphPreviewProps {
+  readonly workflow: WorkflowYaml;
+  /** Preview width. Number is treated as px; string is used verbatim. Defaults to `'100%'`. */
+  readonly width?: number | string;
+  /** Preview height in px. Defaults to 320 (dense inline preview). */
+  readonly height?: number;
+  /** Optional icon renderer forwarded to the underlying canvas nodes. */
+  readonly renderStepIcon?: RenderStepIcon;
+  /** Maximum number of steps to render before showing a placeholder. */
+  readonly maxSteps?: number;
+  /** Layout direction. Defaults to `'LR'` (horizontal) — denser for inline previews. */
+  readonly direction?: LayoutDirection;
+  /** Rank separation (arrow length in layout direction). Defaults to a tight 32px. */
+  readonly rankSep?: number;
+  /** Node separation (gap between siblings in a rank). Defaults to 24px. */
+  readonly nodeSep?: number;
+  /** Per-node width used by dagre. Defaults to 200px (denser than the editor's 300). */
+  readonly nodeWidth?: number;
+  /** Per-node height used by dagre. Defaults to 56px (denser than the editor's 64). */
+  readonly nodeHeight?: number;
+}
+
+const isNonBypassNode = (style: { width: number; height: number }) =>
+  style.width !== 1 || style.height !== 1;
+
+const DEFAULT_MAX_PREVIEW_STEPS = 11;
+
+const noop = () => {};
+
+/**
+ * Compact, static graph preview suitable for inline attachment previews or
+ * popovers. Renders the same `WorkflowGraphCanvas` in `previewMode` — icon-only
+ * nodes, no minimap, no banner, no interaction, autofit.
+ *
+ * Workflows with more than `maxSteps` total steps (including nested steps
+ * inside loops) show a "too large to preview" placeholder instead.
+ *
+ * Callers are responsible for handling YAML parse errors before invoking this
+ * component; the preview always receives an already-parsed `WorkflowYaml`.
+ */
+export function WorkflowGraphPreview({
+  workflow,
+  width = '100%',
+  height = 240,
+  renderStepIcon,
+  maxSteps = DEFAULT_MAX_PREVIEW_STEPS,
+  direction = 'LR',
+  rankSep = 32,
+  nodeSep = 24,
+  nodeWidth = 200,
+  nodeHeight = 56,
+}: WorkflowGraphPreviewProps) {
+  const totalSteps = collectAllSteps(workflow.steps ?? []).length;
+  const tooLarge = totalSteps > maxSteps;
+
+  // Precompute the transform and override every non-bypass node's dimensions
+  // so dagre packs them tightly. Bypass-lane placeholders (1x1) are left
+  // untouched — they're layout hints, not visible nodes.
+  const transformed = useMemo<TransformResult | undefined>(() => {
+    if (tooLarge) return undefined;
+    const t = transformWorkflowToGraph(workflow);
+    const shrink = <N extends { style: { width: number; height: number } }>(n: N): N =>
+      isNonBypassNode(n.style) ? { ...n, style: { width: nodeWidth, height: nodeHeight } } : n;
+    return {
+      ...t,
+      nodes: t.nodes.map(shrink),
+      foreachGroups: t.foreachGroups.map((g) => ({
+        ...g,
+        innerNodes: g.innerNodes.map(shrink),
+      })),
+    };
+  }, [workflow, nodeWidth, nodeHeight, tooLarge]);
+
+  return (
+    <div style={{ width, height }} data-test-subj="workflowGraphPreview">
+      {tooLarge ? (
+        <div
+          css={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+          }}
+          data-test-subj="workflowGraphPreviewTooLarge"
+        >
+          <EuiIcon type="graphApp" size="xl" aria-hidden={true} />
+          <EuiText size="s" color="subdued" textAlign="center">
+            {i18n.translate('workflowsUi.graphPreview.tooLarge', {
+              defaultMessage: 'Workflow is too large to preview',
+            })}
+          </EuiText>
+        </div>
+      ) : (
+        <ReactFlowProvider>
+          <WorkflowGraphCanvasWithoutProvider
+            workflow={workflow}
+            transformed={transformed}
+            isYamlValid
+            onStepSelect={noop}
+            renderStepIcon={renderStepIcon}
+            direction={direction}
+            rankSep={rankSep}
+            nodeSep={nodeSep}
+            showBackground
+            previewMode
+          />
+        </ReactFlowProvider>
+      )}
+    </div>
+  );
+}

--- a/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_layout_pipeline.ts
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/components/workflow_graph/workflow_layout_pipeline.ts
@@ -33,7 +33,11 @@ export interface LayoutSnapshot {
  */
 export const computeWorkflowLayout = (
   transformed: TransformResult,
-  { direction }: { direction: LayoutDirection }
+  {
+    direction,
+    nodeSep,
+    rankSep,
+  }: { direction: LayoutDirection; nodeSep?: number; rankSep?: number }
 ): LayoutSnapshot => {
   const { nodes, edges, foreachGroups, bypassLaneNodes } = transformed;
 
@@ -71,8 +75,8 @@ export const computeWorkflowLayout = (
 
   const laid = dagLayout(dagNodes, dagEdges, dagGroups, {
     direction,
-    nodeSep: WORKFLOW_NODE_SEP,
-    rankSep: WORKFLOW_RANK_SEP,
+    nodeSep: nodeSep ?? WORKFLOW_NODE_SEP,
+    rankSep: rankSep ?? WORKFLOW_RANK_SEP,
     compoundPadding: WORKFLOW_COMPOUND_PADDING,
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.test.tsx
@@ -32,6 +32,13 @@ jest.mock('@kbn/workflows-ui', () => {
     ...actual,
     useWorkflowsApi: jest.fn(() => mockWorkflowApi),
     useWorkflowsCapabilities: jest.fn(() => mockAllWorkflowCapabilitiesTrue),
+    WorkflowGraphPreview: (props: { width?: number | string; height?: number }) => (
+      <div
+        data-test-subj="workflowGraphPreview"
+        data-width={props.width ?? ''}
+        data-height={props.height ?? ''}
+      />
+    ),
   };
 });
 
@@ -85,6 +92,51 @@ describe('createWorkflowYamlAttachmentUiDefinition', () => {
     expect(definition.getIcon).toBeDefined();
     expect(definition.getActionButtons).toBeDefined();
     expect(definition.renderCanvasContent).toBeDefined();
+    expect(definition.renderInlineContent).toBeDefined();
+  });
+
+  describe('renderInlineContent', () => {
+    it('renders a taller graph preview in the main chat (not sidebar)', () => {
+      const services = createMockServices();
+      const definition = createWorkflowYamlAttachmentUiDefinition(services);
+      const attachment = createAttachment();
+
+      const { getByTestId } = render(
+        <>{definition.renderInlineContent!({ attachment, isSidebar: false })}</>
+      );
+
+      const preview = getByTestId('workflowGraphPreview');
+      expect(preview.getAttribute('data-height')).toBe('220');
+    });
+
+    it('renders a shorter graph preview in the sidebar', () => {
+      const services = createMockServices();
+      const definition = createWorkflowYamlAttachmentUiDefinition(services);
+      const attachment = createAttachment();
+
+      const { getByTestId } = render(
+        <>{definition.renderInlineContent!({ attachment, isSidebar: true })}</>
+      );
+
+      const preview = getByTestId('workflowGraphPreview');
+      expect(preview.getAttribute('data-height')).toBe('180');
+    });
+
+    it('renders an invalid-yaml callout when the yaml cannot be parsed', () => {
+      const services = createMockServices();
+      const definition = createWorkflowYamlAttachmentUiDefinition(services);
+      const attachment = {
+        ...createAttachment(),
+        data: { yaml: 'not: valid: yaml: [{' },
+      };
+
+      const { queryByTestId } = render(
+        <>{definition.renderInlineContent!({ attachment, isSidebar: false })}</>
+      );
+
+      expect(queryByTestId('workflowYamlInlinePreviewInvalid')).not.toBeNull();
+      expect(queryByTestId('workflowGraphPreview')).toBeNull();
+    });
   });
 
   describe('getLabel', () => {

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.test.tsx
@@ -137,6 +137,25 @@ describe('createWorkflowYamlAttachmentUiDefinition', () => {
       expect(queryByTestId('workflowYamlInlinePreviewInvalid')).not.toBeNull();
       expect(queryByTestId('workflowGraphPreview')).toBeNull();
     });
+
+    it('renders an invalid-yaml callout when steps is not an array', () => {
+      const services = createMockServices();
+      const definition = createWorkflowYamlAttachmentUiDefinition(services);
+      const attachment = {
+        ...createAttachment(),
+        // Valid YAML, wrong shape: steps authored as a mapping instead of a list.
+        // WorkflowGraphPreview iterates workflow.steps, so this would throw
+        // "object is not iterable" without the shape guard in parseWorkflowYaml.
+        data: { yaml: 'name: shape-mismatch\nsteps:\n  foo: bar\n' },
+      };
+
+      const { queryByTestId } = render(
+        <>{definition.renderInlineContent!({ attachment, isSidebar: false })}</>
+      );
+
+      expect(queryByTestId('workflowYamlInlinePreviewInvalid')).not.toBeNull();
+      expect(queryByTestId('workflowGraphPreview')).toBeNull();
+    });
   });
 
   describe('getLabel', () => {

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.tsx
@@ -25,8 +25,12 @@ import {
   useWorkflowsCapabilities,
   useWorkflowsMonacoTheme,
   WORKFLOW_READ_ONLY_MONACO_OPTIONS,
+  WorkflowGraphPreview,
   type WorkflowApi,
 } from '@kbn/workflows-ui';
+import type { WorkflowYaml } from '@kbn/workflows';
+import { parse as parseYaml } from 'yaml';
+import { EuiCallOut } from '@elastic/eui';
 import type { QueryClient } from '@kbn/react-query';
 import { PLUGIN_ID as WORKFLOW_PLUGIN_ID } from '@kbn/workflows-management-plugin/common';
 import type { WorkflowsBaseTelemetry } from '@kbn/workflows-management-plugin/public';
@@ -348,6 +352,53 @@ const WorkflowYamlCanvasContent: React.FC<{
   );
 };
 
+// Dense inline preview: stretches to the panel's full width and uses a
+// horizontal (LR) dagre layout, so the whole workflow fits in a short strip.
+// Sidebar keeps a smaller strip since the panel is narrower.
+const INLINE_PREVIEW_HEIGHT_SIDEBAR = 180;
+const INLINE_PREVIEW_HEIGHT_DEFAULT = 220;
+
+const parseWorkflowYaml = (yaml: string): WorkflowYaml | null => {
+  try {
+    const parsed = parseYaml(yaml);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as WorkflowYaml;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const WorkflowYamlInlinePreview: React.FC<{
+  attachment: WorkflowYamlAttachment;
+  isSidebar: boolean;
+}> = ({ attachment, isSidebar }) => {
+  const parsed = React.useMemo(
+    () => parseWorkflowYaml(attachment.data.yaml),
+    [attachment.data.yaml]
+  );
+
+  if (!parsed) {
+    return (
+      <EuiCallOut
+        size="s"
+        color="warning"
+        iconType="warning"
+        data-test-subj="workflowYamlInlinePreviewInvalid"
+        title={i18n.translate(
+          'workflowsManagement.attachmentRenderers.workflowYaml.inlinePreview.invalidYaml',
+          { defaultMessage: 'Workflow YAML could not be parsed' }
+        )}
+      />
+    );
+  }
+
+  const height = isSidebar ? INLINE_PREVIEW_HEIGHT_SIDEBAR : INLINE_PREVIEW_HEIGHT_DEFAULT;
+
+  return <WorkflowGraphPreview workflow={parsed} height={height} />;
+};
+
 export const createWorkflowYamlAttachmentUiDefinition = ({
   core,
   telemetry,
@@ -384,6 +435,12 @@ export const createWorkflowYamlAttachmentUiDefinition = ({
       }),
 
     getIcon: () => 'workflowsApp',
+
+    renderInlineContent: ({ attachment, isSidebar }) => (
+      <KibanaContextProvider services={core}>
+        <WorkflowYamlInlinePreview attachment={attachment} isSidebar={isSidebar} />
+      </KibanaContextProvider>
+    ),
 
     getActionButtons: ({ attachment, isCanvas, openCanvas }) => {
       if (isCanvas) return [];

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { EuiPanel } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Subscription } from 'rxjs';
@@ -34,7 +33,6 @@ import { EuiCallOut } from '@elastic/eui';
 import type { QueryClient } from '@kbn/react-query';
 import { PLUGIN_ID as WORKFLOW_PLUGIN_ID } from '@kbn/workflows-management-plugin/common';
 import type { WorkflowsBaseTelemetry } from '@kbn/workflows-management-plugin/public';
-import { WorkflowInfoStripe } from './workflow_info_stripe';
 
 interface WorkflowYamlData {
   yaml: string;
@@ -390,7 +388,10 @@ const WorkflowYamlInlinePreview: React.FC<{
 
   if (!parsed) {
     return (
+      // Rendered as part of the attachment body, not in response to a user
+      // action, so it must not steal the screen reader on mount.
       <EuiCallOut
+        announceOnMount={false}
         size="s"
         color="warning"
         iconType="warning"
@@ -487,12 +488,6 @@ export const createWorkflowYamlAttachmentUiDefinition = ({
 
       return buttons;
     },
-
-    renderInlineContent: ({ attachment }) => (
-      <EuiPanel paddingSize="m" hasShadow={false} hasBorder={false}>
-        <WorkflowInfoStripe yaml={attachment.data.yaml} showTitle />
-      </EuiPanel>
-    ),
 
     renderCanvasContent: ({ attachment, isSidebar }, { registerActionButtons, updateOrigin }) => (
       <KibanaContextProvider services={core}>

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_attachment_renderer.tsx
@@ -358,10 +358,19 @@ const WorkflowYamlCanvasContent: React.FC<{
 const INLINE_PREVIEW_HEIGHT_SIDEBAR = 180;
 const INLINE_PREVIEW_HEIGHT_DEFAULT = 220;
 
+// Guards against valid-YAML/wrong-shape (e.g. LLM emits `steps:` as a mapping):
+// WorkflowGraphPreview iterates `workflow.steps` / `workflow.triggers`, which
+// would throw "object is not iterable" — there's no error boundary in the
+// inline attachment render path, so a throw crashes the whole chat message.
 const parseWorkflowYaml = (yaml: string): WorkflowYaml | null => {
   try {
     const parsed = parseYaml(yaml);
-    if (parsed && typeof parsed === 'object') {
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      (parsed.steps === undefined || Array.isArray(parsed.steps)) &&
+      (parsed.triggers === undefined || Array.isArray(parsed.triggers))
+    ) {
       return parsed as WorkflowYaml;
     }
     return null;

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_diff_attachment_renderer.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/public/attachment_types/workflow_yaml_diff_attachment_renderer.tsx
@@ -321,6 +321,7 @@ const componentStyles = {
   wrapper: ({ euiTheme }: UseEuiTheme) =>
     css({
       position: 'relative',
+      padding: '10px 0',
       backgroundColor: euiTheme.colors.backgroundBaseSubdued,
       '.diff-hidden-lines .center': {
         gap: euiTheme.size.s,


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/18063

## Summary

Render a dense, non-interactive graph preview inline in Agent Builder chat whenever the agent returns a `workflow.yaml` attachment, so users can grasp the workflow's shape at a glance without clicking **Preview** to open the canvas.

![inline preview](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260705/3k4duhwg-conversation_v4.png)

## What changed

- **New:** `WorkflowGraphPreview` in `@kbn/workflows-ui` — parses YAML, guards parse errors, shows a "too large to preview" placeholder over 11 steps. Restored from the pre-strip POC (commit [1ec93394bc76](https://github.com/elastic/kibana/commit/1ec93394bc76048a016fa795a7080a841ef2742a)).
- **Canvas:** new `previewMode` prop forces `fitView`, disables all interactions, hides the invalid-YAML callout, and marks every node with `data.preview: true` (which triggers the existing icon-only compact node branch). New `rankSep` / `nodeSep` props expose dagre tuning per-usage; the main editor keeps its 70/50 defaults.
- **Preview node render:** icon on left, step name (bold), step type (mono subtitle). Replaces the previous icon-only compact render.
- **Attachment renderer:** `workflow_yaml_attachment_renderer.tsx` gains an always-on `renderInlineContent`. Sidebar variant is 180px tall, main-chat is 220px.
- **Layout defaults for the preview:** LR direction, `rankSep=32`, `nodeSep=24`, 200×56 node dimensions (vs 300×64 in the editor), dot-pattern background matching the main visualization.

## Storybook coverage

Added `workflow_graph_preview.stories.tsx` (in the `workflows_ui` Storybook) that feeds real workflow YAML through the real preview component. A few scenarios worth showing:

| Linear · persisted | Control flow · if/else + foreach | Complex · alert triage w/ retry + nested foreach |
| --- | --- | --- |
| ![linear persisted](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260706/nu10bbzd-01-linear-cropped.png) | ![national parks](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260706/iri8pbmx-02-national-parks-cropped.png) | ![alert triage](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260706/6u3zdahd-03-alert-triage-cropped.png) |
| Persisted workflow — action bar shows both **Preview** and **Open in editor**. | If/else + foreach — both branches are laid out under the `if` node with `true`/`false` edge labels; the `foreach` body is wrapped in its own container. | Nested control flow — the `check_severity` if fans out to two branches that rejoin at `create_case`, and `for_each_ioc` contains its own two-step body. |

Run locally with `SB_PORT=9002 node scripts/storybook workflows_ui` and open the `WorkflowGraphPreview` group.

## Test plan

- [x] `node scripts/jest` — new inline-preview tests (invalid yaml, sidebar vs main heights) + updated node preview test (name + type now visible). 142 workflow_graph + 29 attachment renderer tests pass.
- [x] `node scripts/type_check --project x-pack/platform/plugins/shared/agent_builder_workflows/tsconfig.json` — green.
- [x] `node scripts/type_check --project src/platform/packages/shared/kbn-workflows-ui/tsconfig.json` — green.
- [x] `node scripts/eslint` on all touched files — clean.
- [x] `node scripts/i18n_check` — clean.
- [x] Manual: verified inline preview renders in an AB conversation with a `workflow.yaml` attachment (screenshot above).
- [ ] Verify **Preview** action button still opens the canvas YAML editor (regression).
- [ ] Verify parse-error fallback (`workflowYamlInlinePreviewInvalid` test-subj) renders when YAML is malformed.
- [ ] Verify "too large to preview" placeholder shows for a workflow >11 steps.

## Follow-ups

- Hover affordance to expand preview → canvas.
- PNG rasterization fallback if react-flow-per-message becomes a perf issue in long conversations.

## Context

The stripped POC plus the react-flow `download-image` demo give us a quick path to an inline visualization. The longer-term embedded Agent Builder visualization is still on the roadmap; this PR is the quick path in the meantime.
