### PR TITLE
[Nightshift] Merge causal features into impacted services

### DIFF
--- a/x-pack/solutions/observability/plugins/nightshift/public/__storybook__/provider.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/__storybook__/provider.tsx
@@ -19,11 +19,11 @@ import {
   type NightshiftSignificantEventsQueryData,
 } from '../hooks/use_fetch_significant_events';
 import {
-  checkoutFeature,
   checkoutLifecycle,
   checkoutOccurrences,
   dismissedShippingEvent,
   nightshiftEvents,
+  nightshiftFeatures,
   inventoryEvent,
   checkoutEvent,
   resolvedPaymentEvent,
@@ -41,15 +41,7 @@ export type NightshiftStorybookScenario =
   | 'error';
 
 export type NightshiftLifecycleScenario = 'populated' | 'loading' | 'empty' | 'error';
-export type NightshiftStreamFeaturesScenario =
-  | 'populated'
-  | 'loading'
-  | 'empty'
-  | 'error'
-  | 'partialError';
-
-/** The one stream `partialError` refuses to serve, so the others still resolve their services. */
-const UNREACHABLE_STREAM_NAME = 'logs.inventory-service';
+export type NightshiftStreamFeaturesScenario = 'populated' | 'loading' | 'empty' | 'error';
 
 const performanceApi = {
   onPageReady: () => undefined,
@@ -180,15 +172,9 @@ const createServices = ({
         if (streamFeaturesScenario === 'empty') {
           return { features: [] };
         }
-        if (
-          streamFeaturesScenario === 'partialError' &&
-          options?.params?.path?.name === UNREACHABLE_STREAM_NAME
-        ) {
-          throw new Error(`The ${UNREACHABLE_STREAM_NAME} features request failed`);
-        }
       }
 
-      return { features: [checkoutFeature] };
+      return { features: nightshiftFeatures };
     },
   };
 

--- a/x-pack/solutions/observability/plugins/nightshift/public/__storybook__/sample_events.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/__storybook__/sample_events.ts
@@ -34,6 +34,16 @@ export const checkoutEvent: SignificantEventResponse = {
       name: 'checkout-api',
       stream_name: 'logs.checkout-api',
     },
+    {
+      feature_id: 'payment-gateway',
+      name: 'payment-gateway',
+      stream_name: 'logs.payment-gateway',
+    },
+    {
+      feature_id: 'checkout-api-mirror',
+      name: 'Checkout-API',
+      stream_name: 'logs.checkout-api-mirror',
+    },
   ],
   blast_radius: [
     {
@@ -42,12 +52,17 @@ export const checkoutEvent: SignificantEventResponse = {
       name: 'checkout-api',
       stream_name: 'logs.checkout-api',
     },
-    // Spans a second stream so one event alone can show a partial knowledge-indicator failure.
     {
       type: 'entity',
       feature_id: 'inventory-service',
       name: 'inventory-service',
       stream_name: 'logs.inventory-service',
+    },
+    {
+      type: 'infrastructure',
+      feature_id: 'es-data-tier',
+      title: 'Elasticsearch data tier',
+      stream_name: 'logs.elasticsearch',
     },
   ],
 };
@@ -209,6 +224,66 @@ export const checkoutFeature: Feature = {
     related_apm_service: 'checkout-api',
   },
 };
+
+export const inventoryFeature: Feature = {
+  ...checkoutFeature,
+  uuid: 'inventory-service',
+  id: 'inventory-service',
+  stream_name: 'logs.inventory-service',
+  title: 'inventory-service',
+  description: 'The inventory service tracks product availability across warehouses.',
+  properties: { 'service.name': 'inventory-service' },
+  confidence: 88,
+  evidence: ['service.name = inventory-service'],
+  meta: undefined,
+};
+
+/** Named only by `checkoutEvent.causal_features`, so it proves both arrays feed impacted services. */
+export const paymentGatewayFeature: Feature = {
+  ...checkoutFeature,
+  uuid: 'payment-gateway',
+  id: 'payment-gateway',
+  stream_name: 'logs.payment-gateway',
+  title: 'payment-gateway',
+  description: 'The payment gateway authorizes card transactions for checkout.',
+  properties: { 'service.name': 'payment-gateway' },
+  confidence: 91,
+  evidence: ['service.name = payment-gateway'],
+  meta: undefined,
+};
+
+/** Same service seen in a second stream under a differently cased title, so it must not chip twice. */
+export const checkoutApiMirrorFeature: Feature = {
+  ...checkoutFeature,
+  uuid: 'checkout-api-mirror',
+  id: 'checkout-api-mirror',
+  stream_name: 'logs.checkout-api-mirror',
+  title: 'Checkout-API',
+  meta: undefined,
+};
+
+/** Backs an `infrastructure` blast radius row, which is never an impacted service. */
+export const elasticsearchDataTierFeature: Feature = {
+  ...checkoutFeature,
+  uuid: 'es-data-tier',
+  id: 'es-data-tier',
+  stream_name: 'logs.elasticsearch',
+  subtype: 'infrastructure',
+  title: 'Elasticsearch data tier',
+  description: 'The Elasticsearch data tier backing catalog search.',
+  properties: {},
+  confidence: 76,
+  evidence: [],
+  meta: undefined,
+};
+
+export const nightshiftFeatures: Feature[] = [
+  checkoutFeature,
+  inventoryFeature,
+  paymentGatewayFeature,
+  checkoutApiMirrorFeature,
+  elasticsearchDataTierFeature,
+];
 
 export const completedInvestigation = {
   workflow_execution_id: 'checkout-investigation',

--- a/x-pack/solutions/observability/plugins/nightshift/public/app/app.stories.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/app/app.stories.tsx
@@ -137,38 +137,7 @@ export const ImpactedServicesUnavailable: Story = {
     docs: {
       description: {
         story:
-          'Every stream refuses its knowledge indicators, so nothing resolves and the panel shows only the error and a retry.',
-      },
-    },
-  },
-};
-
-export const ImpactedServicesPartiallyUnavailable: Story = {
-  args: {
-    scenario: 'populated',
-    streamFeaturesScenario: 'partialError',
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'One stream is unreachable while the others resolve. The chips that did resolve stay on the page and the callout names the stream that did not, rather than presenting a short list as a complete one.',
-      },
-    },
-  },
-};
-
-export const EventFlyoutImpactedServicesPartiallyUnavailable: Story = {
-  args: {
-    initialEntry: `/?eventUuid=${checkoutEvent.event_uuid}`,
-    scenario: 'populated',
-    streamFeaturesScenario: 'partialError',
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'The same partial failure inside a detection. Select the detection card to see the impacted services section keep its resolved chips alongside the callout.',
+          'Every stream refuses its knowledge indicators. Unresolvable services fail silently, so no impacted services section renders at all — no callout and no retry.',
       },
     },
   },
