### PR TITLE
[8.19] [Console] Fix body autocomplete triggers, template insertion, and completion range bugs (#284530)

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/console/utils/autocomplete/index.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/utils/autocomplete/index.ts
@@ -9,8 +9,13 @@
 
 export {
   checkForTripleQuotesAndEsqlQuery,
+  endsWithConsoleBodyContinuation,
+  getLineRemainderWithoutConsoleComments,
+  isInsideConsoleComment,
+  isInsideConsoleString,
   isInsideTripleQuotedJsonValue,
 } from './triple_quote_scanner';
+export { isEscaped } from './chars';
 export { findRequestLineNumber, isRequestLineWithUrl } from './request_line';
 export { getFallbackRequestStartPosition } from './request_anchor';
 export { unescapeInvalidChars } from './unescape_invalid_chars';

--- a/src/platform/packages/shared/kbn-monaco/src/console/utils/autocomplete/triple_quote_scanner.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/utils/autocomplete/triple_quote_scanner.test.ts
@@ -7,12 +7,26 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { performance } from 'node:perf_hooks';
+
 import {
   checkForTripleQuotesAndEsqlQuery,
+  endsWithConsoleBodyContinuation,
+  getLineRemainderWithoutConsoleComments,
+  isInsideConsoleComment,
+  isInsideConsoleString,
   isInsideTripleQuotedJsonValue,
 } from './triple_quote_scanner';
 
 describe('triple_quote_scanner', () => {
+  it('scans long request lines without repeatedly rescanning the comment boundary', () => {
+    const request = `GET _search?q=${'a'.repeat(16_000)}`;
+    const start = performance.now();
+
+    expect(isInsideConsoleString(request)).toBe(false);
+    expect(performance.now() - start).toBeLessThan(500);
+  });
+
   describe('checkForTripleQuotesAndQueries', () => {
     it('returns false for all flags for an empty string', () => {
       expect(checkForTripleQuotesAndEsqlQuery('')).toEqual({
@@ -245,6 +259,184 @@ describe('triple_quote_scanner', () => {
       });
     }
   );
+
+  it.each([
+    { content: '# docs', expected: true },
+    { content: '// docs', expected: true },
+    { content: '/* docs', expected: true },
+    { content: '/* docs */', expected: false },
+    { content: '{"pattern": "*/", "nested": {', expected: false },
+    { content: '"""# not a comment"""', expected: false },
+  ])(
+    'detects whether the end of Console input is inside a comment: $content',
+    ({ content, expected }) => {
+      expect(isInsideConsoleComment(content)).toBe(expected);
+    }
+  );
+
+  it.each([
+    { content: '"open', expected: true },
+    { content: '"closed"', expected: false },
+    { content: '"""open', expected: true },
+    { content: '"""def quote = \'"\';""", "nested": {', expected: false },
+    { content: 'GET _search?q="foo{', expected: true },
+  ])(
+    'detects whether the end of Console input is inside a string: $content',
+    ({ content, expected }) => {
+      expect(isInsideConsoleString(content)).toBe(expected);
+    }
+  );
+
+  it.each([
+    {
+      contentBeforePosition: 'GET _search\n{"field": "',
+      lineContentAfterPosition: '"}',
+      expected: '"}',
+    },
+    {
+      contentBeforePosition: 'GET _search\n{"field": "',
+      lineContentAfterPosition: '"} // note',
+      expected: '"} ',
+    },
+    {
+      contentBeforePosition: 'GET _search\n{"field": "',
+      lineContentAfterPosition: '" /* note */ }',
+      expected: '"  }',
+    },
+    {
+      contentBeforePosition: 'GET _search\n{"field": "',
+      lineContentAfterPosition: 'http://host/*path#x"}',
+      expected: 'http://host/*path#x"}',
+    },
+    {
+      contentBeforePosition: 'GET _search\n{"field": 1, /* note',
+      lineContentAfterPosition: ' */ "next": 2}',
+      expected: ' "next": 2}',
+    },
+    {
+      contentBeforePosition: 'GET _search\n{"script": """',
+      lineContentAfterPosition: '// not comment""", "next": 1}',
+      expected: '// not comment""", "next": 1}',
+    },
+  ])(
+    'removes only Console comments from the line remainder: $lineContentAfterPosition',
+    ({ contentBeforePosition, lineContentAfterPosition, expected }) => {
+      expect(
+        getLineRemainderWithoutConsoleComments(contentBeforePosition, lineContentAfterPosition)
+      ).toBe(expected);
+    }
+  );
+
+  it('detects an inline comment at the end of a request line', () => {
+    expect(isInsideConsoleComment('GET _search // docs {')).toBe(true);
+    expect(isInsideConsoleComment('GET _search # docs {')).toBe(true);
+  });
+
+  it('detects a whitespace-separated block comment at the end of a request line', () => {
+    expect(isInsideConsoleComment('GET _search /* docs {')).toBe(true);
+    expect(isInsideConsoleComment('GET _search /* docs */ ')).toBe(false);
+  });
+
+  it('preserves an unterminated trailing block comment across request lines', () => {
+    const openComment = 'GET _search /* docs\n{';
+    expect(isInsideConsoleComment(openComment)).toBe(true);
+    expect(endsWithConsoleBodyContinuation(openComment)).toBe(false);
+
+    const openCommentAfterQuotedUrl = 'GET _search?q="foo bar" /* docs\n{';
+    expect(isInsideConsoleComment(openCommentAfterQuotedUrl)).toBe(true);
+    expect(endsWithConsoleBodyContinuation(openCommentAfterQuotedUrl)).toBe(false);
+
+    const closedComment = 'GET _search /* docs\n*/\n{';
+    expect(isInsideConsoleComment(closedComment)).toBe(false);
+    expect(endsWithConsoleBodyContinuation(closedComment)).toBe(true);
+  });
+
+  it.each([
+    'GET _search // docs /* not block\n{',
+    'GET _search # docs /* not block\n{',
+    'GET _search?q="foo /* bar"\n{',
+  ])('does not carry block-like request-line text into the next line: %s', (content) => {
+    expect(isInsideConsoleComment(content)).toBe(false);
+    expect(endsWithConsoleBodyContinuation(content)).toBe(true);
+  });
+
+  it('preserves ES|QL body state after block-like text in a quoted URL', () => {
+    const content = 'POST _query?q="foo /* bar"\n{"query": """FROM logs';
+    const analysis = checkForTripleQuotesAndEsqlQuery(content);
+    expect(analysis.insideTripleQuotes).toBe(true);
+    expect(analysis.insideEsqlQuery).toBe(true);
+  });
+
+  // The URL token itself may start with a comment-like marker; only a marker
+  // after both the method and the URL is a trailing comment.
+  it.each(['DELETE /*', 'GET /*', 'GET /*/_search?pretty', 'GET //_search'])(
+    'treats a comment-like marker in the URL position as a URL: %s',
+    (content) => {
+      expect(isInsideConsoleComment(content)).toBe(false);
+    }
+  );
+
+  it.each([
+    'GET _search?q=http://example.com/path&size=',
+    'GET _search?q=tag#1&size=',
+    'GET _search?q=value/*pattern&size=',
+  ])('preserves comment-like text inside a request URL: %s', (content) => {
+    expect(isInsideConsoleComment(content)).toBe(false);
+  });
+
+  it.each([
+    'GET _search\n{',
+    'GET _search\n  "fields": [',
+    'GET _search\n    "field", // note',
+    'GET _search\n    "field", /* note */',
+    'GET _search\n    "field", /* note\n      more */',
+    'GET _search\n{"script": """code""", "fields": [',
+  ])('detects a body continuation before whitespace or a trailing comment: %s', (content) => {
+    expect(endsWithConsoleBodyContinuation(content)).toBe(true);
+  });
+
+  it.each([
+    'GET _search\n{\n  # next item,',
+    'GET _search\n{\n  // next item,',
+    'GET _search\n{\n  /* next item, */',
+    'GET _search\n["field"',
+    'GET _search\n["value,',
+    'GET index-a, // request docs',
+    '/* docs */ GET index-a,',
+    '/* docs\n*/ GET index-a,',
+    'GET _search\n{\n  "field"',
+  ])('rejects a non-code or non-continuation ending: %s', (content) => {
+    expect(endsWithConsoleBodyContinuation(content)).toBe(false);
+  });
+
+  it('uses request-line comment rules after a leading block-comment prefix', () => {
+    expect(isInsideConsoleComment('/* c */ GET _search?q=http://example.com&size=')).toBe(false);
+    expect(isInsideConsoleComment('/* c */ GET _search // docs')).toBe(true);
+  });
+
+  it('uses request-line comment rules after closing a multiline block comment', () => {
+    expect(isInsideConsoleComment('/* c\n*/ GET _search?q=http://example.com&size=')).toBe(false);
+    expect(isInsideConsoleComment('/* c\n*/ GET _search // docs')).toBe(true);
+  });
+
+  it.each([
+    '/* c */ GET _search?q="foo\n{',
+    '/* c\n*/ GET _search?q="foo\n{',
+    '/* c */ GET _search?q=value/*pattern\n{',
+    '/* c\n*/ GET _search?q=value/*pattern\n{',
+    'GET _search\n{} /* c\n*/ GET _search?q="foo\n{',
+    'GET _search\n{} /* c\n*/ GET _search?q=value/*pattern\n{',
+  ])('preserves request-line state after a closed block-comment prefix: %s', (content) => {
+    expect(isInsideConsoleComment(content)).toBe(false);
+    expect(isInsideConsoleString(content)).toBe(false);
+    expect(endsWithConsoleBodyContinuation(content)).toBe(true);
+  });
+
+  it('does not treat a comment-prefixed request-like line inside triple quotes as a request', () => {
+    const content = 'POST _query\n{"script": """\n/* c */ GET _search?q=http://example.com';
+    expect(isInsideConsoleString(content)).toBe(true);
+    expect(isInsideConsoleComment(content)).toBe(false);
+  });
 
   it.each(['# """', '// """', '/* """ */'])(
     'does not treat comment markers inside triple-quoted content as comments: %s',

--- a/src/platform/packages/shared/kbn-monaco/src/console/utils/autocomplete/triple_quote_scanner.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/utils/autocomplete/triple_quote_scanner.ts
@@ -9,10 +9,11 @@
 
 import { isEscaped, isStartOfLine, isWhitespace, skipWhitespaceBackward } from './chars';
 import { MAX_REQUEST_LINE_LOOKBACK_CHARS } from './constants';
-import { scanRequestLineFrom } from './request_line';
+import { isRequestLineWithUrl, scanRequestLineFrom } from './request_line';
 
 const TRIPLE_QUOTES = '"""';
 const QUERY_KEY = '"query"';
+const BODY_CONTINUATION_TOKENS = new Set(['{', '[', ',']);
 
 /**
  * Checks whether `text[quoteIndex]` (the opening quote character of either `"` or `"""`) is the
@@ -44,10 +45,16 @@ const getQueryValueStartIndex = (text: string, quoteIndex: number, quoteLen: 1 |
   return isQueryValueStartAtQuote(text, quoteIndex) ? quoteIndex + quoteLen : -1;
 };
 
-/**
- * Mutable state for one scan pass. `json` is only present when the caller asked to track whether
- * the current triple quote opened in a JSON *value* position (see `isInsideTripleQuotedJsonValue`).
- */
+type CommentRange = readonly [start: number, end: number];
+
+interface JsonScanState {
+  containers: Array<'object' | 'array'>;
+  lastSignificantChar?: string;
+  lastSignificantCharIndex?: number;
+  trailingCommentStartIndex?: number;
+}
+
+/** Mutable state for one scan pass. */
 interface ScanState {
   index: number;
   // Quote tracking for the JSON body:
@@ -55,6 +62,9 @@ interface ScanState {
   // - inTripleQuoteString: between `""" ... """` (only toggled when not already in double quotes)
   inDoubleQuoteString: boolean;
   inTripleQuoteString: boolean;
+  insideComment: boolean;
+  requestLineMode: boolean;
+  requestLineCommentIndex?: number;
   // Whether the *current* string (double or triple) is the value for `"query"`.
   inQueryValueString: boolean;
   // Whether the current request section is a POST /_query(/async) request.
@@ -62,10 +72,27 @@ interface ScanState {
   // Start index of the query text (first char after the opening quote(s)) when inQueryValueString.
   esqlQueryStartIndex: number;
   tripleQuoteIsJsonValue: boolean;
-  json?: {
-    containers: Array<'object' | 'array'>;
-    lastSignificantChar?: string;
-  };
+  commentRanges?: CommentRange[];
+  json?: JsonScanState;
+}
+
+interface ScanOptions {
+  collectCommentRanges?: boolean;
+  requestLineMode?: boolean;
+  trackJsonValue?: boolean;
+}
+
+interface ScanResult {
+  commentRanges?: CommentRange[];
+  esqlQueryIndex: number;
+  insideComment: boolean;
+  insideEsqlQuery: boolean;
+  insideString: boolean;
+  insideTripleQuotedJsonValue: boolean;
+  insideTripleQuotes: boolean;
+  lastSignificantChar?: string;
+  lastSignificantCharIndex?: number;
+  trailingCommentStartIndex?: number;
 }
 
 /**
@@ -78,12 +105,109 @@ type ScanConsumer = (text: string, state: ScanState) => boolean;
 const isInsideAnyString = ({ inDoubleQuoteString, inTripleQuoteString }: ScanState): boolean =>
   inDoubleQuoteString || inTripleQuoteString;
 
-// A request line (e.g. `POST /_query`) starts a new request section and resets JSON context.
-const consumeRequestLine: ScanConsumer = (text, state) => {
-  if (isInsideAnyString(state) || !isStartOfLine(text, state.index)) {
-    return false;
+// On request lines, `#`, `//` and `/*` only start a comment after both the method and the URL
+// token: a URL can legitimately contain them (`_search#frag`, `_search/*`) or even start with
+// them (`DELETE /*`, `GET //_search`), but a marker after two whitespace-separated tokens is
+// past the URL and reads as a trailing comment (`GET _search // docs`).
+const findRequestLineComment = (line: string): number | undefined => {
+  let tokenCount = 0;
+  let insideToken = false;
+  let insideQuote = false;
+  for (let index = 0; index < line.length; index++) {
+    const char = line[index];
+    if (char === '"' && !isEscaped(line, index)) {
+      if (!insideToken) {
+        tokenCount++;
+        insideToken = true;
+      }
+      insideQuote = !insideQuote;
+      continue;
+    }
+    if (!insideQuote && isWhitespace(char)) {
+      insideToken = false;
+      continue;
+    }
+    const startsComment =
+      !insideQuote &&
+      (char === '#' || line.startsWith('//', index) || line.startsWith('/*', index));
+    if (!insideToken && tokenCount >= 2 && startsComment) {
+      return index;
+    }
+    if (!insideToken) {
+      tokenCount++;
+      insideToken = true;
+    }
   }
-  const requestLineScan = scanRequestLineFrom(text, state.index);
+};
+
+const skipWhitespaceForward = (text: string, startIndex: number): number => {
+  let index = startIndex;
+  while (isWhitespace(text[index])) {
+    index++;
+  }
+  return index;
+};
+
+const skipBlockComment = (
+  text: string,
+  startIndex: number,
+  startsInsideComment: boolean
+): number | undefined => {
+  const commentEndIndex = text.indexOf('*/', startIndex + (startsInsideComment ? 0 : 2));
+  return commentEndIndex === -1 ? undefined : skipWhitespaceForward(text, commentEndIndex + 2);
+};
+
+const skipBlockCommentPrefixes = (
+  text: string,
+  startIndex: number,
+  startsInsideComment = false
+): { index: number; skipped: boolean } | undefined => {
+  let index = skipWhitespaceForward(text, startIndex);
+  let skipped = startsInsideComment;
+
+  if (startsInsideComment) {
+    const nextIndex = skipBlockComment(text, index, true);
+    if (nextIndex === undefined) {
+      return;
+    }
+    index = nextIndex;
+  }
+
+  while (text.startsWith('/*', index)) {
+    const nextIndex = skipBlockComment(text, index, false);
+    if (nextIndex === undefined) {
+      return;
+    }
+    skipped = true;
+    index = nextIndex;
+  }
+
+  return { index, skipped };
+};
+
+const getRequestLineCommentStart = (
+  text: string,
+  lineStartIndex: number,
+  nextLineStartIndex: number
+): number | undefined => {
+  const lineEndIndex =
+    text[nextLineStartIndex - 1] === '\n' ? nextLineStartIndex - 1 : nextLineStartIndex;
+  const line = text.slice(lineStartIndex, lineEndIndex);
+  const commentIndex = findRequestLineComment(line);
+  return commentIndex === undefined ? undefined : lineStartIndex + commentIndex;
+};
+
+const getRequestLineStartAfterBlockCommentPrefixes = (
+  text: string,
+  lineStartIndex: number
+): number | undefined => skipBlockCommentPrefixes(text, lineStartIndex)?.index;
+
+const consumeRequestLineAt = (
+  text: string,
+  state: ScanState,
+  requestLineStartIndex: number
+): boolean => {
+  const requestLineScan = scanRequestLineFrom(text, requestLineStartIndex);
   if (!requestLineScan) {
     return false;
   }
@@ -91,28 +215,87 @@ const consumeRequestLine: ScanConsumer = (text, state) => {
   if (state.json) {
     state.json.containers.length = 0;
     state.json.lastSignificantChar = undefined;
+    state.json.lastSignificantCharIndex = undefined;
+    state.json.trailingCommentStartIndex = undefined;
   }
-  state.index = requestLineScan.nextIndex;
+  state.index =
+    getRequestLineCommentStart(text, requestLineStartIndex, requestLineScan.nextIndex) ??
+    requestLineScan.nextIndex;
+  return true;
+};
+
+// A request line (e.g. `POST /_query`) starts a new request section and resets JSON context.
+const consumeRequestLine: ScanConsumer = (text, state) => {
+  if (state.requestLineMode || isInsideAnyString(state) || !isStartOfLine(text, state.index)) {
+    return false;
+  }
+  const requestLineStartIndex = getRequestLineStartAfterBlockCommentPrefixes(text, state.index);
+  return (
+    requestLineStartIndex !== undefined && consumeRequestLineAt(text, state, requestLineStartIndex)
+  );
+};
+
+const recordComment = (state: ScanState, start: number, end: number): void => {
+  state.commentRanges?.push([start, end]);
+};
+
+const recordTrailingComment = (state: ScanState): void => {
+  if (state.json?.lastSignificantCharIndex !== undefined) {
+    state.json.trailingCommentStartIndex ??= state.index;
+  }
+};
+
+const consumeLineComment: ScanConsumer = (text, state) => {
+  const { index } = state;
+  const startsLineComment = text[index] === '#' || text.startsWith('//', index);
+  if (!startsLineComment) {
+    return false;
+  }
+  recordTrailingComment(state);
+  const newlineIndex = text.indexOf('\n', index);
+  recordComment(state, index, newlineIndex === -1 ? text.length : newlineIndex);
+  state.insideComment = newlineIndex === -1;
+  state.index = newlineIndex === -1 ? text.length : newlineIndex + 1;
+  return true;
+};
+
+const consumeBlockComment: ScanConsumer = (text, state) => {
+  const { index } = state;
+  if (!text.startsWith('/*', index)) {
+    return false;
+  }
+  recordTrailingComment(state);
+  const commentEndIndex = text.indexOf('*/', index + 2);
+  recordComment(state, index, commentEndIndex === -1 ? text.length : commentEndIndex + 2);
+  state.insideComment = commentEndIndex === -1;
+  if (commentEndIndex === -1) {
+    state.index = text.length;
+    return true;
+  }
+
+  state.index = commentEndIndex + 2;
+  const newlineIndex = text.indexOf('\n', index + 2);
+  if (!state.requestLineMode && newlineIndex !== -1 && newlineIndex < commentEndIndex) {
+    const requestLineStartIndex = getRequestLineStartAfterBlockCommentPrefixes(text, state.index);
+    if (
+      requestLineStartIndex !== undefined &&
+      consumeRequestLineAt(text, state, requestLineStartIndex)
+    ) {
+      return true;
+    }
+  }
   return true;
 };
 
 // Console comments can contain quote-like text that must not affect string state.
 const consumeComment: ScanConsumer = (text, state) => {
-  if (isInsideAnyString(state)) {
+  if (
+    isInsideAnyString(state) ||
+    (state.requestLineMode && state.requestLineCommentIndex !== state.index)
+  ) {
     return false;
   }
-  const { index } = state;
-  if (text[index] === '#' || (text[index] === '/' && text[index + 1] === '/')) {
-    const newlineIndex = text.indexOf('\n', index);
-    state.index = newlineIndex === -1 ? text.length : newlineIndex + 1;
-    return true;
-  }
-  if (text[index] === '/' && text[index + 1] === '*') {
-    const commentEndIndex = text.indexOf('*/', index + 2);
-    state.index = commentEndIndex === -1 ? text.length : commentEndIndex + 2;
-    return true;
-  }
-  return false;
+  return consumeLineComment(text, state) || consumeBlockComment(text, state);
 };
 
 const enterString = (text: string, state: ScanState, quoteLen: 1 | 3): void => {
@@ -120,18 +303,17 @@ const enterString = (text: string, state: ScanState, quoteLen: 1 | 3): void => {
   state.inQueryValueString = state.esqlQueryStartIndex !== -1;
 };
 
-const leaveString = (state: ScanState): void => {
+const leaveString = (state: ScanState, closingQuoteOffset = 0): void => {
   if (state.json) {
     state.json.lastSignificantChar = '"';
+    state.json.lastSignificantCharIndex = state.index + closingQuoteOffset;
+    state.json.trailingCommentStartIndex = undefined;
   }
   state.inQueryValueString = false;
   state.esqlQueryStartIndex = -1;
 };
 
-const isJsonValuePosition = ({
-  containers,
-  lastSignificantChar,
-}: NonNullable<ScanState['json']>): boolean =>
+const isJsonValuePosition = ({ containers, lastSignificantChar }: JsonScanState): boolean =>
   (containers.at(-1) === 'object' && lastSignificantChar === ':') ||
   (containers.at(-1) === 'array' && (lastSignificantChar === '[' || lastSignificantChar === ','));
 
@@ -147,7 +329,7 @@ const consumeTripleQuote: ScanConsumer = (text, state) => {
     }
     enterString(text, state, 3);
   } else {
-    leaveString(state);
+    leaveString(state, 2);
   }
   state.index += 3;
   return true;
@@ -182,6 +364,8 @@ const consumeChar: ScanConsumer = (text, state) => {
     }
     if (!isWhitespace(char)) {
       json.lastSignificantChar = char;
+      json.lastSignificantCharIndex = state.index;
+      json.trailingCommentStartIndex = undefined;
     }
   }
   state.index++;
@@ -197,23 +381,26 @@ const SCAN_CONSUMERS: readonly ScanConsumer[] = [
   consumeChar,
 ];
 
-const analyzeTripleQuotesAndEsqlQuery = (
+const scanConsoleText = (
   text: string,
-  { trackJsonValue = false }: { trackJsonValue?: boolean } = {}
-): {
-  insideTripleQuotes: boolean;
-  insideEsqlQuery: boolean;
-  esqlQueryIndex: number;
-  insideTripleQuotedJsonValue: boolean;
-} => {
+  {
+    collectCommentRanges = false,
+    requestLineMode = false,
+    trackJsonValue = false,
+  }: ScanOptions = {}
+): ScanResult => {
   const state: ScanState = {
     index: 0,
     inDoubleQuoteString: false,
     inTripleQuoteString: false,
+    insideComment: false,
+    requestLineMode,
+    requestLineCommentIndex: requestLineMode ? findRequestLineComment(text) : undefined,
     inQueryValueString: false,
     inEsqlQueryRequest: false,
     esqlQueryStartIndex: -1,
     tripleQuoteIsJsonValue: false,
+    ...(collectCommentRanges && { commentRanges: [] }),
     ...(trackJsonValue && { json: { containers: [] } }),
   };
 
@@ -227,11 +414,88 @@ const analyzeTripleQuotesAndEsqlQuery = (
 
   return {
     insideTripleQuotes: state.inTripleQuoteString,
+    insideString: isInsideAnyString(state),
     insideEsqlQuery: state.inEsqlQueryRequest && state.inQueryValueString,
     esqlQueryIndex: state.inEsqlQueryRequest ? state.esqlQueryStartIndex : -1,
+    insideComment: state.insideComment,
+    lastSignificantChar: state.json?.lastSignificantChar,
+    lastSignificantCharIndex: state.json?.lastSignificantCharIndex,
+    trailingCommentStartIndex: state.json?.trailingCommentStartIndex,
+    commentRanges: state.commentRanges,
     insideTripleQuotedJsonValue:
       state.json !== undefined && state.inTripleQuoteString && state.tripleQuoteIsJsonValue,
   };
+};
+
+const getTextOutsideRanges = (
+  text: string,
+  startIndex: number,
+  ranges: readonly CommentRange[]
+): string => {
+  const parts: string[] = [];
+  let nextIndex = startIndex;
+
+  for (const [rangeStart, rangeEnd] of ranges) {
+    if (rangeEnd <= nextIndex) {
+      continue;
+    }
+    parts.push(text.slice(nextIndex, Math.max(nextIndex, rangeStart)));
+    nextIndex = Math.max(nextIndex, rangeEnd);
+  }
+
+  parts.push(text.slice(nextIndex));
+  return parts.join('');
+};
+
+/** Returns the current-line text after the cursor with Console comments removed. */
+export const getLineRemainderWithoutConsoleComments = (
+  contentBeforePosition: string,
+  lineContentAfterPosition: string
+): string => {
+  const text = contentBeforePosition + lineContentAfterPosition;
+  const { commentRanges = [] } = scanConsoleText(text, {
+    collectCommentRanges: true,
+  });
+  return getTextOutsideRanges(text, contentBeforePosition.length, commentRanges);
+};
+
+const getRequestLineContent = (
+  line: string,
+  startsInsideBlockComment: boolean
+): { content: string; startsAfterPrefix: boolean } | undefined => {
+  const prefix = skipBlockCommentPrefixes(line, 0, startsInsideBlockComment);
+  if (!prefix) {
+    return;
+  }
+  const requestLine = line.slice(prefix.index);
+  return isRequestLineWithUrl(requestLine)
+    ? { content: requestLine, startsAfterPrefix: prefix.skipped }
+    : undefined;
+};
+
+const scanConsoleEnd = (
+  text: string,
+  { trackJsonValue = false }: { trackJsonValue?: boolean } = {}
+): ReturnType<typeof scanConsoleText> => {
+  const fullAnalysis = scanConsoleText(text, { trackJsonValue });
+  const lastLineStart = text.lastIndexOf('\n') + 1;
+  const lastLine = text.slice(lastLineStart);
+  const analysisBeforeLastLine = scanConsoleText(text.slice(0, lastLineStart));
+  const requestLine = getRequestLineContent(
+    lastLine,
+    analysisBeforeLastLine.insideComment && !analysisBeforeLastLine.insideString
+  );
+  const isRequestLine = Boolean(
+    requestLine &&
+      !analysisBeforeLastLine.insideString &&
+      (requestLine.startsAfterPrefix || (!fullAnalysis.insideString && !fullAnalysis.insideComment))
+  );
+  // `trackJsonValue` is deliberately not forwarded to the request-line rescan: a request line has
+  // no JSON body context, and its indices would point into the sliced line rather than `text`
+  // (so e.g. a comma-continued request line `GET index-a,` must not read as a body continuation).
+  return isRequestLine && requestLine
+    ? scanConsoleText(requestLine.content, { requestLineMode: true })
+    : fullAnalysis;
 };
 
 /**
@@ -247,8 +511,38 @@ export const checkForTripleQuotesAndEsqlQuery = (
   insideEsqlQuery: boolean;
   esqlQueryIndex: number;
 } => {
-  const { insideTripleQuotedJsonValue, ...result } = analyzeTripleQuotesAndEsqlQuery(text);
-  return result;
+  const { insideTripleQuotes, insideEsqlQuery, esqlQueryIndex } = scanConsoleText(text);
+  return { insideTripleQuotes, insideEsqlQuery, esqlQueryIndex };
+};
+
+/** Returns true when the end of `text` is inside a Console line or block comment. */
+export const isInsideConsoleComment = (text: string): boolean => scanConsoleEnd(text).insideComment;
+
+/** Returns true when the end of `text` is inside a standard or triple-quoted Console string. */
+export const isInsideConsoleString = (text: string): boolean => scanConsoleEnd(text).insideString;
+
+/** Returns true when the last line's final Console code token opens another body value. */
+export const endsWithConsoleBodyContinuation = (text: string): boolean => {
+  const { insideString, lastSignificantChar, lastSignificantCharIndex, trailingCommentStartIndex } =
+    scanConsoleEnd(text, { trackJsonValue: true });
+  if (
+    insideString ||
+    lastSignificantCharIndex === undefined ||
+    !lastSignificantChar ||
+    !BODY_CONTINUATION_TOKENS.has(lastSignificantChar)
+  ) {
+    return false;
+  }
+
+  const lastLineStartIndex = text.lastIndexOf('\n') + 1;
+  if (lastSignificantCharIndex >= lastLineStartIndex) {
+    return true;
+  }
+
+  return (
+    trailingCommentStartIndex !== undefined &&
+    !text.slice(lastSignificantCharIndex + 1, trailingCommentStartIndex).includes('\n')
+  );
 };
 
 /**
@@ -258,4 +552,4 @@ export const checkForTripleQuotesAndEsqlQuery = (
  */
 export const isInsideTripleQuotedJsonValue = (text: string): boolean =>
   text.length <= MAX_REQUEST_LINE_LOOKBACK_CHARS &&
-  analyzeTripleQuotesAndEsqlQuery(text, { trackJsonValue: true }).insideTripleQuotedJsonValue;
+  scanConsoleText(text, { trackJsonValue: true }).insideTripleQuotedJsonValue;

--- a/src/platform/packages/shared/kbn-monaco/src/console/utils/index.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/utils/index.ts
@@ -9,8 +9,13 @@
 
 export {
   checkForTripleQuotesAndEsqlQuery,
+  endsWithConsoleBodyContinuation,
   findRequestLineNumber,
   getFallbackRequestStartPosition,
+  getLineRemainderWithoutConsoleComments,
+  isEscaped,
+  isInsideConsoleComment,
+  isInsideConsoleString,
   isInsideTripleQuotedJsonValue,
   isRequestLineWithUrl,
   unescapeInvalidChars,

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
@@ -228,6 +228,12 @@ export const MonacoEditor = ({ localStorageValue, value, setValue }: EditorProps
           fontSize: settings.fontSize,
           wordWrap: settings.wrapMode === true ? 'on' : 'off',
           theme: CONSOLE_THEME_ID,
+          // Only let Enter accept an auto-triggered suggestion when accepting it would actually
+          // change the text. Without this, a fully typed term (e.g. `?pretty`) keeps the widget
+          // open and Enter gets consumed by a no-op acceptance instead of inserting a new line.
+          // Snippets (e.g. conditional templates) always count as a text edit, so they are
+          // still accepted with Enter.
+          acceptSuggestionOnEnter: 'smart',
           // Force the hover views to always render below the cursor to avoid clipping
           // when the cursor is near the top of the editor.
           hover: {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
@@ -49,11 +49,104 @@ jest.mock('../../../lib/autocomplete/engine', () => {
 });
 
 import { MonacoEditorActionsProvider } from './monaco_editor_actions_provider';
-import { monaco } from '@kbn/monaco';
+import type { monaco } from '@kbn/monaco';
+import { monaco as monacoRuntime } from '@kbn/monaco';
+import { createParser } from '@kbn/monaco/src/console/parser';
 
 describe('Editor actions provider', () => {
   let editorActionsProvider: MonacoEditorActionsProvider;
   let editor: jest.Mocked<monaco.editor.IStandaloneCodeEditor>;
+
+  // A model mock backed by real line content, implementing the offset/range
+  // methods with faithful semantics so code under test can navigate the text.
+  const createModel = (lines: string[]) => {
+    const getPositionAt = jest.fn((offset: number) => {
+      let remainingOffset = offset;
+      for (const [index, line] of lines.entries()) {
+        if (remainingOffset <= line.length) {
+          return { lineNumber: index + 1, column: remainingOffset + 1 };
+        }
+        remainingOffset -= line.length + 1;
+      }
+      return { lineNumber: lines.length, column: (lines.at(-1)?.length ?? 0) + 1 };
+    });
+    const getOffsetAt = jest.fn(({ lineNumber, column }: monaco.IPosition) => {
+      const precedingLinesLength = lines
+        .slice(0, lineNumber - 1)
+        .reduce((length, line) => length + line.length + 1, 0);
+      return precedingLinesLength + column - 1;
+    });
+    const getValueInRange = jest.fn(
+      ({ startLineNumber, startColumn, endLineNumber, endColumn }: monaco.IRange) => {
+        if (startLineNumber === endLineNumber) {
+          return (lines[startLineNumber - 1] ?? '').slice(startColumn - 1, endColumn - 1);
+        }
+
+        const selectedLines = lines.slice(startLineNumber - 1, endLineNumber);
+        selectedLines[0] = selectedLines[0].slice(startColumn - 1);
+        selectedLines[selectedLines.length - 1] = selectedLines[selectedLines.length - 1].slice(
+          0,
+          endColumn - 1
+        );
+        return selectedLines.join('\n');
+      }
+    );
+    const getWordUntilPosition = jest.fn(({ column }: monaco.IPosition) => ({
+      word: '',
+      startColumn: column,
+      endColumn: column,
+    }));
+    const getWordAtPosition = jest.fn(({ lineNumber, column }: monaco.IPosition) => {
+      const line = lines[lineNumber - 1] ?? '';
+      for (const match of line.matchAll(/[A-Za-z]+/g)) {
+        const startColumn = match.index + 1;
+        const endColumn = startColumn + match[0].length;
+        if (startColumn <= column && column <= endColumn) {
+          return { word: match[0], startColumn, endColumn };
+        }
+      }
+      return null;
+    });
+    return {
+      isDisposed: jest.fn(() => false),
+      getVersionId: jest.fn(() => 1),
+      getLineCount: () => lines.length,
+      getLineContent: (lineNumber: number) => lines[lineNumber - 1] ?? '',
+      getLineMaxColumn: (lineNumber: number) => (lines[lineNumber - 1] ?? '').length + 1,
+      getOffsetAt,
+      getPositionAt,
+      getValueInRange,
+      getWordAtPosition,
+      getWordUntilPosition,
+    } as unknown as jest.Mocked<monaco.editor.ITextModel>;
+  };
+
+  it.each([
+    { lines: ['abc'], offset: 4, expectedPosition: { lineNumber: 1, column: 4 } },
+    { lines: ['abc', ''], offset: 5, expectedPosition: { lineNumber: 2, column: 1 } },
+  ])(
+    'SHOULD clamp offset $offset past EOF to Monaco position $expectedPosition',
+    ({ lines, offset, expectedPosition }) => {
+      expect(createModel(lines).getPositionAt(offset)).toEqual(expectedPosition);
+    }
+  );
+
+  const createDisposableModel = (lines: string[]) => {
+    let isDisposed = false;
+    return Object.assign(createModel(lines), {
+      isDisposed: jest.fn(() => isDisposed),
+      dispose: jest.fn(() => {
+        isDisposed = true;
+      }),
+      getLineContent: jest.fn((lineNumber: number) => {
+        if (isDisposed) {
+          throw new Error('Model is disposed!');
+        }
+        return lines[lineNumber - 1] ?? '';
+      }),
+    });
+  };
+
   beforeEach(() => {
     editor = {
       getModel: jest.fn(),
@@ -66,11 +159,14 @@ describe('Editor actions provider', () => {
       onDidScrollChange: jest.fn(),
       onDidChangeCursorSelection: jest.fn(),
       onDidContentSizeChange: jest.fn(),
+      onKeyDown: jest.fn(),
       onKeyUp: jest.fn(),
       getSelection: jest.fn(),
       getPosition: jest.fn(),
       getTopForLineNumber: jest.fn(),
       getScrollTop: jest.fn(),
+      getOption: jest.fn(() => false),
+      trigger: jest.fn(),
       executeEdits: jest.fn(),
       setPosition: jest.fn(),
     } as unknown as jest.Mocked<monaco.editor.IStandaloneCodeEditor>;
@@ -96,6 +192,1247 @@ describe('Editor actions provider', () => {
     const setEditorActionsCssMock = jest.fn();
 
     editorActionsProvider = new MonacoEditorActionsProvider(editor, setEditorActionsCssMock, true);
+  });
+
+  describe('WHEN the opening brace key is released', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('SHOULD trigger autocomplete after the debounce period', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      editor.getModel.mockReturnValue(createModel(['{}']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD NOT trigger before the debounce period elapses', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      editor.getModel.mockReturnValue(createModel(['{}']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.advanceTimersByTimeAsync(499);
+      expect(editor.trigger).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1);
+      await jest.runAllTimersAsync();
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD cancel a pending trigger when Escape is released', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      editor.getModel.mockReturnValue(createModel(['{']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyDown = editor.onKeyDown.mock.calls[0][0];
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      onKeyDown({ keyCode: monacoRuntime.KeyCode.Escape } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD ignore a pending trigger after the cursor moves', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      editor.getModel.mockReturnValue(createModel(['{', '']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      editor.getPosition.mockReturnValue({ lineNumber: 2, column: 1 } as monaco.Position);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD ignore a pending trigger after the editor swaps models', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      const originalModel = Object.assign(createModel(['{}']), {
+        getLineContent: jest.fn(() => {
+          throw new Error('Model is disposed!');
+        }),
+      });
+      editor.getModel.mockReturnValue(originalModel);
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      editor.getModel.mockReturnValue(createModel(['']));
+
+      await expect(jest.runAllTimersAsync()).resolves.toBeUndefined();
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD ignore a pending trigger after its model is disposed', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      const model = createDisposableModel(['{}']);
+      editor.getModel.mockReturnValue(model);
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      model.dispose();
+
+      await expect(jest.runAllTimersAsync()).resolves.toBeUndefined();
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD ignore an in-flight trigger after its model is disposed', async () => {
+      let resolveRequests: (requests: []) => void;
+      mockGetParsedRequests.mockReturnValue(
+        new Promise<[]>((resolve) => {
+          resolveRequests = resolve;
+        })
+      );
+      const model = createDisposableModel(['{}']);
+      editor.getModel.mockReturnValue(model);
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.advanceTimersByTimeAsync(500);
+      model.dispose();
+      resolveRequests!([]);
+
+      await expect(jest.runAllTimersAsync()).resolves.toBeUndefined();
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD ignore an in-flight trigger after Escape is released', async () => {
+      let resolveRequests: (requests: []) => void;
+      mockGetParsedRequests.mockReturnValue(
+        new Promise<[]>((resolve) => {
+          resolveRequests = resolve;
+        })
+      );
+      editor.getModel.mockReturnValue(createModel(['{']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyDown = editor.onKeyDown.mock.calls[0][0];
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.advanceTimersByTimeAsync(500);
+      onKeyDown({ keyCode: monacoRuntime.KeyCode.Escape } as monaco.IKeyboardEvent);
+      resolveRequests!([]);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD ignore a trigger cancelled during request-line classification', async () => {
+      let resolveRequests: (requests: []) => void;
+      mockGetParsedRequests.mockResolvedValueOnce([]).mockReturnValueOnce(
+        new Promise<[]>((resolve) => {
+          resolveRequests = resolve;
+        })
+      );
+      editor.getModel.mockReturnValue(createModel(['{']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyDown = editor.onKeyDown.mock.calls[0][0];
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.advanceTimersByTimeAsync(500);
+      onKeyDown({ keyCode: monacoRuntime.KeyCode.Escape } as monaco.IKeyboardEvent);
+      resolveRequests!([]);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD ignore a trigger after the cursor moves during request-line classification', async () => {
+      let resolveRequests: (requests: []) => void;
+      mockGetParsedRequests.mockResolvedValueOnce([]).mockReturnValueOnce(
+        new Promise<[]>((resolve) => {
+          resolveRequests = resolve;
+        })
+      );
+      editor.getModel.mockReturnValue(createModel(['{']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.advanceTimersByTimeAsync(500);
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 1 } as monaco.Position);
+      resolveRequests!([]);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD ignore parser errors during triple-quote classification', async () => {
+      mockGetParsedRequests.mockRejectedValueOnce(new Error('stale parser range'));
+      editor.getModel.mockReturnValue(createModel(['{']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+
+      await expect(jest.runAllTimersAsync()).resolves.toBeUndefined();
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD ignore parser errors during request-line classification', async () => {
+      mockGetParsedRequests
+        .mockResolvedValueOnce([])
+        .mockRejectedValueOnce(new Error('stale parser range'));
+      editor.getModel.mockReturnValue(createModel(['{']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 2 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD not trigger when the cursor is before the end of a block comment', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      editor.getModel.mockReturnValue(createModel(['/* docs { */']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 10 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD not trigger for an opening brace inside a JSON property name', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      editor.getModel.mockReturnValue(createModel(['"field{']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 8 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD not trigger for an opening brace inside a quoted URL value', async () => {
+      // No request on the line: the suppression must come from the string scanner,
+      // not from the request-line classification.
+      mockGetParsedRequests.mockResolvedValue([]);
+      const line = 'GET _search?q="foo{';
+      editor.getModel.mockReturnValue(createModel([line]));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 1,
+        column: line.length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD not trigger for an opening brace inside a request-line comment', async () => {
+      // No request on the line: the suppression must come from the comment scanner,
+      // not from the request-line classification.
+      mockGetParsedRequests.mockResolvedValue([]);
+      const line = 'GET _search // docs {';
+      editor.getModel.mockReturnValue(createModel([line]));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 1,
+        column: line.length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD not treat an opening brace in a URL value as a body object', async () => {
+      const line = 'GET _search?q=${';
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: line.length, method: 'GET', url: line.slice(4) },
+      ]);
+      editor.getModel.mockReturnValue(createModel([line]));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 1,
+        column: line.length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD not treat a brace after a comment-prefixed request as a body object', async () => {
+      const prefix = '/* c */ ';
+      const line = `${prefix}GET _search?q=\${`;
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: prefix.length,
+          endOffset: line.length,
+          method: 'GET',
+          url: '_search?q=${',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel([line]));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 1,
+        column: line.length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD trigger for a body brace on a line that begins with a letter', async () => {
+      const lines = ['GET _search', '{"script": """', 'return 1;""", "query": {'];
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: lines.join('\n').length },
+      ]);
+      editor.getModel.mockReturnValue(createModel(lines));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 3,
+        column: lines[2].length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '{' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD ignore other keys', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      editor.getModel.mockReturnValue(createModel([' "a']));
+      editor.getPosition.mockReturnValue({ lineNumber: 1, column: 4 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: 'a' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+  });
+
+  // #284530 review: pressing Enter between `{` and `}` must re-open suggestions.
+  describe('WHEN Enter is released inside a just-opened object', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const pressEnterAt = async (
+      lines: string[],
+      position: monaco.IPosition,
+      requests: Array<{
+        startOffset: number;
+        endOffset?: number;
+        method?: string;
+        url?: string;
+      }> = []
+    ) => {
+      mockGetParsedRequests.mockResolvedValue(requests);
+      editor.getModel.mockReturnValue(createModel(lines));
+      editor.getPosition.mockReturnValue(position as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({
+        keyCode: monacoRuntime.KeyCode.Enter,
+        browserEvent: { key: 'Enter' },
+      } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+    };
+
+    it('SHOULD trigger autocomplete when the previous line ends with an opening brace', async () => {
+      await pressEnterAt(['      {', '', '      }'], { lineNumber: 2, column: 1 });
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD NOT trigger when the brace on the previous line is inside a string', async () => {
+      await pressEnterAt(['"q": "abc{', ''], { lineNumber: 2, column: 1 });
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD trigger when a quoted comment token precedes the opening brace', async () => {
+      await pressEnterAt(['{"pattern": "*/", "nested": {', ''], {
+        lineNumber: 2,
+        column: 1,
+      });
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger when a completed triple-quoted string precedes the opening brace', async () => {
+      await pressEnterAt(['{"script": """def quote = \'"\';""", "query": {', ''], {
+        lineNumber: 2,
+        column: 1,
+      });
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger when a multiline triple-quoted string precedes the opening brace', async () => {
+      const lines = ['GET _search', '{"script": """', 'code', '""", "query": {', ''];
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: lines.slice(0, -1).join('\n').length },
+      ]);
+      editor.getModel.mockReturnValue(createModel(lines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 1 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({
+        keyCode: monacoRuntime.KeyCode.Enter,
+        browserEvent: { key: 'Enter' },
+      } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD NOT trigger when the previous line ends with an opening brace in a block comment', async () => {
+      await pressEnterAt(['{"field": 1} /* docs {', ''], { lineNumber: 2, column: 1 });
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD NOT trigger inside a multiline block comment', async () => {
+      await pressEnterAt(['/* docs', '  {', ''], { lineNumber: 3, column: 1 });
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD NOT treat a request-line brace as a body object after Enter', async () => {
+      const lines = ['GET _search?q=${', ''];
+      await pressEnterAt(lines, { lineNumber: 2, column: 1 }, [
+        { startOffset: 0, endOffset: lines[0].length, method: 'GET', url: '_search?q=${' },
+      ]);
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD trigger for a body brace on a line that begins with a letter', async () => {
+      const lines = ['GET _search', '{"script": """', 'return 1;""", "query": {', ''];
+      await pressEnterAt(lines, { lineNumber: 4, column: 1 }, [
+        { startOffset: 0, endOffset: lines.slice(0, -1).join('\n').length },
+      ]);
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+  });
+
+  // #284530 review: adding space inside `{}` must re-open suggestions.
+  describe('WHEN space is released inside a just-opened object', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const pressKeyAt = async (
+      key: string,
+      lines: string[],
+      position: monaco.IPosition,
+      requests: Array<{
+        startOffset: number;
+        endOffset?: number;
+        method?: string;
+        url?: string;
+      }> = []
+    ) => {
+      mockGetParsedRequests.mockResolvedValue(requests);
+      editor.getModel.mockReturnValue(createModel(lines));
+      editor.getPosition.mockReturnValue(position as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+    };
+
+    it('SHOULD trigger autocomplete after space following an opening brace', async () => {
+      const line = '"query": { ';
+      await pressKeyAt(' ', [line], { lineNumber: 1, column: line.length + 1 });
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD NOT trigger for space after a brace inside a string', async () => {
+      const line = '"description": "hello { ';
+      await pressKeyAt(' ', [line], { lineNumber: 1, column: line.length + 1 });
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD trigger after a completed triple-quoted string and an opening brace', async () => {
+      const line = '{"script": """def quote = \'"\';""", "query": { ';
+      await pressKeyAt(' ', [line], { lineNumber: 1, column: line.length + 1 });
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger after a multiline triple-quoted string and an opening brace', async () => {
+      const lines = ['GET _search', '{"script": """', 'code', '""", "query": { '];
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: lines.join('\n').length },
+      ]);
+      editor.getModel.mockReturnValue(createModel(lines));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 4,
+        column: lines[3].length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ' ' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD NOT treat a request-line brace as a body object after space', async () => {
+      const line = 'GET _search?q=${ ';
+      await pressKeyAt(' ', [line], { lineNumber: 1, column: line.length + 1 }, [
+        { startOffset: 0, endOffset: line.length, method: 'GET', url: line.slice(4) },
+      ]);
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD trigger for a body brace after triple-quoted content that begins with a letter', async () => {
+      const lines = ['GET _search', '{"script": """', 'return 1;""", "query": { '];
+      await pressKeyAt(' ', lines, { lineNumber: 3, column: lines[2].length + 1 }, [
+        { startOffset: 0, endOffset: lines.join('\n').length },
+      ]);
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+  });
+
+  describe('WHEN body edits change the completion position', () => {
+    const lines = ['GET _search', '{', '  "fields": [', '    "field",', '      ', '  ]', '}'];
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: lines.join('\n').length, method: 'GET', url: '_search' },
+      ]);
+      editor.getModel.mockReturnValue(createModel(lines));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('SHOULD trigger suggestions when the comma is released', async () => {
+      editor.getPosition.mockReturnValue({
+        lineNumber: 4,
+        column: lines[3].length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ',' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it.each(['// "note"', '# note', '/* note */'])(
+      'SHOULD trigger suggestions when a comma precedes a trailing %s comment',
+      async (comment) => {
+        const commentLines = ['GET _search', '{', `  "field": 1, ${comment}`, '}'];
+        mockGetParsedRequests.mockResolvedValue([
+          {
+            startOffset: 0,
+            endOffset: commentLines.join('\n').length,
+            method: 'GET',
+            url: '_search',
+          },
+        ]);
+        editor.getModel.mockReturnValue(createModel(commentLines));
+        editor.getPosition.mockReturnValue({
+          lineNumber: 3,
+          column: commentLines[2].indexOf(',') + 2,
+        } as monaco.Position);
+
+        const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+        onKeyUp({ browserEvent: { key: ',' } } as monaco.IKeyboardEvent);
+        await jest.runAllTimersAsync();
+
+        expect(editor.trigger).toHaveBeenCalledWith(
+          'Trigger suggestions',
+          'editor.action.triggerSuggest',
+          {}
+        );
+      }
+    );
+
+    it('SHOULD trigger before a trailing comment after a triple-quoted value with a raw quote', async () => {
+      const tripleQuoteLines = [
+        'GET _search',
+        '{',
+        `  "script": """def quote = '"';""", // note`,
+        '}',
+      ];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: tripleQuoteLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(tripleQuoteLines));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 3,
+        column: tripleQuoteLines[2].lastIndexOf(',') + 2,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ',' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger before a trailing comment after a multiline triple-quoted value', async () => {
+      const tripleQuoteLines = [
+        'GET _search',
+        '{',
+        '  "script": """',
+        `def quote = '"';`,
+        '""", // note',
+        '}',
+      ];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: tripleQuoteLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(tripleQuoteLines));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 5,
+        column: tripleQuoteLines[4].indexOf(',') + 2,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ',' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger after a multiline block comment containing triple quotes', async () => {
+      const commentLines = [
+        'GET _search',
+        '{',
+        '  "field": 1, /*',
+        '    """ */ "other": 2, // note',
+        '}',
+      ];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: commentLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(commentLines));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 4,
+        column: commentLines[3].lastIndexOf(',') + 2,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ',' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it.each(['"//existing"', '/* note */ "existing"'])(
+      'SHOULD NOT trigger suggestions when %s follows a comma',
+      async (suffix) => {
+        const existingContentLines = ['GET _search', '{', `  "field": 1, ${suffix}`, '}'];
+        mockGetParsedRequests.mockResolvedValue([
+          {
+            startOffset: 0,
+            endOffset: existingContentLines.join('\n').length,
+            method: 'GET',
+            url: '_search',
+          },
+        ]);
+        editor.getModel.mockReturnValue(createModel(existingContentLines));
+        editor.getPosition.mockReturnValue({
+          lineNumber: 3,
+          column: existingContentLines[2].indexOf(',') + 2,
+        } as monaco.Position);
+
+        const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+        onKeyUp({ browserEvent: { key: ',' } } as monaco.IKeyboardEvent);
+        await jest.runAllTimersAsync();
+
+        expect(editor.trigger).not.toHaveBeenCalled();
+      }
+    );
+
+    it('SHOULD trigger suggestions when an opening bracket is released', async () => {
+      const bracketLines = ['GET _search', '{', '  "fields": ['];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: bracketLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(bracketLines));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 3,
+        column: bracketLines[2].length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: '[' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger suggestions when a property-value colon is released', async () => {
+      const colonLines = ['GET _search', '{', '  "track_total_hits":'];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: colonLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(colonLines));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 3,
+        column: colonLines[2].length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ':' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger suggestions for an inline property value', async () => {
+      const inlineLines = [
+        'POST _ingest/pipeline/_simulate',
+        '{"community_id": {"ignore_failure": ',
+      ];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: inlineLines.join('\n').length,
+          method: 'POST',
+          url: '_ingest/pipeline/_simulate',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(inlineLines));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 2,
+        column: inlineLines[1].length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ' ' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger suggestions after Enter follows the comma', async () => {
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 7 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({
+        keyCode: monacoRuntime.KeyCode.Enter,
+        browserEvent: { key: 'Enter' },
+      } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger suggestions when space advances the indented blank line', async () => {
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 7 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ' ' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger when structural closers remain after the indented position', async () => {
+      const inlineClosingLines = [...lines];
+      inlineClosingLines[4] = '      } ]}}';
+      editor.getModel.mockReturnValue(createModel(inlineClosingLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 7 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ' ' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger suggestions when Tab indents the blank line', async () => {
+      const beforeTabLines = [...lines];
+      beforeTabLines[4] = '  ';
+      editor.getModel.mockReturnValue(createModel(beforeTabLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 3 } as monaco.Position);
+
+      const onKeyDown = editor.onKeyDown.mock.calls[0][0];
+      onKeyDown({ keyCode: monacoRuntime.KeyCode.Tab } as monaco.IKeyboardEvent);
+      expect(editor.trigger).not.toHaveBeenCalled();
+
+      editor.getModel.mockReturnValue(createModel(lines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 7 } as monaco.Position);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD NOT trigger suggestions when Tab moves focus out of the editor', async () => {
+      editor.getOption.mockReturnValue(true);
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 5 } as monaco.Position);
+
+      const onKeyDown = editor.onKeyDown.mock.calls[0][0];
+      onKeyDown({ keyCode: monacoRuntime.KeyCode.Tab } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD cancel a deferred Tab trigger when Escape is pressed', async () => {
+      const beforeTabLines = [...lines];
+      beforeTabLines[4] = '  ';
+      editor.getModel.mockReturnValue(createModel(beforeTabLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 3 } as monaco.Position);
+
+      const onKeyDown = editor.onKeyDown.mock.calls[0][0];
+      onKeyDown({ keyCode: monacoRuntime.KeyCode.Tab } as monaco.IKeyboardEvent);
+      onKeyDown({ keyCode: monacoRuntime.KeyCode.Escape } as monaco.IKeyboardEvent);
+      editor.getModel.mockReturnValue(createModel(lines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 7 } as monaco.Position);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD trigger after Enter follows a comma with a trailing comment', async () => {
+      const commentLines = ['GET _search', '{', '  "fields": [', '    "field", // note', '  '];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: commentLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(commentLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 3 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ keyCode: monacoRuntime.KeyCode.Enter } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger after Enter closes a multiline comment trailing a comma', async () => {
+      const commentLines = [
+        'GET _search',
+        '{',
+        '  "fields": [',
+        '    "field", /* note',
+        '      more */',
+        '  ',
+      ];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: commentLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(commentLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 6, column: 3 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ keyCode: monacoRuntime.KeyCode.Enter } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger when space follows a comma with a trailing comment', async () => {
+      const commentLines = ['GET _search', '{', '  "fields": [', '    "field", // note', '   '];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: commentLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(commentLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 4 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ' ' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD trigger when Tab follows a comma with a trailing comment', async () => {
+      const commentLines = ['GET _search', '{', '  "fields": [', '    "field", // note', '  '];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: commentLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(commentLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 3 } as monaco.Position);
+
+      const onKeyDown = editor.onKeyDown.mock.calls[0][0];
+      onKeyDown({ keyCode: monacoRuntime.KeyCode.Tab } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('SHOULD NOT trigger for a comma inside a string', async () => {
+      const stringLines = ['GET _search', '{', '  "description": "value,'];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: stringLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(stringLines));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 3,
+        column: stringLines[2].length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ',' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD NOT trigger for a comma on a request line', async () => {
+      const requestLine = 'GET index-a,';
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: requestLine.length,
+          method: 'GET',
+          url: 'index-a,',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel([requestLine]));
+      editor.getPosition.mockReturnValue({
+        lineNumber: 1,
+        column: requestLine.length + 1,
+      } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ',' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD NOT trigger for space on a blank line without a preceding delimiter', async () => {
+      const noCommaLines = [...lines];
+      noCommaLines[3] = '    "field"';
+      editor.getModel.mockReturnValue(createModel(noCommaLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 7 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ browserEvent: { key: ' ' } } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD NOT trigger after Enter without a preceding delimiter', async () => {
+      const noCommaLines = [...lines];
+      noCommaLines[3] = '    "field"';
+      editor.getModel.mockReturnValue(createModel(noCommaLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 7 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ keyCode: monacoRuntime.KeyCode.Enter } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD NOT trigger after Tab without a preceding delimiter', async () => {
+      const noCommaLines = [...lines];
+      noCommaLines[3] = '    "field"';
+      editor.getModel.mockReturnValue(createModel(noCommaLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 5 } as monaco.Position);
+
+      const onKeyDown = editor.onKeyDown.mock.calls[0][0];
+      onKeyDown({ keyCode: monacoRuntime.KeyCode.Tab } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { input: 'Space', key: ' ', keyCode: undefined, line: '   "next"', column: 4 },
+      {
+        input: 'Enter',
+        key: undefined,
+        keyCode: monacoRuntime.KeyCode.Enter,
+        line: '  "next"',
+        column: 3,
+      },
+      {
+        input: 'Tab',
+        key: undefined,
+        keyCode: monacoRuntime.KeyCode.Tab,
+        line: '  "next"',
+        column: 3,
+      },
+    ])(
+      'SHOULD NOT trigger after $input when content remains after the cursor',
+      async ({ key, keyCode, line, column }) => {
+        const existingItemLines = ['GET _search', '{', '  "fields": [', '    "field",', line];
+        mockGetParsedRequests.mockResolvedValue([
+          {
+            startOffset: 0,
+            endOffset: existingItemLines.join('\n').length,
+            method: 'GET',
+            url: '_search',
+          },
+        ]);
+        editor.getModel.mockReturnValue(createModel(existingItemLines));
+        editor.getPosition.mockReturnValue({ lineNumber: 5, column } as monaco.Position);
+
+        if (keyCode === monacoRuntime.KeyCode.Tab) {
+          const onKeyDown = editor.onKeyDown.mock.calls[0][0];
+          onKeyDown({ keyCode } as monaco.IKeyboardEvent);
+        } else {
+          const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+          onKeyUp({ keyCode, browserEvent: { key } } as monaco.IKeyboardEvent);
+        }
+        await jest.runAllTimersAsync();
+
+        expect(editor.trigger).not.toHaveBeenCalled();
+      }
+    );
+
+    it('SHOULD NOT trigger after Enter follows a comma in a comment', async () => {
+      const commentLines = ['GET _search', '{', '  # next item,', '  '];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: commentLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(commentLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 4, column: 3 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({
+        keyCode: monacoRuntime.KeyCode.Enter,
+        browserEvent: { key: 'Enter' },
+      } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD NOT trigger after Enter remains inside an open block comment', async () => {
+      const commentLines = ['GET _search', '{', '  "field", /* note', '  '];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: commentLines.join('\n').length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      editor.getModel.mockReturnValue(createModel(commentLines));
+      editor.getPosition.mockReturnValue({ lineNumber: 4, column: 3 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ keyCode: monacoRuntime.KeyCode.Enter } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('SHOULD preserve the existing Backspace trigger at the same body position', async () => {
+      editor.getPosition.mockReturnValue({ lineNumber: 5, column: 7 } as monaco.Position);
+
+      const onKeyUp = editor.onKeyUp.mock.calls[0][0];
+      onKeyUp({ keyCode: monacoRuntime.KeyCode.Backspace } as monaco.IKeyboardEvent);
+      await jest.runAllTimersAsync();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
   });
 
   describe('getCurl', () => {
@@ -206,6 +1543,13 @@ describe('Editor actions provider', () => {
 
   describe('provideCompletionItems', () => {
     const mockModel = {
+      getWordAtPosition: () => {
+        return {
+          word: 'GET',
+          startColumn: 1,
+          endColumn: 4,
+        };
+      },
       getWordUntilPosition: () => {
         return {
           startColumn: 1,
@@ -363,6 +1707,747 @@ describe('Editor actions provider', () => {
       expect(completionItems?.suggestions.length).toBe(2);
       const endpoints = completionItems?.suggestions.map((suggestion) => suggestion.label);
       expect((endpoints as string[]).sort()).toEqual(['_cat', '_search']);
+    });
+
+    it.each([
+      'GET _search?q=http://example.com/path&size=',
+      'GET _search?q=tag#1&size=',
+      'GET _search?q=value/*pattern&size=',
+    ])('returns URL parameter completions after comment-like text: %s', async (line) => {
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: line.length,
+          method: 'GET',
+          url: line.slice(4),
+        },
+      ]);
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = [{ name: 'size' }];
+      });
+      const model = createModel([line]);
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        model,
+        { lineNumber: 1, column: line.length + 1 } as monaco.Position,
+        mockContext
+      );
+
+      expect(completionItems.suggestions.map(({ label }) => label)).toEqual(['size']);
+    });
+
+    it('returns URL parameter completions after a multiline block-comment prefix', async () => {
+      const lines = ['/* docs', '*/ GET _search?q=http://example.com/path&size='];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: lines[0].length + 1 + '*/ '.length,
+          endOffset: lines.join('\n').length,
+          method: 'GET',
+          url: '_search?q=http://example.com/path&size=',
+        },
+      ]);
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = [{ name: 'size' }];
+      });
+      const model = createModel(lines);
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        model,
+        { lineNumber: 2, column: lines[1].length + 1 } as monaco.Position,
+        mockContext
+      );
+
+      expect(completionItems.suggestions.map(({ label }) => label)).toEqual(['size']);
+    });
+
+    describe('WHEN body completion follows a comment-prefixed request', () => {
+      it('SHOULD parse the request from its start column', async () => {
+        mockPopulateContext.mockClear();
+        const prefix = '/* docs */ ';
+        const lines = [
+          `${prefix}POST _ingest/pipeline/_simulate`,
+          '{',
+          '  "pipeline": {',
+          '    "processors": [',
+          '      {"a',
+        ];
+        mockGetParsedRequests.mockResolvedValue([
+          {
+            startOffset: prefix.length,
+            endOffset: lines.join('\n').length,
+            method: 'POST',
+            url: '_ingest/pipeline/_simulate',
+          },
+        ]);
+        mockPopulateContext.mockImplementation((...args) => {
+          const context = args[0][1];
+          context.autoCompleteSet = [{ name: 'append', template: { field: '', value: [] } }];
+        });
+        const model = createModel(lines);
+
+        const completionItems = await editorActionsProvider.provideCompletionItems(
+          model,
+          { lineNumber: 5, column: lines[4].length + 1 } as monaco.Position,
+          mockContext
+        );
+
+        const contextCall = mockPopulateContext.mock.calls[0]?.[0];
+        expect(contextCall?.[1].method).toBe('POST');
+        expect(completionItems.suggestions.map(({ label }) => label)).toContain('append');
+      });
+    });
+
+    it.each([0, 1])(
+      'replaces the whole method at offset %d inside a comment-prefixed request',
+      async (cursorOffset) => {
+        const prefix = '/* docs */ ';
+        const line = `${prefix}GET _search`;
+        mockGetParsedRequests.mockResolvedValue([
+          {
+            startOffset: prefix.length,
+            endOffset: line.length,
+            method: 'GET',
+            url: '_search',
+          },
+        ]);
+        const model = createModel([line]);
+        const completionItems = await editorActionsProvider.provideCompletionItems(
+          model,
+          { lineNumber: 1, column: prefix.length + 1 + cursorOffset } as monaco.Position,
+          mockContext
+        );
+
+        expect(completionItems.suggestions.find(({ label }) => label === 'GET')?.range).toEqual({
+          startColumn: prefix.length + 1,
+          startLineNumber: 1,
+          endColumn: prefix.length + 4,
+          endLineNumber: 1,
+        });
+      }
+    );
+
+    it('does not offer a method before a comment-prefixed request', async () => {
+      const prefix = '/* docs */ ';
+      const line = `${prefix}GET _search`;
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: prefix.length,
+          endOffset: line.length,
+          method: 'GET',
+          url: '_search',
+        },
+      ]);
+      const model = createModel([line]);
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        model,
+        { lineNumber: 1, column: prefix.length } as monaco.Position,
+        mockContext
+      );
+
+      expect(completionItems.suggestions).toEqual([]);
+    });
+  });
+
+  describe('triggerSuggestions', () => {
+    /*
+     * Regression tests for https://github.com/elastic/kibana/issues/257917
+     *
+     * While a triple-quoted string is still unterminated, the Console parser reports the
+     * request without an `endOffset`. `getRequestEndLineNumber` then falls back to the last
+     * non-empty line, so a cursor on the trailing empty line sits *past* the request's
+     * computed `endLineNumber` and no request matches the cursor. Without a fallback,
+     * `isPositionInsideTripleQuotesAndQuery` reported `insideTripleQuotes: false` and
+     * suggestions were triggered inside a non-query string.
+     */
+    const triggerSuggestions = () =>
+      (
+        editorActionsProvider as unknown as {
+          triggerSuggestions: () => Promise<void>;
+        }
+      ).triggerSuggestions();
+
+    // The shape the real parser returns for an unterminated triple-quoted string:
+    // a single request with no `endOffset`.
+    const unterminatedRequest = [{ startOffset: 0 }];
+
+    const setup = (lines: string[], positionLineNumber = lines.length, positionColumn = 1) => {
+      editor.getPosition.mockReturnValue({
+        lineNumber: positionLineNumber,
+        column: positionColumn,
+      } as monaco.Position);
+      const model = createModel(lines);
+      editor.getModel.mockReturnValue(model);
+      editor.getSelection.mockReturnValue({
+        startLineNumber: positionLineNumber,
+        endLineNumber: positionLineNumber,
+      } as unknown as monaco.Selection);
+      return model;
+    };
+
+    it('does not trigger suggestions inside non-query triple quotes', async () => {
+      mockGetParsedRequests.mockResolvedValue(unterminatedRequest);
+      setup(['POST _query', '{', '\t"script": """', '']);
+      mockGetParsedRequests.mockClear();
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+      expect(mockGetParsedRequests).toHaveBeenCalledTimes(1);
+    });
+
+    it('still triggers suggestions inside ES|QL query triple quotes', async () => {
+      mockGetParsedRequests.mockResolvedValue(unterminatedRequest);
+      setup(['POST _query', '{', '\t"query": """', '']);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('does not trigger suggestions inside non-query triple quotes when no request is parsed', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      setup(['POST _query', '{', '\t"script": """', '']);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('does not mistake request-like triple-quoted content for a request when none is parsed', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      setup(['POST _query', '{', '\t"script": """', 'GET /not-a-request', '']);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('does not mistake parser-recovered triple-quoted content for a request line', async () => {
+      const lines = ['POST _query', '{', '\t"script": """', 'GET /not-a-request', ''];
+      const recoveredRequestOffset = lines.slice(0, 3).join('\n').length + 1;
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: recoveredRequestOffset - 2 },
+        {
+          startOffset: recoveredRequestOffset,
+          endOffset: lines.join('\n').length,
+        },
+      ]);
+      setup(lines);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('does not trust a selected parser-recovered request inside triple-quoted content', async () => {
+      const lines = ['POST _search', '{"script": """', 'GET /not-a-request'];
+      const parsedRequests = createParser()(lines.join('\n'), undefined)?.requests ?? [];
+      mockGetParsedRequests.mockResolvedValue(parsedRequests);
+      setup(lines, 3, 5);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger suggestions after the cursor moves while requests resolve', async () => {
+      const lines = ['POST _query', '{"query":"""', '  "', 'GET /not-a-request', ''];
+      const parsedRequests = createParser()(lines.join('\n'), undefined)?.requests ?? [];
+      let resolveParsedRequests: (requests: typeof parsedRequests) => void = () => {};
+      mockGetParsedRequests.mockReturnValue(
+        new Promise<typeof parsedRequests>((resolve) => {
+          resolveParsedRequests = resolve;
+        })
+      );
+      setup(lines, 3, 4);
+
+      void (
+        editorActionsProvider as unknown as {
+          triggerSuggestions: () => Promise<void>;
+        }
+      ).triggerSuggestions();
+      editor.getPosition.mockReturnValue({ lineNumber: 4, column: 1 } as monaco.Position);
+      editor.getSelection.mockReturnValue({
+        startLineNumber: 4,
+        endLineNumber: 4,
+      } as unknown as monaco.Selection);
+      resolveParsedRequests(parsedRequests);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger suggestions after the model changes while requests resolve', async () => {
+      const lines = ['POST _query', '{"query":"""', '  "'];
+      const parsedRequests = createParser()(lines.join('\n'), undefined)?.requests ?? [];
+      let resolveParsedRequests: (requests: typeof parsedRequests) => void = () => {};
+      mockGetParsedRequests.mockReturnValue(
+        new Promise<typeof parsedRequests>((resolve) => {
+          resolveParsedRequests = resolve;
+        })
+      );
+      const model = setup(lines, 3, 4);
+
+      void (
+        editorActionsProvider as unknown as {
+          triggerSuggestions: () => Promise<void>;
+        }
+      ).triggerSuggestions();
+      model.getVersionId.mockReturnValue(2);
+      resolveParsedRequests(parsedRequests);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger suggestions after the editor swaps models while requests resolve', async () => {
+      const lines = ['POST _query', '{"query":"""', '  "'];
+      const parsedRequests = createParser()(lines.join('\n'), undefined)?.requests ?? [];
+      let resolveParsedRequests: (requests: typeof parsedRequests) => void = () => {};
+      mockGetParsedRequests.mockReturnValue(
+        new Promise<typeof parsedRequests>((resolve) => {
+          resolveParsedRequests = resolve;
+        })
+      );
+      setup(lines, 3, 4);
+
+      void (
+        editorActionsProvider as unknown as {
+          triggerSuggestions: () => Promise<void>;
+        }
+      ).triggerSuggestions();
+      editor.getModel.mockReturnValue(createModel(lines));
+      resolveParsedRequests(parsedRequests);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('resolves the request from the cursor line, not the selection', async () => {
+      const lines = ['POST _query', '{', '  "script": """', '', 'GET _search', '{}'];
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: 29 },
+        { startOffset: 31, endOffset: 44 },
+      ]);
+      setup(lines, 4, 1);
+      // A selection spanning requests below the cursor must not change the outcome: the cursor
+      // sits inside the unterminated triple quote, so no suggestions may open.
+      editor.getSelection.mockReturnValue({
+        startLineNumber: 4,
+        endLineNumber: 6,
+      } as unknown as monaco.Selection);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        lines: ['GET/foo', '{"x":"""', 'GET _search', ''],
+        requests: [
+          { startOffset: 0, endOffset: 16 },
+          { startOffset: 17, endOffset: 28 },
+        ],
+      },
+      {
+        lines: ['GET\u00a0/foo', '{"x":"""', 'GET _search', ''],
+        requests: [
+          { startOffset: 0, endOffset: 17 },
+          { startOffset: 18, endOffset: 29 },
+        ],
+      },
+      {
+        lines: ['\u00a0GET /foo', '{"x":"""', 'GET _search', ''],
+        requests: [
+          { startOffset: 0, endOffset: 0 },
+          { startOffset: 1, endOffset: 17 },
+          { startOffset: 19, endOffset: 30 },
+        ],
+      },
+      {
+        lines: ['GET /foo', '{"x"} : """', 'GET _search', ''],
+        requests: [
+          { startOffset: 0, endOffset: 20 },
+          { startOffset: 21, endOffset: 32 },
+        ],
+      },
+    ])(
+      'does not anchor a valid request to malformed request content: $lines',
+      async ({ lines, requests }) => {
+        mockGetParsedRequests.mockResolvedValue(requests);
+        setup(lines);
+
+        await triggerSuggestions();
+
+        expect(editor.trigger).toHaveBeenCalledWith(
+          'Trigger suggestions',
+          'editor.action.triggerSuggest',
+          {}
+        );
+      }
+    );
+
+    it('checks nearby parser recovery before an oversized earlier request', async () => {
+      const oversizedRequestLine = `GET /${'x'.repeat(100_000)}`;
+      const lines = [oversizedRequestLine, 'POST _query', '{', '  "script": """', 'GET '];
+      const currentRequestOffset = oversizedRequestLine.length + 1;
+      const recoveredRequestOffset = lines.slice(0, 4).join('\n').length + 1;
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: oversizedRequestLine.length },
+        { startOffset: currentRequestOffset, endOffset: recoveredRequestOffset - 2 },
+        { startOffset: recoveredRequestOffset },
+      ]);
+      setup(lines, 5, 5);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('ignores recovered request content after the cursor when applying bounds', async () => {
+      const lines = [
+        'POST _query',
+        '{"script":"""',
+        'GET /not-a-request',
+        '',
+        `{"field":"${'x'.repeat(100_001)}"}`,
+      ];
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: 24 },
+        { startOffset: 26, endOffset: 100_059 },
+      ]);
+      setup(lines, 4);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('anchors a request that follows an inline block comment', async () => {
+      const lines = ['/* c */ POST _query', '{', '  "script": """', 'GET /not-a-request', ''];
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 8, endOffset: 36 },
+        { startOffset: 38, endOffset: 56 },
+      ]);
+      setup(lines);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('preserves ES|QL suggestions after an inline block comment', async () => {
+      const lines = ['/* c */ POST _query', '{', '  "query": """', 'GET /not-a-request', ''];
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 8, endOffset: 35 },
+        { startOffset: 37, endOffset: 55 },
+      ]);
+      setup(lines);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('preserves ES|QL suggestions in a selected inline-comment request', async () => {
+      const lines = ['/* c */ POST _query', '{', '  "query": """'];
+      mockGetParsedRequests.mockResolvedValue([{ startOffset: 8 }]);
+      setup(lines, 3, lines[2].length + 1);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('rejects a same-line recovered request after malformed JSON', async () => {
+      const lines = ['GET /foo', '{"x"} POST _query', '{"query": """'];
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: 13 },
+        { startOffset: 15 },
+      ]);
+      setup(lines, 3, lines[2].length + 1);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('triggers suggestions after a completed triple quote containing a request-like line', async () => {
+      const lines = ['POST _query', '{', '\t"script": """', 'GET /not-a-request', '"""', '}', ''];
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: 0,
+          endOffset: lines.slice(0, -1).join('\n').length,
+          method: 'POST',
+          url: '_query',
+        },
+      ]);
+      setup(lines);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('ignores triple quotes in comments before the current request', async () => {
+      const lines = ['GET _search', '{}', '# """', 'GET _search', ''];
+      const secondRequestOffset = lines.slice(0, 3).join('\n').length + 1;
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: lines[0].length + lines[1].length + 1 },
+        {
+          startOffset: secondRequestOffset,
+          endOffset: lines.slice(0, -1).join('\n').length,
+        },
+      ]);
+      setup(lines);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('does not treat request-like text inside a block comment as the request start', async () => {
+      const lines = ['/*', 'GET /not-a-request', '"""', '*/', 'GET _search', ''];
+      const requestOffset = lines.slice(0, 4).join('\n').length + 1;
+      mockGetParsedRequests.mockResolvedValue([
+        {
+          startOffset: requestOffset,
+          endOffset: lines.slice(0, -1).join('\n').length,
+        },
+      ]);
+      setup(lines);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('handles an escaped-backslash string before the current triple-quoted request', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      setup(['GET _search', '{"path":"\\\\"}', 'POST _query', '{', '\t"script": """', '']);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        lines: ['"""', 'GET _search', ''],
+        requests: [
+          { startOffset: 0, endOffset: 3 },
+          { startOffset: 4, endOffset: 15 },
+        ],
+      },
+      {
+        lines: ['GET', '"""', 'GET _search', ''],
+        requests: [
+          { startOffset: 0, endOffset: 7 },
+          { startOffset: 8, endOffset: 19 },
+        ],
+      },
+      {
+        lines: ['GET/foo', '"""', 'GET _search', ''],
+        requests: [
+          { startOffset: 0, endOffset: 11 },
+          { startOffset: 12, endOffset: 23 },
+        ],
+      },
+      {
+        lines: ['GET /foo', '"""', 'GET _search', ''],
+        requests: [
+          { startOffset: 0, endOffset: 8 },
+          { startOffset: 9, endOffset: 12 },
+          { startOffset: 13, endOffset: 24 },
+        ],
+      },
+      {
+        lines: ['GET /foo', '{', '"""', 'GET _search', ''],
+        requests: [
+          { startOffset: 0, endOffset: 13 },
+          { startOffset: 15, endOffset: 26 },
+        ],
+      },
+    ])('ignores malformed parser artifacts before a parsed request: $lines', async (fixture) => {
+      mockGetParsedRequests.mockResolvedValue(fixture.requests);
+      setup(fixture.lines);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
+    });
+
+    it('keeps a comment-separated triple-quoted value anchored to its request', async () => {
+      const lines = [
+        'POST _query',
+        '{',
+        '  "script":',
+        '  # value comment',
+        '  """',
+        'GET /not-a-request',
+        '',
+      ];
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: 48 },
+        { startOffset: 50, endOffset: 68 },
+      ]);
+      setup(lines);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).not.toHaveBeenCalled();
+    });
+
+    it('stops inspecting parsed requests after passing the cursor', async () => {
+      const lines = ['"""', 'GET _search', '', ...new Array(2500).fill('GET _search')];
+      let requestOffset = lines.slice(0, 3).join('\n').length + 1;
+      const laterRequests = new Array(2500).fill(undefined).map(() => {
+        const request = { startOffset: requestOffset, endOffset: requestOffset + 11 };
+        requestOffset += 12;
+        return request;
+      });
+      mockGetParsedRequests.mockResolvedValue([
+        { startOffset: 0, endOffset: lines[0].length },
+        { startOffset: lines[0].length + 1, endOffset: lines.slice(0, 2).join('\n').length },
+        ...laterRequests,
+      ]);
+      const model = setup(lines, 3);
+
+      await triggerSuggestions();
+
+      expect(model.getOffsetAt).toHaveBeenCalledTimes(1);
+      expect(model.getPositionAt).toHaveBeenCalledTimes(9);
+    });
+
+    describe('provideCompletionItems (manual/trigger-character invocations)', () => {
+      const provideCompletionItems = (
+        model: monaco.editor.ITextModel,
+        position: monaco.IPosition
+      ) =>
+        editorActionsProvider.provideCompletionItems(
+          model,
+          position as monaco.Position,
+          {} as monaco.languages.CompletionContext
+        );
+
+      it('returns no completion items inside non-query triple quotes', async () => {
+        mockGetParsedRequests.mockResolvedValue([{ startOffset: 0 }]);
+        const model = setup(['POST _query', '{', '  "script": """', '']);
+
+        const { suggestions } = await provideCompletionItems(model, { lineNumber: 4, column: 1 });
+
+        expect(suggestions).toHaveLength(0);
+      });
+
+      it('still returns method completion items on an empty line outside triple quotes', async () => {
+        mockGetParsedRequests.mockResolvedValue([{ startOffset: 0, endOffset: 14 }]);
+        const model = setup(['GET _search', '{}', '']);
+
+        const { suggestions } = await provideCompletionItems(model, { lineNumber: 3, column: 1 });
+
+        expect(suggestions.map(({ label }) => label)).toEqual(
+          expect.arrayContaining(['GET', 'POST'])
+        );
+      });
+
+      it('does not return method completion items on a whitespace-only line inside an unfinished body', async () => {
+        // The request's computed line range stops at the last non-empty line, so a
+        // whitespace-only line below it parses as outside any request. It must still be
+        // treated as a body position of the unfinished request above, not as the start
+        // of a new request.
+        mockGetParsedRequests.mockResolvedValue(unterminatedRequest);
+        mockPopulateContext.mockImplementation((...args) => {
+          const context = args[0][1];
+          context.autoCompleteSet = [{ name: 'repository' }];
+        });
+        const model = setup(['POST _snapshot/test_repo', '{', '  "type": "url",', '  ']);
+
+        const { suggestions } = await provideCompletionItems(model, { lineNumber: 4, column: 3 });
+
+        expect(suggestions.map(({ label }) => label)).toEqual(['repository']);
+      });
+
+      it('uses the nearest unfinished request when earlier requests exist', async () => {
+        const lines = [
+          'GET _search',
+          '{}',
+          '',
+          'POST _snapshot/test_repo',
+          '{',
+          '  "type": "url",',
+          '  ',
+        ];
+        const secondRequestStartOffset = lines.slice(0, 3).join('\n').length + 1;
+        mockGetParsedRequests.mockResolvedValue([
+          { startOffset: 0, endOffset: lines.slice(0, 2).join('\n').length },
+          { startOffset: secondRequestStartOffset },
+        ]);
+        mockPopulateContext.mockImplementation((...args) => {
+          const context = args[0][1];
+          context.autoCompleteSet = [{ name: 'repository' }];
+        });
+        const model = setup(lines, 7, 3);
+
+        const { suggestions } = await provideCompletionItems(model, { lineNumber: 7, column: 3 });
+
+        expect(suggestions.map(({ label }) => label)).toEqual(['repository']);
+      });
+
+      it('still returns method completion items after malformed non-request text', async () => {
+        const lines = ['nonsense', '  '];
+        mockGetParsedRequests.mockResolvedValue(
+          createParser()(lines.join('\n'), undefined)?.requests ?? []
+        );
+        const model = setup(lines, 2, 3);
+
+        const { suggestions } = await provideCompletionItems(model, { lineNumber: 2, column: 3 });
+
+        expect(suggestions.map(({ label }) => label)).toEqual(
+          expect.arrayContaining(['GET', 'POST'])
+        );
+      });
+    });
+
+    it('still triggers suggestions inside ES|QL query triple quotes when no request is parsed', async () => {
+      mockGetParsedRequests.mockResolvedValue([]);
+      setup(['POST _query', '{', '\t"query": """', '']);
+
+      await triggerSuggestions();
+
+      expect(editor.trigger).toHaveBeenCalledWith(
+        'Trigger suggestions',
+        'editor.action.triggerSuggest',
+        {}
+      );
     });
   });
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts
@@ -9,7 +9,15 @@
 
 import { CSSProperties, Dispatch } from 'react';
 import { debounce, range } from 'lodash';
-import { ConsoleParsedRequestsProvider, getParsedRequestsProvider, monaco } from '@kbn/monaco';
+import type { ConsoleParsedRequestsProvider, ParsedRequest } from '@kbn/monaco';
+import { getParsedRequestsProvider, monaco } from '@kbn/monaco';
+import {
+  endsWithConsoleBodyContinuation,
+  getLineRemainderWithoutConsoleComments,
+  isInsideConsoleComment,
+  isInsideConsoleString,
+  isRequestLineWithUrl,
+} from '@kbn/monaco/src/console/utils';
 import { i18n } from '@kbn/i18n';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { XJson } from '@kbn/es-ui-shared-plugin/public';
@@ -48,6 +56,7 @@ import { type RequestToRestore, RestoreMethod } from '../../../types';
 import { StorageQuotaError } from '../../components/storage_quota_error';
 import { ContextValue } from '../../contexts';
 import { containsComments, removeCommentsFromData } from './utils/requests_utils';
+import { onlyBodyClosingTokensRegex } from './utils/constants';
 
 const AUTO_INDENTATION_ACTION_LABEL = 'Apply indentations';
 const TRIGGER_SUGGESTIONS_ACTION_LABEL = 'Trigger suggestions';
@@ -56,11 +65,72 @@ const DEBOUNCE_HIGHLIGHT_WAIT_MS = 200;
 const DEBOUNCE_AUTOCOMPLETE_WAIT_MS = 500;
 const INSPECT_TOKENS_LABEL = 'Inspect tokens';
 const INSPECT_TOKENS_HANDLER_ID = 'editor.action.inspectTokens';
+type BodyTriggerLine = 'current' | 'previous';
+interface AutocompleteTriggerSnapshot {
+  generation: number;
+  model: monaco.editor.ITextModel;
+  modelVersionId: number;
+  position: monaco.Position;
+}
 const { collapseLiteralStrings } = XJson;
+
+const BODY_PUNCTUATION_KEYS = new Set(['{', '[', ',', ':']);
+
+const getContentThroughPosition = (
+  model: monaco.editor.ITextModel,
+  { lineNumber, column }: monaco.IPosition
+): string =>
+  model.getValueInRange({
+    startLineNumber: 1,
+    startColumn: 1,
+    endLineNumber: lineNumber,
+    endColumn: column,
+  });
+
+const getLineContentBeforePosition = (
+  model: monaco.editor.ITextModel,
+  { lineNumber, column }: monaco.IPosition
+): string => model.getLineContent(lineNumber).slice(0, column - 1);
+
+const getBodyTriggerLineAfterIndentation = (
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition
+): BodyTriggerLine | undefined => {
+  const lineContentBefore = getLineContentBeforePosition(model, position);
+  const contentBeforePosition = getContentThroughPosition(model, position);
+  if (shouldTriggerSuggestions(lineContentBefore, isInsideConsoleString(contentBeforePosition))) {
+    return 'current';
+  }
+  if (lineContentBefore.trim() || position.lineNumber === 1) {
+    return;
+  }
+
+  const previousLinePosition = {
+    lineNumber: position.lineNumber - 1,
+    column: model.getLineMaxColumn(position.lineNumber - 1),
+  };
+  return endsWithConsoleBodyContinuation(getContentThroughPosition(model, previousLinePosition))
+    ? 'previous'
+    : undefined;
+};
+
+const hasOnlyBodyClosingTokensAfterPosition = (
+  model: monaco.editor.ITextModel,
+  { lineNumber, column }: monaco.IPosition
+): boolean => {
+  const lineContentAfterPosition = model.getLineContent(lineNumber).slice(column - 1);
+  return onlyBodyClosingTokensRegex.test(
+    getLineRemainderWithoutConsoleComments(
+      getContentThroughPosition(model, { lineNumber, column }),
+      lineContentAfterPosition
+    ).trim()
+  );
+};
 
 export class MonacoEditorActionsProvider {
   private parsedRequestsProvider: ConsoleParsedRequestsProvider;
   private highlightedLines: monaco.editor.IEditorDecorationsCollection;
+  private autocompleteTriggerGeneration = 0;
   constructor(
     private editor: monaco.editor.IStandaloneCodeEditor,
     private setEditorActionsCss: (css: CSSProperties) => void,
@@ -84,8 +154,8 @@ export class MonacoEditorActionsProvider {
     );
 
     const debouncedTriggerSuggestions = debounce(
-      () => {
-        this.triggerSuggestions();
+      (snapshot: AutocompleteTriggerSnapshot, bodyTriggerLine?: BodyTriggerLine) => {
+        this.triggerSuggestions(snapshot, bodyTriggerLine);
       },
       DEBOUNCE_AUTOCOMPLETE_WAIT_MS,
       {
@@ -93,6 +163,38 @@ export class MonacoEditorActionsProvider {
         trailing: true,
       }
     );
+    const cancelTriggerSuggestions = () => {
+      this.autocompleteTriggerGeneration++;
+      debouncedTriggerSuggestions.cancel();
+    };
+    const scheduleTriggerSuggestions = (
+      bodyTriggerLine?: BodyTriggerLine,
+      snapshot = this.getAutocompleteTriggerSnapshot(this.autocompleteTriggerGeneration)
+    ) => {
+      if (snapshot) {
+        debouncedTriggerSuggestions(snapshot, bodyTriggerLine);
+      }
+    };
+    const scheduleBodySuggestionsAfterIndentation = () => {
+      const snapshot = this.getAutocompleteTriggerSnapshot(this.autocompleteTriggerGeneration);
+      if (!snapshot) {
+        return;
+      }
+      const { model, position } = snapshot;
+      const bodyTriggerLine = getBodyTriggerLineAfterIndentation(model, position);
+      if (bodyTriggerLine) {
+        scheduleTriggerSuggestions(bodyTriggerLine, snapshot);
+      }
+    };
+    const scheduleBodySuggestionsAfterTab = () => {
+      const generation = this.autocompleteTriggerGeneration;
+      // Defer until Monaco applies the Tab indentation.
+      void Promise.resolve().then(() => {
+        if (generation === this.autocompleteTriggerGeneration) {
+          scheduleBodySuggestionsAfterIndentation();
+        }
+      });
+    };
 
     // init all listeners
     editor.onDidChangeCursorPosition(async (event) => {
@@ -107,18 +209,42 @@ export class MonacoEditorActionsProvider {
     editor.onDidContentSizeChange(async (event) => {
       await debouncedHighlightRequests();
     });
+    editor.onKeyDown((event) => {
+      if (event.keyCode === monaco.KeyCode.Escape) {
+        cancelTriggerSuggestions();
+      }
+      if (
+        event.keyCode === monaco.KeyCode.Tab &&
+        !editor.getOption(monaco.editor.EditorOption.tabFocusMode)
+      ) {
+        scheduleBodySuggestionsAfterTab();
+      }
+    });
 
     editor.onKeyUp((event) => {
+      if (event.keyCode === monaco.KeyCode.Escape) {
+        cancelTriggerSuggestions();
+        return;
+      }
       // trigger autocomplete on backspace
       if (event.keyCode === monaco.KeyCode.Backspace) {
-        debouncedTriggerSuggestions();
+        scheduleTriggerSuggestions();
       }
       if (this.isDevMode && event.keyCode === monaco.KeyCode.F1) {
         this.editor.trigger(INSPECT_TOKENS_LABEL, INSPECT_TOKENS_HANDLER_ID, {});
       }
       // trigger autocomplete on dot (period) for nested field suggestions
       if (event.keyCode === monaco.KeyCode.Period) {
-        debouncedTriggerSuggestions();
+        scheduleTriggerSuggestions();
+      }
+      // trigger body autocomplete after punctuation that opens a new value position
+      const typedKey = event.browserEvent?.key;
+      if (typedKey && BODY_PUNCTUATION_KEYS.has(typedKey)) {
+        scheduleTriggerSuggestions('current');
+      }
+      // Space and Enter move the cursor to a body completion position.
+      if (event.browserEvent?.key === ' ' || event.keyCode === monaco.KeyCode.Enter) {
+        scheduleBodySuggestionsAfterIndentation();
       }
     });
   }
@@ -208,19 +334,27 @@ export class MonacoEditorActionsProvider {
     model: monaco.editor.ITextModel,
     startLineNumber: number,
     endLineNumber: number,
-    parsedRequests?: Awaited<ReturnType<ConsoleParsedRequestsProvider['getRequests']>>
+    parsedRequests?: ParsedRequest[]
   ): Promise<AdjustedParsedRequest[]> {
     if (!model) {
       return [];
     }
-    const resolvedParsedRequests =
-      parsedRequests ?? (await this.parsedRequestsProvider.getRequests());
+    const requests = parsedRequests ?? (await this.parsedRequestsProvider.getRequests());
+    return this.filterRequestsBetweenLines(model, startLineNumber, endLineNumber, requests);
+  }
+
+  private filterRequestsBetweenLines(
+    model: monaco.editor.ITextModel,
+    startLineNumber: number,
+    endLineNumber: number,
+    requests: ParsedRequest[]
+  ): AdjustedParsedRequest[] {
     const selectedRequests: AdjustedParsedRequest[] = [];
-    for (const [index, parsedRequest] of resolvedParsedRequests.entries()) {
+    for (const [index, parsedRequest] of requests.entries()) {
       const requestStartLineNumber = getRequestStartLineNumber(parsedRequest, model);
       const requestEndLineNumber = getRequestEndLineNumber({
         parsedRequest,
-        nextRequest: resolvedParsedRequests.at(index + 1),
+        nextRequest: requests.at(index + 1),
         model,
         startLineNumber,
       });
@@ -465,37 +599,65 @@ export class MonacoEditorActionsProvider {
     return getDocumentationLinkFromAutocomplete(request, docLinkVersion);
   }
 
-  private isInsideMultilineComment(model: monaco.editor.ITextModel, lineNumber: number): boolean {
-    let insideComment = false;
-    for (let i = 1; i <= lineNumber; i++) {
-      const lineContent = model.getLineContent(i).trim();
-      if (lineContent.startsWith('/*')) {
-        insideComment = true;
-      }
-      if (lineContent.includes('*/')) {
-        insideComment = false;
-      }
+  // Column where the request starts on the given line, or 1 when the request does not
+  // start there. Skips prefixes before the method, e.g. `/* note */ GET _search`.
+  private getRequestStartColumn(
+    model: monaco.editor.ITextModel,
+    request: AdjustedParsedRequest | undefined,
+    lineNumber: number
+  ): number {
+    if (!request) {
+      return 1;
     }
-    return insideComment;
+    const requestStartPosition = model.getPositionAt(request.startOffset);
+    return requestStartPosition.lineNumber === lineNumber ? requestStartPosition.column : 1;
+  }
+
+  private isPositionInsideComment(
+    model: monaco.editor.ITextModel,
+    position: monaco.IPosition
+  ): boolean {
+    return isInsideConsoleComment(getContentThroughPosition(model, position));
+  }
+
+  /** Returns the nearest request starting at or before the line, if any. */
+  private async getRequestEndingAtOrBeforeLine(
+    model: monaco.editor.ITextModel,
+    lineNumber: number
+  ): Promise<AdjustedParsedRequest | undefined> {
+    const requests = await this.getRequestsBetweenLines(model, 1, lineNumber);
+    return requests.at(-1);
+  }
+
+  /**
+   * True when the line sits after the start of a request the parser could not finish
+   * (no `endOffset`, e.g. an unclosed body). Such lines belong to that request's body even
+   * when they fall outside the request's computed line range, which stops at the last
+   * non-empty line.
+   */
+  private async isPositionInsideUnfinishedRequest(
+    model: monaco.editor.ITextModel,
+    lineNumber: number
+  ): Promise<boolean> {
+    const request = await this.getRequestEndingAtOrBeforeLine(model, lineNumber);
+    if (
+      request === undefined ||
+      request.endOffset !== undefined ||
+      request.startLineNumber >= lineNumber
+    ) {
+      return false;
+    }
+    const startColumn = this.getRequestStartColumn(model, request, request.startLineNumber);
+    const requestLine = model.getLineContent(request.startLineNumber).slice(startColumn - 1);
+    return isRequestLineWithUrl(requestLine);
   }
 
   private async getAutocompleteType(
     model: monaco.editor.ITextModel,
     { lineNumber, column }: monaco.Position
   ): Promise<AutocompleteType | null> {
-    // Get the content of the current line up until the cursor position
-    const currentLineContent = model.getLineContent(lineNumber);
-    const trimmedContent = currentLineContent.trim();
-
     // If we are positioned inside a comment block, no autocomplete should be provided
-    if (
-      trimmedContent.startsWith('#') ||
-      trimmedContent.startsWith('//') ||
-      trimmedContent.startsWith('/*') ||
-      trimmedContent.startsWith('*') ||
-      trimmedContent.includes('*/') ||
-      this.isInsideMultilineComment(model, lineNumber)
-    ) {
+    if (this.isPositionInsideComment(model, { lineNumber, column })) {
       return null;
     }
 
@@ -509,6 +671,13 @@ export class MonacoEditorActionsProvider {
     // trigger method suggestions.
     // https://github.com/elastic/kibana/issues/186767
     if (!currentRequest) {
+      // A whitespace-only line inside an unfinished body parses as outside any request
+      // (request ranges stop at the last non-empty line), but it is a body position, not
+      // the start of a new request: `{ "type": "url",` followed by an empty line must get
+      // body suggestions, not methods.
+      if (await this.isPositionInsideUnfinishedRequest(model, lineNumber)) {
+        return AutocompleteType.BODY;
+      }
       if (isRequestLineStart(model.getLineContent(lineNumber))) {
         return AutocompleteType.METHOD;
       }
@@ -518,14 +687,18 @@ export class MonacoEditorActionsProvider {
     // if on the 1st line of the request, suggest method, url or url_params depending on the content
     const { startLineNumber: requestStartLineNumber } = currentRequest;
     if (lineNumber === requestStartLineNumber) {
+      const startColumn = this.getRequestStartColumn(model, currentRequest, lineNumber);
+      const fullLineContent = model.getLineContent(lineNumber).slice(startColumn - 1);
+      if (column < startColumn && fullLineContent.trim()) {
+        return null;
+      }
       // get the content on the line up until the position
       const lineContent = model.getValueInRange({
         startLineNumber: lineNumber,
-        startColumn: 1,
+        startColumn,
         endLineNumber: lineNumber,
         endColumn: column,
       });
-      const fullLineContent = model.getLineContent(lineNumber);
       const lineTokens = getLineTokens(lineContent);
       // if there is 1 or fewer tokens, suggest method — but only when the
       // full line could plausibly start a request. The parser produces a
@@ -580,15 +753,25 @@ export class MonacoEditorActionsProvider {
         suggestions: getMethodCompletionItems(model, position),
       };
     }
-    if (autocompleteType === AutocompleteType.PATH) {
+    if (
+      autocompleteType === AutocompleteType.PATH ||
+      autocompleteType === AutocompleteType.URL_PARAMS
+    ) {
+      const requests = await this.getRequestsBetweenLines(
+        model,
+        position.lineNumber,
+        position.lineNumber
+      );
+      const requestStartColumn = this.getRequestStartColumn(
+        model,
+        requests.at(0),
+        position.lineNumber
+      );
       return {
-        suggestions: getUrlPathCompletionItems(model, position),
-      };
-    }
-
-    if (autocompleteType === AutocompleteType.URL_PARAMS) {
-      return {
-        suggestions: getUrlParamsCompletionItems(model, position),
+        suggestions:
+          autocompleteType === AutocompleteType.PATH
+            ? getUrlPathCompletionItems(model, position, requestStartColumn)
+            : getUrlParamsCompletionItems(model, position, requestStartColumn),
       };
     }
 
@@ -597,17 +780,20 @@ export class MonacoEditorActionsProvider {
       if (context.triggerCharacter && context.triggerCharacter !== '"') {
         return { suggestions: [] };
       }
-      const requests = await this.getRequestsBetweenLines(
-        model,
-        position.lineNumber,
-        position.lineNumber
-      );
-      const requestStartLineNumber = requests[0].startLineNumber;
+      // The containing request: for a whitespace-only line inside an unfinished body the
+      // request's computed line range stops before this line, so look at the nearest
+      // request above the position instead of only at the position's own line.
+      const request = await this.getRequestEndingAtOrBeforeLine(model, position.lineNumber);
+      if (!request) {
+        return { suggestions: [] };
+      }
+      const requestStartLineNumber = request.startLineNumber;
       const suggestions = await getBodyCompletionItems(
         model,
         position,
         requestStartLineNumber,
-        this
+        this,
+        this.getRequestStartColumn(model, request, requestStartLineNumber)
       );
       return {
         suggestions,
@@ -815,70 +1001,151 @@ export class MonacoEditorActionsProvider {
     return this.editor.getPosition() ?? { lineNumber: 1, column: 1 };
   }
 
-  private async isPositionInsideTripleQuotesAndQuery(
+  private resolveTripleQuoteContext(
     model: monaco.editor.ITextModel,
-    position: monaco.Position
-  ): Promise<TripleQuoteContext> {
-    const parsedRequests = await this.parsedRequestsProvider.getRequests();
-    const selectedRequests = await this.getRequestsBetweenLines(
+    position: monaco.Position,
+    parsedRequests: ParsedRequest[]
+  ): TripleQuoteContext {
+    const requestsAtPosition = this.filterRequestsBetweenLines(
       model,
       position.lineNumber,
       position.lineNumber,
       parsedRequests
     );
-    return getTripleQuoteContext(model, position, selectedRequests, parsedRequests);
+    return getTripleQuoteContext(model, position, requestsAtPosition, parsedRequests);
   }
 
-  private hasEditorStateChanged(
+  private async isPositionInsideTripleQuotesAndQuery(
     model: monaco.editor.ITextModel,
-    modelVersionId: number,
     position: monaco.Position
-  ): boolean {
+  ): Promise<TripleQuoteContext> {
+    const parsedRequests = await this.parsedRequestsProvider.getRequests();
+    return this.resolveTripleQuoteContext(model, position, parsedRequests);
+  }
+
+  private async getTripleQuoteContextForTrigger(
+    snapshot: AutocompleteTriggerSnapshot
+  ): Promise<TripleQuoteContext | undefined> {
+    const { model, position } = snapshot;
+    try {
+      const parsedRequests = await this.parsedRequestsProvider.getRequests();
+      if (this.isAutocompleteTriggerStale(snapshot)) {
+        return;
+      }
+      return this.resolveTripleQuoteContext(model, position, parsedRequests);
+    } catch {
+      // Ignore parser/model races while the debounced trigger is pending.
+      return;
+    }
+  }
+
+  private getAutocompleteTriggerSnapshot(
+    generation: number
+  ): AutocompleteTriggerSnapshot | undefined {
+    const model = this.editor.getModel();
+    const position = this.editor.getPosition();
+    if (!model || !position) {
+      return;
+    }
+    return { generation, model, modelVersionId: model.getVersionId(), position };
+  }
+
+  /**
+   * True when the editor moved on (trigger cancelled, model swapped/disposed, content edited,
+   * or cursor moved) since the snapshot was taken, so an async answer computed for it must
+   * not be acted upon.
+   */
+  private isAutocompleteTriggerStale({
+    generation,
+    model,
+    modelVersionId,
+    position,
+  }: AutocompleteTriggerSnapshot): boolean {
     const currentPosition = this.editor.getPosition();
     return (
+      generation !== this.autocompleteTriggerGeneration ||
       this.editor.getModel() !== model ||
+      model.isDisposed() ||
       model.getVersionId() !== modelVersionId ||
       !currentPosition ||
       !monaco.Position.equals(currentPosition, position)
     );
   }
 
-  private triggerSuggestions() {
-    const model = this.editor.getModel();
-    const position = this.editor.getPosition();
-    if (!model || !position) {
+  private async canTriggerBodySuggestions(
+    snapshot: AutocompleteTriggerSnapshot,
+    bodyTriggerLine: BodyTriggerLine,
+    insideString: boolean
+  ): Promise<boolean> {
+    if (insideString) {
+      return false;
+    }
+
+    const { model, position } = snapshot;
+    const lineNumber =
+      bodyTriggerLine === 'previous' ? position.lineNumber - 1 : position.lineNumber;
+    try {
+      const requests = await this.getRequestsBetweenLines(model, lineNumber, lineNumber);
+      return (
+        !this.isAutocompleteTriggerStale(snapshot) &&
+        requests.every(({ startLineNumber }) => startLineNumber !== lineNumber)
+      );
+    } catch {
+      // The parser can briefly reference removed lines while it catches up with an edit.
+      return false;
+    }
+  }
+
+  private async triggerSuggestions(
+    snapshot = this.getAutocompleteTriggerSnapshot(this.autocompleteTriggerGeneration),
+    bodyTriggerLine?: BodyTriggerLine
+  ): Promise<void> {
+    if (!snapshot || this.isAutocompleteTriggerStale(snapshot)) {
       return;
     }
-    const modelVersionId = model.getVersionId();
-    this.isPositionInsideTripleQuotesAndQuery(model, position).then(
-      ({ insideTripleQuotes, insideEsqlQuery }) => {
-        if (this.hasEditorStateChanged(model, modelVersionId, position)) {
-          return;
-        }
-        if (insideTripleQuotes && !insideEsqlQuery) {
-          // Don't trigger autocomplete suggestions inside scripts and strings
-          return;
-        }
+    const { model, position } = snapshot;
 
-        const lineContentBefore = model.getValueInRange({
-          startLineNumber: position.lineNumber,
-          startColumn: 1,
-          endLineNumber: position.lineNumber,
-          endColumn: position.column,
-        });
-        // Trigger suggestions if the line:
-        // - is empty
-        // - matches specified regex
-        // - is inside an ESQL query
-        if (
-          !lineContentBefore.trim() ||
-          shouldTriggerSuggestions(lineContentBefore) ||
-          insideEsqlQuery
-        ) {
-          this.editor.trigger(TRIGGER_SUGGESTIONS_ACTION_LABEL, TRIGGER_SUGGESTIONS_HANDLER_ID, {});
-        }
-      }
-    );
+    if (bodyTriggerLine && !hasOnlyBodyClosingTokensAfterPosition(model, position)) {
+      return;
+    }
+
+    // Don't trigger (and visually open) the suggestions widget inside comments.
+    // Even when our completion provider returns 0 results, Monaco can still surface
+    // an empty suggestions widget, which breaks user expectations and our UI tests.
+    if (this.isPositionInsideComment(model, position)) {
+      return;
+    }
+
+    const tripleQuoteContext = await this.getTripleQuoteContextForTrigger(snapshot);
+    if (!tripleQuoteContext || this.isAutocompleteTriggerStale(snapshot)) {
+      return;
+    }
+    const { insideTripleQuotes, insideEsqlQuery, insideString } = tripleQuoteContext;
+    const insideStringAtPosition =
+      insideString ?? isInsideConsoleString(getContentThroughPosition(model, position));
+    // Don't trigger autocomplete suggestions inside scripts and strings
+    if (insideTripleQuotes && !insideEsqlQuery) {
+      return;
+    }
+    if (
+      bodyTriggerLine &&
+      !(await this.canTriggerBodySuggestions(snapshot, bodyTriggerLine, insideStringAtPosition))
+    ) {
+      return;
+    }
+
+    const lineContentBefore = getLineContentBeforePosition(model, position);
+    // Trigger suggestions if the line:
+    // - is empty
+    // - matches specified regex
+    // - is inside an ESQL query
+    if (
+      !lineContentBefore.trim() ||
+      shouldTriggerSuggestions(lineContentBefore, insideStringAtPosition) ||
+      insideEsqlQuery
+    ) {
+      this.editor.trigger(TRIGGER_SUGGESTIONS_ACTION_LABEL, TRIGGER_SUGGESTIONS_HANDLER_ID, {});
+    }
   }
 
   /*

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -27,6 +27,7 @@ import {
   getUrlPathCompletionItems,
   getBodyCompletionItems,
   shouldTriggerSuggestions,
+  shouldInsertAutocompleteTemplate,
   getInsertText,
 } from './autocomplete_utils';
 
@@ -150,6 +151,12 @@ describe('autocomplete_utils', () => {
       const actual = shouldTriggerSuggestions(' "propertyName": "');
       expect(actual).toBe(true);
     });
+    it.each(['{"ignore_failure": ', '["ignore_failure": ', '"enabled": true, "ignore_failure": '])(
+      'triggers suggestions for an inline property value after a body delimiter',
+      (line) => {
+        expect(shouldTriggerSuggestions(line)).toBe(true);
+      }
+    );
     it('triggers no suggestions for the property value when the value is typed (string)', () => {
       const actual = shouldTriggerSuggestions(' "propertyName": "value');
       expect(actual).toBe(false);
@@ -157,6 +164,86 @@ describe('autocomplete_utils', () => {
     it('triggers no suggestions for the property value when the value is typed (number)', () => {
       const actual = shouldTriggerSuggestions(' "propertyName": 5');
       expect(actual).toBe(false);
+    });
+
+    // #259250 C1: a body delimiter leaves the cursor at a new value position.
+    it('triggers suggestions after a body continuation delimiter', () => {
+      expect(shouldTriggerSuggestions('{')).toBe(true);
+      expect(shouldTriggerSuggestions('  {')).toBe(true);
+      expect(shouldTriggerSuggestions('\t{')).toBe(true);
+      expect(shouldTriggerSuggestions('  "fields": [')).toBe(true);
+      expect(shouldTriggerSuggestions('  "field",')).toBe(true);
+    });
+
+    it('does not treat a brace followed by object content as a trigger position', () => {
+      expect(shouldTriggerSuggestions('{ "already": 1')).toBe(false);
+      expect(shouldTriggerSuggestions('{foo')).toBe(false);
+      expect(shouldTriggerSuggestions('{"partial')).toBe(false);
+    });
+
+    // #284530 review: `{` typed after a property name should also auto-trigger.
+    it('triggers suggestions when the line ends with an opening brace after content', () => {
+      expect(shouldTriggerSuggestions('"query": {')).toBe(true);
+      expect(shouldTriggerSuggestions('  "pipeline": {')).toBe(true);
+      expect(shouldTriggerSuggestions('"query": {  ')).toBe(true);
+    });
+
+    it('does not trigger for a body delimiter inside an unclosed string', () => {
+      expect(shouldTriggerSuggestions('"foo": "bar {')).toBe(false);
+      expect(shouldTriggerSuggestions('"regex": "a{')).toBe(false);
+      expect(shouldTriggerSuggestions('"description": "value,')).toBe(false);
+    });
+
+    it('handles even backslashes before a closing quote', () => {
+      expect(shouldTriggerSuggestions('{"path":"C:\\\\","nested": {')).toBe(true);
+      expect(shouldTriggerSuggestions('{"path":"C:\\\\","description":"a{')).toBe(false);
+    });
+
+    it('handles a completed triple-quoted string before an opening brace', () => {
+      expect(shouldTriggerSuggestions('{"script": """def quote = \'"\';""", "query": {')).toBe(
+        true
+      );
+    });
+
+    it('handles a multiline triple-quoted string before an opening brace', () => {
+      expect(shouldTriggerSuggestions('{"script": """\ndef quote = \'"\';\n""", "query": {')).toBe(
+        true
+      );
+    });
+  });
+
+  describe('shouldInsertAutocompleteTemplate', () => {
+    it('allows template when the rest of the line is empty or a lone quote', () => {
+      expect(shouldInsertAutocompleteTemplate('')).toBe(true);
+      expect(shouldInsertAutocompleteTemplate('   ')).toBe(true);
+      expect(shouldInsertAutocompleteTemplate('"')).toBe(true);
+      expect(shouldInsertAutocompleteTemplate('  "')).toBe(true);
+    });
+
+    it('allows template when the rest of the line is only closing braces', () => {
+      expect(shouldInsertAutocompleteTemplate('}')).toBe(true);
+      expect(shouldInsertAutocompleteTemplate('}}')).toBe(true);
+    });
+
+    it('rejects template when other content follows the cursor', () => {
+      expect(shouldInsertAutocompleteTemplate(': 1')).toBe(false);
+      expect(shouldInsertAutocompleteTemplate(', "other"')).toBe(false);
+      expect(shouldInsertAutocompleteTemplate('"already": 1')).toBe(false);
+    });
+
+    describe('WHEN only a trailing comma follows the cursor', () => {
+      it.each([',', '",', ' , '])('SHOULD allow template insertion for %p', (suffix) => {
+        expect(shouldInsertAutocompleteTemplate(suffix)).toBe(true);
+      });
+    });
+
+    // #259250 C2: Monaco auto-closes `"` inside `{}`, leaving `"}` after the cursor.
+    it('allows template when Monaco auto-closed quote sits before closing braces', () => {
+      expect(shouldInsertAutocompleteTemplate('"}')).toBe(true);
+      expect(shouldInsertAutocompleteTemplate('  "}')).toBe(true);
+      expect(shouldInsertAutocompleteTemplate('"}]')).toBe(true);
+      expect(shouldInsertAutocompleteTemplate('"}}}')).toBe(true);
+      expect(shouldInsertAutocompleteTemplate('"} ],')).toBe(true);
     });
   });
 
@@ -305,6 +392,23 @@ describe('autocomplete_utils', () => {
         endColumn: 9,
       });
     });
+
+    it('parses the request from its start column when a block comment prefixes the line', () => {
+      const line = '/* note */ GET ind';
+      const mockModel = {
+        getValueInRange: jest.fn(({ startColumn, endColumn }: any) =>
+          line.slice(startColumn - 1, endColumn - 1)
+        ),
+        getWordUntilPosition: () => ({ startColumn: 16 }),
+      } as unknown as monaco.editor.ITextModel;
+      const mockPosition = { lineNumber: 1, column: line.length + 1 } as unknown as monaco.Position;
+      // request starts at column 12 (`GET ...`), after the block-comment prefix
+      const items = getUrlPathCompletionItems(mockModel, mockPosition, 12);
+      // `parseLine` must see `GET ind`, not `/* note */ GET ind` (method would parse as `/*`)
+      const lastCallArgs = mockPopulateContext.mock.calls.at(-1)?.[0];
+      expect(lastCallArgs?.[1].method).toBe('GET');
+      expect(items.map((item) => item.label)).toEqual(['index1', 'index2']);
+    });
   });
 
   describe('getBodyCompletionItems', () => {
@@ -361,6 +465,43 @@ describe('autocomplete_utils', () => {
       });
     });
 
+    it('parses the method+url line from the request start column when comment-prefixed', async () => {
+      const mockAutocompleteSet = [
+        { name: 'index.mode', template: 'standard' },
+      ] as unknown as AutoCompleteContext['autoCompleteSet'];
+
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = mockAutocompleteSet;
+      });
+
+      const mockModel = {
+        getLineContent: () => '/* note */ PUT my-index',
+        getValueInRange: jest.fn((range: any) => {
+          if (range.startLineNumber === 2) {
+            return '{\n    "settings": {\n        index.mode';
+          }
+          if (range.startColumn === 1 && range.endLineNumber === 4) {
+            return '        index.mode';
+          }
+          return '';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 15, word: 'mode' }),
+        getLineMaxColumn: () => 19,
+      } as unknown as monaco.editor.ITextModel;
+
+      const mockPosition = { lineNumber: 4, column: 19 } as monaco.Position;
+
+      // request starts at column 12 (`PUT ...`), after the block-comment prefix
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor, 12);
+
+      // `parseLine` must see `PUT my-index`, not the comment prefix (method would parse as `/*`)
+      const urlContextCallArgs = mockPopulateContext.mock.calls[0]?.[0];
+      expect(urlContextCallArgs?.[1].method).toBe('PUT');
+      expect(items.length).toBe(1);
+      expect(items[0].label).toBe('index.mode');
+    });
+
     it('calculates correct replacement range for quoted fields with dots', async () => {
       const mockAutocompleteSet = [
         { name: 'index.mode', template: 'standard' },
@@ -399,6 +540,212 @@ describe('autocomplete_utils', () => {
         startColumn: 10, // After the opening quote
         endLineNumber: 4,
         endColumn: 21, // Including the closing quote
+      });
+    });
+
+    it('replaces the rest of a quoted field when completing in the middle', async () => {
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = [
+          { name: 'icmp.type', template: 'standard' },
+        ] as unknown as AutoCompleteContext['autoCompleteSet'];
+      });
+
+      const mockModel = {
+        getLineContent: () => 'PUT my-index',
+        getValueInRange: jest.fn((range: monaco.IRange) => {
+          if (range.startLineNumber === 2) {
+            return '{\n    "settings": {\n        "icmp.ty';
+          }
+          if (range.startColumn === 1 && range.endLineNumber === 4) {
+            return '        "icmp.ty';
+          }
+          return 'pe"';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 15, word: 'ty' }),
+        getLineMaxColumn: () => 20,
+      } as unknown as monaco.editor.ITextModel;
+      const mockPosition = { lineNumber: 4, column: 17 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      expect(items).toHaveLength(1);
+      expect(items[0].insertText).toBe('icmp.type"');
+      expect(items[0].range).toEqual({
+        startLineNumber: 4,
+        startColumn: 10,
+        endLineNumber: 4,
+        endColumn: 20,
+      });
+    });
+
+    it('ignores quotes inside comments when completing in the middle of a quoted field', async () => {
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = [{ name: 'query', template: 'standard' }];
+      });
+      const lines = ['GET _search', '{ /* " */ "query": {} }'];
+      const lineContentBeforePosition = '{ /* " */ "que';
+      const position = {
+        lineNumber: 2,
+        column: lineContentBeforePosition.length + 1,
+      } as monaco.Position;
+      const mockModel = {
+        getLineContent: (lineNumber: number) => lines[lineNumber - 1],
+        getValueInRange: jest.fn(
+          ({ startLineNumber, startColumn, endLineNumber, endColumn }: monaco.IRange) => {
+            if (startLineNumber === endLineNumber) {
+              return lines[startLineNumber - 1].slice(startColumn - 1, endColumn - 1);
+            }
+            const selectedLines = lines.slice(startLineNumber - 1, endLineNumber);
+            selectedLines[0] = selectedLines[0].slice(startColumn - 1);
+            selectedLines[selectedLines.length - 1] = selectedLines[selectedLines.length - 1].slice(
+              0,
+              endColumn - 1
+            );
+            return selectedLines.join('\n');
+          }
+        ),
+        getWordUntilPosition: () => ({ startColumn: 12, word: 'que' }),
+        getLineMaxColumn: (lineNumber: number) => lines[lineNumber - 1].length + 1,
+      } as unknown as monaco.editor.ITextModel;
+
+      const items = await getBodyCompletionItems(mockModel, position, 1, mockEditor);
+
+      expect(items).toHaveLength(1);
+      expect(items[0]).toEqual(
+        expect.objectContaining({
+          insertText: 'query"',
+          range: {
+            startLineNumber: 2,
+            startColumn: 12,
+            endLineNumber: 2,
+            endColumn: 18,
+          },
+        })
+      );
+    });
+
+    it('replaces through an escaped quote when completing in the middle of a string', async () => {
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = [
+          { name: 'icmp.type', template: 'standard' },
+        ] as unknown as AutoCompleteContext['autoCompleteSet'];
+      });
+
+      const mockModel = {
+        getLineContent: () => 'PUT my-index',
+        getValueInRange: jest.fn((range: monaco.IRange) => {
+          if (range.startLineNumber === 2) {
+            return '{\n    "settings": {\n        "icmp.ty';
+          }
+          if (range.startColumn === 1 && range.endLineNumber === 4) {
+            return '        "icmp.ty';
+          }
+          return 'pe\\"suffix"';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 15, word: 'ty' }),
+        getLineMaxColumn: () => 28,
+      } as unknown as monaco.editor.ITextModel;
+      const mockPosition = { lineNumber: 4, column: 17 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      expect(items).toHaveLength(1);
+      expect(items[0].range).toEqual({
+        startLineNumber: 4,
+        startColumn: 10,
+        endLineNumber: 4,
+        endColumn: 28,
+      });
+    });
+
+    it.each([
+      {
+        caseName: 'an odd backslash run ending before the cursor',
+        lineContentBeforePosition: '        "value\\',
+        lineContentAfterPosition: '"tail"',
+        closingQuoteLength: 6,
+      },
+      {
+        caseName: 'an even backslash run ending before the cursor',
+        lineContentBeforePosition: '        "value\\\\',
+        lineContentAfterPosition: '"tail"',
+        closingQuoteLength: 1,
+      },
+      {
+        caseName: 'an even backslash run after the cursor',
+        lineContentBeforePosition: '        "value',
+        lineContentAfterPosition: '\\\\"tail"',
+        closingQuoteLength: 3,
+      },
+    ])('uses quote-escape parity for $caseName', async (testCase) => {
+      const { lineContentBeforePosition, lineContentAfterPosition, closingQuoteLength } = testCase;
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = [{ name: 'replacement' }];
+      });
+      const position = {
+        lineNumber: 4,
+        column: lineContentBeforePosition.length + 1,
+      } as monaco.Position;
+      const mockModel = {
+        getLineContent: () => 'PUT my-index',
+        getValueInRange: jest.fn((range: monaco.IRange) => {
+          if (range.startLineNumber === 2) {
+            return `{\n    "settings": {\n${lineContentBeforePosition}`;
+          }
+          if (range.startColumn === 1 && range.endLineNumber === 4) {
+            return lineContentBeforePosition;
+          }
+          return lineContentAfterPosition;
+        }),
+        getWordUntilPosition: () => ({ startColumn: position.column, word: '' }),
+        getLineMaxColumn: () =>
+          lineContentBeforePosition.length + lineContentAfterPosition.length + 1,
+      } as unknown as monaco.editor.ITextModel;
+
+      const items = await getBodyCompletionItems(mockModel, position, 1, mockEditor);
+
+      expect(items[0].range).toEqual({
+        startLineNumber: 4,
+        startColumn: position.column,
+        endLineNumber: 4,
+        endColumn: position.column + closingQuoteLength,
+      });
+    });
+
+    it('does not consume a later quoted property when completing outside a string', async () => {
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = [{ name: false }, { name: true }];
+      });
+
+      const mockModel = {
+        getLineContent: () => 'PUT my-index',
+        getValueInRange: jest.fn((range: monaco.IRange) => {
+          if (range.startLineNumber === 2) {
+            return '{\n    "settings": {\n        "enabled": ';
+          }
+          if (range.startColumn === 1 && range.endLineNumber === 4) {
+            return '        "enabled": ';
+          }
+          return 'true, "other": "';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 20, word: '' }),
+        getLineMaxColumn: () => 36,
+      } as unknown as monaco.editor.ITextModel;
+      const mockPosition = { lineNumber: 4, column: 20 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      expect(items).toHaveLength(2);
+      expect(items[0].range).toEqual({
+        startLineNumber: 4,
+        startColumn: 20,
+        endLineNumber: 4,
+        endColumn: 20,
       });
     });
 
@@ -511,6 +858,152 @@ describe('autocomplete_utils', () => {
 
       expect(items.map((item) => item.label)).toEqual(['type']);
     });
+
+    // #284530 review: accepting `{` from the widget leaves the cursor inside `{}` without any
+    // keypress, so the suggestion itself must re-open the widget via a post-accept command.
+    it('adds a re-trigger command to suggestions that leave the cursor inside an empty container', async () => {
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = [
+          { name: '{' },
+          { name: '[' },
+          { name: 'community_id', template: {} },
+          { name: 'fields', value: '[' },
+          { name: 'append', template: { field: '', value: [] } },
+        ] as AutoCompleteContext['autoCompleteSet'];
+      });
+
+      const mockModel = {
+        getLineContent: () => 'POST _ingest/pipeline/_simulate',
+        getValueInRange: jest.fn((range: monaco.IRange) => {
+          if (range.startLineNumber === 2) {
+            return '{\n  "pipeline": {\n    "processors": [\n      ';
+          }
+          if (range.startLineNumber === 5 && range.startColumn === 1) {
+            return '      ';
+          }
+          return '';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 7, word: '' }),
+        getLineMaxColumn: () => 7,
+      } as unknown as monaco.editor.ITextModel;
+      const mockPosition = { lineNumber: 5, column: 7 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      const structural = items.find((item) => item.label === '{');
+      const structuralArray = items.find((item) => item.label === '[');
+      const withEmptyObject = items.find((item) => item.label === 'community_id');
+      const withEmptyArray = items.find((item) => item.label === 'fields');
+      const withTemplate = items.find((item) => item.label === 'append');
+      expect(structural?.insertText).toBe('{$0}');
+      expect(structural?.command).toEqual({ id: 'editor.action.triggerSuggest', title: '' });
+      expect(structuralArray?.insertText).toBe('[$0]');
+      expect(structuralArray?.command).toEqual({ id: 'editor.action.triggerSuggest', title: '' });
+      expect(withEmptyObject?.insertText).toBe('"community_id": {$0}');
+      expect(withEmptyObject?.command).toEqual({ id: 'editor.action.triggerSuggest', title: '' });
+      expect(withEmptyArray?.insertText).toBe('"fields": [$0]');
+      expect(withEmptyArray?.command).toEqual({ id: 'editor.action.triggerSuggest', title: '' });
+      expect(withTemplate?.command).toBeUndefined();
+    });
+
+    describe('WHEN only body-closing tokens follow a templated completion', () => {
+      it.each([
+        { lineContentAfterPosition: '"}]', expectedEndColumn: 10 },
+        { lineContentAfterPosition: '  "}]', expectedEndColumn: 12 },
+        { lineContentAfterPosition: '"} ],', expectedEndColumn: 10 },
+        { lineContentAfterPosition: '",', expectedEndColumn: 10 },
+        { lineContentAfterPosition: ',', expectedEndColumn: 9 },
+        { lineContentAfterPosition: '"}, // note', expectedEndColumn: 10 },
+      ])(
+        'SHOULD expand the template and replace the closing quote in $lineContentAfterPosition',
+        async ({ lineContentAfterPosition, expectedEndColumn }) => {
+          mockPopulateContext.mockImplementation((...args) => {
+            const context = args[0][1];
+            context.autoCompleteSet = [
+              { name: 'append', template: { field: '', ['value' as string]: [] } },
+            ] as AutoCompleteContext['autoCompleteSet'];
+          });
+
+          const mockModel = {
+            getLineContent: () => 'POST _ingest/pipeline/_simulate',
+            getValueInRange: jest.fn((range: monaco.IRange) => {
+              if (range.startLineNumber === 2) {
+                return '{\n  "pipeline": {\n    "processors": [\n      {"';
+              }
+              if (range.startLineNumber === 5 && range.startColumn === 1) {
+                return '      {"';
+              }
+              return lineContentAfterPosition;
+            }),
+            getWordUntilPosition: () => ({ startColumn: 9, word: '' }),
+            getLineMaxColumn: () => 9 + lineContentAfterPosition.length,
+          } as unknown as monaco.editor.ITextModel;
+          const mockPosition = { lineNumber: 5, column: 9 } as monaco.Position;
+
+          const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+          expect(items).toHaveLength(1);
+          expect(items[0]).toEqual(
+            expect.objectContaining({
+              insertText: 'append": {\n  "field": "",\n  "value": []\n}',
+              range: {
+                startLineNumber: 5,
+                startColumn: 9,
+                endLineNumber: 5,
+                endColumn: expectedEndColumn,
+              },
+            })
+          );
+        }
+      );
+
+      it('does not consume a quote inside a trailing comment', async () => {
+        mockPopulateContext.mockImplementation((...args) => {
+          const context = args[0][1];
+          context.autoCompleteSet = [{ name: 'next_field' }];
+        });
+
+        const lineContentBeforePosition = '      "field",';
+        const lineContentAfterPosition = ' // "next field"';
+        const position = {
+          lineNumber: 4,
+          column: lineContentBeforePosition.length + 1,
+        } as monaco.Position;
+        const mockModel = {
+          getLineContent: () => 'GET _search',
+          getValueInRange: jest.fn((range: monaco.IRange) => {
+            if (range.startLineNumber === 2) {
+              return `{
+  "fields": [
+${lineContentBeforePosition}`;
+            }
+            if (range.startLineNumber === position.lineNumber && range.startColumn === 1) {
+              return lineContentBeforePosition;
+            }
+            return lineContentAfterPosition;
+          }),
+          getWordUntilPosition: () => ({ startColumn: position.column, word: '' }),
+          getLineMaxColumn: () =>
+            lineContentBeforePosition.length + lineContentAfterPosition.length + 1,
+        } as unknown as monaco.editor.ITextModel;
+
+        const items = await getBodyCompletionItems(mockModel, position, 1, mockEditor);
+
+        expect(items).toHaveLength(1);
+        expect(items[0]).toEqual(
+          expect.objectContaining({
+            insertText: '"next_field"',
+            range: {
+              startLineNumber: position.lineNumber,
+              startColumn: position.column,
+              endLineNumber: position.lineNumber,
+              endColumn: position.column,
+            },
+          })
+        );
+      });
+    });
   });
 
   describe('getInsertText', () => {
@@ -554,6 +1047,12 @@ describe('autocomplete_utils', () => {
       ).toBe('"match_all"');
     });
 
+    it('adds an opening quote after a string closed following even backslashes', () => {
+      expect(
+        getInsertText({ name: 'nested' } as ResultTerm, '{"path":"C:\\\\","nested": ', mockContext)
+      ).toBe('"nested"');
+    });
+
     it('uses name when insertValue is a structural token', () => {
       expect(
         getInsertText(
@@ -571,6 +1070,17 @@ describe('autocomplete_utils', () => {
           addTemplate: true,
         })
       ).toBe('"query": {$0}');
+    });
+
+    it('expands ingest append processor template when addTemplate is true', () => {
+      const body =
+        'POST _ingest/pipeline/_simulate\n{\n  "pipeline": {\n    "processors": [\n      {"';
+      expect(
+        getInsertText({ name: 'append', template: { field: '', ['value' as string]: [] } }, body, {
+          ...mockContext,
+          addTemplate: true,
+        })
+      ).toBe('append": {\n' + '  "field": "",\n' + '  "value": []\n' + '}');
     });
 
     it('inserts template when provided directly and context.addTemplate is true', () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -8,7 +8,12 @@
  */
 
 import { monaco } from '@kbn/monaco';
-import { MonacoEditorActionsProvider } from '../monaco_editor_actions_provider';
+import {
+  getLineRemainderWithoutConsoleComments,
+  isEscaped,
+  isInsideConsoleString,
+} from '@kbn/monaco/src/console/utils';
+import type { MonacoEditorActionsProvider } from '../monaco_editor_actions_provider';
 import {
   getEndpointBodyCompleteComponents,
   getGlobalAutocompleteComponents,
@@ -26,9 +31,11 @@ import { parseBody, parseLine, parseUrl } from './tokens_utils';
 import {
   END_OF_URL_TOKEN,
   i18nTexts,
+  lineEndsWithBodyContinuationRegex,
   methodWhitespaceRegex,
   methodWithUrlRegex,
   newLineRegex,
+  onlyBodyClosingTokensRegex,
   propertyNameRegex,
   propertyValueRegex,
 } from './constants';
@@ -74,8 +81,10 @@ export const getMethodCompletionItems = (
   model: monaco.editor.ITextModel,
   position: monaco.Position
 ): monaco.languages.CompletionItem[] => {
-  // get the word before suggestions to replace when selecting a suggestion from the list
-  const wordUntilPosition = model.getWordUntilPosition(position);
+  // Replace the whole method even when the cursor is at its start or in its middle.
+  const wordAtPosition = model.getWordAtPosition(position);
+  const startColumn = wordAtPosition?.startColumn ?? position.column;
+  const endColumn = wordAtPosition?.endColumn ?? position.column;
   return autocompleteMethods.map((method, index) => ({
     label: method,
     insertText: method,
@@ -85,9 +94,9 @@ export const getMethodCompletionItems = (
     sortText: String(index),
     range: {
       // replace the whole word with the suggestion
-      startColumn: wordUntilPosition.startColumn,
+      startColumn,
       startLineNumber: position.lineNumber,
-      endColumn: position.column,
+      endColumn,
       endLineNumber: position.lineNumber,
     },
   }));
@@ -112,21 +121,30 @@ const populateContextForMethodAndUrl = (method: string, urlTokenPath: string[]) 
   return context;
 };
 
+// Line content from the request start (`requestStartColumn` skips a block-comment prefix such as
+// `/* note */ GET _search`, so `parseLine` sees the method first) up to the cursor.
+const getRequestLineContentBeforePosition = (
+  model: monaco.editor.ITextModel,
+  { lineNumber, column }: monaco.Position,
+  requestStartColumn: number
+): string =>
+  model.getValueInRange({
+    startLineNumber: lineNumber,
+    startColumn: Math.min(requestStartColumn, column),
+    endLineNumber: lineNumber,
+    endColumn: column,
+  });
+
 /*
  * This function returns an array of completion items for the request method and the url path
  */
 export const getUrlPathCompletionItems = (
   model: monaco.editor.ITextModel,
-  position: monaco.Position
+  position: monaco.Position,
+  requestStartColumn = 1
 ): monaco.languages.CompletionItem[] => {
   const { lineNumber, column } = position;
-  // get the content of the line up until the current position
-  const lineContent = model.getValueInRange({
-    startLineNumber: lineNumber,
-    startColumn: 1,
-    endLineNumber: lineNumber,
-    endColumn: column,
-  });
+  const lineContent = getRequestLineContentBeforePosition(model, position, requestStartColumn);
 
   // flag to only suggest index names
   let onlyIndexNames = false;
@@ -210,16 +228,10 @@ export const getUrlPathCompletionItems = (
  */
 export const getUrlParamsCompletionItems = (
   model: monaco.editor.ITextModel,
-  position: monaco.Position
+  position: monaco.Position,
+  requestStartColumn = 1
 ): monaco.languages.CompletionItem[] => {
-  const { lineNumber, column } = position;
-  // get the content of the line up until the current position
-  const lineContent = model.getValueInRange({
-    startLineNumber: lineNumber,
-    startColumn: 1,
-    endLineNumber: lineNumber,
-    endColumn: column,
-  });
+  const lineContent = getRequestLineContentBeforePosition(model, position, requestStartColumn);
 
   // get the method and previous url parts for context
   const { method, urlPathTokens, urlParamsTokens } = parseLine(lineContent);
@@ -272,12 +284,15 @@ export const getBodyCompletionItems = async (
   model: monaco.editor.ITextModel,
   position: monaco.Position,
   requestStartLineNumber: number,
-  editor: MonacoEditorActionsProvider
+  editor: MonacoEditorActionsProvider,
+  // Column where the request starts on its first line; skips a block-comment prefix
+  // (e.g. `/* note */ GET _search`) so `parseLine` sees the method first.
+  requestStartColumn = 1
 ): Promise<monaco.languages.CompletionItem[]> => {
   const { lineNumber, column } = position;
 
-  // get the content on the method+url line
-  const lineContent = model.getLineContent(requestStartLineNumber);
+  // get the content on the method+url line, starting at the request itself
+  const lineContent = model.getLineContent(requestStartLineNumber).slice(requestStartColumn - 1);
   // get the method and previous url parts for context
   const { method, urlPathTokens } = parseLine(lineContent);
   urlPathTokens.push(END_OF_URL_TOKEN);
@@ -335,6 +350,80 @@ const getStructuralSnippet = (token: string) => {
 const usesStructuralSnippet = ({ name }: Pick<ResultTerm, 'name'>): boolean =>
   typeof name === 'string' && getStructuralSnippet(name) !== undefined;
 
+const findUnescapedQuoteIndex = (
+  lineContentBeforePosition: string,
+  lineContentAfterPosition: string
+): number => {
+  const lineContent = lineContentBeforePosition + lineContentAfterPosition;
+  const positionIndex = lineContentBeforePosition.length;
+  for (let index = positionIndex; index < lineContent.length; index++) {
+    if (lineContent[index] === '"' && !isEscaped(lineContent, index)) {
+      return index - positionIndex;
+    }
+  }
+  return -1;
+};
+
+// If there is a closing `"` after the cursor, include it in the replacement range so accepting
+// a suggestion replaces the rest of the token instead of duplicating the quote.
+const getCompletionEndColumn = (
+  positionColumn: number,
+  lineContentBeforePosition: string,
+  lineContentAfterPosition: string,
+  isInsideQuotedString: boolean,
+  canInsertTemplate: boolean
+): number => {
+  const closingQuoteIndex = findUnescapedQuoteIndex(
+    lineContentBeforePosition,
+    lineContentAfterPosition
+  );
+  const whitespaceBeforeQuote =
+    closingQuoteIndex > 0 && !lineContentAfterPosition.slice(0, closingQuoteIndex).trim();
+  const shouldReplaceClosingQuote =
+    closingQuoteIndex === 0 ||
+    (closingQuoteIndex > 0 &&
+      (isInsideQuotedString || (canInsertTemplate && whitespaceBeforeQuote)));
+
+  return shouldReplaceClosingQuote ? positionColumn + closingQuoteIndex + 1 : positionColumn;
+};
+
+const getCompletionLineState = (
+  model: monaco.editor.ITextModel,
+  position: monaco.Position,
+  bodyContentBeforePosition: string
+) => {
+  const lineContentBeforePosition = model.getValueInRange({
+    startLineNumber: position.lineNumber,
+    startColumn: 1,
+    endLineNumber: position.lineNumber,
+    endColumn: position.column,
+  });
+  const lineContentAfterPosition = model.getValueInRange({
+    startLineNumber: position.lineNumber,
+    startColumn: position.column,
+    endLineNumber: position.lineNumber,
+    endColumn: model.getLineMaxColumn(position.lineNumber),
+  });
+  // Expand templates only when nothing except an auto-closed quote and closing delimiters follows.
+  const canInsertTemplate = shouldInsertAutocompleteTemplate(
+    getLineRemainderWithoutConsoleComments(bodyContentBeforePosition, lineContentAfterPosition)
+  );
+  const isInsideQuotedString = isInsideConsoleString(bodyContentBeforePosition);
+
+  return {
+    canInsertTemplate,
+    isInsideQuotedString,
+    lineContentBeforePosition,
+    endColumn: getCompletionEndColumn(
+      position.column,
+      lineContentBeforePosition,
+      lineContentAfterPosition,
+      isInsideQuotedString,
+      canInsertTemplate
+    ),
+  };
+};
+
 const getSuggestions = (
   model: monaco.editor.ITextModel,
   position: monaco.Position,
@@ -342,32 +431,12 @@ const getSuggestions = (
   context: AutoCompleteContext,
   bodyContentBeforePosition: string
 ) => {
+  // get the word before suggestions to replace when selecting a suggestion from the list
   const wordUntilPosition = model.getWordUntilPosition(position);
-  const lineContentAfterPosition = model.getValueInRange({
-    startLineNumber: position.lineNumber,
-    startColumn: position.column,
-    endLineNumber: position.lineNumber,
-    endColumn: model.getLineMaxColumn(position.lineNumber),
-  });
-  // if the rest of the line is empty or there is only " or ends with closing parentheses
-  // then template can be inserted, otherwise only name
-  context.addTemplate =
-    isEmptyOrDoubleQuote(lineContentAfterPosition) || /^}*$/.test(lineContentAfterPosition);
-
-  // if there is " after the cursor, include it in the insert range
-  let endColumn = position.column;
-
-  if (lineContentAfterPosition.startsWith('"')) {
-    endColumn = endColumn + 1;
-  }
+  const { canInsertTemplate, endColumn, isInsideQuotedString, lineContentBeforePosition } =
+    getCompletionLineState(model, position, bodyContentBeforePosition);
+  context.addTemplate = canInsertTemplate;
   // Check if we're typing a field name with a trailing dot
-  const lineContentBeforePosition = model.getValueInRange({
-    startLineNumber: position.lineNumber,
-    startColumn: 1,
-    endLineNumber: position.lineNumber,
-    endColumn: position.column,
-  });
-
   // Check if we're typing a nested field name (contains a dot)
   // This handles both "category." (trailing dot) and "category.keywor" (partial field after dot)
   const quotedFieldWithDotMatch = lineContentBeforePosition.match(/"([^"]*\.[^"]*)$/);
@@ -381,10 +450,6 @@ const getSuggestions = (
     ? unquotedFieldWithDotMatch[1]
     : null;
   const isQuotedField = !!quotedFieldWithDotMatch;
-  const bodyContentLines = bodyContentBeforePosition.split('\n');
-  const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
-  const isInsideQuotedString = hasUnclosedQuote(currentContentLine);
-
   // Adjust the range start column if we have a field with a dot
   let startColumn = wordUntilPosition.startColumn;
   if (fieldBeingTyped) {
@@ -427,15 +492,22 @@ const getSuggestions = (
       })
       // map autocomplete items to completion items
       .map((item) => {
-        const suggestion = {
+        const insertText = getInsertText(item, bodyContentBeforePosition, context);
+        // When the accepted snippet leaves the cursor inside an empty container,
+        // re-open the suggestions widget so the user can keep completing without typing `"`.
+        const endsInsideEmptyContainer = insertText.endsWith('{$0}') || insertText.endsWith('[$0]');
+        const suggestion: monaco.languages.CompletionItem = {
           // convert name to a string
           label: item.name + '',
-          insertText: getInsertText(item, bodyContentBeforePosition, context),
+          insertText,
           detail: i18nTexts.api,
           // the kind is only used to configure the icon
           kind: monaco.languages.CompletionItemKind.Constant,
           range,
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          ...(endsInsideEmptyContainer
+            ? { command: { id: 'editor.action.triggerSuggest', title: '' } }
+            : {}),
         };
         return suggestion;
       })
@@ -457,9 +529,7 @@ export const getInsertText = (
     if (structuralSnippet) {
       insertText = structuralSnippet;
     } else {
-      const bodyContentLines = bodyContent.split('\n');
-      const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
-      if (hasUnclosedQuote(currentContentLine)) {
+      if (isInsideConsoleString(bodyContent)) {
         // The cursor is after an unmatched quote (e.g. '..."abc', '..."')
         insertText = '';
       } else {
@@ -535,41 +605,32 @@ const getConditionalTemplate = (
 };
 
 /*
+ * Whether the line ends with an object/array opening or comma that is not part of a string.
+ */
+const endsWithBodyContinuationOutsideString = (
+  contentBeforePosition: string,
+  insideString = isInsideConsoleString(contentBeforePosition)
+): boolean => lineEndsWithBodyContinuationRegex.test(contentBeforePosition) && !insideString;
+
+const autocompleteTriggerPatterns = [
+  methodWhitespaceRegex,
+  methodWithUrlRegex,
+  propertyNameRegex,
+  propertyValueRegex,
+];
+
+/*
  * This function checks the content of the line before the cursor and decides if the autocomplete
  * suggestions should be triggered
  */
-export const shouldTriggerSuggestions = (lineContent: string): boolean => {
-  return (
-    methodWhitespaceRegex.test(lineContent) ||
-    methodWithUrlRegex.test(lineContent) ||
-    propertyNameRegex.test(lineContent) ||
-    propertyValueRegex.test(lineContent)
-  );
-};
+export const shouldTriggerSuggestions = (lineContent: string, insideString?: boolean): boolean =>
+  autocompleteTriggerPatterns.some((pattern) => pattern.test(lineContent)) ||
+  endsWithBodyContinuationOutsideString(lineContent, insideString);
 
 /*
- * This function checks if the content of the line after the cursor is either empty
- * or it only has a double quote.
+ * Whether selecting a body suggestion may expand its __template based on
+ * the remainder of the line after the cursor.
  */
-export const isEmptyOrDoubleQuote = (lineContent: string): boolean => {
-  lineContent = lineContent.trim();
-  return !lineContent || lineContent === '"';
-};
-
-export const hasUnclosedQuote = (lineContent: string): boolean => {
-  let insideString = false;
-  let prevChar = '';
-  for (let i = 0; i < lineContent.length; i++) {
-    const char = lineContent[i];
-
-    if (!insideString && char === '"') {
-      insideString = true;
-    } else if (insideString && char === '"' && prevChar !== '\\') {
-      insideString = false;
-    }
-
-    prevChar = char;
-  }
-
-  return insideString;
+export const shouldInsertAutocompleteTemplate = (lineContentAfterPosition: string): boolean => {
+  return onlyBodyClosingTokensRegex.test(lineContentAfterPosition.trim());
 };

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/constants.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/constants.ts
@@ -60,10 +60,21 @@ export const methodWithUrlRegex = /^\s*(GET|POST|PUT|PATCH|DELETE)\s+[a-z0-9\/._
 export const propertyNameRegex = /^\s*"[^"]*$/;
 /*
  * This regex matches a string that has
- * a property name, a colon and an optional double quote, for example `"query" : "`.
+ * a property name after the line start or a body delimiter, a colon and an optional double quote,
+ * for example `{"query" : "`.
  * In this case autocomplete suggestions should be triggered for a property value.
  */
-export const propertyValueRegex = /^\s*"[a-zA-Z0-9_]+"\s*:\s*"?$/;
+export const propertyValueRegex = /(?:^|[{\[,])\s*"[a-zA-Z0-9_]+"\s*:\s*"?$/;
+/*
+ * This regex matches a string that ends with an opening object/array or a comma.
+ * In this case the cursor is at a new request-body completion position.
+ */
+export const lineEndsWithBodyContinuationRegex = /(?:\{|\[|,)\s*$/;
+/*
+ * Matches trimmed content that is only body closing tokens: an optional closing quote,
+ * closing braces/brackets, and an optional trailing comma.
+ */
+export const onlyBodyClosingTokensRegex = /^"?[}\]\s]*,?$/;
 
 /*
  * i18n for autocomplete labels

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/triple_quote_context.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/triple_quote_context.test.ts
@@ -61,7 +61,7 @@ describe('getTripleQuoteContext', () => {
 
     expect(
       getTripleQuoteContext(model, { lineNumber: 3, column: 5 }, selectedRequests, parsedRequests)
-    ).toEqual({ insideTripleQuotes: true, insideEsqlQuery: false });
+    ).toEqual({ insideTripleQuotes: true, insideEsqlQuery: false, insideString: true });
   });
 
   it('SHOULD retain ES|QL context for a parser-recovered request inside a query string', () => {
@@ -78,6 +78,6 @@ describe('getTripleQuoteContext', () => {
 
     expect(
       getTripleQuoteContext(model, { lineNumber: 3, column: 5 }, selectedRequests, parsedRequests)
-    ).toEqual({ insideTripleQuotes: true, insideEsqlQuery: true });
+    ).toEqual({ insideTripleQuotes: true, insideEsqlQuery: true, insideString: true });
   });
 });

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/triple_quote_context.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/triple_quote_context.ts
@@ -13,12 +13,14 @@ import {
   checkForTripleQuotesAndEsqlQuery,
   findRequestLineNumber,
   getFallbackRequestStartPosition,
+  isInsideConsoleString,
 } from '@kbn/monaco/src/console/utils';
 import type { AdjustedParsedRequest } from '../types';
 
 export interface TripleQuoteContext {
   insideTripleQuotes: boolean;
   insideEsqlQuery: boolean;
+  insideString?: boolean;
 }
 
 const OUTSIDE_TRIPLE_QUOTES: TripleQuoteContext = {
@@ -69,7 +71,7 @@ const getContentBeforePosition = (
 
 const toTripleQuoteContext = (content: string): TripleQuoteContext => {
   const { insideTripleQuotes, insideEsqlQuery } = checkForTripleQuotesAndEsqlQuery(content);
-  return { insideTripleQuotes, insideEsqlQuery };
+  return { insideTripleQuotes, insideEsqlQuery, insideString: isInsideConsoleString(content) };
 };
 
 const coversLine = (request: AdjustedParsedRequest, lineNumber: number): boolean =>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Fix body autocomplete triggers, template insertion, and completion range bugs (#284530)](https://github.com/elastic/kibana/pull/284530)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-08-19T10:38:50Z","message":"[Console] Fix body autocomplete triggers, template insertion, and completion range bugs (#284530)\n\nAddresses #259250\n\n## Summary\n\n- Autocomplete now triggers automatically at request-body completion\npositions: after `{`, `[`, `,`, `:`, after space/Enter/Tab inside an\nexpanded `{}`/`[]`, and for inline property values (`\"ignore_failure\":\n`). Suggestions accepted before an auto-closed `\"` expand their full\ntemplate, and snippets that leave the cursor inside an empty `{}`/`[]`\nchain the next suggestions widget automatically.\n- Trigger decisions are backed by a small scanner in kbn-monaco that\nunderstands Console strings, triple quotes, and comments, so the new\ntriggers stay quiet inside strings and comments and survive editor races\n(model swaps/disposal, cursor moves, Escape).\n- Six pre-existing issues the new triggers exposed are fixed as well:\n- requests prefixed by a block comment (`/* note */ GET _search`) parsed\nthe method as `/*`, breaking method/URL/body completions\n- comment detection used line heuristics (`includes('*/')` etc.) and\nmisclassified strings/URLs containing comment-like text\n- accepting a suggestion mid-string (`\"icmp.ty|pe\"`) corrupted the token\ninstead of replacing through the closing quote\n- method suggestions did not replace the method when the cursor was at\nits start\n- a whitespace-only line under an unclosed body was classified as a\nrequest start and offered method suggestions instead of body suggestions\n(reproducible on main with Ctrl+Space)\n- Enter was consumed by a no-op suggestion acceptance when the typed\ntext already matched the suggestion (`GET /_search?pretty` + Enter\nstayed on one line)\n\n## Review guide\n\nThe growth is split into six stacked commits on top of the original fix\ncommit, each green on its own — see [the commit\nguide](https://github.com/elastic/kibana/pull/284530#issuecomment-5310192545).\nMost of the added lines are tests (2266 test vs 862 prod).\n\n## Before/After Screenshots (or Video)\n\nEach behavior below has a before video (recorded on main) and an after\nvideo (this PR).\n\n**1. Suggestions open after `{` and re-open when Enter expands the\nbraces**\n\nBefore (suggestions only via Ctrl+Space):\n\n\nhttps://github.com/user-attachments/assets/2bd8ab76-5a25-4452-8d64-fdb8caccc7f1\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/5d000d4d-05cf-4133-a479-05f06ce4cba5\n\n**2. Inside an array: `[` suggests `{`, and Enter inside the expanded\nprocessor object re-opens suggestions**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/d42c1e09-7f59-494b-8aab-45f95f75b5b5\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/95f78ea8-c4d9-4f50-9619-15bed84a6a08\n\n**3. Boolean values suggested after `\"ignore_failure\": `, next\nproperties after the comma**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/3f5349bf-a40d-4ef7-a7d4-db78f961a633\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/df324d47-5389-46b5-b73f-6c06d76a6843\n\n**4. Accepting `append` before the auto-closed quote expands the full\ntemplate**\n\nBefore (only the bare name is inserted):\n\n\nhttps://github.com/user-attachments/assets/cc1d6b57-a608-43b0-8a9a-af6838c08bed\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/b4b5bd5c-bcd7-4fd0-9f16-a2a9f431a544\n\n**5. Accepting `query` chains straight into the nested query-type\nsuggestions**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/b9ea48da-a7a5-4794-912b-5d3b702b212d\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/31e8c805-d9c9-4caa-9e85-5423fd10d269\n\n**6. Accepting a suggestion mid-string replaces the token cleanly\n(`fieldx` -> `field`) instead of corrupting it**\n\nBefore (token gets corrupted):\n\n\nhttps://github.com/user-attachments/assets/098763b4-5430-4996-ba42-7adca07fcef2\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/14e043e1-bb8a-480e-80af-cf96ee72e591\n\n**7. Method, URL, and body completions work when the request is prefixed\nby a block comment**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/2a3458ed-545d-42f0-b06c-2021f357a9a5\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/703573f7-6097-4e93-b344-8af4fa29601e\n\n**8. Method suggestions at line start replace the method instead of\nprepending**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/582d9108-98eb-42b4-9317-504c11debabe\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/d0ae5862-4afe-459d-9599-8cdbb38ae639\n\n**9. A blank line inside an unclosed body gets body suggestions (was:\nmethod suggestions)**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/938bccde-5740-41a1-824e-edb4794105eb\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/8eb626c2-4366-48e7-9ce0-f73d12d9485e\n\n**10. Enter after a fully typed `?pretty` inserts a newline instead of\nbeing swallowed**\n\nBefore (Enter is swallowed):\n\n\nhttps://github.com/user-attachments/assets/567c61d9-ce6a-4545-8388-6bd6aa1a9bb5\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/c8aaee9c-bf64-4279-bf49-26dae19d26cd\n\n## Test Plan\n\n- `node scripts/jest`: 411 console editor tests + 267 kbn-monaco console\ntests pass (trigger matrix incl. strings/comments/triple quotes,\nrace/disposal guards, template gating, mid-string replacement ranges,\ncomment-prefixed requests, unfinished-body classification).\n- The two console FTR suites that failed on CI (`_autocomplete.ts`\nconditional templates, `_output_panel.ts` request line numbers) pass\nlocally with the last two commits.\n- Manual verification on a local Kibana of the scenarios from the review\nvideo: space/Enter inside expanded `{}` in `_ingest/pipeline/_simulate`\nprocessors re-opens suggestions; `\"query\": {` triggers; inline property\nvalues and comma continuations trigger; accepting mid-string no longer\ncorrupts the token.\n- Out of scope: red-underline validation of invalid keys and the\nstale-suggestions-after-typo widget from the same issue.\n\n## Release Note\n\n- Fixes Dev Tools Console autocomplete not triggering at request-body\ncompletion positions (after `{`, `[`, `,`, `:`, or inside expanded\nobjects) and several completion-range bugs, including template expansion\nbefore auto-closed quotes and text corruption when accepting a\nsuggestion mid-string.\n\nAssisted with Cursor using Fable 5\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"72ae2e1d763400876995b302c4eb75238563bed9","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","release_note:fix","Team:Kibana Management","backport:all-open","ci:cloud-deploy","ci:cloud-persist-deployment","v9.6.0"],"title":"[Console] Fix body autocomplete triggers, template insertion, and completion range bugs","number":284530,"url":"https://github.com/elastic/kibana/pull/284530","mergeCommit":{"message":"[Console] Fix body autocomplete triggers, template insertion, and completion range bugs (#284530)\n\nAddresses #259250\n\n## Summary\n\n- Autocomplete now triggers automatically at request-body completion\npositions: after `{`, `[`, `,`, `:`, after space/Enter/Tab inside an\nexpanded `{}`/`[]`, and for inline property values (`\"ignore_failure\":\n`). Suggestions accepted before an auto-closed `\"` expand their full\ntemplate, and snippets that leave the cursor inside an empty `{}`/`[]`\nchain the next suggestions widget automatically.\n- Trigger decisions are backed by a small scanner in kbn-monaco that\nunderstands Console strings, triple quotes, and comments, so the new\ntriggers stay quiet inside strings and comments and survive editor races\n(model swaps/disposal, cursor moves, Escape).\n- Six pre-existing issues the new triggers exposed are fixed as well:\n- requests prefixed by a block comment (`/* note */ GET _search`) parsed\nthe method as `/*`, breaking method/URL/body completions\n- comment detection used line heuristics (`includes('*/')` etc.) and\nmisclassified strings/URLs containing comment-like text\n- accepting a suggestion mid-string (`\"icmp.ty|pe\"`) corrupted the token\ninstead of replacing through the closing quote\n- method suggestions did not replace the method when the cursor was at\nits start\n- a whitespace-only line under an unclosed body was classified as a\nrequest start and offered method suggestions instead of body suggestions\n(reproducible on main with Ctrl+Space)\n- Enter was consumed by a no-op suggestion acceptance when the typed\ntext already matched the suggestion (`GET /_search?pretty` + Enter\nstayed on one line)\n\n## Review guide\n\nThe growth is split into six stacked commits on top of the original fix\ncommit, each green on its own — see [the commit\nguide](https://github.com/elastic/kibana/pull/284530#issuecomment-5310192545).\nMost of the added lines are tests (2266 test vs 862 prod).\n\n## Before/After Screenshots (or Video)\n\nEach behavior below has a before video (recorded on main) and an after\nvideo (this PR).\n\n**1. Suggestions open after `{` and re-open when Enter expands the\nbraces**\n\nBefore (suggestions only via Ctrl+Space):\n\n\nhttps://github.com/user-attachments/assets/2bd8ab76-5a25-4452-8d64-fdb8caccc7f1\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/5d000d4d-05cf-4133-a479-05f06ce4cba5\n\n**2. Inside an array: `[` suggests `{`, and Enter inside the expanded\nprocessor object re-opens suggestions**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/d42c1e09-7f59-494b-8aab-45f95f75b5b5\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/95f78ea8-c4d9-4f50-9619-15bed84a6a08\n\n**3. Boolean values suggested after `\"ignore_failure\": `, next\nproperties after the comma**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/3f5349bf-a40d-4ef7-a7d4-db78f961a633\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/df324d47-5389-46b5-b73f-6c06d76a6843\n\n**4. Accepting `append` before the auto-closed quote expands the full\ntemplate**\n\nBefore (only the bare name is inserted):\n\n\nhttps://github.com/user-attachments/assets/cc1d6b57-a608-43b0-8a9a-af6838c08bed\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/b4b5bd5c-bcd7-4fd0-9f16-a2a9f431a544\n\n**5. Accepting `query` chains straight into the nested query-type\nsuggestions**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/b9ea48da-a7a5-4794-912b-5d3b702b212d\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/31e8c805-d9c9-4caa-9e85-5423fd10d269\n\n**6. Accepting a suggestion mid-string replaces the token cleanly\n(`fieldx` -> `field`) instead of corrupting it**\n\nBefore (token gets corrupted):\n\n\nhttps://github.com/user-attachments/assets/098763b4-5430-4996-ba42-7adca07fcef2\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/14e043e1-bb8a-480e-80af-cf96ee72e591\n\n**7. Method, URL, and body completions work when the request is prefixed\nby a block comment**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/2a3458ed-545d-42f0-b06c-2021f357a9a5\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/703573f7-6097-4e93-b344-8af4fa29601e\n\n**8. Method suggestions at line start replace the method instead of\nprepending**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/582d9108-98eb-42b4-9317-504c11debabe\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/d0ae5862-4afe-459d-9599-8cdbb38ae639\n\n**9. A blank line inside an unclosed body gets body suggestions (was:\nmethod suggestions)**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/938bccde-5740-41a1-824e-edb4794105eb\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/8eb626c2-4366-48e7-9ce0-f73d12d9485e\n\n**10. Enter after a fully typed `?pretty` inserts a newline instead of\nbeing swallowed**\n\nBefore (Enter is swallowed):\n\n\nhttps://github.com/user-attachments/assets/567c61d9-ce6a-4545-8388-6bd6aa1a9bb5\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/c8aaee9c-bf64-4279-bf49-26dae19d26cd\n\n## Test Plan\n\n- `node scripts/jest`: 411 console editor tests + 267 kbn-monaco console\ntests pass (trigger matrix incl. strings/comments/triple quotes,\nrace/disposal guards, template gating, mid-string replacement ranges,\ncomment-prefixed requests, unfinished-body classification).\n- The two console FTR suites that failed on CI (`_autocomplete.ts`\nconditional templates, `_output_panel.ts` request line numbers) pass\nlocally with the last two commits.\n- Manual verification on a local Kibana of the scenarios from the review\nvideo: space/Enter inside expanded `{}` in `_ingest/pipeline/_simulate`\nprocessors re-opens suggestions; `\"query\": {` triggers; inline property\nvalues and comma continuations trigger; accepting mid-string no longer\ncorrupts the token.\n- Out of scope: red-underline validation of invalid keys and the\nstale-suggestions-after-typo widget from the same issue.\n\n## Release Note\n\n- Fixes Dev Tools Console autocomplete not triggering at request-body\ncompletion positions (after `{`, `[`, `,`, `:`, or inside expanded\nobjects) and several completion-range bugs, including template expansion\nbefore auto-closed quotes and text corruption when accepting a\nsuggestion mid-string.\n\nAssisted with Cursor using Fable 5\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"72ae2e1d763400876995b302c4eb75238563bed9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284530","number":284530,"mergeCommit":{"message":"[Console] Fix body autocomplete triggers, template insertion, and completion range bugs (#284530)\n\nAddresses #259250\n\n## Summary\n\n- Autocomplete now triggers automatically at request-body completion\npositions: after `{`, `[`, `,`, `:`, after space/Enter/Tab inside an\nexpanded `{}`/`[]`, and for inline property values (`\"ignore_failure\":\n`). Suggestions accepted before an auto-closed `\"` expand their full\ntemplate, and snippets that leave the cursor inside an empty `{}`/`[]`\nchain the next suggestions widget automatically.\n- Trigger decisions are backed by a small scanner in kbn-monaco that\nunderstands Console strings, triple quotes, and comments, so the new\ntriggers stay quiet inside strings and comments and survive editor races\n(model swaps/disposal, cursor moves, Escape).\n- Six pre-existing issues the new triggers exposed are fixed as well:\n- requests prefixed by a block comment (`/* note */ GET _search`) parsed\nthe method as `/*`, breaking method/URL/body completions\n- comment detection used line heuristics (`includes('*/')` etc.) and\nmisclassified strings/URLs containing comment-like text\n- accepting a suggestion mid-string (`\"icmp.ty|pe\"`) corrupted the token\ninstead of replacing through the closing quote\n- method suggestions did not replace the method when the cursor was at\nits start\n- a whitespace-only line under an unclosed body was classified as a\nrequest start and offered method suggestions instead of body suggestions\n(reproducible on main with Ctrl+Space)\n- Enter was consumed by a no-op suggestion acceptance when the typed\ntext already matched the suggestion (`GET /_search?pretty` + Enter\nstayed on one line)\n\n## Review guide\n\nThe growth is split into six stacked commits on top of the original fix\ncommit, each green on its own — see [the commit\nguide](https://github.com/elastic/kibana/pull/284530#issuecomment-5310192545).\nMost of the added lines are tests (2266 test vs 862 prod).\n\n## Before/After Screenshots (or Video)\n\nEach behavior below has a before video (recorded on main) and an after\nvideo (this PR).\n\n**1. Suggestions open after `{` and re-open when Enter expands the\nbraces**\n\nBefore (suggestions only via Ctrl+Space):\n\n\nhttps://github.com/user-attachments/assets/2bd8ab76-5a25-4452-8d64-fdb8caccc7f1\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/5d000d4d-05cf-4133-a479-05f06ce4cba5\n\n**2. Inside an array: `[` suggests `{`, and Enter inside the expanded\nprocessor object re-opens suggestions**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/d42c1e09-7f59-494b-8aab-45f95f75b5b5\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/95f78ea8-c4d9-4f50-9619-15bed84a6a08\n\n**3. Boolean values suggested after `\"ignore_failure\": `, next\nproperties after the comma**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/3f5349bf-a40d-4ef7-a7d4-db78f961a633\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/df324d47-5389-46b5-b73f-6c06d76a6843\n\n**4. Accepting `append` before the auto-closed quote expands the full\ntemplate**\n\nBefore (only the bare name is inserted):\n\n\nhttps://github.com/user-attachments/assets/cc1d6b57-a608-43b0-8a9a-af6838c08bed\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/b4b5bd5c-bcd7-4fd0-9f16-a2a9f431a544\n\n**5. Accepting `query` chains straight into the nested query-type\nsuggestions**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/b9ea48da-a7a5-4794-912b-5d3b702b212d\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/31e8c805-d9c9-4caa-9e85-5423fd10d269\n\n**6. Accepting a suggestion mid-string replaces the token cleanly\n(`fieldx` -> `field`) instead of corrupting it**\n\nBefore (token gets corrupted):\n\n\nhttps://github.com/user-attachments/assets/098763b4-5430-4996-ba42-7adca07fcef2\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/14e043e1-bb8a-480e-80af-cf96ee72e591\n\n**7. Method, URL, and body completions work when the request is prefixed\nby a block comment**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/2a3458ed-545d-42f0-b06c-2021f357a9a5\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/703573f7-6097-4e93-b344-8af4fa29601e\n\n**8. Method suggestions at line start replace the method instead of\nprepending**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/582d9108-98eb-42b4-9317-504c11debabe\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/d0ae5862-4afe-459d-9599-8cdbb38ae639\n\n**9. A blank line inside an unclosed body gets body suggestions (was:\nmethod suggestions)**\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/938bccde-5740-41a1-824e-edb4794105eb\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/8eb626c2-4366-48e7-9ce0-f73d12d9485e\n\n**10. Enter after a fully typed `?pretty` inserts a newline instead of\nbeing swallowed**\n\nBefore (Enter is swallowed):\n\n\nhttps://github.com/user-attachments/assets/567c61d9-ce6a-4545-8388-6bd6aa1a9bb5\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/c8aaee9c-bf64-4279-bf49-26dae19d26cd\n\n## Test Plan\n\n- `node scripts/jest`: 411 console editor tests + 267 kbn-monaco console\ntests pass (trigger matrix incl. strings/comments/triple quotes,\nrace/disposal guards, template gating, mid-string replacement ranges,\ncomment-prefixed requests, unfinished-body classification).\n- The two console FTR suites that failed on CI (`_autocomplete.ts`\nconditional templates, `_output_panel.ts` request line numbers) pass\nlocally with the last two commits.\n- Manual verification on a local Kibana of the scenarios from the review\nvideo: space/Enter inside expanded `{}` in `_ingest/pipeline/_simulate`\nprocessors re-opens suggestions; `\"query\": {` triggers; inline property\nvalues and comma continuations trigger; accepting mid-string no longer\ncorrupts the token.\n- Out of scope: red-underline validation of invalid keys and the\nstale-suggestions-after-typo widget from the same issue.\n\n## Release Note\n\n- Fixes Dev Tools Console autocomplete not triggering at request-body\ncompletion positions (after `{`, `[`, `,`, `:`, or inside expanded\nobjects) and several completion-range bugs, including template expansion\nbefore auto-closed quotes and text corruption when accepting a\nsuggestion mid-string.\n\nAssisted with Cursor using Fable 5\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"72ae2e1d763400876995b302c4eb75238563bed9"}},{"url":"https://github.com/elastic/kibana/pull/285968","number":285968,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/285969","number":285969,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->