### PR TITLE
[Security Solution][CPS] fix issue where correlations alert by ancestry not working on alerts created from linked documents

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/correlations_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/correlations_overview.tsx
@@ -54,7 +54,11 @@ export const CorrelationsOverview = memo(
   ({ hit, scopeId, showIcon, onShowCorrelationsDetails }: CorrelationsOverviewProps) => {
     const documentId = useMemo(() => hit.raw._id || '', [hit.raw._id]);
 
-    const { show: showAlertsByAncestry, ancestryDocumentId } = useShowRelatedAlertsByAncestry({
+    const {
+      show: showAlertsByAncestry,
+      ancestryDocumentId,
+      ancestryDocumentIndex,
+    } = useShowRelatedAlertsByAncestry({
       hit,
     });
     const { show: showSameSourceAlerts, originalEventId } = useShowRelatedAlertsBySameSourceEvent({
@@ -138,6 +142,7 @@ export const CorrelationsOverview = memo(
             {showAlertsByAncestry && (
               <RelatedAlertsByAncestry
                 documentId={ancestryDocumentId}
+                documentIndex={ancestryDocumentIndex}
                 onShowCorrelationsDetails={onShowCorrelationsDetails}
               />
             )}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/related_alerts_by_ancestry.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/related_alerts_by_ancestry.test.tsx
@@ -35,11 +35,12 @@ const LOADING_TEST_ID = SUMMARY_ROW_LOADING_TEST_ID(
   CORRELATIONS_RELATED_ALERTS_BY_ANCESTRY_TEST_ID
 );
 
-const renderRelatedAlertsByAncestry = () =>
+const renderRelatedAlertsByAncestry = (documentIndex?: string) =>
   render(
     <TestProviders>
       <RelatedAlertsByAncestry
         documentId={documentId}
+        documentIndex={documentIndex}
         onShowCorrelationsDetails={mockOnShowCorrelationsDetails}
       />
     </TestProviders>
@@ -127,6 +128,36 @@ describe('<RelatedAlertsByAncestry />', () => {
     expect(useFetchRelatedAlertsByAncestry).toHaveBeenCalledWith(
       expect.objectContaining({
         interval: { from: 'now-1d', to: 'now' },
+      })
+    );
+  });
+
+  it('passes the default patterns unchanged when no document index is provided', () => {
+    (useFetchRelatedAlertsByAncestry as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      dataCount: 0,
+    });
+
+    renderRelatedAlertsByAncestry();
+
+    expect(useFetchRelatedAlertsByAncestry).toHaveBeenCalledWith(
+      expect.objectContaining({ indices: ['index'] })
+    );
+  });
+
+  it('prepends the project-qualified document index to the ancestry search indices', () => {
+    (useFetchRelatedAlertsByAncestry as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      dataCount: 0,
+    });
+
+    renderRelatedAlertsByAncestry('linked_local_project:.ds-logs-endpoint.events-default');
+
+    expect(useFetchRelatedAlertsByAncestry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indices: ['linked_local_project:.ds-logs-endpoint.events-default', 'index'],
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/related_alerts_by_ancestry.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/related_alerts_by_ancestry.tsx
@@ -13,6 +13,7 @@ import { CORRELATIONS_RELATED_ALERTS_BY_ANCESTRY_TEST_ID } from './test_ids';
 import { useSecurityDefaultPatterns } from '../../../../data_view_manager/hooks/use_security_default_patterns';
 import { useKibana } from '../../../../common/lib/kibana';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
+import { withDocumentIndex } from '../../../shared/utils/non_local_index';
 
 const DEFAULT_FROM = 'now-1d';
 const DEFAULT_TO = 'now';
@@ -22,6 +23,12 @@ export interface RelatedAlertsByAncestryProps {
    * Id of the document
    */
   documentId: string;
+  /**
+   * Project-qualified index of the ancestry document, prepended to the search indices so entity
+   * lookup can disambiguate the same `_id` across linked projects (CPS). `undefined` when the
+   * document has no index; required so every render site consciously threads it.
+   */
+  documentIndex: string | undefined;
   /**
    * Callback to navigate to correlations details
    */
@@ -33,6 +40,7 @@ export interface RelatedAlertsByAncestryProps {
  */
 export const RelatedAlertsByAncestry: React.VFC<RelatedAlertsByAncestryProps> = ({
   documentId,
+  documentIndex,
   onShowCorrelationsDetails,
 }) => {
   const { storage } = useKibana().services;
@@ -43,9 +51,14 @@ export const RelatedAlertsByAncestry: React.VFC<RelatedAlertsByAncestryProps> = 
   // so this summary row stays bounded without rendering its own picker.
   const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.ANCESTRY_ALERTS_TIME_RANGE);
 
+  const indices = useMemo(
+    () => withDocumentIndex(indexPatterns, documentIndex),
+    [indexPatterns, documentIndex]
+  );
+
   const { loading, error, dataCount } = useFetchRelatedAlertsByAncestry({
     documentId,
-    indices: indexPatterns,
+    indices,
     interval: {
       from: timeSavedInLocalStorage?.start || DEFAULT_FROM,
       to: timeSavedInLocalStorage?.end || DEFAULT_TO,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/correlations_details_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/correlations_details_view.tsx
@@ -71,7 +71,11 @@ export const CorrelationsDetailsView = memo(
       [hit]
     );
 
-    const { show: showAlertsByAncestry, ancestryDocumentId } = useShowRelatedAlertsByAncestry({
+    const {
+      show: showAlertsByAncestry,
+      ancestryDocumentId,
+      ancestryDocumentIndex,
+    } = useShowRelatedAlertsByAncestry({
       hit,
     });
     const { show: showSameSourceAlerts, originalEventId } = useShowRelatedAlertsBySameSourceEvent({
@@ -137,6 +141,7 @@ export const CorrelationsDetailsView = memo(
                 <RelatedAlertsByAncestry
                   scopeId={scopeId}
                   documentId={ancestryDocumentId}
+                  documentIndex={ancestryDocumentIndex}
                   onShowAlert={onShowAlert}
                   useLegacyExpandableFlyout={useLegacyExpandableFlyout}
                 />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/related_alerts_by_ancestry.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/related_alerts_by_ancestry.test.tsx
@@ -57,12 +57,13 @@ const TITLE_TEXT = EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(
   CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TEST_ID
 );
 
-const renderRelatedAlertsByAncestry = () =>
+const renderRelatedAlertsByAncestry = (documentIndex?: string) =>
   render(
     <TestProviders>
       <DocumentDetailsContext.Provider value={mockContextValue}>
         <RelatedAlertsByAncestry
           documentId={documentId}
+          documentIndex={documentIndex}
           scopeId={scopeId}
           onShowAlert={mockOnShowAlert}
           useLegacyExpandableFlyout={false}
@@ -185,6 +186,48 @@ describe('<RelatedAlertsByAncestry />', () => {
     expect(
       getByTestId(CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_DATE_PICKER_TEST_ID)
     ).toBeInTheDocument();
+  });
+
+  it('passes the default patterns unchanged when no document index is provided', () => {
+    (useFetchRelatedAlertsByAncestry as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      data: [],
+      dataCount: 0,
+    });
+    (usePaginatedAlerts as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      data: [],
+    });
+
+    renderRelatedAlertsByAncestry();
+
+    expect(useFetchRelatedAlertsByAncestry).toHaveBeenCalledWith(
+      expect.objectContaining({ indices: ['index1'] })
+    );
+  });
+
+  it('prepends the project-qualified document index to the ancestry search indices', () => {
+    (useFetchRelatedAlertsByAncestry as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      data: [],
+      dataCount: 0,
+    });
+    (usePaginatedAlerts as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      data: [],
+    });
+
+    renderRelatedAlertsByAncestry('linked_local_project:.ds-logs-endpoint.events-default');
+
+    expect(useFetchRelatedAlertsByAncestry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indices: ['linked_local_project:.ds-logs-endpoint.events-default', 'index1'],
+      })
+    );
   });
 
   it('should use the default time range when nothing is persisted in local storage', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/related_alerts_by_ancestry.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/components/related_alerts_by_ancestry.tsx
@@ -20,6 +20,7 @@ import { getColumns } from '../utils/get_columns';
 import { useSecurityDefaultPatterns } from '../../../../../data_view_manager/hooks/use_security_default_patterns';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { FLYOUT_STORAGE_KEYS } from '../../../main/constants/local_storage';
+import { withDocumentIndex } from '../../../../shared/utils/non_local_index';
 
 const DEFAULT_FROM = 'now-1d';
 const DEFAULT_TO = 'now';
@@ -29,6 +30,12 @@ export interface RelatedAlertsByAncestryProps {
    * Id of the document
    */
   documentId: string;
+  /**
+   * Project-qualified index of the ancestry document, prepended to the search indices so entity
+   * lookup can disambiguate the same `_id` across linked projects (CPS). `undefined` when the
+   * document has no index; required so every render site consciously threads it.
+   */
+  documentIndex: string | undefined;
   /**
    * Maintain backwards compatibility // TODO remove when possible
    */
@@ -50,6 +57,7 @@ export interface RelatedAlertsByAncestryProps {
  */
 export const RelatedAlertsByAncestry: React.FC<RelatedAlertsByAncestryProps> = ({
   documentId,
+  documentIndex,
   scopeId,
   onShowAlert,
   useLegacyExpandableFlyout,
@@ -74,9 +82,14 @@ export const RelatedAlertsByAncestry: React.FC<RelatedAlertsByAncestryProps> = (
     [storage]
   );
 
+  const indices = useMemo(
+    () => withDocumentIndex(indexPatterns, documentIndex),
+    [indexPatterns, documentIndex]
+  );
+
   const { loading, error, data, dataCount, refetch } = useFetchRelatedAlertsByAncestry({
     documentId,
-    indices: indexPatterns,
+    indices,
     interval: { from: start, to: end },
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/hooks/use_show_related_alerts_by_ancestry.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/hooks/use_show_related_alerts_by_ancestry.test.tsx
@@ -15,6 +15,7 @@ import { useShowRelatedAlertsByAncestry } from './use_show_related_alerts_by_anc
 import { licenseService } from '../../../../../common/hooks/use_license';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { ALERT_ANCESTORS_ID } from '../../../../../../common/field_maps/field_names';
+import { ANCESTOR_INDEX } from '../../../main/constants/field_names';
 import { useIsAnalyzerEnabled } from '../../../../../detections/hooks/use_is_analyzer_enabled';
 
 jest.mock('../../../../../common/hooks/use_license', () => {
@@ -52,6 +53,16 @@ const hitWithAncestorsPreview: DataTableRecord = {
   isAnchor: false,
 } as unknown as DataTableRecord;
 
+const hitWithQualifiedAncestorsPreview: DataTableRecord = {
+  id: 'event-id',
+  raw: { _id: 'event-id', _index: '.preview.alerts-security.alerts-default' },
+  flattened: {
+    [ALERT_ANCESTORS_ID]: 'ancestors-id',
+    [ANCESTOR_INDEX]: 'linked_local_project:.ds-logs-endpoint.events-default',
+  },
+  isAnchor: false,
+} as unknown as DataTableRecord;
+
 describe('useShowRelatedAlertsByAncestry', () => {
   let hookResult: RenderHookResult<
     UseShowRelatedAlertsByAncestryResult,
@@ -70,6 +81,7 @@ describe('useShowRelatedAlertsByAncestry', () => {
     expect(hookResult.result.current).toEqual({
       show: false,
       ancestryDocumentId: 'event-id',
+      ancestryDocumentIndex: 'index',
     });
   });
 
@@ -84,6 +96,7 @@ describe('useShowRelatedAlertsByAncestry', () => {
     expect(hookResult.result.current).toEqual({
       show: false,
       ancestryDocumentId: 'event-id',
+      ancestryDocumentIndex: 'index',
     });
   });
 
@@ -99,6 +112,7 @@ describe('useShowRelatedAlertsByAncestry', () => {
     expect(hookResult.result.current).toEqual({
       show: true,
       ancestryDocumentId: 'event-id',
+      ancestryDocumentIndex: 'index',
     });
   });
 
@@ -114,6 +128,23 @@ describe('useShowRelatedAlertsByAncestry', () => {
     expect(hookResult.result.current).toEqual({
       show: true,
       ancestryDocumentId: 'ancestors-id',
+      ancestryDocumentIndex: '.preview.alerts-security.alerts-default',
+    });
+  });
+
+  it('should return the project-qualified ancestor index when previewing a rule off a linked document', () => {
+    (useIsAnalyzerEnabled as jest.Mock).mockReturnValue(true);
+    licenseServiceMock.isPlatinumPlus.mockReturnValue(true);
+    hookResult = renderHook(() =>
+      useShowRelatedAlertsByAncestry({
+        hit: hitWithQualifiedAncestorsPreview,
+      })
+    );
+
+    expect(hookResult.result.current).toEqual({
+      show: true,
+      ancestryDocumentId: 'ancestors-id',
+      ancestryDocumentIndex: 'linked_local_project:.ds-logs-endpoint.events-default',
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/hooks/use_show_related_alerts_by_ancestry.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/tools/correlations/hooks/use_show_related_alerts_by_ancestry.ts
@@ -11,6 +11,8 @@ import { ALERT_ANCESTORS_ID } from '../../../../../../common/field_maps/field_na
 import { useIsAnalyzerEnabled } from '../../../../../detections/hooks/use_is_analyzer_enabled';
 import { useLicense } from '../../../../../common/hooks/use_license';
 import { isRulePreviewDocument } from '../../../../shared/utils/is_rule_preview_document';
+import { getNonLocalQualifiedIndex } from '../../../../shared/utils/non_local_index';
+import { ANCESTOR_INDEX } from '../../../main/constants/field_names';
 
 export interface UseShowRelatedAlertsByAncestryParams {
   /**
@@ -28,6 +30,11 @@ export interface UseShowRelatedAlertsByAncestryResult {
    * Value of the document id for fetching ancestry alerts
    */
   ancestryDocumentId: string;
+  /**
+   * Project-qualified index of the ancestry document, used to disambiguate the same `_id` across
+   * linked projects (CPS). Undefined when the document has no index.
+   */
+  ancestryDocumentIndex?: string;
 }
 
 /**
@@ -43,6 +50,17 @@ export const useShowRelatedAlertsByAncestry = ({
   const ancestorId = (getFieldValue(hit, ALERT_ANCESTORS_ID) as string) ?? '';
   const ancestryDocumentId = isRulePreview ? ancestorId : hit.raw._id ?? '';
 
+  // Mirror the index the Analyzer preview threads: for rule-preview documents the ancestry lookup
+  // targets the ancestor (which can live in a linked project even though the preview alert is
+  // stored locally), so pass its project-qualified index for cross-project disambiguation;
+  // otherwise use the document's own `_index` (the fanned-in linked-alert case).
+  const ancestryDocumentIndex = isRulePreview
+    ? getNonLocalQualifiedIndex(
+        (getFieldValue(hit, ANCESTOR_INDEX) as string) ?? hit.raw._index ?? '',
+        hit.raw._index ?? (getFieldValue(hit, '_index') as string) ?? ''
+      )
+    : hit.raw._index;
+
   const hasAtLeastPlatinum = useLicense().isPlatinumPlus();
 
   const show = hasProcessEntityInfo && hasAtLeastPlatinum;
@@ -51,7 +69,8 @@ export const useShowRelatedAlertsByAncestry = ({
     () => ({
       show,
       ancestryDocumentId,
+      ancestryDocumentIndex,
     }),
-    [ancestryDocumentId, show]
+    [ancestryDocumentId, ancestryDocumentIndex, show]
   );
 };


### PR DESCRIPTION
> [!NOTE]
> This other [PR](https://github.com/elastic/kibana/pull/285846) is related and might needs to be merged first.

## Summary

The "related by ancestry" feature uses the same resolver/entity lookup as Analyzer. On a Cross-Project Search (CPS) deployment the same document _id can exist in more than one project, so the entity lookup needs the project-qualified index of the document it should anchor on. Previously this section passed only the default index patterns, so it could not disambiguate:
- a linked (fanned-in) alert whose _index carries a cluster: prefix, and
- a rule-preview alert generated off a linked document, where the preview alert is stored locally but its ancestor lives in a linked project.

Both cases now thread the qualified ancestor/document index through to the fetch, matching the Analyzer behavior already introduced in the parent PR.

### Testing
Updated/added unit tests for the hook and both components:
- hook returns the project-qualified ancestor index when previewing a rule off a linked document;
- both components pass default patterns unchanged when no document index is provided, and prepend the project-qualified index when one is.

Manually desk-tested on a CPS-local environment against alerts generated off linked documents (linked-alert and rule-preview cases).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/284892.