@@ -176,7 +145,7 @@ export const EventFlyoutImpactedServicesPartiallyUnavailable: Story = {
 
 export const BlastRadiusFilterActive: Story = {
   args: {
-    initialEntry: '/?blastRadius=entity%3Acheckout-api%3Acheckout-api',
+    initialEntry: '/?blastRadius=checkout-api',
     scenario: 'populated',
   },
 };

--- a/x-pack/solutions/observability/plugins/nightshift/public/app/app.test.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/app/app.test.tsx
@@ -48,24 +48,31 @@ const impactedService = (name: string, streamName = 'logs.app') => ({
   stream_name: streamName,
 });
 
+const causalService = (name: string, streamName = 'logs.app') => ({
+  feature_id: `feat-${name}`,
+  name,
+  stream_name: streamName,
+});
+
 /** Every impacted-service entry in a fixture resolves to a matching service knowledge indicator. */
 const featuresForEvents = (events: SignificantEvent[]): Feature[] =>
   events.flatMap((event) =>
-    (event.blast_radius ?? [])
-      .filter((entry) => entry.type === 'entity')
-      .map(
-        (entry): Feature => ({
-          uuid: entry.feature_id,
-          id: entry.feature_id,
-          stream_name: entry.stream_name,
-          type: 'entity',
-          subtype: 'service',
-          title: entry.type === 'entity' ? entry.name : entry.feature_id,
-          description: '',
-          properties: {},
-          confidence: 90,
-        })
-      )
+    [
+      ...(event.blast_radius ?? []).filter((entry) => entry.type === 'entity'),
+      ...(event.causal_features ?? []),
+    ].map(
+      ({ feature_id: featureId, name, stream_name: streamName }): Feature => ({
+        uuid: featureId,
+        id: featureId,
+        stream_name: streamName ?? 'logs.app',
+        type: 'entity',
+        subtype: 'service',
+        title: name,
+        description: '',
+        properties: {},
+        confidence: 90,
+      })
+    )
   );
 
 const openChat = jest.fn();
@@ -112,9 +119,6 @@ function setEvents({
   mockUseFetchStreamFeatures.mockReturnValue({
     features: featuresForEvents(events),
     isInitialLoading: false,
-    isFetching: false,
-    isError: false,
-    refetch: jest.fn(),
   });
 }
 
@@ -363,21 +367,47 @@ describe('NightshiftApp', () => {
     expect(screen.getByRole('button', { name: /service-resolved/i })).toBeInTheDocument();
   });
 
-  it('surfaces a retry when the impacted services lookup fails', () => {
-    const refetch = jest.fn();
-    setEvents({ events: [mockEvent({ event_id: '1' })] });
-    mockUseFetchStreamFeatures.mockReturnValue({
-      features: [],
-      isInitialLoading: false,
-      isFetching: false,
-      isError: true,
-      refetch,
+  it('builds chips from causal features as well as blast radius entities', () => {
+    setEvents({
+      events: [
+        mockEvent({
+          event_id: '1',
+          blast_radius: [impactedService('service-downstream')],
+          causal_features: [causalService('service-cause')],
+        }),
+      ],
     });
+    const { container } = renderWithIntl();
+
+    expect(container.querySelectorAll('[data-test-subj="blast-radius-chip"]')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: /service-downstream/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /service-cause/i })).toBeInTheDocument();
+  });
+
+  it('shows one chip counted once when both arrays name the same service', () => {
+    setEvents({
+      events: [
+        mockEvent({
+          event_id: '1',
+          blast_radius: [impactedService('service-a')],
+          causal_features: [causalService('service-a')],
+        }),
+      ],
+    });
+    const { container } = renderWithIntl();
+
+    expect(container.querySelectorAll('[data-test-subj="blast-radius-chip"]')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'service-a: 1' })).toBeInTheDocument();
+  });
+
+  it('shows no impacted services panel, callout or retry when nothing resolves', () => {
+    setEvents({ events: [mockEvent({ event_id: '1' })] });
+    mockUseFetchStreamFeatures.mockReturnValue({ features: [], isInitialLoading: false });
     renderWithIntl();
 
-    expect(screen.getByText('Unable to load impacted services')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('blast-radius-retry'));
-    expect(refetch).toHaveBeenCalled();
+    expect(screen.queryByText('Impacted services')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('blast-radius-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('blast-radius-retry')).not.toBeInTheDocument();
   });
 
   it('filters significant events by blast radius', () => {
@@ -399,7 +429,7 @@ describe('NightshiftApp', () => {
 
     const blastRadiusButton = screen.getByRole('button', { name: /service-b/i });
     expect(blastRadiusButton).toHaveAttribute('data-ebt-action', 'filterByBlastRadius');
-    expect(blastRadiusButton).toHaveAttribute('data-ebt-detail', 'entity');
+    expect(blastRadiusButton).toHaveAttribute('data-ebt-element', 'nightshiftBlastRadius');
     fireEvent.click(blastRadiusButton);
 
     expect(screen.getByText('Service B event')).toBeInTheDocument();

--- a/x-pack/solutions/observability/plugins/nightshift/public/app/app.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/app/app.tsx
@@ -197,13 +197,7 @@ export function NightshiftApp(): React.ReactElement {
 
   // Chips cover every event on the page, resolved included, so filtering by a service that only
   // appears in resolved events is still reachable.
-  const {
-    features,
-    failedStreamNames: blastRadiusFailedStreamNames,
-    isInitialLoading: isLoadingBlastRadius,
-    isError: isBlastRadiusError,
-    refetch: refetchBlastRadius,
-  } = useFetchStreamFeatures(
+  const { features, isInitialLoading: isLoadingBlastRadius } = useFetchStreamFeatures(
     useMemo(() => getImpactedServiceStreamNames(shownEvents), [shownEvents])
   );
   const blastRadius = useMemo(
@@ -485,10 +479,7 @@ export function NightshiftApp(): React.ReactElement {
 
           <BlastRadiusEntities
             entities={blastRadius}
-            failedStreamNames={blastRadiusFailedStreamNames}
-            isError={isBlastRadiusError}
             isLoading={isLoadingBlastRadius}
-            onRetry={refetchBlastRadius}
             onSelect={handleBlastRadiusSelect}
             selectedEntityKey={activeBlastRadiusChip}
           />

--- a/x-pack/solutions/observability/plugins/nightshift/public/common/ebt_constants.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/common/ebt_constants.ts
@@ -43,12 +43,3 @@ export const NIGHTSHIFT_EBT_DETAILS = {
   NEEDS_ACTION: 'needsAction',
   RESOLVED: 'resolved',
 } as const;
-
-const BLAST_RADIUS_ENTRY_TYPES = ['dependency', 'entity', 'infrastructure'] as const;
-
-/**
- * Returns a fixed, privacy-safe category instead of the chip key, which can
- * contain customer-provided entity and stream names.
- */
-export const getBlastRadiusEbtDetail = (chipKey: string): string =>
-  BLAST_RADIUS_ENTRY_TYPES.find((type) => chipKey.startsWith(`${type}:`)) ?? 'stream';

--- a/x-pack/solutions/observability/plugins/nightshift/public/common/impacted_services.test.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/common/impacted_services.test.ts
@@ -153,14 +153,31 @@ describe('getImpactedServices', () => {
     ).toBe(byUuid);
   });
 
-  // `Feature.subtype` is an unconstrained string written by a model, so casing is not guaranteed.
-  it('accepts a service subtype regardless of casing', () => {
-    const feature = mockFeature({ subtype: 'Service' });
+  // `Feature.type` and `Feature.subtype` are unconstrained strings written by a model, so casing is
+  // not guaranteed.
+  it('accepts an entity type and service subtype regardless of casing', () => {
+    const feature = mockFeature({ type: 'Entity', subtype: 'Service' });
 
     expect(getImpactedServices(mockEvent({ blast_radius: [entityEntry] }), [feature])).toHaveLength(
       1
     );
   });
+
+  // A knowledge indicator's own type is the only gate that covers `causal_features[]`, which carry
+  // no row type of their own.
+  it.each(['dependency', 'infrastructure', 'technology', 'schema'])(
+    'drops a %s knowledge indicator even when its subtype is service',
+    (type) => {
+      const feature = mockFeature({ type, subtype: 'service' });
+
+      expect(getImpactedServices(mockEvent({ blast_radius: [entityEntry] }), [feature])).toEqual(
+        []
+      );
+      expect(getImpactedServices(mockEvent({ causal_features: [causalEntry] }), [feature])).toEqual(
+        []
+      );
+    }
+  );
 
   // An infrastructure row names a component, not a service an operator acts on — even when its
   // knowledge indicator claims the `service` subtype.

--- a/x-pack/solutions/observability/plugins/nightshift/public/common/impacted_services.test.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/common/impacted_services.test.ts
@@ -6,11 +6,7 @@
  */
 
 import type { Feature, SignificantEvent } from '@kbn/significant-events-schema';
-import {
-  getImpactedServiceKey,
-  getImpactedServiceStreamNames,
-  getImpactedServices,
-} from './impacted_services';
+import { getImpactedServiceStreamNames, getImpactedServices } from './impacted_services';
 
 const mockEvent = (overrides: Partial<SignificantEvent> = {}): SignificantEvent => ({
   '@timestamp': '2026-07-10T12:00:00Z',
@@ -45,18 +41,99 @@ const entityEntry = {
   stream_name: 'logs.checkout',
 };
 
+const causalEntry = {
+  feature_id: 'feat-checkout',
+  name: 'checkout-api',
+  stream_name: 'logs.checkout',
+};
+
 describe('getImpactedServices', () => {
-  it('resolves entity entries backed by a service knowledge indicator', () => {
+  it('resolves blast radius entity entries backed by a service knowledge indicator', () => {
     const feature = mockFeature();
 
     expect(getImpactedServices(mockEvent({ blast_radius: [entityEntry] }), [feature])).toEqual([
-      {
-        key: 'entity:feat-checkout:checkout-api',
-        name: 'checkout-api',
-        streamName: 'logs.checkout',
-        feature,
-      },
+      { key: 'checkout api', name: 'Checkout API', feature },
     ]);
+  });
+
+  it('resolves causal features backed by a service knowledge indicator', () => {
+    const feature = mockFeature();
+
+    expect(getImpactedServices(mockEvent({ causal_features: [causalEntry] }), [feature])).toEqual([
+      { key: 'checkout api', name: 'Checkout API', feature },
+    ]);
+  });
+
+  // Neither array alone is complete, so the list is their union.
+  it('merges services named only by one of the two arrays', () => {
+    const checkout = mockFeature();
+    const payments = mockFeature({
+      uuid: 'feat-payments',
+      id: 'payments-api',
+      title: 'Payments API',
+    });
+    const event = mockEvent({
+      blast_radius: [entityEntry],
+      causal_features: [{ ...causalEntry, feature_id: 'feat-payments', name: 'payments-api' }],
+    });
+
+    expect(getImpactedServices(event, [checkout, payments]).map(({ name }) => name)).toEqual([
+      'Checkout API',
+      'Payments API',
+    ]);
+  });
+
+  it('collapses a service named by both arrays into one entry', () => {
+    const event = mockEvent({ blast_radius: [entityEntry], causal_features: [causalEntry] });
+
+    expect(getImpactedServices(event, [mockFeature()])).toHaveLength(1);
+  });
+
+  // The reported duplicate: `elasticsearch` in one stream and `Elasticsearch` in another are two
+  // knowledge indicators with two uuids, and rendered as two chips before this collapsing.
+  it('collapses knowledge indicators whose titles differ only in casing', () => {
+    const lower = mockFeature({ uuid: 'feat-es-a', id: 'elasticsearch', title: 'elasticsearch' });
+    const upper = mockFeature({
+      uuid: 'feat-es-b',
+      id: 'elasticsearch',
+      stream_name: 'logs.search',
+      title: 'Elasticsearch',
+    });
+    const event = mockEvent({
+      blast_radius: [
+        { ...entityEntry, feature_id: 'feat-es-a' },
+        { ...entityEntry, feature_id: 'feat-es-b' },
+      ],
+    });
+
+    expect(getImpactedServices(event, [lower, upper])).toEqual([
+      { key: 'elasticsearch', name: 'elasticsearch', feature: lower },
+    ]);
+  });
+
+  it('labels a service from its knowledge indicator, not the free-text entry name', () => {
+    const event = mockEvent({ blast_radius: [{ ...entityEntry, name: 'checkout-api' }] });
+
+    expect(getImpactedServices(event, [mockFeature({ title: 'Checkout API' })])[0].name).toBe(
+      'Checkout API'
+    );
+  });
+
+  it('falls back to the knowledge indicator id when it has no title', () => {
+    const event = mockEvent({ blast_radius: [entityEntry] });
+
+    expect(getImpactedServices(event, [mockFeature({ title: undefined })])[0].name).toBe(
+      'checkout-api'
+    );
+    expect(getImpactedServices(event, [mockFeature({ title: '  ' })])[0].name).toBe('checkout-api');
+  });
+
+  // Both fields are unbounded below, so a blank pair would otherwise chip with a count and no name.
+  it('drops a knowledge indicator whose title and id are both blank', () => {
+    const event = mockEvent({ blast_radius: [entityEntry] });
+
+    expect(getImpactedServices(event, [mockFeature({ title: '  ', id: '' })])).toEqual([]);
+    expect(getImpactedServices(event, [mockFeature({ title: undefined, id: '   ' })])).toEqual([]);
   });
 
   it('matches a feature by its id when the entry does not reference the uuid', () => {
@@ -85,9 +162,9 @@ describe('getImpactedServices', () => {
     );
   });
 
-  // A row's `type` is the agent's per-event wording; the knowledge indicator decides what the thing
-  // it points at actually is.
-  it('resolves an infrastructure entry whose knowledge indicator is a service', () => {
+  // An infrastructure row names a component, not a service an operator acts on — even when its
+  // knowledge indicator claims the `service` subtype.
+  it('drops infrastructure entries', () => {
     const event = mockEvent({
       blast_radius: [
         {
@@ -98,37 +175,8 @@ describe('getImpactedServices', () => {
         },
       ],
     });
-    const feature = mockFeature({ uuid: 'feat-ingress' });
 
-    expect(getImpactedServices(event, [feature])).toEqual([
-      {
-        key: 'infrastructure:feat-ingress:Ingress controller',
-        name: 'Ingress controller',
-        streamName: 'logs.checkout',
-        feature,
-      },
-    ]);
-  });
-
-  it('names an infrastructure entry from its title, then the indicator title, then its id', () => {
-    const named = (feature: Feature, title?: string) =>
-      getImpactedServices(
-        mockEvent({
-          blast_radius: [
-            {
-              type: 'infrastructure',
-              feature_id: 'feat-checkout',
-              stream_name: 'logs.checkout',
-              title,
-            },
-          ],
-        }),
-        [feature]
-      )[0].name;
-
-    expect(named(mockFeature(), 'Ingress controller')).toBe('Ingress controller');
-    expect(named(mockFeature())).toBe('Checkout API');
-    expect(named(mockFeature({ title: undefined }))).toBe('checkout-api');
+    expect(getImpactedServices(event, [mockFeature({ uuid: 'feat-ingress' })])).toEqual([]);
   });
 
   // A dependency row names an edge — `source` → `target` behind one `feature_id` — so there is no
@@ -149,52 +197,32 @@ describe('getImpactedServices', () => {
     expect(getImpactedServices(event, [mockFeature({ uuid: 'feat-edge' })])).toEqual([]);
   });
 
-  it('drops an infrastructure entry whose knowledge indicator is not a service', () => {
-    const event = mockEvent({
-      blast_radius: [
-        {
-          type: 'infrastructure',
-          feature_id: 'feat-nodes',
-          title: 'Wolfi Linux nodes',
-          stream_name: 'logs.checkout',
-        },
-      ],
-    });
-
-    expect(
-      getImpactedServices(event, [mockFeature({ uuid: 'feat-nodes', subtype: 'infrastructure' })])
-    ).toEqual([]);
-  });
-
-  it('drops entities whose knowledge indicator is not a service', () => {
+  it('drops references whose knowledge indicator is not a service', () => {
     const feature = mockFeature({ subtype: 'database' });
 
     expect(getImpactedServices(mockEvent({ blast_radius: [entityEntry] }), [feature])).toEqual([]);
+    expect(getImpactedServices(mockEvent({ causal_features: [causalEntry] }), [feature])).toEqual(
+      []
+    );
   });
 
-  it('drops entities whose knowledge indicator has no subtype', () => {
+  it('drops references whose knowledge indicator has no subtype', () => {
     const feature = mockFeature({ subtype: undefined });
 
     expect(getImpactedServices(mockEvent({ blast_radius: [entityEntry] }), [feature])).toEqual([]);
   });
 
-  it('drops entities whose feature_id resolves to nothing', () => {
+  it('drops references whose feature_id resolves to nothing', () => {
     expect(getImpactedServices(mockEvent({ blast_radius: [entityEntry] }), [])).toEqual([]);
   });
 
-  it('never falls back to a stream name when there is no blast radius', () => {
+  it('never falls back to a stream name when an event names no services', () => {
     expect(getImpactedServices(mockEvent(), [mockFeature()])).toEqual([]);
-  });
-
-  it('deduplicates repeated entries', () => {
-    const event = mockEvent({ blast_radius: [entityEntry, { ...entityEntry }] });
-
-    expect(getImpactedServices(event, [mockFeature()])).toHaveLength(1);
   });
 });
 
 describe('getImpactedServiceStreamNames', () => {
-  it('collects distinct streams from every entry that can name a service', () => {
+  it('collects distinct streams from blast radius entities and causal features', () => {
     const events = [
       mockEvent({ blast_radius: [entityEntry] }),
       mockEvent({
@@ -205,20 +233,8 @@ describe('getImpactedServiceStreamNames', () => {
             name: 'eis-gateway',
             stream_name: 'logging-eis',
           },
-          {
-            type: 'infrastructure',
-            feature_id: 'feat-nodes',
-            title: 'Wolfi Linux nodes',
-            stream_name: 'logs.infra',
-          },
-          {
-            type: 'dependency',
-            feature_id: 'feat-edge',
-            source: 'checkout-api',
-            target: 'payments-api',
-            stream_name: 'logs.edges',
-          },
         ],
+        causal_features: [{ ...causalEntry, stream_name: 'logs.payments' }],
       }),
       mockEvent(),
     ];
@@ -226,20 +242,39 @@ describe('getImpactedServiceStreamNames', () => {
     expect(getImpactedServiceStreamNames(events)).toEqual([
       'logs.checkout',
       'logging-eis',
-      'logs.infra',
+      'logs.payments',
     ]);
   });
-});
 
-describe('getImpactedServiceKey', () => {
-  it('separates entries that share a feature but name different services', () => {
-    expect(getImpactedServiceKey(entityEntry, 'checkout-api')).not.toBe(
-      getImpactedServiceKey(entityEntry, 'checkout-worker')
-    );
+  it('skips streams of entries that describe no service', () => {
+    const event = mockEvent({
+      blast_radius: [
+        {
+          type: 'infrastructure',
+          feature_id: 'feat-nodes',
+          title: 'Wolfi Linux nodes',
+          stream_name: 'logs.infra',
+        },
+        {
+          type: 'dependency',
+          feature_id: 'feat-edge',
+          source: 'checkout-api',
+          target: 'payments-api',
+          stream_name: 'logs.edges',
+        },
+      ],
+    });
+
+    expect(getImpactedServiceStreamNames([event])).toEqual([]);
   });
 
-  // `getBlastRadiusEbtDetail` reads this prefix to derive the privacy-safe analytics category.
-  it('keeps the entry type as the leading key segment', () => {
-    expect(getImpactedServiceKey(entityEntry, 'checkout-api')).toMatch(/^entity:/);
+  // `causal_features[].stream_name` is optional, unlike every blast radius row.
+  it('skips causal features that declare no stream', () => {
+    const event = mockEvent({
+      blast_radius: [entityEntry],
+      causal_features: [{ feature_id: 'feat-payments', name: 'payments-api' }],
+    });
+
+    expect(getImpactedServiceStreamNames([event])).toEqual(['logs.checkout']);
   });
 });

--- a/x-pack/solutions/observability/plugins/nightshift/public/common/impacted_services.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/common/impacted_services.ts
@@ -8,12 +8,16 @@
 import type { Feature, SignificantEvent } from '@kbn/significant-events-schema';
 
 /**
- * Knowledge-indicator subtype that qualifies a feature reference as an impacted service.
+ * Knowledge-indicator type and subtype that together qualify a feature reference as an impacted
+ * service. A knowledge indicator can also be `infrastructure`, `technology`, `dependency` or
+ * `schema` (`INFERRED_FEATURE_TYPES`), and any of those can still carry `subtype: 'service'`, so
+ * both halves have to match.
  *
- * `Feature.subtype` is an unconstrained `z.string()` written by the model that derives knowledge
- * indicators, so this is a value match rather than a typed one. Comparison is case-insensitive so
- * a row is not dropped over capitalisation alone.
+ * `Feature.type` and `Feature.subtype` are unconstrained `z.string()`s written by the model that
+ * derives knowledge indicators, so these are value matches rather than typed ones. Comparison is
+ * case-insensitive so a feature is not dropped over capitalisation alone.
  */
+export const IMPACTED_SERVICE_TYPE = 'entity';
 export const IMPACTED_SERVICE_SUBTYPE = 'service';
 
 export interface ImpactedService {
@@ -28,7 +32,8 @@ export interface ImpactedService {
  *
  * `blast_radius[]` also carries `infrastructure` rows (components) and `dependency` rows (edges
  * between two services behind one `feature_id`); neither is a service an operator can act on, so
- * only `entity` rows qualify. `causal_features[]` has no row type — every entry names one feature.
+ * only `entity` rows qualify. `causal_features[]` has no row type — every entry names one feature,
+ * so its references are filtered on the resolved knowledge indicator alone.
  */
 const getCandidateReferences = (
   event: SignificantEvent
@@ -71,8 +76,13 @@ const indexFeaturesByReference = (features: Feature[]): Map<string, Feature> => 
 
 /**
  * Impacted services are the feature references of an event — `blast_radius[]` entity rows and
- * `causal_features[]` alike — that resolve to a `service` knowledge indicator. Both arrays
- * routinely name the same service, and neither alone is complete.
+ * `causal_features[]` alike — that resolve to an `entity` knowledge indicator of subtype `service`.
+ * Both arrays routinely name the same service, and neither alone is complete.
+ *
+ * The knowledge indicator is the authority on what a reference *is*, and it is the only check that
+ * covers both arrays: `blast_radius[]` rows carry their own agent-written type, but
+ * `causal_features[]` rows carry none, so without this gate a causal reference to a `dependency` or
+ * `technology` indicator would render as a service.
  *
  * The label is the knowledge indicator's own, not the free-text `name` on the row, and one service
  * appears once: entries collapse on the case-insensitive label. A knowledge indicator's `uuid` is
@@ -96,7 +106,10 @@ export const getImpactedServices = (
 
   for (const { feature_id: featureId } of getCandidateReferences(event)) {
     const feature = featuresByReference.get(featureId);
-    if (feature?.subtype?.toLowerCase() !== IMPACTED_SERVICE_SUBTYPE) {
+    if (
+      feature?.type.toLowerCase() !== IMPACTED_SERVICE_TYPE ||
+      feature.subtype?.toLowerCase() !== IMPACTED_SERVICE_SUBTYPE
+    ) {
       continue;
     }
 

--- a/x-pack/solutions/observability/plugins/nightshift/public/common/impacted_services.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/common/impacted_services.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import type { BlastRadiusEntry, Feature, SignificantEvent } from '@kbn/significant-events-schema';
+import type { Feature, SignificantEvent } from '@kbn/significant-events-schema';
 
 /**
- * Knowledge-indicator subtype that qualifies a blast radius entry as an impacted service.
+ * Knowledge-indicator subtype that qualifies a feature reference as an impacted service.
  *
  * `Feature.subtype` is an unconstrained `z.string()` written by the model that derives knowledge
  * indicators, so this is a value match rather than a typed one. Comparison is case-insensitive so
@@ -16,49 +16,43 @@ import type { BlastRadiusEntry, Feature, SignificantEvent } from '@kbn/significa
  */
 export const IMPACTED_SERVICE_SUBTYPE = 'service';
 
-/**
- * A `dependency` row names an edge — `source` → `target` behind a single `feature_id` — so it has
- * no unambiguous subject to render as one service. Every other row type is a candidate.
- */
-type ImpactedServiceCandidate = Exclude<BlastRadiusEntry, { type: 'dependency' }>;
-
 export interface ImpactedService {
   key: string;
   name: string;
-  streamName: string;
   feature: Feature;
 }
 
-const isCandidateEntry = (entry: BlastRadiusEntry): entry is ImpactedServiceCandidate =>
-  entry.type !== 'dependency';
-
-const getCandidateEntries = (event: SignificantEvent): ImpactedServiceCandidate[] =>
-  (event.blast_radius ?? []).filter(isCandidateEntry);
-
-/** `entity` rows carry a required `name`; `infrastructure` rows only an optional `title`. */
-const getEntryName = (entry: ImpactedServiceCandidate, feature: Feature): string =>
-  entry.type === 'entity' ? entry.name : entry.title ?? feature.title ?? feature.id;
-
 /**
- * A single `feature_id` can name more than one service, so the name is part of the key.
+ * Feature references an event offers as impacted services: its `blast_radius[]` entity rows and
+ * its `causal_features[]`.
  *
- * `getBlastRadiusEbtDetail` derives the privacy-safe analytics category from the leading entry
- * type, so the prefix has to stay.
+ * `blast_radius[]` also carries `infrastructure` rows (components) and `dependency` rows (edges
+ * between two services behind one `feature_id`); neither is a service an operator can act on, so
+ * only `entity` rows qualify. `causal_features[]` has no row type — every entry names one feature.
  */
-export const getImpactedServiceKey = (entry: ImpactedServiceCandidate, name: string): string =>
-  `${entry.type}:${entry.feature_id}:${name}`;
+const getCandidateReferences = (
+  event: SignificantEvent
+): Array<{ feature_id: string; stream_name?: string }> => [
+  ...(event.blast_radius ?? []).filter((entry) => entry.type === 'entity'),
+  ...(event.causal_features ?? []),
+];
 
 /** Streams whose knowledge indicators must be loaded before impacted services can be resolved. */
 export const getImpactedServiceStreamNames = (events: SignificantEvent[]): string[] => [
   ...new Set(
-    events.flatMap((event) => getCandidateEntries(event).map(({ stream_name }) => stream_name))
+    events.flatMap((event) =>
+      getCandidateReferences(event)
+        .map(({ stream_name: streamName }) => streamName)
+        .filter((streamName): streamName is string => Boolean(streamName))
+    )
   ),
 ];
 
 /**
- * Indexes features under both `uuid` and `id`, because `blast_radius[].feature_id` is written with
- * either. `uuid` is the canonical identifier, so it wins when one feature's `id` collides with
- * another's `uuid`; among `id`s alone the first feature in the list wins.
+ * Indexes features under both `uuid` and `id`, because `blast_radius[].feature_id` and
+ * `causal_features[].feature_id` are written with either. `uuid` is the canonical identifier, so it
+ * wins when one feature's `id` collides with another's `uuid`; among `id`s alone the first feature
+ * in the list wins.
  */
 const indexFeaturesByReference = (features: Feature[]): Map<string, Feature> => {
   const byReference = new Map<string, Feature>();
@@ -76,17 +70,22 @@ const indexFeaturesByReference = (features: Feature[]): Map<string, Feature> => 
 };
 
 /**
- * Impacted services are the `blast_radius[]` rows backed by a `service` knowledge indicator.
- * `causal_features[]` is deliberately not used: it names what *caused* the incident.
+ * Impacted services are the feature references of an event — `blast_radius[]` entity rows and
+ * `causal_features[]` alike — that resolve to a `service` knowledge indicator. Both arrays
+ * routinely name the same service, and neither alone is complete.
  *
- * The knowledge indicator decides whether a row is a service, not the row's own `type`:
- * `blast_radius[].type` is written per event by the agent while `subtype` comes from the knowledge
- * indicator pipeline, so an `infrastructure` row resolving to a service is still an impacted
- * service.
+ * The label is the knowledge indicator's own, not the free-text `name` on the row, and one service
+ * appears once: entries collapse on the case-insensitive label. A knowledge indicator's `uuid` is
+ * derived from `(stream_name, id)`, so the same service observed in two streams has two uuids —
+ * deduplicating on it would leave the visibly duplicated chips this collapsing exists to remove.
+ * Two genuinely distinct services sharing a label therefore collapse too, and the surviving entry
+ * carries the first resolved feature.
  *
- * Rows whose `feature_id` resolves to no stored feature are dropped — without the feature there is
- * no subtype to check, and keeping them would break the services-only guarantee. Nothing falls back
- * to a stream name, so an event with no resolvable rows contributes no services at all.
+ * References that resolve to no stored feature are dropped — without the feature there is no
+ * subtype to check, and keeping them would break the services-only guarantee. So is a feature left
+ * with no label: `title` and `id` are both unbounded below, and a blank one would render as a chip
+ * carrying a count and no name. Nothing falls back to a stream name, so an event with no resolvable
+ * references contributes no services at all.
  */
 export const getImpactedServices = (
   event: SignificantEvent,
@@ -95,16 +94,20 @@ export const getImpactedServices = (
   const featuresByReference = indexFeaturesByReference(features);
   const byKey = new Map<string, ImpactedService>();
 
-  for (const entry of getCandidateEntries(event)) {
-    const feature = featuresByReference.get(entry.feature_id);
+  for (const { feature_id: featureId } of getCandidateReferences(event)) {
+    const feature = featuresByReference.get(featureId);
     if (feature?.subtype?.toLowerCase() !== IMPACTED_SERVICE_SUBTYPE) {
       continue;
     }
 
-    const name = getEntryName(entry, feature);
-    const key = getImpactedServiceKey(entry, name);
+    const name = feature.title?.trim() || feature.id.trim();
+    if (!name) {
+      continue;
+    }
+
+    const key = name.toLowerCase();
     if (!byKey.has(key)) {
-      byKey.set(key, { key, name, streamName: feature.stream_name, feature });
+      byKey.set(key, { key, name, feature });
     }
   }
 

--- a/x-pack/solutions/observability/plugins/nightshift/public/detection/detection_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/detection/detection_flyout.test.tsx
@@ -130,11 +130,7 @@ describe('DetectionFlyout', () => {
     mockOpenChat.mockClear();
     mockStreamFeatures.mockReturnValue({
       features: [webFrontendFeature],
-      failedStreamNames: [],
       isInitialLoading: false,
-      isFetching: false,
-      isError: false,
-      refetch: jest.fn(),
     });
   });
 
@@ -258,35 +254,40 @@ describe('DetectionFlyout', () => {
   });
 
   it('hides the impacted services section when no entry resolves to a service', () => {
-    mockStreamFeatures.mockReturnValue({
-      features: [],
-      failedStreamNames: [],
-      isInitialLoading: false,
-      isFetching: false,
-      isError: false,
-      refetch: jest.fn(),
-    });
+    mockStreamFeatures.mockReturnValue({ features: [], isInitialLoading: false });
     renderFlyout();
 
     expect(screen.queryByText('Impacted services')).not.toBeInTheDocument();
+    expect(screen.queryByText(/could not be loaded/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument();
   });
 
-  it('names the unreachable streams while keeping the services that did resolve', () => {
+  it('includes services named only by the event causal features', () => {
+    const paymentsFeature = {
+      ...webFrontendFeature,
+      uuid: 'feat-payments',
+      id: 'payments-api',
+      stream_name: 'logs.payments',
+      title: 'payments-api',
+    };
     mockStreamFeatures.mockReturnValue({
-      features: [webFrontendFeature],
-      failedStreamNames: ['logs.payments', 'logs.checkout'],
+      features: [webFrontendFeature, paymentsFeature],
       isInitialLoading: false,
-      isFetching: false,
-      isError: false,
-      refetch: jest.fn(),
     });
-    renderFlyout();
+    renderFlyout({
+      event: {
+        ...mockEvent,
+        causal_features: [
+          { feature_id: 'feat-payments', name: 'payments-api', stream_name: 'logs.payments' },
+        ],
+      },
+    });
 
-    expect(screen.getByText('Some impacted services could not be loaded')).toBeInTheDocument();
-    expect(screen.getByTestId('nightshiftDetectionFlyoutEntitiesFailedStreams')).toHaveTextContent(
-      'No response from logs.payments, logs.checkout.'
-    );
-    expect(screen.getAllByTestId('nightshiftDetectionFlyoutEntityChip').length).toBeGreaterThan(0);
+    expect(
+      screen
+        .getAllByTestId('nightshiftDetectionFlyoutEntityChip')
+        .map(({ textContent }) => textContent)
+    ).toEqual(['web-frontend', 'payments-api']);
   });
 
   it('renders the Lens occurrence chart in the trend section', () => {

--- a/x-pack/solutions/observability/plugins/nightshift/public/detection/detection_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/detection/detection_flyout.tsx
@@ -10,7 +10,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   EuiBadge,
   EuiButtonEmpty,
-  EuiCallOut,
   EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
@@ -72,15 +71,8 @@ export function DetectionFlyout({
   const { share, agentBuilder } = useKibana().services;
   const [selectedEntity, setSelectedEntity] = useState<ImpactedService | undefined>();
 
-  const {
-    services: associatedEntities,
-    failedStreamNames: failedStreamFeatureNames,
-    isInitialLoading: isLoadingStreamFeatures,
-    isFetching: isFetchingStreamFeatures,
-    isError: isStreamFeaturesError,
-    refetch: refetchStreamFeatures,
-  } = useImpactedServices(event);
-  const hasStreamFeatureFailures = isStreamFeaturesError || failedStreamFeatureNames.length > 0;
+  const { services: associatedEntities, isInitialLoading: isLoadingStreamFeatures } =
+    useImpactedServices(event);
   const selectedEntityFeature = selectedEntity?.feature;
 
   useEffect(() => {
@@ -203,9 +195,7 @@ export function DetectionFlyout({
             </>
           )}
 
-          {(isLoadingStreamFeatures ||
-            hasStreamFeatureFailures ||
-            associatedEntities.length > 0) && (
+          {(isLoadingStreamFeatures || associatedEntities.length > 0) && (
             <>
               <FlyoutSectionTitle>
                 {i18n.translate('xpack.nightshift.detectionFlyout.entitiesTitle', {
@@ -219,51 +209,6 @@ export function DetectionFlyout({
                     <EuiLoadingSpinner size="m" />
                   </EuiFlexItem>
                 </EuiFlexGroup>
-              )}
-              {hasStreamFeatureFailures && (
-                <EuiCallOut
-                  announceOnMount
-                  color="warning"
-                  iconType="warning"
-                  size="s"
-                  title={
-                    isStreamFeaturesError
-                      ? i18n.translate('xpack.nightshift.detectionFlyout.entitiesErrorTitle', {
-                          defaultMessage: 'Unable to load impacted services',
-                        })
-                      : i18n.translate(
-                          'xpack.nightshift.detectionFlyout.entitiesPartialErrorTitle',
-                          { defaultMessage: 'Some impacted services could not be loaded' }
-                        )
-                  }
-                  text={
-                    isStreamFeaturesError ? undefined : (
-                      <p data-test-subj="nightshiftDetectionFlyoutEntitiesFailedStreams">
-                        {i18n.translate(
-                          'xpack.nightshift.detectionFlyout.entitiesPartialErrorDescription',
-                          {
-                            defaultMessage: 'No response from {streamNames}.',
-                            values: { streamNames: failedStreamFeatureNames.join(', ') },
-                          }
-                        )}
-                      </p>
-                    )
-                  }
-                >
-                  <EuiButtonEmpty
-                    color="warning"
-                    data-test-subj="nightshiftDetectionFlyoutEntitiesRetryButton"
-                    flush="left"
-                    iconType="refresh"
-                    isLoading={isFetchingStreamFeatures}
-                    onClick={() => refetchStreamFeatures()}
-                    size="s"
-                  >
-                    {i18n.translate('xpack.nightshift.detectionFlyout.entitiesRetryButtonText', {
-                      defaultMessage: 'Retry',
-                    })}
-                  </EuiButtonEmpty>
-                </EuiCallOut>
               )}
               {!isLoadingStreamFeatures && associatedEntities.length > 0 && (
                 <EuiFlexGroup gutterSize="s" wrap responsive={false}>

--- a/x-pack/solutions/observability/plugins/nightshift/public/event/detections_list.test.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/event/detections_list.test.tsx
@@ -102,9 +102,6 @@ function setLifecycle({
   mockUseFetchStreamFeatures.mockReturnValue({
     features: [serviceFeature('feat-web-frontend', 'web-frontend')],
     isInitialLoading: false,
-    isFetching: false,
-    isError: false,
-    refetch: jest.fn(),
   });
   return { refetch };
 }

--- a/x-pack/solutions/observability/plugins/nightshift/public/event/event_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/event/event_flyout.test.tsx
@@ -32,14 +32,7 @@ jest.mock('@kbn/investigation-output', () => ({
 }));
 
 jest.mock('../hooks/use_fetch_stream_features', () => ({
-  useFetchStreamFeatures: () => ({
-    features: [],
-    failedStreamNames: [],
-    isInitialLoading: false,
-    isFetching: false,
-    isError: false,
-    refetch: jest.fn(),
-  }),
+  useFetchStreamFeatures: () => ({ features: [], isInitialLoading: false }),
 }));
 
 jest.mock('../detection/change_point_lens_chart', () => ({

--- a/x-pack/solutions/observability/plugins/nightshift/public/hooks/use_fetch_stream_features.test.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/hooks/use_fetch_stream_features.test.ts
@@ -20,53 +20,26 @@ const mockFeature = (id: string, streamName: string): Feature => ({
   confidence: 80,
 });
 
-const loaded = (features: Feature[]): PromiseSettledResult<Feature[]> => ({
-  status: 'fulfilled',
-  value: features,
-});
-
-const unreachable = (reason: Error): PromiseSettledResult<Feature[]> => ({
-  status: 'rejected',
-  reason,
-});
-
 describe('collectStreamFeatures', () => {
-  it('reports no failures when every stream resolves', () => {
-    const checkout = mockFeature('checkout-api', 'logs.checkout');
-    const payments = mockFeature('payments-api', 'logs.payments');
-
-    expect(
-      collectStreamFeatures(
-        ['logs.checkout', 'logs.payments'],
-        [loaded([checkout]), loaded([payments])]
-      )
-    ).toEqual({ features: [checkout, payments], failedStreamNames: [] });
-  });
-
-  // The whole point of the partial state: a short list must not pass for a complete one.
-  it('keeps the features that resolved and names the streams that did not', () => {
+  // Silent failure: an unreachable stream must not blank out the services of the reachable ones,
+  // and must not surface an error either.
+  it('keeps the features of the streams that answered and ignores the ones that did not', () => {
     const checkout = mockFeature('checkout-api', 'logs.checkout');
 
     expect(
-      collectStreamFeatures(
-        ['logs.checkout', 'logs.payments', 'logs.orders'],
-        [loaded([checkout]), unreachable(new Error('gateway timeout')), loaded([])]
-      )
-    ).toEqual({ features: [checkout], failedStreamNames: ['logs.payments'] });
+      collectStreamFeatures([
+        { status: 'fulfilled', value: [checkout] },
+        { status: 'rejected', reason: new Error('gateway timeout') },
+      ])
+    ).toEqual([checkout]);
   });
 
-  it('throws the first reason when every stream fails', () => {
-    const firstFailure = new Error('gateway timeout');
-
-    expect(() =>
-      collectStreamFeatures(
-        ['logs.checkout', 'logs.payments'],
-        [unreachable(firstFailure), unreachable(new Error('connection refused'))]
-      )
-    ).toThrow(firstFailure);
-  });
-
-  it('returns nothing rather than throwing when there are no streams to load', () => {
-    expect(collectStreamFeatures([], [])).toEqual({ features: [], failedStreamNames: [] });
+  it('returns nothing when every stream fails', () => {
+    expect(
+      collectStreamFeatures([
+        { status: 'rejected', reason: new Error('gateway timeout') },
+        { status: 'rejected', reason: new Error('connection refused') },
+      ])
+    ).toEqual([]);
   });
 });

--- a/x-pack/solutions/observability/plugins/nightshift/public/hooks/use_fetch_stream_features.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/hooks/use_fetch_stream_features.ts
@@ -11,49 +11,21 @@ import { isComputedFeature, type Feature } from '@kbn/significant-events-schema'
 import { useKibana } from './use_kibana';
 
 const NO_FEATURES: Feature[] = [];
-const NO_STREAM_NAMES: string[] = [];
-
-export interface StreamFeaturesQueryData {
-  features: Feature[];
-  failedStreamNames: string[];
-}
 
 /**
- * Splits per-stream loads into the features that resolved and the streams that did not.
+ * Keeps the features of every stream that answered and drops the streams that did not.
  *
- * One unreachable stream must not blank out the services resolved from the others, so a partial
- * failure returns what loaded and names the rest. A total failure rethrows instead: an empty
- * impact list would otherwise read as "nothing was impacted".
+ * An unreachable stream fails silently: its services are simply absent. Nothing is surfaced to the
+ * operator, so this must never reject — one refused stream would otherwise blank out the services
+ * resolved from all the others.
  */
-export const collectStreamFeatures = (
-  streamNames: string[],
-  settled: Array<PromiseSettledResult<Feature[]>>
-): StreamFeaturesQueryData => {
-  const failedStreamNames = streamNames.filter((_, index) => settled[index].status === 'rejected');
-  if (streamNames.length > 0 && failedStreamNames.length === streamNames.length) {
-    throw (settled[0] as PromiseRejectedResult).reason;
-  }
-
-  return {
-    features: settled.flatMap((result) => (result.status === 'fulfilled' ? result.value : [])),
-    failedStreamNames,
-  };
-};
+export const collectStreamFeatures = (settled: Array<PromiseSettledResult<Feature[]>>): Feature[] =>
+  settled.flatMap((result) => (result.status === 'fulfilled' ? result.value : []));
 
 export interface StreamFeaturesResult {
   features: Feature[];
-  /**
-   * Streams that could not be reached. Their services are missing from `features`, so a caller
-   * rendering an impact list has to say so rather than present a short list as a complete one.
-   */
-  failedStreamNames: string[];
   /** True only until the first load settles; a refetch keeps the previous features on screen. */
   isInitialLoading: boolean;
-  /** True for any request in flight, including a retry after an error. */
-  isFetching: boolean;
-  /** True only when every stream failed; a partial failure reports `failedStreamNames` instead. */
-  isError: boolean;
-  refetch: () => void;
 }
 
 const fetchStreamFeatures = async (
@@ -79,7 +51,7 @@ const fetchStreamFeatures = async (
 
 /**
  * Loads every stream's knowledge indicators under a single cache entry so the returned array keeps
- * a stable identity across renders — callers memoize impacted entities on it, and a fresh array
+ * a stable identity across renders — callers memoize impacted services on it, and a fresh array
  * each render would retrigger their effects.
  */
 export const useFetchStreamFeatures = (streamNames: string[]): StreamFeaturesResult => {
@@ -88,15 +60,11 @@ export const useFetchStreamFeatures = (streamNames: string[]): StreamFeaturesRes
   } = useKibana().services;
   const uniqueStreamNames = [...new Set(streamNames)].sort();
 
-  const { data, isInitialLoading, isFetching, isError, refetch } = useQuery<
-    StreamFeaturesQueryData,
-    Error
-  >({
+  const { data, isInitialLoading } = useQuery<Feature[], Error>({
     queryKey: ['nightshift.streamFeatures', uniqueStreamNames],
     enabled: uniqueStreamNames.length > 0,
     queryFn: async ({ signal }) =>
       collectStreamFeatures(
-        uniqueStreamNames,
         await Promise.allSettled(
           uniqueStreamNames.map((streamName) =>
             fetchStreamFeatures(significantEventsRepositoryClient, streamName, signal)
@@ -106,11 +74,7 @@ export const useFetchStreamFeatures = (streamNames: string[]): StreamFeaturesRes
   });
 
   return {
-    features: data?.features ?? NO_FEATURES,
-    failedStreamNames: data?.failedStreamNames ?? NO_STREAM_NAMES,
+    features: data ?? NO_FEATURES,
     isInitialLoading,
-    isFetching,
-    isError,
-    refetch,
   };
 };

--- a/x-pack/solutions/observability/plugins/nightshift/public/hooks/use_impacted_services.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/hooks/use_impacted_services.ts
@@ -16,23 +16,18 @@ import { useFetchStreamFeatures } from './use_fetch_stream_features';
 
 export interface ImpactedServicesResult {
   services: ImpactedService[];
-  /** Streams that could not be reached, so `services` is known to be incomplete. */
-  failedStreamNames: string[];
   isInitialLoading: boolean;
-  isFetching: boolean;
-  isError: boolean;
-  refetch: () => void;
 }
 
 /**
  * Resolves one event's impacted services, loading the knowledge indicators of the streams its
- * blast radius points at. Impacted services are event-level: every detection of an event shares
- * this list.
+ * blast radius and causal features point at. Impacted services are event-level: every detection of
+ * an event shares this list.
  */
 export const useImpactedServices = (event: SignificantEvent): ImpactedServicesResult => {
   const streamNames = useMemo(() => getImpactedServiceStreamNames([event]), [event]);
-  const { features, ...queryState } = useFetchStreamFeatures(streamNames);
+  const { features, isInitialLoading } = useFetchStreamFeatures(streamNames);
   const services = useMemo(() => getImpactedServices(event, features), [event, features]);
 
-  return { services, ...queryState };
+  return { services, isInitialLoading };
 };

--- a/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_chips.test.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_chips.test.ts
@@ -6,7 +6,6 @@
  */
 
 import type { Feature, SignificantEvent } from '@kbn/significant-events-schema';
-import { getBlastRadiusEbtDetail } from '../common/ebt_constants';
 import {
   buildBlastRadiusChips,
   eventHasBlastRadiusChip,
@@ -26,13 +25,13 @@ const mockEvent = (overrides: Partial<SignificantEvent> = {}): SignificantEvent 
   ...overrides,
 });
 
-const serviceFeature = (uuid: string, streamName = 'logs.checkout'): Feature => ({
+const serviceFeature = (uuid: string, title: string, streamName = 'logs.checkout'): Feature => ({
   uuid,
   id: uuid,
   stream_name: streamName,
   type: 'entity',
   subtype: 'service',
-  title: uuid,
+  title,
   description: '',
   properties: {},
   confidence: 90,
@@ -45,19 +44,39 @@ const entityEntry = (featureId: string, name: string, streamName = 'logs.checkou
   stream_name: streamName,
 });
 
-describe('blast_radius_chips', () => {
-  it('reduces customer-derived chip keys to privacy-safe EBT categories', () => {
-    expect(getBlastRadiusEbtDetail('entity:feat-1:checkout-api')).toBe('entity');
-    expect(getBlastRadiusEbtDetail('logs.customer-stream')).toBe('stream');
-  });
+const causalFeature = (featureId: string, name: string, streamName = 'logs.checkout') => ({
+  feature_id: featureId,
+  name,
+  stream_name: streamName,
+});
 
+describe('blast_radius_chips', () => {
   it('builds chips from the impacted services of need-action events', () => {
     const chips = buildBlastRadiusChips(
       [mockEvent({ blast_radius: [entityEntry('feat-1', 'checkout-api')] })],
-      { features: [serviceFeature('feat-1')] }
+      { features: [serviceFeature('feat-1', 'checkout-api')] }
     );
 
-    expect(chips).toEqual([{ count: 1, key: 'entity:feat-1:checkout-api', name: 'checkout-api' }]);
+    expect(chips).toEqual([{ count: 1, key: 'checkout-api', name: 'checkout-api' }]);
+  });
+
+  it('builds chips from causal features as well as blast radius entities', () => {
+    const chips = buildBlastRadiusChips(
+      [
+        mockEvent({
+          blast_radius: [entityEntry('feat-1', 'checkout-api')],
+          causal_features: [causalFeature('feat-2', 'payments-api')],
+        }),
+      ],
+      {
+        features: [
+          serviceFeature('feat-1', 'checkout-api'),
+          serviceFeature('feat-2', 'payments-api'),
+        ],
+      }
+    );
+
+    expect(chips.map(({ name }) => name)).toEqual(['checkout-api', 'payments-api']);
   });
 
   it('renders no chips when nothing resolves to a service', () => {
@@ -70,7 +89,10 @@ describe('blast_radius_chips', () => {
   });
 
   it('sorts chips by event count descending, then by name', () => {
-    const features = [serviceFeature('feat-popular'), serviceFeature('feat-rare')];
+    const features = [
+      serviceFeature('feat-popular', 'popular'),
+      serviceFeature('feat-rare', 'rare'),
+    ];
     const chips = buildBlastRadiusChips(
       [
         mockEvent({ event_id: '1', blast_radius: [entityEntry('feat-rare', 'rare')] }),
@@ -97,22 +119,34 @@ describe('blast_radius_chips', () => {
           ],
         }),
       ],
-      { features: [serviceFeature('feat-1')] }
+      { features: [serviceFeature('feat-1', 'checkout-api')] }
     );
 
-    expect(chips).toEqual([{ count: 1, key: 'entity:feat-1:checkout-api', name: 'checkout-api' }]);
+    expect(chips).toEqual([{ count: 1, key: 'checkout-api', name: 'checkout-api' }]);
+  });
+
+  it('counts an event once when both of its arrays name the same service', () => {
+    const chips = buildBlastRadiusChips(
+      [
+        mockEvent({
+          blast_radius: [entityEntry('feat-1', 'checkout-api')],
+          causal_features: [causalFeature('feat-1', 'checkout-api')],
+        }),
+      ],
+      { features: [serviceFeature('feat-1', 'checkout-api')] }
+    );
+
+    expect(chips).toEqual([{ count: 1, key: 'checkout-api', name: 'checkout-api' }]);
   });
 
   it('filters events by chip key', () => {
-    const features = [serviceFeature('f1')];
+    const features = [serviceFeature('f1', 'checkout-api')];
     const events = [
       mockEvent({ event_id: '1', blast_radius: [entityEntry('f1', 'checkout-api')] }),
       mockEvent({ event_id: '2', stream_names: ['other-service'] }),
     ];
 
-    expect(
-      filterEventsByBlastRadiusChip(events, 'entity:f1:checkout-api', { features })
-    ).toHaveLength(1);
+    expect(filterEventsByBlastRadiusChip(events, 'checkout-api', { features })).toHaveLength(1);
     expect(eventHasBlastRadiusChip(events[1], 'other-service', { features })).toBe(false);
   });
 });

--- a/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_chips.ts
+++ b/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_chips.ts
@@ -15,7 +15,7 @@ export interface BlastRadiusChip {
 }
 
 interface BlastRadiusChipOptions {
-  /** Knowledge indicators used to resolve each event's blast radius into impacted services. */
+  /** Knowledge indicators used to resolve each event's feature references into impacted services. */
   features: Feature[];
 }
 
@@ -26,8 +26,9 @@ export const eventHasBlastRadiusChip = (
 ): boolean => getImpactedServices(event, features).some(({ key }) => key === chipKey);
 
 /**
- * Landing blast-radius pills. Each pill is one impacted service — the subset of `blast_radius[]`
- * that resolves to a `service` knowledge indicator — counted across the events it appears in.
+ * Landing blast-radius pills. Each pill is one impacted service — the `blast_radius[]` entity rows
+ * and `causal_features[]` that resolve to a `service` knowledge indicator, deduplicated by label —
+ * counted across the events it appears in.
  */
 export const buildBlastRadiusChips = (
   events: SignificantEvent[],

--- a/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_entities.test.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_entities.test.tsx
@@ -73,31 +73,4 @@ describe('BlastRadiusEntities', () => {
 
     expect(screen.getByTestId('blast-radius-loading')).toBeInTheDocument();
   });
-
-  it('offers a retry instead of an empty panel when the lookup failed', () => {
-    const onRetry = jest.fn();
-    renderState({ isError: true, onRetry });
-
-    expect(screen.getByText('Unable to load impacted services')).toBeInTheDocument();
-    expect(screen.queryByTestId('blast-radius-failed-streams')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('blast-radius-retry'));
-    expect(onRetry).toHaveBeenCalled();
-  });
-
-  it('names the unreachable streams while keeping the chips that did resolve', () => {
-    const onRetry = jest.fn();
-    renderState({
-      entities: buildEntities(2),
-      failedStreamNames: ['logs.payments', 'logs.checkout'],
-      onRetry,
-    });
-
-    expect(screen.getByText('Some impacted services could not be loaded')).toBeInTheDocument();
-    expect(screen.getByTestId('blast-radius-failed-streams')).toHaveTextContent(
-      'No response from logs.payments, logs.checkout.'
-    );
-    expect(screen.getAllByTestId('blast-radius-chip')).toHaveLength(2);
-    fireEvent.click(screen.getByTestId('blast-radius-retry'));
-    expect(onRetry).toHaveBeenCalled();
-  });
 });

--- a/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_entities.tsx
+++ b/x-pack/solutions/observability/plugins/nightshift/public/landing/blast_radius_entities.tsx
@@ -10,7 +10,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   EuiBadge,
   EuiButtonEmpty,
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
@@ -21,18 +20,13 @@ import {
 } from '@elastic/eui';
 import { getEbtProps } from '@kbn/ebt-click';
 import { i18n } from '@kbn/i18n';
-import {
-  getBlastRadiusEbtDetail,
-  NIGHTSHIFT_EBT_ACTIONS,
-  NIGHTSHIFT_EBT_ELEMENTS,
-} from '../common/ebt_constants';
+import { NIGHTSHIFT_EBT_ACTIONS, NIGHTSHIFT_EBT_ELEMENTS } from '../common/ebt_constants';
 import { nightshiftInteractiveSurfaceTransition } from '../common/transition';
 import type { BlastRadiusChip } from './blast_radius_chips';
 
 export const MAX_VISIBLE_BLAST_RADIUS_ENTITIES = 10;
 
 interface BlastRadiusEntityButtonProps {
-  chipKey: string;
   count: number;
   isSelected: boolean;
   name: string;
@@ -40,7 +34,6 @@ interface BlastRadiusEntityButtonProps {
 }
 
 function BlastRadiusEntityButton({
-  chipKey,
   count,
   isSelected,
   name,
@@ -61,7 +54,6 @@ function BlastRadiusEntityButton({
           ? NIGHTSHIFT_EBT_ACTIONS.CLEAR_BLAST_RADIUS_FILTER
           : NIGHTSHIFT_EBT_ACTIONS.FILTER_BY_BLAST_RADIUS,
         element: NIGHTSHIFT_EBT_ELEMENTS.BLAST_RADIUS,
-        detail: getBlastRadiusEbtDetail(chipKey),
       })}
       css={css`
         align-items: center;
@@ -128,24 +120,14 @@ function BlastRadiusEntityButton({
 
 export interface BlastRadiusEntitiesProps {
   entities: BlastRadiusChip[];
-  /** Streams that could not be reached, so `entities` is known to be incomplete. */
-  failedStreamNames?: string[];
-  /** Every stream failed, so nothing could be resolved at all. */
-  isError?: boolean;
   isLoading?: boolean;
-  onRetry?: () => void;
   onSelect: (chipKey: string) => void;
   selectedEntityKey?: string;
 }
 
-const NO_STREAM_NAMES: string[] = [];
-
 export function BlastRadiusEntities({
   entities,
-  failedStreamNames = NO_STREAM_NAMES,
-  isError = false,
   isLoading = false,
-  onRetry,
   onSelect,
   selectedEntityKey,
 }: BlastRadiusEntitiesProps): React.ReactElement | null {
@@ -178,10 +160,8 @@ export function BlastRadiusEntities({
   }, [entities, expanded, hasOverflow, selectedEntityKey]);
   const hiddenCount = Math.max(entities.length - visibleEntities.length, 0);
 
-  const hasFailures = isError || failedStreamNames.length > 0;
-
-  // A failed lookup must not read as "nothing was impacted", so the panel stays up to explain it.
-  if (entities.length === 0 && !isLoading && !hasFailures) {
+  // Unresolvable services fail silently, so there is nothing to show and nothing to explain.
+  if (entities.length === 0 && !isLoading) {
     return null;
   }
 
@@ -219,48 +199,6 @@ export function BlastRadiusEntities({
           </EuiFlexGroup>
         )}
 
-        {hasFailures && !isLoading && (
-          <EuiCallOut
-            announceOnMount
-            color="warning"
-            data-test-subj="blast-radius-error"
-            iconType="warning"
-            size="s"
-            title={
-              isError
-                ? i18n.translate('xpack.nightshift.blastRadiusErrorTitle', {
-                    defaultMessage: 'Unable to load impacted services',
-                  })
-                : i18n.translate('xpack.nightshift.blastRadiusPartialErrorTitle', {
-                    defaultMessage: 'Some impacted services could not be loaded',
-                  })
-            }
-            text={
-              isError ? undefined : (
-                <p data-test-subj="blast-radius-failed-streams">
-                  {i18n.translate('xpack.nightshift.blastRadiusPartialErrorDescription', {
-                    defaultMessage: 'No response from {streamNames}.',
-                    values: { streamNames: failedStreamNames.join(', ') },
-                  })}
-                </p>
-              )
-            }
-          >
-            <EuiButtonEmpty
-              color="warning"
-              data-test-subj="blast-radius-retry"
-              flush="left"
-              iconType="refresh"
-              onClick={() => onRetry?.()}
-              size="s"
-            >
-              {i18n.translate('xpack.nightshift.blastRadiusRetryButtonText', {
-                defaultMessage: 'Retry',
-              })}
-            </EuiButtonEmpty>
-          </EuiCallOut>
-        )}
-
         {!isLoading && entities.length > 0 && (
           <EuiFlexGroup
             alignItems="center"
@@ -274,7 +212,6 @@ export function BlastRadiusEntities({
             {visibleEntities.map(({ count, key, name }) => (
               <EuiFlexItem grow={false} key={key}>
                 <BlastRadiusEntityButton
-                  chipKey={key}
                   count={count}
                   isSelected={selectedEntityKey === key}
                   name={name}


### PR DESCRIPTION
## Summary

Follow-up to #283352, closing the remaining acceptance criteria on elastic/nightshift-program#957.

#283352 made every surface derive impacted services from `blast_radius[]` through one shared helper. Three things were still wrong after it: `causal_features[]` was ignored, so the list was incomplete; components survived when their knowledge indicator claimed `subtype: 'service'`; and an unreachable stream produced a callout nobody asked for. The same knowledge indicator could also chip twice — the reported `elasticsearch` / `elasticsearch` / `Elasticsearch` trio.

## What changed

- **Both arrays feed the list.** Impacted services are the union of `blast_radius[]` entity rows and `causal_features[]`. Neither alone is complete, and both routinely name the same service.
- **Services only, decided by the knowledge indicator.** A reference survives only when the indicator it resolves to is `type: 'entity'` **and** `subtype: 'service'`. On top of that, `blast_radius[]` rows must themselves be `type: 'entity'`, so `infrastructure` and `dependency` rows are dropped regardless. This reverses #283352's decision to keep `infrastructure` rows that resolved to a service subtype.
- **One chip per service.** Entries collapse on the case-insensitive label, and the label is now the knowledge indicator's `title ?? id` rather than the per-event free-text `name` written by the agent.
- **Failures are silent.** Both callouts ("Some impacted services could not be loaded", "Unable to load impacted services") and both Retry buttons are gone, on the landing page and in the detection flyout. `Promise.allSettled` no longer rethrows, so `useQuery` has no error state to expose and `failedStreamNames` / `isError` / `isFetching` / `refetch` left the hook contracts. Loading spinners stay — loading is not failure.

Net effect is a deletion: 470 insertions against 547 deletions.

## Why the gate is on the indicator, not the row

`Feature.type` can be any of `INFERRED_FEATURE_TYPES` — `entity`, `infrastructure`, `technology`, `dependency`, `schema` — and any of those can still carry `subtype: 'service'`. Checking the subtype alone let a `dependency` indicator render as an impacted service.

It also matters because the two sources are not symmetric. `blast_radius[]` is a discriminated union, so its rows carry their own type. `causalFeatureSchema` is `{ feature_id, name, stream_name? }` — **no type field at all**. The indicator's type is therefore the only check that reaches both arrays; without it every causal reference bypassed the type filter entirely.

## Notable implementation details

- **Dedup is keyed on the label, not `uuid`.** `Feature.uuid` is `v5(hash([stream_name, id]))`, so the same service slug observed in two streams has two uuids — deduplicating on it would leave exactly the visibly duplicated chips this is meant to remove. Two genuinely distinct services sharing a label therefore collapse too, and the surviving entry carries the first resolved feature.
- **`getBlastRadiusEbtDetail` is gone.** It derived a privacy-safe EBT dimension from the chip key's `entity:` / `infrastructure:` / `dependency:` prefix. The key is now a customer-provided service name, so it cannot be sent as telemetry, and post-change every chip is a service so the dimension was constant. The chips still emit `data-ebt-action` and `data-ebt-element`.
- **The `?blastRadius=` value changed shape**, from `entity:<feature_id>:<name>` to the normalized label. `app.tsx` already guards with `blastRadius.some(({ key }) => key === selectedBlastRadiusKey)`, so a stale bookmarked link renders unfiltered rather than breaking.
- **A feature left with no label is dropped.** `Feature.title` and `Feature.id` are both unbounded below, and a blank pair would render a chip carrying a count and no name.

## Reviewer notes

- **`causal_features[].stream_name` is optional**, unlike every `blast_radius[]` row where it is required. A causal row that declares no stream resolves only if a sibling row already loaded that stream; otherwise it is dropped silently. Widening the search to `event.stream_names` would cost extra requests for a maybe, so it is deliberately not done.
- **Classification is now entirely the knowledge indicator's call.** On the demo seed, `coredns` and `ingress-controller` are both `type: 'entity'`, `subtype: 'service'`, so "CoreDNS" and "Ingress controller" show as impacted services. If that is wrong they should be reclassified in the indicator pipeline — `elasticsearch-data` already is `subtype: 'infrastructure'` and is correctly excluded. The UI has no better signal to filter on.
- **Two reviewer objections were raised and consciously accepted**, both against agreed requirements rather than the implementation: folding suspected causes into a list titled "Impacted services" mixes causes with symptoms, and dropping `infrastructure` rows hides a concrete component failure that maps to no service.
- Silent failure means an empty impact list is indistinguishable from a failed one, for operators and for us. Adding telemetry (rather than UI) for failed stream fetches was considered and deferred.

## Verification

- `node scripts/check.js --scope=local` — tsc clean, eslint 0 errors, 211 jest tests passing
- `node scripts/i18n_check` — clean; 8 message keys removed
- Scout UI suite for the plugin — 1 passed
- Storybook driven in a real browser: one `checkout-api` chip (not two, despite `causal_features[]` naming it twice with differing case), a causal-only `payment-gateway` chip, no `Elasticsearch data tier` chip; with nothing resolving, the event list renders and no panel, callout or retry appears.
- **Live dev cluster with `seed_nightshift.sh`** (15 events, 16 knowledge indicators across 9 streams): 13 chips, zero duplicate labels, no callout or retry. `elasticsearch-data` (`subtype: 'infrastructure'`) and `order-processors` (`subtype: 'consumer_group'`) are both correctly absent. Clicking a count-1 chip narrows 8 events to 1; the same filter deep-links from a cold load; a stale pre-change key falls back to unfiltered with nothing selected.
