### PR TITLE
[Agent Builder] Use CurrentUser admin state for agent access

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/access_control/authorization.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/access_control/authorization.test.ts
@@ -25,6 +25,7 @@ import {
 const owner: UserIdAndName = { id: 'owner-id', username: 'alice' };
 const ownerUser: CurrentUser = { id: 'owner-id', username: 'alice', isAdmin: false };
 const bob: CurrentUser = { id: 'bob-id', username: 'bob', isAdmin: false };
+const adminUser: CurrentUser = { id: 'admin-id', username: 'admin', isAdmin: true };
 
 describe('agent access-control authorization', () => {
   describe('isAgentOwner', () => {
@@ -75,8 +76,7 @@ describe('agent access-control authorization', () => {
         getEffectiveAgentRole({
           accessControl: { access_mode: AgentAccessControlMode.Private, entries: [] },
           owner,
-          currentUser: bob,
-          isAdmin: true,
+          currentUser: adminUser,
         })
       ).toBe('admin');
 
@@ -85,7 +85,6 @@ describe('agent access-control authorization', () => {
           accessControl: { access_mode: AgentAccessControlMode.Private, entries: [] },
           owner,
           currentUser: ownerUser,
-          isAdmin: false,
         })
       ).toBe('owner');
     });
@@ -99,7 +98,6 @@ describe('agent access-control authorization', () => {
           },
           owner,
           currentUser: bob,
-          isAdmin: false,
         })
       ).toBe(AgentAccessControlRole.Manager);
 
@@ -108,13 +106,12 @@ describe('agent access-control authorization', () => {
           accessControl: { access_mode: AgentAccessControlMode.Public, entries: [] },
           owner,
           currentUser: bob,
-          isAdmin: false,
         })
       ).toBe(AgentAccessControlRole.Editor);
     });
 
     it('treats a missing access control as public so built-in agents stay usable', () => {
-      const args = { accessControl: undefined, owner, currentUser: bob, isAdmin: false };
+      const args = { accessControl: undefined, owner, currentUser: bob };
 
       expect(getEffectiveAgentRole(args)).toBe(AgentAccessControlRole.Editor);
       expect(hasAgentReadAccess(args)).toBe(true);
@@ -131,7 +128,6 @@ describe('agent access-control authorization', () => {
         },
         owner,
         currentUser: bob,
-        isAdmin: false,
       };
 
       expect(hasAgentReadAccess(args)).toBe(true);
@@ -149,7 +145,6 @@ describe('agent access-control authorization', () => {
         },
         owner,
         currentUser: bob,
-        isAdmin: false,
       };
 
       expect(canDeleteAgent(args)).toBe(true);
@@ -166,7 +161,6 @@ describe('agent access-control authorization', () => {
           },
           owner,
           currentUser: bob,
-          isAdmin: false,
         })
       ).toBe(false);
     });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/access_control/authorization.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/access_control/authorization.ts
