### PR TITLE
chore: rename cloud-services team to siem-conduit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1218,7 +1218,7 @@ x-pack/platform/plugins/shared/alerting @elastic/response-ops
 x-pack/platform/plugins/shared/alerting_v2 @elastic/rna-project-team
 x-pack/platform/plugins/shared/anonymization @elastic/workchat-eng @elastic/security-threat-hunting
 x-pack/platform/plugins/shared/apm_sources_access @elastic/obs-signals-traces-team
-x-pack/platform/plugins/shared/automatic_import @elastic/cloud-services
+x-pack/platform/plugins/shared/automatic_import @elastic/siem-conduit
 x-pack/platform/plugins/shared/cases @elastic/kibana-cases
 x-pack/platform/plugins/shared/cloud @elastic/kibana-core
 x-pack/platform/plugins/shared/cloud_connect @elastic/kibana-management
@@ -1492,7 +1492,7 @@ x-pack/platform/test/serverless/api_integration/test_suites/platform_security @e
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/config @elastic/appex-sharedux
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/connector_token @elastic/response-ops
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/data_connector @elastic/kibana-core
-/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/data_stream-config @elastic/cloud-services
+/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/data_stream-config @elastic/siem-conduit
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/entity-analytics-monitoring-entity-source @elastic/security-entity-analytics
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/entity-engine-descriptor-v2 @elastic/core-analysis
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/entity-store-global-state @elastic/core-analysis
@@ -1505,7 +1505,7 @@ x-pack/platform/test/serverless/api_integration/test_suites/platform_security @e
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/ingest-outputs @elastic/streams-ui
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/ingest-package-policies @elastic/streams-ui
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/ingest_manager_settings @elastic/streams-ui
-/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/integration-config @elastic/cloud-services
+/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/integration-config @elastic/siem-conduit
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/maintenance-window @elastic/response-ops
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/markdown @elastic/kibana-presentation
 /packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/old-type-no-migrations @elastic/kibana-core
@@ -3616,7 +3616,7 @@ x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/entity_an
 x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai @elastic/security-threat-hunting
 
 ## Security Solution sub teams - Automatic Import
-x-pack/platform/test/automatic_import_api_integration @elastic/cloud-services
+x-pack/platform/test/automatic_import_api_integration @elastic/siem-conduit
 
 
 # Security Defend Workflows - OSQuery Ownership
@@ -3645,10 +3645,10 @@ x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/to
 
 ## Fleet plugin (co-owned with Fleet team)
 x-pack/platform/plugins/shared/fleet/public/components/cloud_security_posture @elastic/streams-ui @elastic/contextual-security-apps
-x-pack/platform/plugins/shared/fleet/public/components/cloud_connector @elastic/streams-ui @elastic/cloud-services
-x-pack/platform/plugins/shared/fleet/common/services/cloud_connectors @elastic/streams-ui @elastic/cloud-services
-x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector @elastic/streams-ui @elastic/cloud-services
-x-pack/platform/plugins/shared/fleet/server/services/cloud_connectors @elastic/streams-ui @elastic/cloud-services
+x-pack/platform/plugins/shared/fleet/public/components/cloud_connector @elastic/streams-ui @elastic/siem-conduit
+x-pack/platform/plugins/shared/fleet/common/services/cloud_connectors @elastic/streams-ui @elastic/siem-conduit
+x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector @elastic/streams-ui @elastic/siem-conduit
+x-pack/platform/plugins/shared/fleet/server/services/cloud_connectors @elastic/streams-ui @elastic/siem-conduit
 x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/components/cloud_security_posture @elastic/streams-ui @elastic/contextual-security-apps
 x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/components/cloud_posture_third_party_support_callout.* @elastic/streams-ui @elastic/contextual-security-apps
 ## SessionView tests
@@ -3674,11 +3674,11 @@ x-pack/solutions/security/test/security_solution_cypress/cypress/screens/asset_i
 x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/asset_inventory @elastic/security-entity-analytics
 
 # Security integrations
