### PR TITLE
[Fleet] Add allow list for cluster privileges declared in package manifests

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -8,6 +8,8 @@
 jest.mock('../epm/packages');
 jest.mock('../app_context');
 
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+
 import { DATA_STREAM_TYPE_VAR_NAME, DATASET_VAR_NAME } from '../../../common/constants';
 import type { PackagePolicy } from '../../types';
 import { PackagePolicyValidationError } from '../../errors';
@@ -690,6 +692,113 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
         cluster: ['monitor'],
       },
     });
+  });
+
+  it('Filters out disallowed cluster privileges and logs a warning', async () => {
+    const mockLogger = loggingSystemMock.createLogger();
+    jest.spyOn(appContextService, 'getLogger').mockReturnValue(mockLogger);
+
+    const packagePolicies: PackagePolicy[] = [
+      {
+        id: 'package-policy-uuid-test-123',
+        name: 'test-policy',
+        namespace: 'test',
+        enabled: true,
+        package: { name: 'test_package', version: '0.0.0', title: 'Test Package' },
+        elasticsearch: {
+          privileges: {
+            cluster: ['monitor', 'all'],
+          },
+        },
+        inputs: [
+          {
+            type: 'test-logs',
+            enabled: true,
+            streams: [
+              {
+                id: 'test-logs',
+                enabled: true,
+                data_stream: { type: 'logs', dataset: 'some-logs' },
+                compiled_stream: { data_stream: { dataset: 'compiled' } },
+              },
+            ],
+          },
+        ],
+        created_at: '',
+        updated_at: '',
+        created_by: '',
+        updated_by: '',
+        revision: 1,
+        policy_id: '',
+        policy_ids: [''],
+      },
+    ];
+
+    const permissions = await storedPackagePoliciesToAgentPermissions(
+      packageInfoCache,
+      'test',
+      packagePolicies
+    );
+    expect(permissions).toMatchObject({
+      'package-policy-uuid-test-123': {
+        cluster: ['monitor'],
+      },
+    });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('package-policy-uuid-test-123')
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('all'));
+  });
+
+  it('Omits cluster descriptor when all declared cluster privileges are disallowed', async () => {
+    const mockLogger = loggingSystemMock.createLogger();
+    jest.spyOn(appContextService, 'getLogger').mockReturnValue(mockLogger);
+
+    const packagePolicies: PackagePolicy[] = [
+      {
+        id: 'package-policy-uuid-test-123',
+        name: 'test-policy',
+        namespace: 'test',
+        enabled: true,
+        package: { name: 'test_package', version: '0.0.0', title: 'Test Package' },
+        elasticsearch: {
+          privileges: {
+            cluster: ['all', 'manage_security'],
+          },
+        },
+        inputs: [
+          {
+            type: 'test-logs',
+            enabled: true,
+            streams: [
+              {
+                id: 'test-logs',
+                enabled: true,
+                data_stream: { type: 'logs', dataset: 'some-logs' },
+                compiled_stream: { data_stream: { dataset: 'compiled' } },
+              },
+            ],
+          },
+        ],
+        created_at: '',
+        updated_at: '',
+        created_by: '',
+        updated_by: '',
+        revision: 1,
+        policy_id: '',
+        policy_ids: [''],
+      },
+    ];
+
+    const permissions = await storedPackagePoliciesToAgentPermissions(
+      packageInfoCache,
+      'test',
+      packagePolicies
+    );
+    expect(permissions?.['package-policy-uuid-test-123']).not.toHaveProperty('cluster');
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('package-policy-uuid-test-123')
+    );
   });
 
   it('Returns the dataset for osquery_manager package', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -45,6 +45,8 @@ import { getEffectiveOtelStreamDataset } from './get_effective_otel_stream_datas
 
 export const DEFAULT_CLUSTER_PERMISSIONS = ['monitor'];
 
+export const PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES = new Set(['monitor']);
+
 export const UNIVERSAL_PROFILING_PERMISSIONS = [
   'auto_configure',
   'read',
@@ -328,9 +330,18 @@ export function storedPackagePoliciesToAgentPermissions(
 
     let clusterRoleDescriptor = {};
     const cluster = packagePolicy?.elasticsearch?.privileges?.cluster ?? [];
-    if (cluster.length > 0) {
+    const validCluster = cluster.filter((p) => PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES.has(p));
+    const invalidCluster = cluster.filter((p) => !PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES.has(p));
+    if (invalidCluster.length) {
+      appContextService
+        .getLogger()
+        .warn(
+          `Ignoring invalid or forbidden cluster privilege(s) in package policy "${packagePolicy.id}": ${invalidCluster}`
+        );
+    }
+    if (validCluster.length > 0) {
       clusterRoleDescriptor = {
-        cluster,
+        cluster: validCluster,
       };
     }
     // namespace is either the package policy's or the agent policy one


### PR DESCRIPTION
## Summary

This PR adds a `PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES` allow-list (`{ monitor })` to `package_policies_to_agent_permissions.ts` and filters `elasticsearch.privileges.cluster` from the package manifest against it before writing the agent API-key role descriptor, mirroring the existing `DATA_STREAM_ALLOWED_INDEX_PRIVILEGES` filter that already protects index privileges. Anything outside the allow-list is dropped with a warning log; if nothing survives, no `cluster` field is written at all. The allow-list is intentionally narrow (`monitor` only) since that covers every legitimate use case in published packages; hardcoded paths for APM and connectors are unaffected as they bypass this code entirely.

### Testing

Prerequisites:
* Create a role with Fleet privileges only (no Elasticsearch privileges) and assign it to a test user
* Create a minimal working test package: leave everything to default but add this to the root `manifest.yml`:
   ```yml
   elasticsearch:
     privileges:
       cluster:
         - all
   ```

#### Package with `all` cluster privilege: disallowed privilege is stripped

1. As the test user, upload the test package with `POST /api/fleet/epm/packages`: it should show up in Kibana UI
2. Create an agent policy, add the package, then (still as the test user) call `GET /api/fleet/agent_policies/<id>/full`
3. Expected:` output_permissions.<package-policy-id>` has no `cluster` key
4. Expected: Kibana server logs contain a WARN line referencing the package policy ID and `all`, e.g.
   ```
   [WARN ][plugins.fleet] Ignoring invalid or forbidden cluster privilege(s) in package policy "e8dc6e53-d256-43fc-8db1-581f9e0ecee6": all
   ```

### Package with `monitor` cluster privilege: no change

1. Create a new test package with `cluster: [monitor]` privilege (or edit and rebuild the previous one)
2. Repeat upload + fetch policy steps
3. Expected: in the compiled agent policy, `output_permissions.<package-policy-id>.cluster` is `["monitor"]`
4. Expected: no WARN log

### Package with mixed privileges: only `monitor` survives

1. Create a new test package with `cluster: [monitor, manage_security]` privileges (or edit and rebuild the previous one)
2. Repeat upload + fetch policy steps
3. Expected: `output_permissions.<package-policy-id>.cluster` is `["monitor"]` only
4. Expected: warning log references `manage_security` but not `monitor`

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low. The allow-list (`monitor`) covers every legitimate cluster privilege used by published packages via the manifest path; APM and connectors bypass this code entirely through their own hardcoded paths and are unaffected. The only observable behavior change is that a `cluster` key declaring anything other than monitor is silently dropped with a warning rather than passed through, which is the intended security improvement.

## Release note

Adds an allow-list for cluster privileges declared in package manifests, mirroring the existing filter already applied to index privileges.

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->