### PR TITLE
[Flaky Test Fixer] Post review reminders as kibanamachine so team mentions notify

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3868,6 +3868,8 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /.github/workflows/failed-test-investigator.* @elastic/kibana-operations @elastic/appex-qa
 /.github/workflows/flaky-test-fixer.* @elastic/kibana-operations @elastic/appex-qa
 /.github/workflows/flaky-fix-verifier.* @elastic/kibana-operations @elastic/appex-qa
+/.github/workflows/flaky-fix-review-reminder.yml @elastic/appex-qa
+/.github/scripts/flaky_fix_review_reminder* @elastic/appex-qa
 /.github/aw/ @elastic/kibana-operations
 /.buildkite/ @elastic/kibana-operations
 /moon.yml @elastic/kibana-operations

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -100,8 +100,7 @@ function buildCommentBody(ownerHandles) {
   ].join('\n');
 }
 
-const isBot = (user) =>
-  Boolean(user) && (user.type === 'Bot' || user.login.endsWith('[bot]'));
+const isBot = (user) => Boolean(user) && (user.type === 'Bot' || user.login.endsWith('[bot]'));
 
 /**
  * Whether a human (non-author, non-bot) submitted an APPROVED /
@@ -225,7 +224,10 @@ module.exports = async function flakyFixReviewReminder({ github, context, core }
       pull_number: pr.number,
       per_page: 100,
     });
-    const owners = resolveOwners(entries, files.map((f) => f.filename));
+    const owners = resolveOwners(
+      entries,
+      files.map((f) => f.filename)
+    );
     if (owners.length === 0) {
       core.info(`No codeowners resolved for #${pr.number}, skipping`);
       continue;
@@ -234,7 +236,9 @@ module.exports = async function flakyFixReviewReminder({ github, context, core }
 
     if (dryRun) {
       pinged += 1;
-      core.info(`[dry run] would ping #${pr.number} (${elapsed}d since ${reference}) -> ${mentioned}`);
+      core.info(
+        `[dry run] would ping #${pr.number} (${elapsed}d since ${reference}) -> ${mentioned}`
+      );
       continue;
     }
 

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -18,12 +18,8 @@ const ignore = require('ignore');
 
 const LABEL = 'flaky-test-fixer';
 const REMINDER_MARKER = '<!-- flaky-fix-review-reminder -->';
-// Identities whose marker comments count as prior reminders. Comments are
-// posted as kibanamachine — a real user account is required because team
-// @-mentions in comments posted by GitHub Apps (github-actions) do not
-// trigger notifications. github-actions[bot] is kept for reminders posted
-// before the switch.
-const REMINDER_AUTHORS = ['kibanamachine', 'github-actions[bot]'];
+// must be kibanamachine (github-actions wouldn't send the notification to the team)
+const REMINDER_AUTHOR = 'kibanamachine';
 // Calendar days (weekends included) before the first ping; also the re-ping cadence.
 const REMINDER_AFTER_DAYS = 4;
 // Max reminder comments posted per run. Bounds the noise (and API writes) of a
@@ -156,7 +152,7 @@ async function getLastReminderTime({ github, owner, repo, prNumber }) {
   for (const comment of comments) {
     if (
       comment.user &&
-      REMINDER_AUTHORS.includes(comment.user.login) &&
+      comment.user.login === REMINDER_AUTHOR &&
       comment.body &&
       comment.body.includes(REMINDER_MARKER)
     ) {

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -18,8 +18,10 @@ const ignore = require('ignore');
 
 const LABEL = 'flaky-test-fixer';
 const REMINDER_MARKER = '<!-- flaky-fix-review-reminder -->';
-// The bot that authors our reminder comments (default GITHUB_TOKEN identity).
-const REMINDER_AUTHOR = 'github-actions[bot]';
+// The identity that authors our reminder comments. A real user account is
+// required: team @-mentions in comments posted by GitHub Apps (github-actions)
+// do not trigger notifications.
+const REMINDER_AUTHOR = 'kibanamachine';
 // Calendar days (weekends included) before the first ping; also the re-ping cadence.
 const REMINDER_AFTER_DAYS = 4;
 // Max reminder comments posted per run. Bounds the noise (and API writes) of a

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -18,10 +18,12 @@ const ignore = require('ignore');
 
 const LABEL = 'flaky-test-fixer';
 const REMINDER_MARKER = '<!-- flaky-fix-review-reminder -->';
-// The identity that authors our reminder comments. A real user account is
-// required: team @-mentions in comments posted by GitHub Apps (github-actions)
-// do not trigger notifications.
-const REMINDER_AUTHOR = 'kibanamachine';
+// Identities whose marker comments count as prior reminders. Comments are
+// posted as kibanamachine — a real user account is required because team
+// @-mentions in comments posted by GitHub Apps (github-actions) do not
+// trigger notifications. github-actions[bot] is kept for reminders posted
+// before the switch.
+const REMINDER_AUTHORS = ['kibanamachine', 'github-actions[bot]'];
 // Calendar days (weekends included) before the first ping; also the re-ping cadence.
 const REMINDER_AFTER_DAYS = 4;
 // Max reminder comments posted per run. Bounds the noise (and API writes) of a
@@ -154,7 +156,7 @@ async function getLastReminderTime({ github, owner, repo, prNumber }) {
   for (const comment of comments) {
     if (
       comment.user &&
-      comment.user.login === REMINDER_AUTHOR &&
+      REMINDER_AUTHORS.includes(comment.user.login) &&
       comment.body &&
       comment.body.includes(REMINDER_MARKER)
     ) {

--- a/.github/scripts/flaky_fix_review_reminder.test.js
+++ b/.github/scripts/flaky_fix_review_reminder.test.js
@@ -85,19 +85,6 @@ test('buildCommentBody mentions the owners and includes the marker', () => {
   assert.ok(body.includes('@copilot'));
 });
 
-test('a PR whose files resolve no codeowners is not pinged', async () => {
-  await withFixtureAndNow(async () => {
-    const state = scenarioState();
-    state.files[1] = ['totally/unowned/path.xyz'];
-    process.env.DRY_RUN = 'false';
-    await reminder({ github: makeGithub(state), context, core: silentCore });
-
-    assert.ok(!state.posted.some((c) => c.issue_number === 1));
-    // Other due PRs are unaffected.
-    assert.ok(state.posted.some((c) => c.issue_number === 5));
-  });
-});
-
 // --- Full sweep integration against a mocked Octokit -----------------------
 
 function makeGithub(state) {
@@ -108,20 +95,24 @@ function makeGithub(state) {
       repos: { get: async () => ({ data: { default_branch: 'main' } }) },
       issues: {
         listForRepo: async () => ({ data: state.candidates }),
-        listEventsForTimeline: async ({ issue_number }) => ({
-          data: state.timeline[issue_number] || [],
+        listEventsForTimeline: async ({ issue_number: issueNumber }) => ({
+          data: state.timeline[issueNumber] || [],
         }),
-        listComments: async ({ issue_number }) => ({ data: state.comments[issue_number] || [] }),
+        listComments: async ({ issue_number: issueNumber }) => ({
+          data: state.comments[issueNumber] || [],
+        }),
         createComment: async (args) => {
           state.posted.push(args);
           return { data: {} };
         },
       },
       pulls: {
-        get: async ({ pull_number }) => ({ data: state.prs[pull_number] }),
-        listReviews: async ({ pull_number }) => ({ data: state.reviews[pull_number] || [] }),
-        listFiles: async ({ pull_number }) => ({
-          data: (state.files[pull_number] || []).map((filename) => ({ filename })),
+        get: async ({ pull_number: pullNumber }) => ({ data: state.prs[pullNumber] }),
+        listReviews: async ({ pull_number: pullNumber }) => ({
+          data: state.reviews[pullNumber] || [],
+        }),
+        listFiles: async ({ pull_number: pullNumber }) => ({
+          data: (state.files[pullNumber] || []).map((filename) => ({ filename })),
         }),
       },
     },
@@ -203,6 +194,19 @@ function withFixtureAndNow(fn) {
 
 const context = { repo: { owner: 'elastic', repo: 'kibana' } };
 const silentCore = { info() {}, warning() {} };
+
+test('a PR whose files resolve no codeowners is not pinged', async () => {
+  await withFixtureAndNow(async () => {
+    const state = scenarioState();
+    state.files[1] = ['totally/unowned/path.xyz'];
+    process.env.DRY_RUN = 'false';
+    await reminder({ github: makeGithub(state), context, core: silentCore });
+
+    assert.ok(!state.posted.some((c) => c.issue_number === 1));
+    // Other due PRs are unaffected.
+    assert.ok(state.posted.some((c) => c.issue_number === 5));
+  });
+});
 
 test('sweep pings the first due, ready, unreviewed PR with its codeowners', async () => {
   await withFixtureAndNow(async () => {

--- a/.github/scripts/flaky_fix_review_reminder.test.js
+++ b/.github/scripts/flaky_fix_review_reminder.test.js
@@ -175,7 +175,7 @@ function scenarioState() {
       // #5 was already pinged by us 4 days ago -> due for a re-ping.
       5: [
         {
-          user: { login: 'github-actions[bot]' },
+          user: { login: 'kibanamachine' },
           body: `...\n${reminder.REMINDER_MARKER}`,
           created_at: iso('2026-08-14'),
         },

--- a/.github/workflows/flaky-fix-review-reminder.yml
+++ b/.github/workflows/flaky-fix-review-reminder.yml
@@ -43,7 +43,9 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run == true }}
         with:
-          # github-script defaults to GITHUB_TOKEN; pull-requests: write suffices.
+          # kibanamachine, not the default GITHUB_TOKEN: team @-mentions in
+          # comments posted by GitHub Apps do not notify the team.
+          github-token: ${{ secrets.KIBANAMACHINE_TOKEN }}
           script: |
             const flakyFixReviewReminder = require('./.github/scripts/flaky_fix_review_reminder');
             await flakyFixReviewReminder({ github, context, core });

--- a/.github/workflows/flaky-fix-review-reminder.yml
+++ b/.github/workflows/flaky-fix-review-reminder.yml
@@ -43,8 +43,7 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run == true }}
         with:
-          # kibanamachine, not the default GITHUB_TOKEN: team @-mentions in
-          # comments posted by GitHub Apps do not notify the team.
+          # must be kibanamachine (github-actions wouldn't send the notification to the team)
           github-token: ${{ secrets.KIBANAMACHINE_TOKEN }}
           script: |
             const flakyFixReviewReminder = require('./.github/scripts/flaky_fix_review_reminder');


### PR DESCRIPTION
Team mentions posted by `github-actions[bot]` do not seem to notify teams (e.g., we AppEx QA weren't notified in https://github.com/elastic/kibana/pull/281581), so let's have kibanamachine post them instead. This should finally trigger the notification (and DX-wise it keeps things more "natural", given kibanamachine is the same automation that created the initial PR). 