-x-pack/solutions/security/plugins/security_solution/common/security_integrations @elastic/cloud-services
-x-pack/solutions/security/plugins/security_solution/public/security_integrations @elastic/cloud-services
-x-pack/solutions/security/plugins/security_solution/server/security_integrations @elastic/cloud-services
-x-pack/solutions/security/plugins/security_solution/server/lib/security_integrations @elastic/cloud-services
-x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/ @elastic/cloud-services
+x-pack/solutions/security/plugins/security_solution/common/security_integrations @elastic/siem-conduit
+x-pack/solutions/security/plugins/security_solution/public/security_integrations @elastic/siem-conduit
+x-pack/solutions/security/plugins/security_solution/server/security_integrations @elastic/siem-conduit
+x-pack/solutions/security/plugins/security_solution/server/lib/security_integrations @elastic/siem-conduit
+x-pack/solutions/security/plugins/security_solution/test/scout/security_integrations/ @elastic/siem-conduit
 
 # Kibana design
 # scss overrides should be below this line for specificity

--- a/.github/scripts/flaky_fix_review_reminder.js
+++ b/.github/scripts/flaky_fix_review_reminder.js
@@ -265,7 +265,9 @@ module.exports = async function flakyFixReviewReminder({ github, context, core }
   }
 
   core.info(
-    `Checked ${considered} open ready "${LABEL}" PR(s), pinged ${pinged}${dryRun ? ' (dry run)' : ''}`
+    `Checked ${considered} open ready "${LABEL}" PR(s), pinged ${pinged}${
+      dryRun ? ' (dry run)' : ''
+    }`
   );
 };
 

--- a/renovate.json
+++ b/renovate.json
@@ -2175,7 +2175,7 @@
       "matchDepNames": ["seedrandom", "@types/seedrandom"],
       "reviewers": ["team:siem-conduit"],
       "matchBaseBranches": ["main"],
-      "addLabels": ["Team:SIEM-Conduit"],
+      "addLabels": ["Team:security-siem-conduit"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },

--- a/renovate.json
+++ b/renovate.json
@@ -2173,9 +2173,9 @@
     {
       "groupName": "seedrandom",
       "matchDepNames": ["seedrandom", "@types/seedrandom"],
-      "reviewers": ["team:cloud-services"],
+      "reviewers": ["team:siem-conduit"],
       "matchBaseBranches": ["main"],
-      "addLabels": ["Team:Security-Cloud Services"],
+      "addLabels": ["Team:SIEM-Conduit"],
       "minimumReleaseAge": "14 days",
       "enabled": true
     },

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.test.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.test.ts
@@ -78,7 +78,7 @@ const LEGACY_CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
   security: [
     'elastic/contextual-security-apps',
     'elastic/core-analysis',
-    'elastic/cloud-services',
+    'elastic/siem-conduit',
     'elastic/kibana-cases',
     'elastic/security-data-engineering',
     'elastic/security-defend-workflows',

--- a/src/platform/packages/private/kbn-code-owners/teams.jsonc
+++ b/src/platform/packages/private/kbn-code-owners/teams.jsonc
@@ -90,7 +90,7 @@
     ],
     "github": {
       "team": "elastic/siem-conduit",
-      "label": "Team:SIEM-Conduit"
+      "label": "Team:security-siem-conduit"
     }
   },
   {

--- a/src/platform/packages/private/kbn-code-owners/teams.jsonc
+++ b/src/platform/packages/private/kbn-code-owners/teams.jsonc
@@ -83,14 +83,14 @@
     ]
   },
   {
-    "id": "cloud-services",
-    "name": "Cloud Services",
+    "id": "siem-conduit",
+    "name": "SIEM Conduit",
     "areas": [
       "security"
     ],
     "github": {
-      "team": "elastic/cloud-services",
-      "label": "Team:Security-Cloud Services"
+      "team": "elastic/siem-conduit",
+      "label": "Team:SIEM-Conduit"
     }
   },
   {

--- a/x-pack/platform/plugins/shared/automatic_import/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/automatic_import/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/automatic-import-plugin",
-  "owner": "@elastic/cloud-services",
+  "owner": "@elastic/siem-conduit",
   "group": "platform",
   "visibility": "shared",
   "description": "Plugin implementing the Automatic Import API and UI",

--- a/x-pack/platform/plugins/shared/automatic_import/moon.yml
+++ b/x-pack/platform/plugins/shared/automatic_import/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/automatic-import-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/cloud-services'
+  defaultOwner: '@elastic/siem-conduit'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/automatic-import-plugin'
   description: Moon project for @kbn/automatic-import-plugin
   channel: ''
-  owner: '@elastic/cloud-services'
+  owner: '@elastic/siem-conduit'
   sourceRoot: x-pack/platform/plugins/shared/automatic_import
 dependsOn:
   - '@kbn/core'

--- a/x-pack/platform/plugins/shared/automatic_import/server/services/build_integration/build_integration_service.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/services/build_integration/build_integration_service.ts
@@ -144,7 +144,7 @@ const createManifest = (
     },
     policy_templates: policyTemplates,
     owner: {
-      github: '@elastic/cloud-services',
+      github: '@elastic/siem-conduit',
       type: 'community',
     },
   };