@@ -22,7 +22,6 @@ export interface AgentAuthzArgs {
   accessControl?: AgentAccessControl;
   owner?: UserIdAndName;
   currentUser?: CurrentUser | null;
-  isAdmin: boolean;
 }
 
 /**
@@ -110,9 +109,8 @@ export const getEffectiveAgentRole = ({
   accessControl,
   owner,
   currentUser,
-  isAdmin,
 }: AgentAuthzArgs): EffectiveAgentRole | undefined => {
-  if (isAdmin) {
+  if (currentUser?.isAdmin) {
     return 'admin';
   }
   if (isAgentOwner({ owner, currentUser })) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/access_control/document_access.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/access_control/document_access.test.ts
@@ -34,6 +34,7 @@ const baseSource: AgentProperties = {
 
 const ownerUser = { id: 'user-1', username: 'owner', isAdmin: false };
 const nonOwnerUser = { id: 'user-2', username: 'other', isAdmin: false };
+const adminUser = { id: 'admin-id', username: 'admin', isAdmin: true };
 const ownerByUsernameOnly = { username: 'owner', isAdmin: false };
 
 describe('normalizeAccessControl', () => {
@@ -57,7 +58,7 @@ describe('hasReadAccess', () => {
       access_control: { access_mode: AgentAccessControlMode.Private, entries: [] },
       created_by_name: 'owner',
     };
-    expect(hasReadAccess({ source, user: nonOwnerUser, isAdmin: true })).toBe(true);
+    expect(hasReadAccess({ source, user: adminUser })).toBe(true);
   });
 
   it('returns true for owner regardless of access-control mode', () => {
@@ -67,7 +68,7 @@ describe('hasReadAccess', () => {
       created_by_id: ownerUser.id,
       created_by_name: 'owner',
     };
-    expect(hasReadAccess({ source, user: ownerUser, isAdmin: false })).toBe(true);
+    expect(hasReadAccess({ source, user: ownerUser })).toBe(true);
   });
 
   it('returns true for legacy owners that only stored created_by_name', () => {
@@ -76,8 +77,8 @@ describe('hasReadAccess', () => {
       access_control: { access_mode: AgentAccessControlMode.Private, entries: [] },
       created_by_name: 'owner',
     };
-    expect(hasReadAccess({ source, user: ownerByUsernameOnly, isAdmin: false })).toBe(true);
-    expect(hasReadAccess({ source, user: ownerUser, isAdmin: false })).toBe(true);
+    expect(hasReadAccess({ source, user: ownerByUsernameOnly })).toBe(true);
+    expect(hasReadAccess({ source, user: ownerUser })).toBe(true);
   });
 
   it('returns false for same username when the document stored a different created_by_id', () => {
@@ -87,12 +88,12 @@ describe('hasReadAccess', () => {
       created_by_id: 'other-realm-id',
       created_by_name: 'owner',
     };
-    expect(hasReadAccess({ source, user: ownerUser, isAdmin: false })).toBe(false);
+    expect(hasReadAccess({ source, user: ownerUser })).toBe(false);
   });
 
   it('returns true for non-owner when access-control mode is undefined (legacy agent treated as public)', () => {
     const source = { ...baseSource, created_by_name: 'owner' };
-    expect(hasReadAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(true);
+    expect(hasReadAccess({ source, user: nonOwnerUser })).toBe(true);
   });
 
   it('returns false for non-owner when legacy visibility is private', () => {
@@ -101,7 +102,7 @@ describe('hasReadAccess', () => {
       visibility: AgentAccessControlMode.Private,
       created_by_name: 'owner',
     };
-    expect(hasReadAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(false);
+    expect(hasReadAccess({ source, user: nonOwnerUser })).toBe(false);
   });
 
   it('returns true for a user granted access through legacy acl entries', () => {
@@ -119,7 +120,7 @@ describe('hasReadAccess', () => {
       },
       created_by_name: 'owner',
     };
-    expect(hasReadAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(true);
+    expect(hasReadAccess({ source, user: nonOwnerUser })).toBe(true);
   });
 
   it('returns true for non-owner when access-control mode is shared', () => {
@@ -128,7 +129,7 @@ describe('hasReadAccess', () => {
       access_control: { access_mode: AgentAccessControlMode.Shared, entries: [] },
       created_by_name: 'owner',
     };
-    expect(hasReadAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(true);
+    expect(hasReadAccess({ source, user: nonOwnerUser })).toBe(true);
   });
 
   it('returns false for non-owner when access-control mode is private', () => {
@@ -137,7 +138,7 @@ describe('hasReadAccess', () => {
       access_control: { access_mode: AgentAccessControlMode.Private, entries: [] },
       created_by_name: 'owner',
     };
-    expect(hasReadAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(false);
+    expect(hasReadAccess({ source, user: nonOwnerUser })).toBe(false);
   });
 });
 
@@ -148,7 +149,7 @@ describe('hasWriteAccess', () => {
       access_control: { access_mode: AgentAccessControlMode.Private, entries: [] },
       created_by_name: 'owner',
     };
-    expect(hasWriteAccess({ source, user: nonOwnerUser, isAdmin: true })).toBe(true);
+    expect(hasWriteAccess({ source, user: adminUser })).toBe(true);
   });
 
   it('returns true for owner regardless of access-control mode', () => {
@@ -158,12 +159,12 @@ describe('hasWriteAccess', () => {
       created_by_id: ownerUser.id,
       created_by_name: 'owner',
     };
-    expect(hasWriteAccess({ source, user: ownerUser, isAdmin: false })).toBe(true);
+    expect(hasWriteAccess({ source, user: ownerUser })).toBe(true);
   });
 
   it('returns true for non-owner when access-control mode is undefined (legacy agent treated as public)', () => {
     const source = { ...baseSource, created_by_name: 'owner' };
-    expect(hasWriteAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(true);
+    expect(hasWriteAccess({ source, user: nonOwnerUser })).toBe(true);
   });
 
   it('returns false for non-owner when legacy visibility is shared', () => {
@@ -172,7 +173,7 @@ describe('hasWriteAccess', () => {
       visibility: AgentAccessControlMode.Shared,
       created_by_name: 'owner',
     };
-    expect(hasWriteAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(false);
+    expect(hasWriteAccess({ source, user: nonOwnerUser })).toBe(false);
   });
 
   it('returns true for a user granted edit access through legacy acl entries', () => {
@@ -190,7 +191,7 @@ describe('hasWriteAccess', () => {
       },
       created_by_name: 'owner',
     };
-    expect(hasWriteAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(true);
+    expect(hasWriteAccess({ source, user: nonOwnerUser })).toBe(true);
   });
 
   it('returns false for non-owner when access-control mode is shared', () => {
@@ -199,7 +200,7 @@ describe('hasWriteAccess', () => {
       access_control: { access_mode: AgentAccessControlMode.Shared, entries: [] },
       created_by_name: 'owner',
     };
-    expect(hasWriteAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(false);
+    expect(hasWriteAccess({ source, user: nonOwnerUser })).toBe(false);
   });
 
   it('returns false for non-owner when access-control mode is private', () => {
@@ -208,7 +209,7 @@ describe('hasWriteAccess', () => {
       access_control: { access_mode: AgentAccessControlMode.Private, entries: [] },
       created_by_name: 'owner',
     };
-    expect(hasWriteAccess({ source, user: nonOwnerUser, isAdmin: false })).toBe(false);
+    expect(hasWriteAccess({ source, user: nonOwnerUser })).toBe(false);
   });
 });
 
@@ -229,7 +230,7 @@ describe('getAgentPermissions', () => {
       created_by_name: 'owner',
     };
 
-    expect(getAgentPermissions({ source, user: nonOwnerUser, isAdmin: false })).toEqual({
+    expect(getAgentPermissions({ source, user: nonOwnerUser })).toEqual({
       update_agent: true,
       update_access_control: false,
     });
@@ -243,7 +244,7 @@ describe('getAgentPermissions', () => {
       created_by_name: ownerUser.username,
     };
 
-    expect(getAgentPermissions({ source, user: ownerUser, isAdmin: false })).toEqual({
+    expect(getAgentPermissions({ source, user: ownerUser })).toEqual({
       update_agent: true,
       update_access_control: true,
     });
@@ -258,7 +259,7 @@ describe('getAgentPermissions', () => {
       created_by_name: ownerUser.username,
     };
 
-    expect(getAgentPermissions({ source, user: ownerUser, isAdmin: false })).toEqual({
+    expect(getAgentPermissions({ source, user: ownerUser })).toEqual({
       update_agent: true,
       update_access_control: false,
     });
@@ -277,7 +278,6 @@ describe('validateAccessControlUpdateAccess', () => {
         source,
         update: { name: 'New Name' },
         user: nonOwnerUser,
-        isAdmin: false,
       })
     ).toBe(true);
   });
@@ -293,7 +293,6 @@ describe('validateAccessControlUpdateAccess', () => {
         source,
         update: { description: 'Updated' },
         user: nonOwnerUser,
-        isAdmin: false,
       })
     ).toBe(true);
   });
@@ -309,7 +308,6 @@ describe('validateAccessControlUpdateAccess', () => {
         source,
         update: { access_control: { access_mode: AgentAccessControlMode.Public } },
         user: nonOwnerUser,
-        isAdmin: false,
       })
     ).toBe(true);
   });
@@ -325,7 +323,6 @@ describe('validateAccessControlUpdateAccess', () => {
         source,
         update: { access_control: { access_mode: AgentAccessControlMode.Private } },
         user: nonOwnerUser,
-        isAdmin: false,
       })
     ).toBe(true);
   });
@@ -342,7 +339,6 @@ describe('validateAccessControlUpdateAccess', () => {
         source,
         update: { access_control: { access_mode: AgentAccessControlMode.Private } },
         user: ownerUser,
-        isAdmin: false,
       })
     ).toBe(true);
   });
@@ -367,7 +363,6 @@ describe('validateAccessControlUpdateAccess', () => {
         source,
         update: { access_control: { access_mode: AgentAccessControlMode.Shared } },
         user: nonOwnerUser,
-        isAdmin: false,
       })
     ).toBe(true);
   });
@@ -382,8 +377,7 @@ describe('validateAccessControlUpdateAccess', () => {
       validateAccessControlUpdateAccess({
         source,
         update: { access_control: { access_mode: AgentAccessControlMode.Private } },
-        user: nonOwnerUser,
-        isAdmin: true,
+        user: adminUser,
       })
     ).toBe(true);
   });
@@ -399,7 +393,6 @@ describe('validateAccessControlUpdateAccess', () => {
         source,
         update: { access_control: { access_mode: AgentAccessControlMode.Private } },
         user: nonOwnerUser,
-        isAdmin: false,
       })
     ).toBe(false);
   });
@@ -415,7 +408,6 @@ describe('validateAccessControlUpdateAccess', () => {
         source,
         update: { access_control: { access_mode: AgentAccessControlMode.Shared } },
         user: nonOwnerUser,
-        isAdmin: false,
       })
     ).toBe(false);
   });
@@ -433,7 +425,6 @@ describe('validateAccessControlUpdateAccess', () => {
         source,
         update: { access_control: { access_mode: AgentAccessControlMode.Private } },
         user: ownerUser,
-        isAdmin: false,
       })
     ).toBe(false);
   });
@@ -449,8 +440,7 @@ describe('validateAccessControlUpdateAccess', () => {
       validateAccessControlUpdateAccess({
         source,
         update: { access_control: { access_mode: AgentAccessControlMode.Shared } },
-        user: nonOwnerUser,
-        isAdmin: true,
+        user: adminUser,
       })
     ).toBe(false);
   });
@@ -476,7 +466,6 @@ describe('redactAccessControlForCaller', () => {
       definition,
       source: baseSource,
       user: nonOwnerUser,
-      isAdmin: false,
     });
     expect(result).toBe(definition);
   });
@@ -493,7 +482,6 @@ describe('redactAccessControlForCaller', () => {
         access_control: { access_mode: AgentAccessControlMode.Private, entries: [] },
       },
       user: nonOwnerUser,
-      isAdmin: false,
     });
     expect(result).toBe(definition);
   });
@@ -510,7 +498,6 @@ describe('redactAccessControlForCaller', () => {
       definition,
       source: privateAgentWithAcl,
       user: ownerUser,
-      isAdmin: false,
     });
     expect(result.access_control?.entries).toEqual([aliceEntry, bobEntry]);
   });
@@ -526,8 +513,7 @@ describe('redactAccessControlForCaller', () => {
     const result = redactAccessControlForCaller({
       definition,
       source: privateAgentWithAcl,
-      user: nonOwnerUser,
-      isAdmin: true,
+      user: adminUser,
     });
     expect(result.access_control?.entries).toEqual([aliceEntry, bobEntry]);
   });
@@ -546,7 +532,6 @@ describe('redactAccessControlForCaller', () => {
       definition,
       source: privateAgentWithAcl,
       user: bobUser,
-      isAdmin: false,
     });
     expect(result.access_control?.entries).toEqual([bobEntry]);
     // Shallow-copy: the original definition is untouched.
@@ -567,7 +552,6 @@ describe('redactAccessControlForCaller', () => {
       definition,
       source: privateAgentWithAcl,
       user: aliceUser,
-      isAdmin: false,
     });
     expect(result.access_control?.entries).toEqual([aliceEntry]);
   });
@@ -595,7 +579,6 @@ describe('redactAccessControlForCaller', () => {
         created_by_name: 'owner',
       },
       user: aliceUser,
-      isAdmin: false,
     });
     expect(result.access_control?.entries).toEqual([aliceManagerEntry, bobEntry]);
   });
@@ -616,7 +599,6 @@ describe('redactAccessControlForCaller', () => {
         access_control: { access_mode: AgentAccessControlMode.Private, entries: [aliceEntry] },
       },
       user: ownerUser,
-      isAdmin: false,
     });
     expect(result.access_control?.entries).toEqual([]);
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/access_control/document_access.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/access_control/document_access.ts
@@ -48,95 +48,78 @@ const sourceToOwner = (source: AgentProperties): UserIdAndName | undefined =>
 export const hasReadAccess = ({
   source,
   user,
-  isAdmin,
 }: {
   source: AgentProperties;
   user: CurrentUser;
-  isAdmin: boolean;
 }): boolean =>
   hasAgentReadAccess({
     accessControl: normalizeAccessControl(source),
     owner: sourceToOwner(source),
     currentUser: user,
-    isAdmin,
   });
 
 export const hasUseAccess = ({
   source,
   user,
-  isAdmin,
 }: {
   source: AgentProperties;
   user: CurrentUser;
-  isAdmin: boolean;
 }): boolean =>
   hasAgentUseAccess({
     accessControl: normalizeAccessControl(source),
     owner: sourceToOwner(source),
     currentUser: user,
-    isAdmin,
   });
 
 export const hasWriteAccess = ({
   source,
   user,
-  isAdmin,
 }: {
   source: AgentProperties;
   user: CurrentUser;
-  isAdmin: boolean;
 }): boolean =>
   hasAgentWriteAccess({
     accessControl: normalizeAccessControl(source),
     owner: sourceToOwner(source),
     currentUser: user,
-    isAdmin,
   });
 
 export const hasDeleteAccess = ({
   source,
   user,
-  isAdmin,
 }: {
   source: AgentProperties;
   user: CurrentUser;
-  isAdmin: boolean;
 }): boolean =>
   canDeleteAgent({
     accessControl: normalizeAccessControl(source),
     owner: sourceToOwner(source),
     currentUser: user,
-    isAdmin,
   });
 
 export const hasManageAccessControlAccess = ({
   source,
   user,
-  isAdmin,
 }: {
   source: AgentProperties;
   user: CurrentUser;
-  isAdmin: boolean;
 }): boolean =>
   canChangeAgentAccessControl({
     agentId: source.id,
     accessControl: normalizeAccessControl(source),
     owner: sourceToOwner(source),
     currentUser: user,
-    isAdmin,
   });
 
 export const getAgentPermissions = ({
   source,
   user,
-  isAdmin,
 }: {
   source: AgentProperties;
   user: CurrentUser;
-  isAdmin: boolean;
 }): AgentPermissions => ({
-  update_agent: hasWriteAccess({ source, user, isAdmin }),
-  update_access_control: hasManageAccessControlAccess({ source, user, isAdmin }),
+  update_agent: hasWriteAccess({ source, user }),
+  update_access_control: hasManageAccessControlAccess({ source, user }),
 });
 
 /**
@@ -148,17 +131,15 @@ export const redactAccessControlForCaller = <T extends { access_control?: AgentA
   definition,
   source,
   user,
-  isAdmin,
 }: {
   definition: T;
   source: AgentProperties;
   user: CurrentUser;
-  isAdmin: boolean;
 }): T => {
   if (!definition.access_control || definition.access_control.entries.length === 0) {
     return definition;
   }
-  const canManage = hasManageAccessControlAccess({ source, user, isAdmin });
+  const canManage = hasManageAccessControlAccess({ source, user });
   if (canManage) {
     return definition;
   }
@@ -177,12 +158,10 @@ export const validateAccessControlUpdateAccess = ({
   source,
   update,
   user,
-  isAdmin,
 }: {
   source: AgentProperties;
   update: AgentUpdateRequest;
   user: CurrentUser;
-  isAdmin: boolean;
 }): boolean => {
   const currentAccessControl = normalizeAccessControl(source);
   const currentAccessMode = currentAccessControl.access_mode;
@@ -196,7 +175,6 @@ export const validateAccessControlUpdateAccess = ({
       accessControl: currentAccessControl,
       owner: sourceToOwner(source),
       currentUser: user,
-      isAdmin,
     })
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.test.ts
@@ -8,7 +8,7 @@
 import { loggerMock } from '@kbn/logging-mocks';
 import { isAgentNotFoundError } from '@kbn/agent-builder-common';
 import { buildReadAccessFilter } from '../../access_control';
-import { getUserFromRequest, isAdminFromRequest } from '../../../utils';
+import { getUserFromRequest } from '../../../utils';
 import { createSpaceDslFilter } from '../../../../utils/spaces';
 import { createClient, createSystemClient, type AgentClient } from './client';
 
@@ -37,11 +37,9 @@ jest.mock('./storage', () => ({
 
 jest.mock('../../../utils', () => ({
   getUserFromRequest: jest.fn(),
-  isAdminFromRequest: jest.fn(),
 }));
 
 const getUserFromRequestMock = getUserFromRequest as jest.MockedFunction<typeof getUserFromRequest>;
-const isAdminFromRequestMock = isAdminFromRequest as jest.MockedFunction<typeof isAdminFromRequest>;
 
 describe('AgentClient', () => {
   let client: AgentClient;
@@ -51,7 +49,6 @@ describe('AgentClient', () => {
     logger = loggerMock.create();
     jest.clearAllMocks();
     getUserFromRequestMock.mockResolvedValue(mockUser);
-    isAdminFromRequestMock.mockResolvedValue(false);
 
     client = await createClient({
       space: testSpace,
@@ -107,7 +104,7 @@ describe('AgentClient', () => {
     });
 
     it('omits the read access filter for admin users', async () => {
-      isAdminFromRequestMock.mockResolvedValue(true);
+      getUserFromRequestMock.mockResolvedValue({ ...mockUser, isAdmin: true });
       client = await createClient({
         space: testSpace,
         logger,
@@ -147,7 +144,7 @@ describe('AgentClient', () => {
     };
 
     const buildClient = (isAdmin: boolean): Promise<AgentClient> => {
-      isAdminFromRequestMock.mockResolvedValue(isAdmin);
+      getUserFromRequestMock.mockResolvedValue({ ...mockUser, isAdmin });
       return createClient({
         space: testSpace,
         logger,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/client.ts
@@ -24,7 +24,7 @@ import {
   type ToolSelection,
 } from '@kbn/agent-builder-common';
 import { SYSTEM_USER_ID } from '@kbn/agent-builder-common/constants';
-import { isAdminFromRequest, getUserFromRequest } from '../../../utils';
+import { getUserFromRequest } from '../../../utils';
 import type {
   AgentAccessControlUpdateRequest,
   AgentCreateRequest,
@@ -49,13 +49,13 @@ import {
   type Document,
   fromEs,
   updateRequestToEs,
+  withPermissions,
 } from './converters';
 import { validateToolSelection } from './utils/tools';
 import { runSkillRefCleanup } from '../skill_reference_cleanup';
 import { runToolRefCleanup } from '../tool_reference_cleanup';
 import { runPluginRefCleanup } from '../plugin_reference_cleanup';
 import {
-  getAgentPermissions,
   hasDeleteAccess,
   hasManageAccessControlAccess,
   hasReadAccess,
@@ -241,16 +241,12 @@ export const createClient = async ({
     security,
     esClient: scopedClient.asCurrentUser,
   });
-  const isAdmin = await isAdminFromRequest({
-    esClient: scopedClient.asCurrentUser,
-  });
   const esClient = scopedClient.asInternalUser;
   const storage = createStorage({ logger, esClient });
 
   return new AgentClientImpl({
     storage,
     user,
-    isAdmin,
     request,
     space,
     toolsService,
@@ -280,14 +276,12 @@ class AgentClientImpl implements AgentClient {
   private readonly storage: AgentProfileStorage;
   private readonly toolsService: ToolsServiceStart;
   private readonly user: CurrentUser;
-  private readonly isAdmin: boolean;
   private readonly logger: Logger;
 
   constructor({
     storage,
     toolsService,
     user,
-    isAdmin,
     request,
     space,
     logger,
@@ -295,7 +289,6 @@ class AgentClientImpl implements AgentClient {
     storage: AgentProfileStorage;
     toolsService: ToolsServiceStart;
     user: CurrentUser;
-    isAdmin: boolean;
     request: KibanaRequest;
     space: string;
     logger: Logger;
@@ -304,7 +297,6 @@ class AgentClientImpl implements AgentClient {
     this.toolsService = toolsService;
     this.request = request;
     this.user = user;
-    this.isAdmin = isAdmin;
     this.space = space;
     this.logger = logger;
   }
@@ -373,7 +365,7 @@ class AgentClientImpl implements AgentClient {
   async get(agentId: string): Promise<PersistedAgentDefinitionWithPermissions> {
     const document = await this.getDocumentWithAccess({ agentId, access: 'read' });
 
-    return this.toResponseAgent(document);
+    return withPermissions({ document, user: this.user });
   }
 
   async getWithAccess(
@@ -381,7 +373,7 @@ class AgentClientImpl implements AgentClient {
     access: AgentAccess
   ): Promise<PersistedAgentDefinitionWithPermissions> {
     const document = await this.getDocumentWithAccess({ agentId, access });
-    return this.toResponseAgent(document);
+    return withPermissions({ document, user: this.user });
   }
 
   async has(agentId: string): Promise<boolean> {
@@ -430,13 +422,13 @@ class AgentClientImpl implements AgentClient {
 
     return response.hits.hits.map((hit) => {
       const document = hit as Document;
-      return this.toResponseAgent(document as Required<Document>);
+      return withPermissions({ document: document as Required<Document>, user: this.user });
     });
   }
 
   private getListFilters() {
     const filters = [createSpaceDslFilter(this.space)];
-    if (!this.isAdmin) {
+    if (!this.user.isAdmin) {
       filters.push(buildReadAccessFilter({ user: this.user }));
     }
 
@@ -460,7 +452,7 @@ class AgentClientImpl implements AgentClient {
     assertCanConfigureWorkflows({
       nextWorkflowIds: profile.configuration.workflow_ids,
       currentWorkflowIds: [],
-      isAdmin: this.isAdmin,
+      isAdmin: this.user.isAdmin,
     });
 
     await this.validateAgentToolSelection(profile.configuration.tools);
@@ -515,7 +507,6 @@ class AgentClientImpl implements AgentClient {
         source,
         update: profileUpdate,
         user: this.user,
-        isAdmin: this.isAdmin,
       })
     ) {
       throw createAgentNotFoundError({ agentId });
@@ -526,7 +517,7 @@ class AgentClientImpl implements AgentClient {
     assertCanConfigureWorkflows({
       nextWorkflowIds: profileUpdate.configuration?.workflow_ids,
       currentWorkflowIds: currentConfig?.workflow_ids,
-      isAdmin: this.isAdmin,
+      isAdmin: this.user.isAdmin,
     });
 
     if (profileUpdate.configuration?.tools) {
@@ -565,13 +556,11 @@ class AgentClientImpl implements AgentClient {
     const canManage = hasManageAccessControlAccess({
       source,
       user: this.user,
-      isAdmin: this.isAdmin,
     });
     const definition = redactAccessControlForCaller({
       definition: { access_control: normalizeAccessControl(source) },
       source,
       user: this.user,
-      isAdmin: this.isAdmin,
     });
     return {
       access_control: definition.access_control,
@@ -649,22 +638,21 @@ class AgentClientImpl implements AgentClient {
     let allowed = false;
     switch (access) {
       case 'read':
-        allowed = hasReadAccess({ source, user: this.user, isAdmin: this.isAdmin });
+        allowed = hasReadAccess({ source, user: this.user });
         break;
       case 'use':
-        allowed = hasUseAccess({ source, user: this.user, isAdmin: this.isAdmin });
+        allowed = hasUseAccess({ source, user: this.user });
         break;
       case 'write':
-        allowed = hasWriteAccess({ source, user: this.user, isAdmin: this.isAdmin });
+        allowed = hasWriteAccess({ source, user: this.user });
         break;
       case 'delete':
-        allowed = hasDeleteAccess({ source, user: this.user, isAdmin: this.isAdmin });
+        allowed = hasDeleteAccess({ source, user: this.user });
         break;
       case 'manageAccessControl':
         allowed = hasManageAccessControlAccess({
           source,
           user: this.user,
-          isAdmin: this.isAdmin,
         });
         break;
     }
@@ -674,24 +662,6 @@ class AgentClientImpl implements AgentClient {
     }
 
     return document;
-  }
-
-  private toResponseAgent(document: Required<Document>): PersistedAgentDefinitionWithPermissions {
-    const source = document._source;
-    const redactedDefinition = redactAccessControlForCaller({
-      definition: fromEs(document),
-      source,
-      user: this.user,
-      isAdmin: this.isAdmin,
-    });
-    return {
-      ...redactedDefinition,
-      permissions: getAgentPermissions({
-        source,
-        user: this.user,
-        isAdmin: this.isAdmin,
-      }),
-    };
   }
 
   /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.test.ts
@@ -19,6 +19,7 @@ import {
   createRequestToEs,
   fromEs,
   updateRequestToEs,
+  withPermissions,
 } from './converters';
 
 const creationDate = '2024-09-04T06:44:17.944Z';
@@ -274,6 +275,59 @@ describe('fromEs', () => {
       access_mode: AgentAccessControlMode.Shared,
       entries: accessControlEntries,
     });
+  });
+});
+
+describe('withPermissions', () => {
+  const aliceEntry = { type: 'user' as const, name: 'alice', role: AgentAccessControlRole.Editor };
+  const bobEntry = { type: 'user' as const, name: 'bob', role: AgentAccessControlRole.User };
+
+  const getDocument = (): Required<Document> => ({
+    _id: 'agent-1',
+    _source: {
+      id: 'agent-1',
+      name: 'Agent 1',
+      type: AgentType.chat,
+      space: 'default',
+      description: 'description',
+      access_control: {
+        access_mode: AgentAccessControlMode.Private,
+        entries: [aliceEntry, bobEntry],
+      },
+      created_by_id: 'owner-id',
+      created_by_name: 'owner',
+      config: {
+        tools: [],
+      },
+      created_at: creationDate,
+      updated_at: updateDate,
+    },
+  });
+
+  it('adds permissions from the CurrentUser admin state', () => {
+    const definition = withPermissions({
+      document: getDocument(),
+      user: { id: 'admin-id', username: 'admin', isAdmin: true },
+    });
+
+    expect(definition.permissions).toEqual({
+      update_agent: true,
+      update_access_control: true,
+    });
+    expect(definition.access_control?.entries).toEqual([aliceEntry, bobEntry]);
+  });
+
+  it("keeps only the caller's entry when the caller cannot manage access control", () => {
+    const definition = withPermissions({
+      document: getDocument(),
+      user: { id: 'bob-id', username: 'bob', isAdmin: false },
+    });
+
+    expect(definition.permissions).toEqual({
+      update_agent: false,
+      update_access_control: false,
+    });
+    expect(definition.access_control?.entries).toEqual([bobEntry]);
   });
 });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
@@ -6,7 +6,7 @@
  */
 
 import type { GetResponse } from '@elastic/elasticsearch/lib/api/types';
