### PR TITLE
[8.19] [Synthetics] Fix status rule key mismatch for project monitors and ungrouped recovery context (#265648)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.test.ts
@@ -724,4 +724,337 @@ describe('setRecoveredAlertsContext', () => {
       },
     });
   });
+
+  describe('findConfigKeyByAlertId prefix-match fallback', () => {
+    it('matches staleDownConfigs by prefix when alert ID has no location suffix', () => {
+      const alertsClientMock = {
+        report: jest.fn(),
+        getAlertLimitValue: jest.fn().mockReturnValue(10),
+        setAlertLimitReached: jest.fn(),
+        getRecoveredAlerts: jest.fn().mockReturnValue([
+          {
+            alert: {
+              getUuid: () => alertUuid,
+              getId: () => configId,
+              getState: () => ({ downThreshold: 1 }),
+              setContext: jest.fn(),
+            },
+            hit: {
+              'kibana.alert.instance.id': configId,
+              'location.id': location,
+              configId,
+              '@timestamp': new Date().toISOString(),
+              downThreshold: 1,
+            },
+          },
+        ]),
+        setAlertData: jest.fn(),
+        isTrackedAlert: jest.fn(),
+      };
+      const staleDownConfigs: AlertOverviewStatus['staleDownConfigs'] = {
+        [idWithLocation]: {
+          configId,
+          monitorQueryId: 'stale-config',
+          status: 'down',
+          locationId: location,
+          latestPing: {
+            '@timestamp': new Date().toISOString(),
+            state: { id: '123456' },
+            monitor: { name: monitorName },
+            observer: { geo: { name: location } },
+          } as StaleDownConfig['latestPing'],
+          timestamp: new Date().toISOString(),
+          isDeleted: true,
+          checks: { downWithinXChecks: 1, down: 1 },
+        },
+      };
+      setRecoveredAlertsContext({
+        alertsClient: alertsClientMock,
+        basePath,
+        spaceId: 'default',
+        staleDownConfigs,
+        upConfigs: {},
+        dateFormat,
+        tz: 'UTC',
+        groupByLocation: true,
+        stalePendingConfigs: {},
+      });
+      expect(alertsClientMock.setAlertData).toBeCalledWith(
+        expect.objectContaining({
+          id: configId,
+          context: expect.objectContaining({
+            recoveryStatus: 'has been deleted',
+            recoveryReason: 'has been deleted',
+            stateId: '123456',
+            linkMessage: '',
+          }),
+        })
+      );
+    });
+
+    it('matches stalePendingConfigs by prefix when alert ID has no location suffix', () => {
+      const alertsClientMock = {
+        report: jest.fn(),
+        getAlertLimitValue: jest.fn().mockReturnValue(10),
+        setAlertLimitReached: jest.fn(),
+        getRecoveredAlerts: jest.fn().mockReturnValue([
+          {
+            alert: {
+              getUuid: () => alertUuid,
+              getId: () => configId,
+              getState: () => ({ downThreshold: 1 }),
+              setContext: jest.fn(),
+            },
+            hit: {
+              'kibana.alert.instance.id': configId,
+              'location.id': location,
+              configId,
+              '@timestamp': new Date().toISOString(),
+              downThreshold: 1,
+            },
+          },
+        ]),
+        setAlertData: jest.fn(),
+        isTrackedAlert: jest.fn(),
+      };
+      const stalePendingConfigs: AlertOverviewStatus['stalePendingConfigs'] = {
+        [idWithLocation]: {
+          configId,
+          monitorQueryId: 'stale-config',
+          status: 'pending',
+          locationId: location,
+          monitorInfo: {
+            monitor: { name: monitorName, id: monitorId, type: 'http' },
+            observer: { geo: { name: location } },
+            tags: [],
+            state: { id: '789' },
+          },
+          latestPing: {
+            '@timestamp': new Date().toISOString(),
+            state: { id: '789' },
+            monitor: { name: monitorName },
+            observer: { geo: { name: location } },
+          } as StaleDownConfig['latestPing'],
+          timestamp: new Date().toISOString(),
+          isLocationRemoved: true,
+        },
+      };
+      setRecoveredAlertsContext({
+        alertsClient: alertsClientMock,
+        basePath,
+        spaceId: 'default',
+        staleDownConfigs: {},
+        upConfigs: {},
+        dateFormat,
+        tz: 'UTC',
+        groupByLocation: true,
+        stalePendingConfigs,
+      });
+      expect(alertsClientMock.setAlertData).toBeCalledWith(
+        expect.objectContaining({
+          id: configId,
+          context: expect.objectContaining({
+            recoveryReason: 'this location has been removed from the monitor',
+            recoveryStatus: 'has recovered',
+            stateId: '789',
+            linkMessage: '',
+          }),
+        })
+      );
+    });
+
+    it('matches upConfigs by prefix when alert ID has no location suffix', () => {
+      const alertsClientMock = {
+        report: jest.fn(),
+        getAlertLimitValue: jest.fn().mockReturnValue(10),
+        setAlertLimitReached: jest.fn(),
+        getRecoveredAlerts: jest.fn().mockReturnValue([
+          {
+            alert: {
+              getUuid: () => alertUuid,
+              getId: () => configId,
+              getState: () => ({ downThreshold: 1 }),
+              setContext: jest.fn(),
+            },
+            hit: {
+              'kibana.alert.instance.id': configId,
+              'location.id': location,
+              configId,
+              '@timestamp': new Date().toISOString(),
+              downThreshold: 1,
+            },
+          },
+        ]),
+        setAlertData: jest.fn(),
+        isTrackedAlert: jest.fn(),
+      };
+      setRecoveredAlertsContext({
+        alertsClient: alertsClientMock,
+        basePath,
+        spaceId: 'default',
+        staleDownConfigs: {},
+        upConfigs,
+        dateFormat,
+        tz: 'UTC',
+        groupByLocation: true,
+        stalePendingConfigs: {},
+      });
+      expect(alertsClientMock.setAlertData).toBeCalledWith(
+        expect.objectContaining({
+          id: configId,
+          context: expect.objectContaining({
+            status: 'up',
+            recoveryStatus: 'is now up',
+            linkMessage: expect.stringContaining(
+              `https://localhost:5601/app/synthetics/monitor/${configId}/errors/123456`
+            ),
+          }),
+        })
+      );
+    });
+
+    it('prefers staleDownConfigs over stalePendingConfigs on prefix match', () => {
+      const alertsClientMock = {
+        report: jest.fn(),
+        getAlertLimitValue: jest.fn().mockReturnValue(10),
+        setAlertLimitReached: jest.fn(),
+        getRecoveredAlerts: jest.fn().mockReturnValue([
+          {
+            alert: {
+              getUuid: () => alertUuid,
+              getId: () => configId,
+              getState: () => ({ downThreshold: 1 }),
+              setContext: jest.fn(),
+            },
+            hit: {
+              'kibana.alert.instance.id': configId,
+              'location.id': location,
+              configId,
+              '@timestamp': new Date().toISOString(),
+              downThreshold: 1,
+            },
+          },
+        ]),
+        setAlertData: jest.fn(),
+        isTrackedAlert: jest.fn(),
+      };
+      const staleDownConfigs: AlertOverviewStatus['staleDownConfigs'] = {
+        [idWithLocation]: {
+          configId,
+          monitorQueryId: 'stale-config',
+          status: 'down',
+          locationId: location,
+          latestPing: {
+            '@timestamp': new Date().toISOString(),
+            state: { id: 'down-state' },
+            monitor: { name: monitorName },
+            observer: { geo: { name: location } },
+          } as StaleDownConfig['latestPing'],
+          timestamp: new Date().toISOString(),
+          isDeleted: true,
+          checks: { downWithinXChecks: 1, down: 1 },
+        },
+      };
+      const stalePendingConfigs: AlertOverviewStatus['stalePendingConfigs'] = {
+        [idWithLocation]: {
+          configId,
+          monitorQueryId: 'stale-config',
+          status: 'pending',
+          locationId: location,
+          monitorInfo: {
+            monitor: { name: monitorName, id: monitorId, type: 'http' },
+            observer: { geo: { name: location } },
+            tags: [],
+            state: { id: 'pending-state' },
+          },
+          latestPing: {
+            '@timestamp': new Date().toISOString(),
+            state: { id: 'pending-state' },
+            monitor: { name: monitorName },
+            observer: { geo: { name: location } },
+          } as StaleDownConfig['latestPing'],
+          timestamp: new Date().toISOString(),
+          isDeleted: true,
+        },
+      };
+      setRecoveredAlertsContext({
+        alertsClient: alertsClientMock,
+        basePath,
+        spaceId: 'default',
+        staleDownConfigs,
+        upConfigs: {},
+        dateFormat,
+        tz: 'UTC',
+        groupByLocation: true,
+        stalePendingConfigs,
+      });
+      expect(alertsClientMock.setAlertData).toBeCalledWith(
+        expect.objectContaining({
+          id: configId,
+          context: expect.objectContaining({
+            stateId: 'down-state',
+          }),
+        })
+      );
+    });
+
+    it('does not prefix-match when alert ID does not match any config key', () => {
+      const nonMatchingConfigId = 'no-match-config';
+      const alertsClientMock = {
+        report: jest.fn(),
+        getAlertLimitValue: jest.fn().mockReturnValue(10),
+        setAlertLimitReached: jest.fn(),
+        getRecoveredAlerts: jest.fn().mockReturnValue([
+          {
+            alert: {
+              getUuid: () => alertUuid,
+              getId: () => nonMatchingConfigId,
+              getState: () => ({ downThreshold: 1 }),
+              setContext: jest.fn(),
+            },
+            hit: {
+              'kibana.alert.instance.id': nonMatchingConfigId,
+              'location.id': location,
+              configId: nonMatchingConfigId,
+              '@timestamp': new Date().toISOString(),
+              downThreshold: 1,
+            },
+          },
+        ]),
+        setAlertData: jest.fn(),
+        isTrackedAlert: jest.fn(),
+      };
+      const staleDownConfigs: AlertOverviewStatus['staleDownConfigs'] = {
+        [idWithLocation]: {
+          configId,
+          monitorQueryId: 'stale-config',
+          status: 'down',
+          locationId: location,
+          latestPing: {
+            '@timestamp': new Date().toISOString(),
+            state: { id: '123456' },
+            monitor: { name: monitorName },
+            observer: { geo: { name: location } },
+          } as StaleDownConfig['latestPing'],
+          timestamp: new Date().toISOString(),
+          isDeleted: true,
+          checks: { downWithinXChecks: 1, down: 1 },
+        },
+      };
+      setRecoveredAlertsContext({
+        alertsClient: alertsClientMock,
+        basePath,
+        spaceId: 'default',
+        staleDownConfigs,
+        upConfigs,
+        dateFormat,
+        tz: 'UTC',
+        groupByLocation: true,
+        stalePendingConfigs: {},
+      });
+      const call = alertsClientMock.setAlertData.mock.calls[0][0];
+      expect(call.context.recoveryStatus).toBe('has recovered');
+      expect(call.context.recoveryReason).toBe('the alert condition is no longer met');
+    });
+  });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/common.ts
@@ -141,6 +141,18 @@ export const getRelativeViewInAppUrl = ({
 };
 
 export const getRelativeCertificatesViewInAppUrl = () => getSyntheticsCertificatesRoute();
+/**
+ * For ungrouped alerts, the alert ID is just the configId (no location suffix),
+ * but config maps are keyed by `${configId}-${locationId}`. This helper tries
+ * an exact match first, then falls back to a prefix match.
+ */
+function findConfigKeyByAlertId<T>(
+  configs: Record<string, T>,
+  alertId: string
+): string | undefined {
+  if (configs[alertId]) return alertId;
+  return Object.keys(configs).find((key) => key.startsWith(`${alertId}-`));
+}
 
 export const setRecoveredAlertsContext = ({
   alertsClient,
@@ -219,14 +231,14 @@ export const setRecoveredAlertsContext = ({
       monitorSummary.locationId = formattedLocationIds;
     }
 
-    if (
-      recoveredAlertId &&
-      locationIds &&
-      (staleDownConfigs[recoveredAlertId] || stalePendingConfigs[recoveredAlertId])
-    ) {
+    const staleDownKey = findConfigKeyByAlertId(staleDownConfigs, recoveredAlertId);
+    const stalePendingKey = findConfigKeyByAlertId(stalePendingConfigs, recoveredAlertId);
+
+    if (recoveredAlertId && locationIds && (staleDownKey || stalePendingKey)) {
+      const effectiveKey = (staleDownKey || stalePendingKey)!;
       const summary = getDeletedMonitorOrLocationSummary({
-        staleConfigs: staleDownConfigs[recoveredAlertId] ? staleDownConfigs : stalePendingConfigs,
-        recoveredAlertId,
+        staleConfigs: staleDownKey ? staleDownConfigs : stalePendingConfigs,
+        recoveredAlertId: effectiveKey,
         locationIds,
         dateFormat,
         tz,
@@ -246,10 +258,12 @@ export const setRecoveredAlertsContext = ({
       linkMessage = '';
     }
 
-    if (configId && recoveredAlertId && locationIds && upConfigs[recoveredAlertId]) {
+    const upConfigKey = findConfigKeyByAlertId(upConfigs, recoveredAlertId);
+
+    if (configId && recoveredAlertId && locationIds && upConfigKey) {
       const summary = getUpMonitorRecoverySummary({
         upConfigs,
-        recoveredAlertId,
+        recoveredAlertId: upConfigKey,
         alertHit,
         locationIds,
         configId,
@@ -260,10 +274,12 @@ export const setRecoveredAlertsContext = ({
         params,
       });
       if (summary) {
-        monitorSummary = {
-          ...monitorSummary,
-          ...summary.monitorSummary,
-        };
+        if (groupByLocation) {
+          monitorSummary = {
+            ...monitorSummary,
+            ...summary.monitorSummary,
+          };
+        }
         recoveryStatus = summary.recoveryStatus;
         recoveryReason = summary.recoveryReason;
         isUp = summary.isUp;

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/helpers.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/helpers.test.ts
@@ -5,9 +5,120 @@
  * 2.0.
  */
 
-import { calculateIsValidPing } from './helpers';
+import { loggerMock } from '@kbn/logging-mocks';
+import type { AlertStatusConfigs } from '../../../../common/runtime_types/alert_rules/common';
+import { calculateIsValidPing, getPendingConfigs } from './helpers';
 
 describe('helpers', () => {
+  describe('getPendingConfigs', () => {
+    const logger = loggerMock.create();
+
+    const makeMonitorSO = (
+      soId: string,
+      monitorQueryId: string,
+      name: string,
+      locationIds: string[] = ['loc-1']
+    ) => ({
+      id: soId,
+      type: 'synthetics-monitor' as const,
+      score: 1,
+      attributes: {
+        id: monitorQueryId,
+        name,
+        type: 'http',
+        config_id: soId,
+        locations: locationIds.map((id) => ({ id, label: `Label ${id}` })),
+        tags: [],
+        labels: {},
+      },
+      created_at: '2020-01-01T00:00:00.000Z',
+      references: [],
+    });
+
+    it('uses configId (SO UUID) for keys, not monitorQueryId, for project monitors', () => {
+      const soId = 'so-uuid-123';
+      const journeyId = 'my-project-my-monitor';
+      const locationId = 'us-east';
+
+      const monitors = [makeMonitorSO(soId, journeyId, 'Project Mon', [locationId])];
+
+      const downConfigs = {
+        [`${soId}-${locationId}`]: {
+          configId: soId,
+          monitorQueryId: journeyId,
+          locationId,
+          status: 'down',
+          timestamp: '2025-01-01T00:00:00.000Z',
+          latestPing: {},
+          checks: { downWithinXChecks: 1, down: 1 },
+        },
+      } as unknown as AlertStatusConfigs;
+
+      const result = getPendingConfigs({
+        monitorQueryIds: [journeyId],
+        monitorLocationIds: [locationId],
+        upConfigs: {},
+        downConfigs,
+        monitorsData: {
+          [journeyId]: { scheduleInMs: 60000, locations: [locationId], type: 'http' },
+        },
+        monitors: monitors as any,
+        logger,
+      });
+
+      // Should NOT be pending because down config with SO-UUID key exists
+      expect(result).toEqual({});
+    });
+
+    it('creates pending config with SO UUID as configId for project monitors', () => {
+      const soId = 'so-uuid-456';
+      const journeyId = 'my-project-monitor-2';
+      const locationId = 'us-west';
+
+      const monitors = [makeMonitorSO(soId, journeyId, 'Project Mon 2', [locationId])];
+
+      const result = getPendingConfigs({
+        monitorQueryIds: [journeyId],
+        monitorLocationIds: [locationId],
+        upConfigs: {},
+        downConfigs: {},
+        monitorsData: {
+          [journeyId]: { scheduleInMs: 60000, locations: [locationId], type: 'http' },
+        },
+        monitors: monitors as any,
+        logger,
+      });
+
+      // Key should use SO UUID, not journey ID
+      expect(result[`${soId}-${locationId}`]).toBeDefined();
+      expect(result[`${journeyId}-${locationId}`]).toBeUndefined();
+      expect(result[`${soId}-${locationId}`].configId).toBe(soId);
+      expect(result[`${soId}-${locationId}`].monitorQueryId).toBe(journeyId);
+    });
+
+    it('works correctly for regular monitors where configId === monitorQueryId', () => {
+      const monitorId = 'regular-monitor-id';
+      const locationId = 'eu-west';
+
+      const monitors = [makeMonitorSO(monitorId, monitorId, 'Regular Mon', [locationId])];
+
+      const result = getPendingConfigs({
+        monitorQueryIds: [monitorId],
+        monitorLocationIds: [locationId],
+        upConfigs: {},
+        downConfigs: {},
+        monitorsData: {
+          [monitorId]: { scheduleInMs: 60000, locations: [locationId], type: 'http' },
+        },
+        monitors: monitors as any,
+        logger,
+      });
+
+      expect(result[`${monitorId}-${locationId}`]).toBeDefined();
+      expect(result[`${monitorId}-${locationId}`].configId).toBe(monitorId);
+    });
+  });
+
   describe('calculateIsValidPing', () => {
     // Store the original Date implementation
     const originalDate = global.Date;

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/helpers.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/helpers.ts
@@ -100,8 +100,16 @@ export const getPendingConfigs = ({
   const pendingConfigs: AlertPendingStatusConfigs = {};
 
   for (const monitorQueryId of monitorQueryIds) {
+    // Resolve the saved object to get the canonical configId (SO UUID).
+    // For regular monitors: configId === monitorQueryId.
+    // For project monitors: configId is the SO UUID, monitorQueryId is the journey ID.
+    const monitorSO = monitors.find(
+      (m) => m.id === monitorQueryId || m.attributes[ConfigKey.MONITOR_QUERY_ID] === monitorQueryId
+    );
+    const configId = monitorSO?.id ?? monitorQueryId;
+
     for (const locationId of monitorLocationIds) {
-      const configWithLocationId = `${monitorQueryId}-${locationId}`;
+      const configWithLocationId = `${configId}-${locationId}`;
 
       const isConfigMissing =
         !upConfigs[configWithLocationId] &&
@@ -121,7 +129,7 @@ export const getPendingConfigs = ({
           ) {
             pendingConfigs[configWithLocationId] = {
               status: 'pending',
-              configId: monitorQueryId,
+              configId,
               monitorQueryId,
               locationId,
               monitorInfo,

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/synthetics/custom_status_rule.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/synthetics/custom_status_rule.ts
@@ -444,11 +444,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           `- Link: http://localhost:5620/app/synthetics/monitor/${monitor.id}/errors/Test%20private%20location-18524a3d9a7-0?locationId=dev`
         );
         expect(recoveredResponse.hits.hits[0]._source).property('locationId', 'dev');
-        expect(recoveredResponse.hits.hits[0]._source).property(
-          'recoveryReason',
-          'the alert condition is no longer met'
-        );
-        expect(recoveredResponse.hits.hits[0]._source).property('recoveryStatus', 'has recovered');
+        const recoveryReason = (recoveredResponse.hits.hits[0]._source as Record<string, string>)
+          .recoveryReason;
+        expect(recoveryReason).to.match(/the monitor is now up again\. It ran successfully at /);
+        expect(recoveredResponse.hits.hits[0]._source).property('recoveryStatus', 'is now up');
       });
     });
 
@@ -745,11 +744,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           `- Link: http://localhost:5620/app/synthetics/monitor/${monitor.id}/errors/Test%20private%20location-18524a3d9a7-0?locationId=dev`
         );
         expect(recoveryResponse.hits.hits[1]._source).property('locationId', 'dev and dev2');
-        expect(recoveryResponse.hits.hits[1]._source).property(
-          'recoveryReason',
-          'the alert condition is no longer met'
-        );
-        expect(recoveryResponse.hits.hits[1]._source).property('recoveryStatus', 'has recovered');
+        const recoveryReason = (recoveryResponse.hits.hits[1]._source as Record<string, string>)
+          .recoveryReason;
+        expect(recoveryReason).to.match(/the monitor is now up again\. It ran successfully at /);
+        expect(recoveryResponse.hits.hits[1]._source).property('recoveryStatus', 'is now up');
       });
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Fix status rule key mismatch for project monitors and ungrouped recovery context (#265648)](https://github.com/elastic/kibana/pull/265648)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2026-04-30T20:05:06Z","message":"[Synthetics] Fix status rule key mismatch for project monitors and ungrouped recovery context (#265648)\n\n## Summary\n\nFixes two bugs in the Synthetics monitor status rule executor:\n\n### Bug 1 (High): False \"pending\" alerts for project monitors\n\nIn `getPendingConfigs`, the config lookup keys used `monitorQueryId`\n(the journey ID for project monitors), but `downConfigs`/`upConfigs`\nkeys use `config_id` (the saved object UUID). For project monitors where\nthese differ, the lookup always failed — causing the monitor to be\nincorrectly marked as \"pending\" (no data) even when it had active\ndown/up ping data.\n\n**Fix:** Resolve the saved object UUID from the monitors array and use\nit consistently as the key prefix in `getPendingConfigs`. This ensures\nkeys match across `downConfigs`, `upConfigs`, and `pendingConfigs`.\n\n### Bug 2 (Moderate): Missing recovery context for ungrouped alerts\n\nIn `setRecoveredAlertsContext`, recovery lookups in `upConfigs`,\n`staleDownConfigs`, and `stalePendingConfigs` used the\n`recoveredAlertId` as an exact key. For ungrouped alerts (grouped by\nmonitor, not location), the alert ID is just the `configId` without a\nlocation suffix, but config maps are keyed by\n`${configId}-${locationId}`. The lookup always returned `undefined`, so\nungrouped alerts never received the detailed \"is now up\" or \"monitor\ndeleted\" recovery messages.\n\n**Fix:** Added `findConfigKeyByAlertId` helper that tries exact match\nfirst, then falls back to prefix matching for ungrouped alerts.\n\n## Test plan\n\n- [x] All 71 existing status rule tests pass\n- [x] Added 3 new tests for `getPendingConfigs` covering:\n- Project monitor with existing down config is not falsely marked as\npending\n  - Pending config uses SO UUID (not journey ID) as key and configId\n- Regular monitors (where configId === monitorQueryId) continue working\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"451a94eab3201d3450d9ea53082513e3bba97b4d","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","author:actionable-obs","ci:use-selective-testing","v9.5.0","v9.2.9","v9.3.5","v9.4.1"],"title":"[Synthetics] Fix status rule key mismatch for project monitors and ungrouped recovery context","number":265648,"url":"https://github.com/elastic/kibana/pull/265648","mergeCommit":{"message":"[Synthetics] Fix status rule key mismatch for project monitors and ungrouped recovery context (#265648)\n\n## Summary\n\nFixes two bugs in the Synthetics monitor status rule executor:\n\n### Bug 1 (High): False \"pending\" alerts for project monitors\n\nIn `getPendingConfigs`, the config lookup keys used `monitorQueryId`\n(the journey ID for project monitors), but `downConfigs`/`upConfigs`\nkeys use `config_id` (the saved object UUID). For project monitors where\nthese differ, the lookup always failed — causing the monitor to be\nincorrectly marked as \"pending\" (no data) even when it had active\ndown/up ping data.\n\n**Fix:** Resolve the saved object UUID from the monitors array and use\nit consistently as the key prefix in `getPendingConfigs`. This ensures\nkeys match across `downConfigs`, `upConfigs`, and `pendingConfigs`.\n\n### Bug 2 (Moderate): Missing recovery context for ungrouped alerts\n\nIn `setRecoveredAlertsContext`, recovery lookups in `upConfigs`,\n`staleDownConfigs`, and `stalePendingConfigs` used the\n`recoveredAlertId` as an exact key. For ungrouped alerts (grouped by\nmonitor, not location), the alert ID is just the `configId` without a\nlocation suffix, but config maps are keyed by\n`${configId}-${locationId}`. The lookup always returned `undefined`, so\nungrouped alerts never received the detailed \"is now up\" or \"monitor\ndeleted\" recovery messages.\n\n**Fix:** Added `findConfigKeyByAlertId` helper that tries exact match\nfirst, then falls back to prefix matching for ungrouped alerts.\n\n## Test plan\n\n- [x] All 71 existing status rule tests pass\n- [x] Added 3 new tests for `getPendingConfigs` covering:\n- Project monitor with existing down config is not falsely marked as\npending\n  - Pending config uses SO UUID (not journey ID) as key and configId\n- Regular monitors (where configId === monitorQueryId) continue working\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"451a94eab3201d3450d9ea53082513e3bba97b4d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/265648","number":265648,"mergeCommit":{"message":"[Synthetics] Fix status rule key mismatch for project monitors and ungrouped recovery context (#265648)\n\n## Summary\n\nFixes two bugs in the Synthetics monitor status rule executor:\n\n### Bug 1 (High): False \"pending\" alerts for project monitors\n\nIn `getPendingConfigs`, the config lookup keys used `monitorQueryId`\n(the journey ID for project monitors), but `downConfigs`/`upConfigs`\nkeys use `config_id` (the saved object UUID). For project monitors where\nthese differ, the lookup always failed — causing the monitor to be\nincorrectly marked as \"pending\" (no data) even when it had active\ndown/up ping data.\n\n**Fix:** Resolve the saved object UUID from the monitors array and use\nit consistently as the key prefix in `getPendingConfigs`. This ensures\nkeys match across `downConfigs`, `upConfigs`, and `pendingConfigs`.\n\n### Bug 2 (Moderate): Missing recovery context for ungrouped alerts\n\nIn `setRecoveredAlertsContext`, recovery lookups in `upConfigs`,\n`staleDownConfigs`, and `stalePendingConfigs` used the\n`recoveredAlertId` as an exact key. For ungrouped alerts (grouped by\nmonitor, not location), the alert ID is just the `configId` without a\nlocation suffix, but config maps are keyed by\n`${configId}-${locationId}`. The lookup always returned `undefined`, so\nungrouped alerts never received the detailed \"is now up\" or \"monitor\ndeleted\" recovery messages.\n\n**Fix:** Added `findConfigKeyByAlertId` helper that tries exact match\nfirst, then falls back to prefix matching for ungrouped alerts.\n\n## Test plan\n\n- [x] All 71 existing status rule tests pass\n- [x] Added 3 new tests for `getPendingConfigs` covering:\n- Project monitor with existing down config is not falsely marked as\npending\n  - Pending config uses SO UUID (not journey ID) as key and configId\n- Regular monitors (where configId === monitorQueryId) continue working\n\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"451a94eab3201d3450d9ea53082513e3bba97b4d"}},{"branch":"9.2","label":"v9.2.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266820","number":266820,"state":"MERGED","mergeCommit":{"sha":"9511bed9f0db9c1b16c4167d5dd127190a41cbcd","message":"[9.2] [Synthetics] Fix status rule key mismatch for project monitors and ungrouped recovery context (#265648) (#266820)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Synthetics] Fix status rule key mismatch for project monitors and\nungrouped recovery context\n(#265648)](https://github.com/elastic/kibana/pull/265648)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>"}},{"branch":"9.3","label":"v9.3.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266821","number":266821,"state":"MERGED","mergeCommit":{"sha":"097183f6d7ee1f8128846330d3c91cd004fdd5c4","message":"[9.3] [Synthetics] Fix status rule key mismatch for project monitors and ungrouped recovery context (#265648) (#266821)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Synthetics] Fix status rule key mismatch for project monitors and\nungrouped recovery context\n(#265648)](https://github.com/elastic/kibana/pull/265648)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>"}},{"branch":"9.4","label":"v9.4.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/266822","number":266822,"state":"MERGED","mergeCommit":{"sha":"8f819d3b5f183af1afa46ff11f95c4da6ba79e64","message":"[9.4] [Synthetics] Fix status rule key mismatch for project monitors and ungrouped recovery context (#265648) (#266822)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Synthetics] Fix status rule key mismatch for project monitors and\nungrouped recovery context\n(#265648)](https://github.com/elastic/kibana/pull/265648)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>"}}]}] BACKPORT-->