### PR DESCRIPTION
## Summary

The **Cloud Services** team has been renamed to **SIEM Conduit** on GitHub (`@elastic/cloud-services` → `@elastic/siem-conduit`). This chore updates the ownership metadata in this repo so review requests and issue routing keep landing on the right team.

Changes:

- `src/platform/packages/private/kbn-code-owners/teams.jsonc` — renamed the registry entry: `id` (`cloud-services` → `siem-conduit`), `name` (`Cloud Services` → `SIEM Conduit`), `github.team` and `github.label` (`Team:Security-Cloud Services` → `Team:security-siem-conduit`).
- `.github/CODEOWNERS` — 13 ownership entries updated. The auto-generated section was refreshed via `node scripts/generate codeowners`; the entries below the override marker were updated in place.
- `renovate.json` — the `seedrandom` group's `reviewers` and `addLabels` now point at the renamed team and label.
- `x-pack/platform/plugins/shared/automatic_import` — plugin `owner` in `kibana.jsonc`, plus the regenerated `moon.yml`.
- `build_integration_service.ts` — the `owner.github` handle written into the manifest of every integration package generated by Automatic Import.
- `code_owner_areas.test.ts` — the expected team handle in the `security` area mapping.

There are no remaining references to `cloud-services` or `Team:Security-Cloud Services` in the repo.

### Follow-up required before merge

The GitHub label `Team:security-siem-conduit` referenced by `teams.jsonc` and `renovate.json` **does not exist in this repo yet** — only the old `Team:Security-Cloud Services` label does. The label needs to be renamed in the repo settings, otherwise Renovate will fail to apply it. This is being handled separately by the team.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Not applicable: no user-facing text, no documentation-worthy behavior, no plugin config keys, no HTTP API changes, no test behavior changes that warrant the Flaky Test Runner.

### Identify risks

- **Ownership metadata drifts if the GitHub team handle is wrong.** Mitigated by verifying `elastic/siem-conduit` resolves via the GitHub API before making the change; the team exists and is described as "Siem Conduit (previously Cloud Services)".
- **Renovate cannot apply a non-existent label.** Called out above — the `Team:security-siem-conduit` label must be created/renamed in repo settings before this merges. Blast radius is limited to labeling on one dependency group (`seedrandom`).
- **Registry `id` change breaks the private team overlay.** `teams.jsonc` documents that private operational data (Slack channels, oncall rotations) lives in a separate repo and is joined by team `id`. The overlay entry for `cloud-services` needs the matching `id` update, otherwise that team loses its private overlay data.
- **Generated integration packages change owner.** Packages newly generated by Automatic Import will carry `@elastic/siem-conduit`; already-generated packages are unaffected. No behavior change beyond the handle written into the manifest.

### Release Notes

None — internal ownership metadata only.
