### PR TITLE
Always require CI when PRs change runnable code under .github

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -38,6 +38,7 @@
       "always_require_ci_on_changed": [
         "^docs/developer/plugin-list.asciidoc$",
         "^\\.github/CODEOWNERS$",
+        "^\\.github/.*\\.(js|mjs|cjs|ts)$",
         "/plugins/([^/]+/)+readme\\.(md|asciidoc)$"
       ],
       "enable_trigger_checkbox": true,


### PR DESCRIPTION
PRs that only touch `.github/**` currently skip running the Kibana CI entirely. This is an issue for code changes in that folder: we risk into adding / updating code with linting / quick check errors that are only then caught on kibana-on-merge. This PR fixes this.

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->