-import type { AgentAccessControl, UserIdAndName } from '@kbn/agent-builder-common';
+import type { AgentAccessControl, CurrentUser, UserIdAndName } from '@kbn/agent-builder-common';
 import {
   agentBuilderDefaultAgentId,
   chatAgentTypeId,
@@ -14,8 +14,13 @@ import {
 } from '@kbn/agent-builder-common';
 import type { AgentCreateRequest, AgentUpdateRequest } from '../../../../../common/agents';
 import type { AgentConfigurationProperties, AgentProperties } from './storage';
-import type { PersistedAgentDefinition } from '../types';
-import { isAgentOwner, normalizeAccessControl } from '../../access_control';
+import type { PersistedAgentDefinition, PersistedAgentDefinitionWithPermissions } from '../types';
+import {
+  getAgentPermissions,
+  isAgentOwner,
+  normalizeAccessControl,
+  redactAccessControlForCaller,
+} from '../../access_control';
 
 export type Document = Pick<GetResponse<AgentProperties>, '_id' | '_source'>;
 
@@ -60,6 +65,29 @@ export const fromEs = (document: Document): PersistedAgentDefinition => {
       connector_ids: configuration.connector_ids,
       ai_indices: configuration.ai_indices,
     },
+  };
+};
+
+export const withPermissions = ({
+  document,
+  user,
+}: {
+  document: Required<Document>;
+  user: CurrentUser;
+}): PersistedAgentDefinitionWithPermissions => {
+  const source = document._source;
+  const redactedDefinition = redactAccessControlForCaller({
+    definition: fromEs(document),
+    source,
+    user,
+  });
+
+  return {
+    ...redactedDefinition,
+    permissions: getAgentPermissions({
+      source,
+      user,
+    }),
   };
 };
 


### PR DESCRIPTION
## Summary
- Reuses `CurrentUser.isAdmin` in the persisted Agent client instead of issuing a duplicate admin privilege lookup.
- Aligns Agent access-control helpers with the conversation client pattern by deriving admin state from `CurrentUser`.
- Moves Agent response permission decoration into `withPermissions()` in persisted Agent converters.

Addresses feedback from https://github.com/elastic/kibana/pull/284771#discussion_r3812046384.