### PR TITLE
Persist refreshed tokens on minimal-auth routes

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.test.ts
@@ -3008,10 +3008,75 @@ describe('Authenticator', () => {
       expect(auditLogger.log).not.toHaveBeenCalled();
     });
 
+    it('does not extend session for a minimally authenticated request if no update is needed.', async () => {
+      const user = mockAuthenticatedUser();
+      const request = httpServerMock.createKibanaRequest({
+        kibanaRouteOptions: {
+          xsrfRequired: true,
+          access: 'internal',
+          security: {
+            authc: { enabled: 'minimal', reason: 'test' },
+            authz: { enabled: false, reason: 'test' },
+          },
+        },
+      });
+
+      mockBasicAuthenticationProvider.authenticate.mockResolvedValue(
+        AuthenticationResult.succeeded(user)
+      );
+      mockOptions.session.getSID.mockResolvedValue(mockSessVal.sid);
+      mockOptions.session.get.mockResolvedValue({ error: null, value: mockSessVal });
+
+      await expect(authenticator.reauthenticate(request)).resolves.toEqual(
+        AuthenticationResult.succeeded(user)
+      );
+
+      expect(mockOptions.session.create).not.toHaveBeenCalled();
+      expect(mockOptions.session.update).not.toHaveBeenCalled();
+      expect(mockOptions.session.extend).not.toHaveBeenCalled();
+      expect(mockOptions.session.invalidate).not.toHaveBeenCalled();
+      expect(auditLogger.log).not.toHaveBeenCalled();
+    });
+
     it('replaces existing session with the one returned by authentication provider', async () => {
       const user = mockAuthenticatedUser();
       const newState = { authorization: 'Basic yyy' };
       const request = httpServerMock.createKibanaRequest();
+
+      mockBasicAuthenticationProvider.authenticate.mockResolvedValue(
+        AuthenticationResult.succeeded(user, { state: newState })
+      );
+      mockOptions.session.getSID.mockResolvedValue(mockSessVal.sid);
+      mockOptions.session.get.mockResolvedValue({ error: null, value: mockSessVal });
+
+      await expect(authenticator.reauthenticate(request)).resolves.toEqual(
+        AuthenticationResult.succeeded(user, { state: newState })
+      );
+
+      expect(mockOptions.session.create).not.toHaveBeenCalled();
+      expect(mockOptions.session.update).toHaveBeenCalledTimes(1);
+      expect(mockOptions.session.update).toHaveBeenCalledWith(request, {
+        ...mockSessVal,
+        state: newState,
+      });
+      expect(mockOptions.session.extend).not.toHaveBeenCalled();
+      expect(mockOptions.session.invalidate).not.toHaveBeenCalled();
+      expect(auditLogger.log).not.toHaveBeenCalled();
+    });
+
+    it('replaces existing session for a minimally authenticated request if provider returns new state', async () => {
+      const user = mockAuthenticatedUser();
+      const newState = { authorization: 'Basic yyy' };
+      const request = httpServerMock.createKibanaRequest({
+        kibanaRouteOptions: {
+          xsrfRequired: true,
+          access: 'internal',
+          security: {
+            authc: { enabled: 'minimal', reason: 'test' },
+            authz: { enabled: false, reason: 'test' },
+          },
+        },
+      });
 
       mockBasicAuthenticationProvider.authenticate.mockResolvedValue(
         AuthenticationResult.succeeded(user, { state: newState })

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.test.ts
@@ -11,6 +11,7 @@ jest.mock('./providers/saml');
 jest.mock('./providers/http');
 
 import { errors } from '@elastic/elasticsearch';
+import type { DetailedPeerCertificate } from 'tls';
 
 import {
   elasticsearchServiceMock,
@@ -2135,6 +2136,108 @@ describe('Authenticator', () => {
       }
     );
 
+    it.each([
+      ['full', true],
+      ['minimal', 'minimal'],
+    ] as const)(
+      'replaces the PKI session when a new certificate authenticates a different user on a %s-auth API request',
+      async (_, enabled) => {
+        const provider = { name: 'pki1', type: 'pki' };
+        mockOptions = getMockOptions({
+          providers: { pki: { pki1: { order: 0 } } },
+          http: { enabled: false },
+        });
+        authenticator = new Authenticator(mockOptions);
+
+        const previousSession = sessionMock.createValue({
+          provider,
+          username: 'old-user',
+          state: { accessToken: 'old-token', peerCertificateFingerprint256: 'old-fingerprint' },
+        });
+        mockOptions.session.get.mockResolvedValue({ error: null, value: previousSession });
+        mockOptions.session.create.mockImplementation(async (request, value) =>
+          sessionMock.createValue({ ...value, sid: 'new-session-id' })
+        );
+
+        const request = httpServerMock.createKibanaRequest({
+          path: '/internal/search/es',
+          headers: { 'kbn-xsrf': 'true' },
+          kibanaRouteOptions: {
+            xsrfRequired: true,
+            access: 'internal',
+            security: {
+              authc: { enabled, reason: 'test' },
+              authz: { enabled: false, reason: 'test' },
+            },
+          },
+        });
+        const certificate = {
+          fingerprint256: 'new-fingerprint',
+          raw: Buffer.from('new-certificate'),
+        } as DetailedPeerCertificate;
+        certificate.issuerCertificate = certificate;
+        Object.defineProperty(request.socket, 'authorized', { value: true });
+        jest.spyOn(request.socket, 'getPeerCertificate').mockReturnValue(certificate);
+
+        const user = mockAuthenticatedUser({
+          username: 'new-user',
+          authentication_provider: provider,
+        });
+        mockOptions.clusterClient.asInternalUser.security.invalidateToken.mockResponse({
+          invalidated_tokens: 1,
+          previously_invalidated_tokens: 0,
+          error_count: 0,
+        });
+        mockOptions.clusterClient.asInternalUser.transport.request.mockResolvedValue({
+          access_token: 'new-token',
+          authentication: user,
+        });
+        const userProfileGrant = { type: 'accessToken', accessToken: 'new-token' } as const;
+        mockOptions.userProfileService.activate.mockResolvedValue(
+          userProfileMock.createWithSecurity({ uid: 'new-profile-id' })
+        );
+        const state = {
+          accessToken: 'new-token',
+          peerCertificateFingerprint256: certificate.fingerprint256,
+        };
+
+        await expect(authenticator.authenticate(request)).resolves.toEqual(
+          AuthenticationResult.succeeded(
+            { ...user, profile_uid: 'new-profile-id' },
+            { authHeaders: { authorization: 'Bearer new-token' }, userProfileGrant, state }
+          )
+        );
+
+        expect(
+          mockOptions.clusterClient.asInternalUser.security.invalidateToken
+        ).toHaveBeenCalledWith({ token: 'old-token' });
+        expect(mockOptions.clusterClient.asInternalUser.transport.request).toHaveBeenCalledWith({
+          method: 'POST',
+          path: '/_security/delegate_pki',
+          body: { x509_certificate_chain: [certificate.raw.toString('base64')] },
+        });
+        expect(mockOptions.session.invalidate).toHaveBeenCalledTimes(1);
+        expect(mockOptions.session.invalidate).toHaveBeenCalledWith(request, { match: 'current' });
+        expect(mockOptions.session.create).toHaveBeenCalledTimes(1);
+        expect(mockOptions.session.create).toHaveBeenCalledWith(
+          request,
+          { username: user.username, userProfileId: 'new-profile-id', provider, state },
+          undefined
+        );
+        expect(mockOptions.session.update).not.toHaveBeenCalled();
+        expect(mockOptions.session.extend).not.toHaveBeenCalled();
+        expect(mockOptions.userProfileService.activate).toHaveBeenCalledWith(userProfileGrant);
+        expectAuditEvents(
+          { action: 'user_logout', outcome: 'unknown' },
+          {
+            action: 'user_login',
+            outcome: 'success',
+            kibana: expect.objectContaining({ session_id: 'new-session-id' }),
+          }
+        );
+      }
+    );
+
     it('creates session whenever authentication provider returns state for system API requests', async () => {
       const user = mockAuthenticatedUser();
       const request = httpServerMock.createKibanaRequest({
@@ -3169,7 +3272,7 @@ describe('Authenticator', () => {
       expect(auditLogger.log).not.toHaveBeenCalled();
     });
 
-    it('replaces existing session for a minimally authenticated request if provider returns new state', async () => {
+    it('updates existing session for a minimally authenticated request if provider returns new state', async () => {
       const user = mockAuthenticatedUser();
       const newState = { authorization: 'Basic yyy' };
       const request = httpServerMock.createKibanaRequest({

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
@@ -805,8 +805,12 @@ export class Authenticator {
       );
     }
 
-    // Don't update session if request is "minimally" authenticated.
-    if (request.route.options.security?.authc?.enabled === 'minimal') {
+    // Don't extend the session if request is "minimally" authenticated, but still persist state
+    // updates explicitly returned by the authentication provider (e.g. refreshed access tokens).
+    if (
+      request.route.options.security?.authc?.enabled === 'minimal' &&
+      !authenticationResult.shouldUpdateState()
+    ) {
       this.logger.debug(
         'Session should not be changed for requests that require minimal authentication, skipping session update.'
       );

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
@@ -811,6 +811,7 @@ export class Authenticator {
     const isMinimalAuthentication = request.route.options.security?.authc?.enabled === 'minimal';
 
     // Minimal authentication can persist provider state only for a session that provider already owns.
+    // A different username from the same provider still triggers normal session replacement below.
     if (isMinimalAuthentication && !(ownsSession && authenticationResult.shouldUpdateState())) {
       this.logger.debug(
         'Session should not be changed for requests that require minimal authentication, skipping session update.'

--- a/x-pack/platform/test/security_api_integration/tests/token/login.ts
+++ b/x-pack/platform/test/security_api_integration/tests/token/login.ts
@@ -181,7 +181,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should support minimal authentication even when access token is expired', async function () {
-      this.timeout(60000);
+      this.timeout(90000);
 
       const loginResponse = await supertest
         .post('/internal/security/login')
@@ -213,6 +213,21 @@ export default function ({ getService }: FtrProviderContext) {
 
       expect(minimalResponse.body.principal.username).to.eql('elastic');
       expect(minimalResponse.body.principal.authentication_provider).to.eql({
+        type: 'token',
+        name: 'token',
+      });
+
+      // Wait for the refreshed access token to expire. A second successful request with the
+      // original session cookie proves that the refreshed token pair was persisted in the session.
+      await setTimeoutAsync(20000);
+
+      const secondMinimalResponse = await supertest
+        .get('/authentication/fast/me')
+        .set('Cookie', sessionCookie.cookieString())
+        .expect(200);
+
+      expect(secondMinimalResponse.body.principal.username).to.eql('elastic');
+      expect(secondMinimalResponse.body.principal.authentication_provider).to.eql({
         type: 'token',
         name: 'token',
       });


### PR DESCRIPTION
## Summary

Persist refreshed tokens on minimal-auth routes without extending the session's idle deadline.

Minimal-auth routes skip ordinary session updates to avoid writes on frequent requests. The same guard also discarded new provider state when reauthentication refreshed an expired access token. The current request succeeded, but the next request loaded the old token pair from the session.

This change allows a provider to persist new state only when it owns the existing session. Minimal-auth requests cannot create a session from scratch or replace another provider's session. When refreshed state is written, the session retains the idle and lifespan deadlines from its cookie. Ordinary minimal-auth requests remain write-free.

## Testing

- Authenticator tests cover ordinary requests, refreshed state, missing sessions, provider ownership, and the real anonymous provider's API/XHR gate.
- Session tests verify that refreshed tokens are encrypted and stored while preserving cookie deadlines, including a disabled idle timeout and a cookie with newer expiry information than the session value.
- Token API integration tests cover cookie issuance, two consecutive access-token expirations using the original session cookie, and a decreasing remaining session lifetime after each refresh.

Closes #279975

//cc @drewdaemon

## Release note

**Prevents unexpected logouts after an access token is refreshed**

Searches that refresh an expired access token now save the refreshed credentials in the Kibana session. This prevents subsequent searches and dashboard refreshes from reusing stale credentials and unexpectedly logging the user out.


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->