### PR TITLE
[Cases] Add browser telemetry for template management

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -500,6 +500,18 @@ export const CASE_MARKDOWN_EDITOR_PLUGIN_CLICKED_EVENT_TYPE =
   'case_markdown_editor_plugin_clicked' as const;
 
 /**
+ * Template management events. Each one reports a single confirmed user action on the template
+ * management pages — not a count of templates written. A bulk delete reports one event whatever the
+ * number of removed templates, and the YAML import flow reports nothing. Use the server-side
+ * template counters for write totals; they count every caller.
+ */
+export const CASES_TEMPLATE_CREATED_EVENT_TYPE = 'cases_template_created' as const;
+
+export const CASES_TEMPLATE_UPDATED_EVENT_TYPE = 'cases_template_updated' as const;
+
+export const CASES_TEMPLATE_DELETED_EVENT_TYPE = 'cases_template_deleted' as const;
+
+/**
  * Cases list view toggle. Defined in `common` (rather than the redesign UI package) so that
  * non-UI consumers, such as the analytics/EBT layer, can depend on it without reaching into a
  * specific UI feature's implementation.

--- a/x-pack/platform/plugins/shared/cases/public/analytics/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/index.ts
@@ -18,6 +18,7 @@ import {
   CASES_LIST_PAGE_VIEW_EVENT_TYPE,
   CASES_LIST_VIEW_MODE_CHANGED_EVENT_TYPE,
 } from '../../common/constants';
+import { registerTemplateAnalytics } from './templates';
 
 export const registerAnalytics = ({
   analyticsService,
@@ -268,4 +269,6 @@ export const registerAnalytics = ({
       },
     },
   });
+
+  registerTemplateAnalytics({ analyticsService });
 };

--- a/x-pack/platform/plugins/shared/cases/public/analytics/templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/templates/index.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceSetup } from '@kbn/core/public';
+import { registerTemplateManagementEvents } from './register_management_events';
+
+/**
+ * Registers every browser event for the templates feature.
+ *
+ * The templates feature has more than one event family, and each family owns its own register module
+ * plus its own reporter hooks: managing the templates themselves lives in
+ * `register_management_events`, and applying a template to a case will live beside it. Composing them
+ * here means `public/analytics/index.ts` keeps a single import and a single call however many
+ * families are added, so add each new family's register function to this function rather than to the
+ * parent module.
+ */
+export const registerTemplateAnalytics = ({
+  analyticsService,
+}: {
+  analyticsService: AnalyticsServiceSetup;
+}) => {
+  registerTemplateManagementEvents({ analyticsService });
+};
+
+export {
+  useTemplateCreatedEBT,
+  useTemplateDeletedEBT,
+  useTemplateUpdatedEBT,
+} from './use_template_management_ebt';
+export type {
+  TemplateCreationMode,
+  TemplateDeleteEntryPoint,
+  TemplateDeleteScope,
+  TemplateEntryPoint,
+} from './use_template_management_ebt';

--- a/x-pack/platform/plugins/shared/cases/public/analytics/templates/register_management_events.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/templates/register_management_events.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AnalyticsServiceSetup } from '@kbn/core/public';
+import {
+  CASES_TEMPLATE_CREATED_EVENT_TYPE,
+  CASES_TEMPLATE_DELETED_EVENT_TYPE,
+  CASES_TEMPLATE_UPDATED_EVENT_TYPE,
+} from '../../../common/constants';
+
+/**
+ * Registers the browser events for managing the templates themselves — create, update, and delete on
+ * the template management pages. Applying a template to a case is a separate event family with its
+ * own register module. Each event reports one confirmed user action, so it is never a count of
+ * templates written: a bulk delete reports once whatever the number of removed templates, and the
+ * YAML import flow reports nothing. The server-side template counters remain the totals, because
+ * they count every caller (API, workflows) rather than the UI alone.
+ */
+export const registerTemplateManagementEvents = ({
+  analyticsService,
+}: {
+  analyticsService: AnalyticsServiceSetup;
+}) => {
+  analyticsService.registerEventType({
+    eventType: CASES_TEMPLATE_CREATED_EVENT_TYPE,
+    schema: {
+      owner: {
+        type: 'keyword',
+        _meta: {
+          description: 'The solution ID (owner) in which the template was created',
+          optional: false,
+        },
+      },
+      entry_point: {
+        type: 'keyword',
+        _meta: {
+          description:
+            'The bounded place in the templates UI the create was confirmed from, either ' +
+            '"template_editor" or "templates_list"',
+          optional: false,
+        },
+      },
+      creation_mode: {
+        type: 'keyword',
+        _meta: {
+          description:
+            'How the new template started, either "blank" (authored in the YAML editor) or ' +
+            '"clone" (copied from an existing template). No template name, tag, author, or ' +
+            'definition content is reported',
+          optional: false,
+        },
+      },
+    },
+  });
+
+  analyticsService.registerEventType({
+    eventType: CASES_TEMPLATE_UPDATED_EVENT_TYPE,
+    schema: {
+      owner: {
+        type: 'keyword',
+        _meta: {
+          description: 'The solution ID (owner) in which the template was updated',
+          optional: false,
+        },
+      },
+      entry_point: {
+        type: 'keyword',
+        _meta: {
+          description:
+            'The bounded place in the templates UI the update was confirmed from, either ' +
+            '"template_editor" (a save in the editor) or "templates_list" (the enabled toggle ' +
+            'on a row). No template name, tag, author, or definition content is reported',
+          optional: false,
+        },
+      },
+    },
+  });
+
+  analyticsService.registerEventType({
+    eventType: CASES_TEMPLATE_DELETED_EVENT_TYPE,
+    schema: {
+      owner: {
+        type: 'keyword',
+        _meta: {
+          description: 'The solution ID (owner) in which the template was deleted',
+          optional: false,
+        },
+      },
+      entry_point: {
+        type: 'keyword',
+        _meta: {
+          description:
+            'The bounded place in the templates UI the delete was confirmed from, currently ' +
+            'always "templates_list"',
+          optional: false,
+        },
+      },
+      delete_scope: {
+        type: 'keyword',
+        _meta: {
+          description:
+            'Whether the confirmed delete removed a single row ("single") or the current ' +
+            'selection ("bulk"). The number of deleted templates is not reported',
+          optional: false,
+        },
+      },
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/cases/public/analytics/templates/use_template_management_ebt.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/templates/use_template_management_ebt.test.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import {
+  CASES_TEMPLATE_CREATED_EVENT_TYPE,
+  CASES_TEMPLATE_DELETED_EVENT_TYPE,
+  CASES_TEMPLATE_UPDATED_EVENT_TYPE,
+  OBSERVABILITY_OWNER,
+  SECURITY_SOLUTION_OWNER,
+} from '../../../common/constants';
+import { useKibana } from '../../common/lib/kibana';
+import { useCasesContext } from '../../components/cases_context/use_cases_context';
+import {
+  useTemplateCreatedEBT,
+  useTemplateDeletedEBT,
+  useTemplateUpdatedEBT,
+} from './use_template_management_ebt';
+
+jest.mock('../../common/lib/kibana', () => ({
+  useKibana: jest.fn(),
+}));
+
+jest.mock('../../components/cases_context/use_cases_context', () => ({
+  useCasesContext: jest.fn(),
+}));
+
+const getMockServices = (reportEvent: jest.Mock) => ({
+  services: {
+    analytics: {
+      reportEvent,
+    },
+  },
+});
+
+describe('template management EBT hooks', () => {
+  const reportEvent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useKibana as jest.Mock).mockReturnValue(getMockServices(reportEvent));
+    (useCasesContext as jest.Mock).mockReturnValue({ owner: [SECURITY_SOLUTION_OWNER] });
+  });
+
+  describe('useTemplateCreatedEBT', () => {
+    it('reports a blank create from the editor with the owner', () => {
+      const { result } = renderHook(() => useTemplateCreatedEBT());
+
+      result.current({ entryPoint: 'template_editor', creationMode: 'blank' });
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_TEMPLATE_CREATED_EVENT_TYPE, {
+        owner: SECURITY_SOLUTION_OWNER,
+        entry_point: 'template_editor',
+        creation_mode: 'blank',
+      });
+    });
+
+    it('reports a clone from the templates list with a distinct creation mode', () => {
+      (useCasesContext as jest.Mock).mockReturnValue({ owner: [OBSERVABILITY_OWNER] });
+      const { result } = renderHook(() => useTemplateCreatedEBT());
+
+      result.current({ entryPoint: 'templates_list', creationMode: 'clone' });
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_TEMPLATE_CREATED_EVENT_TYPE, {
+        owner: OBSERVABILITY_OWNER,
+        entry_point: 'templates_list',
+        creation_mode: 'clone',
+      });
+    });
+
+    it('falls back to unknown owner', () => {
+      (useCasesContext as jest.Mock).mockReturnValue({ owner: ['invalid'] });
+      const { result } = renderHook(() => useTemplateCreatedEBT());
+
+      result.current({ entryPoint: 'template_editor', creationMode: 'blank' });
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_TEMPLATE_CREATED_EVENT_TYPE, {
+        owner: 'unknown',
+        entry_point: 'template_editor',
+        creation_mode: 'blank',
+      });
+    });
+  });
+
+  describe('useTemplateUpdatedEBT', () => {
+    it('reports an editor save with the owner', () => {
+      const { result } = renderHook(() => useTemplateUpdatedEBT());
+
+      result.current({ entryPoint: 'template_editor' });
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_TEMPLATE_UPDATED_EVENT_TYPE, {
+        owner: SECURITY_SOLUTION_OWNER,
+        entry_point: 'template_editor',
+      });
+    });
+
+    it('reports an update from the templates list', () => {
+      const { result } = renderHook(() => useTemplateUpdatedEBT());
+
+      result.current({ entryPoint: 'templates_list' });
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_TEMPLATE_UPDATED_EVENT_TYPE, {
+        owner: SECURITY_SOLUTION_OWNER,
+        entry_point: 'templates_list',
+      });
+    });
+
+    it('falls back to unknown owner', () => {
+      (useCasesContext as jest.Mock).mockReturnValue({ owner: [] });
+      const { result } = renderHook(() => useTemplateUpdatedEBT());
+
+      result.current({ entryPoint: 'template_editor' });
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_TEMPLATE_UPDATED_EVENT_TYPE, {
+        owner: 'unknown',
+        entry_point: 'template_editor',
+      });
+    });
+  });
+
+  describe('useTemplateDeletedEBT', () => {
+    it('reports a single row delete with the owner', () => {
+      const { result } = renderHook(() => useTemplateDeletedEBT());
+
+      result.current({ entryPoint: 'templates_list', deleteScope: 'single' });
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_TEMPLATE_DELETED_EVENT_TYPE, {
+        owner: SECURITY_SOLUTION_OWNER,
+        entry_point: 'templates_list',
+        delete_scope: 'single',
+      });
+    });
+
+    it('reports a bulk delete once, with a distinct scope', () => {
+      const { result } = renderHook(() => useTemplateDeletedEBT());
+
+      result.current({ entryPoint: 'templates_list', deleteScope: 'bulk' });
+
+      expect(reportEvent).toHaveBeenCalledTimes(1);
+      expect(reportEvent).toHaveBeenCalledWith(CASES_TEMPLATE_DELETED_EVENT_TYPE, {
+        owner: SECURITY_SOLUTION_OWNER,
+        entry_point: 'templates_list',
+        delete_scope: 'bulk',
+      });
+    });
+
+    it('falls back to unknown owner', () => {
+      (useCasesContext as jest.Mock).mockReturnValue({ owner: ['invalid'] });
+      const { result } = renderHook(() => useTemplateDeletedEBT());
+
+      result.current({ entryPoint: 'templates_list', deleteScope: 'single' });
+
+      expect(reportEvent).toHaveBeenCalledWith(CASES_TEMPLATE_DELETED_EVENT_TYPE, {
+        owner: 'unknown',
+        entry_point: 'templates_list',
+        delete_scope: 'single',
+      });
+    });
+  });
+
+  it('does not report anything when a hook only renders', () => {
+    renderHook(() => useTemplateCreatedEBT());
+    renderHook(() => useTemplateUpdatedEBT());
+    renderHook(() => useTemplateDeletedEBT());
+
+    expect(reportEvent).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/analytics/templates/use_template_management_ebt.ts
+++ b/x-pack/platform/plugins/shared/cases/public/analytics/templates/use_template_management_ebt.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useCallback } from 'react';
+
+import {
+  CASES_TEMPLATE_CREATED_EVENT_TYPE,
+  CASES_TEMPLATE_DELETED_EVENT_TYPE,
+  CASES_TEMPLATE_UPDATED_EVENT_TYPE,
+} from '../../../common/constants';
+import { useKibana } from '../../common/lib/kibana';
+import { useCasesContext } from '../../components/cases_context/use_cases_context';
+import { getEbtOwner } from '../get_ebt_owner';
+
+export type TemplateEntryPoint = 'template_editor' | 'templates_list';
+export type TemplateCreationMode = 'blank' | 'clone';
+export type TemplateDeleteScope = 'single' | 'bulk';
+
+/**
+ * Delete exists only on the templates list (a row action and the bulk menu); the editor has no
+ * delete. Narrowed so the reporter cannot send an entry point the UI has no way to reach. Widen this
+ * to `TemplateEntryPoint` if a delete is ever added to the editor.
+ */
+export type TemplateDeleteEntryPoint = Extract<TemplateEntryPoint, 'templates_list'>;
+
+/**
+ * Events Based Tracking for a template created from the templates UI. Report this only once the
+ * server has confirmed the write, never on render.
+ */
+export const useTemplateCreatedEBT = () => {
+  const { analytics } = useKibana().services;
+  const { owner } = useCasesContext();
+
+  return useCallback(
+    ({
+      entryPoint,
+      creationMode,
+    }: {
+      entryPoint: TemplateEntryPoint;
+      creationMode: TemplateCreationMode;
+    }) => {
+      analytics.reportEvent(CASES_TEMPLATE_CREATED_EVENT_TYPE, {
+        owner: getEbtOwner(owner),
+        entry_point: entryPoint,
+        creation_mode: creationMode,
+      });
+    },
+    [analytics, owner]
+  );
+};
+
+/**
+ * Events Based Tracking for a template updated from the templates UI. Report this only once the
+ * server has confirmed the write, never on render.
+ */
+export const useTemplateUpdatedEBT = () => {
+  const { analytics } = useKibana().services;
+  const { owner } = useCasesContext();
+
+  return useCallback(
+    ({ entryPoint }: { entryPoint: TemplateEntryPoint }) => {
+      analytics.reportEvent(CASES_TEMPLATE_UPDATED_EVENT_TYPE, {
+        owner: getEbtOwner(owner),
+        entry_point: entryPoint,
+      });
+    },
+    [analytics, owner]
+  );
+};
+
+/**
+ * Events Based Tracking for a template deleted from the templates UI. A bulk delete reports one
+ * event for the confirmed action, not one per removed template.
+ */
+export const useTemplateDeletedEBT = () => {
+  const { analytics } = useKibana().services;
+  const { owner } = useCasesContext();
+
+  return useCallback(
+    ({
+      entryPoint,
+      deleteScope,
+    }: {
+      entryPoint: TemplateDeleteEntryPoint;
+      deleteScope: TemplateDeleteScope;
+    }) => {
+      analytics.reportEvent(CASES_TEMPLATE_DELETED_EVENT_TYPE, {
+        owner: getEbtOwner(owner),
+        entry_point: entryPoint,
+        delete_scope: deleteScope,
+      });
+    },
+    [analytics, owner]
+  );
+};

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_bulk_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_bulk_actions.test.tsx
@@ -8,9 +8,12 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
+import type { CoreStart } from '@kbn/core/public';
+import { coreMock } from '@kbn/core/public/mocks';
 import type { Template } from '../../../../common/types/domain/template/v1';
+import { CASES_TEMPLATE_DELETED_EVENT_TYPE } from '../../../../common/constants';
 import { TemplatesBulkActions } from './templates_bulk_actions';
-import { renderWithTestingProviders } from '../../../common/mock';
+import { mockedTestProvidersOwner, renderWithTestingProviders } from '../../../common/mock';
 import * as api from '../api/api';
 
 jest.mock('../api/api');
@@ -19,6 +22,7 @@ const apiMock = api as jest.Mocked<typeof api>;
 
 describe('TemplatesBulkActions', () => {
   let user: ReturnType<typeof userEvent.setup>;
+  let coreStart: CoreStart;
 
   const mockTemplates: Template[] = [
     {
@@ -64,6 +68,7 @@ describe('TemplatesBulkActions', () => {
   beforeEach(() => {
     user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime, pointerEventsCheck: 0 });
     jest.clearAllMocks();
+    coreStart = coreMock.createStart() as unknown as CoreStart;
     apiMock.bulkDeleteTemplates.mockResolvedValue({
       success: true,
       deleted: ['template-1', 'template-2'],
@@ -223,6 +228,57 @@ describe('TemplatesBulkActions', () => {
 
     await waitFor(() => {
       expect(onActionSuccess).toHaveBeenCalled();
+    });
+  });
+
+  describe('telemetry', () => {
+    it('reports one deleted event with the bulk scope when the bulk delete succeeds', async () => {
+      renderWithTestingProviders(<TemplatesBulkActions selectedTemplates={mockTemplates} />, {
+        wrapperProps: { coreStart },
+      });
+
+      await user.click(await screen.findByTestId('templates-bulk-actions-link-icon'));
+      await user.click(await screen.findByTestId('templates-bulk-action-delete'));
+
+      expect(await screen.findByText('Delete 2 templates?')).toBeInTheDocument();
+      // Opening the menu and the modal is not a confirmed action.
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+
+      await user.click(screen.getByTestId('confirmModalConfirmButton'));
+
+      // Two selected templates still report a single event for the one confirmed action.
+      await waitFor(() => {
+        expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      });
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+        CASES_TEMPLATE_DELETED_EVENT_TYPE,
+        {
+          owner: mockedTestProvidersOwner[0],
+          entry_point: 'templates_list',
+          delete_scope: 'bulk',
+        }
+      );
+    });
+
+    it('reports nothing when the bulk delete fails', async () => {
+      apiMock.bulkDeleteTemplates.mockRejectedValue(new Error('Bulk delete failed'));
+
+      renderWithTestingProviders(<TemplatesBulkActions selectedTemplates={mockTemplates} />, {
+        wrapperProps: { coreStart },
+      });
+
+      await user.click(await screen.findByTestId('templates-bulk-actions-link-icon'));
+      await user.click(await screen.findByTestId('templates-bulk-action-delete'));
+
+      expect(await screen.findByText('Delete 2 templates?')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('confirmModalConfirmButton'));
+
+      await waitFor(() => {
+        expect(apiMock.bulkDeleteTemplates).toHaveBeenCalled();
+      });
+
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_bulk_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_bulk_actions.tsx
@@ -29,11 +29,18 @@ const TemplatesBulkActionsComponent: React.FC<TemplatesBulkActionsProps> = ({
   const togglePopover = useCallback(() => setIsPopoverOpen((prev) => !prev), []);
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
 
+  const reportTemplateDeleted = useTemplateDeletedEBT();
+
   const { mutate: bulkDeleteTemplates, isLoading: isBulkDeleting } = useBulkDeleteTemplates({
-    onSuccess: onActionSuccess,
+    onSuccess: () => {
+      // One event for the confirmed action, whatever the number of selected templates. Reported from
+      // the hook-level callback, which React Query awaits even once this component has unsubscribed,
+      // unlike a per-call callback.
+      reportTemplateDeleted({ entryPoint: 'templates_list', deleteScope: 'bulk' });
+      onActionSuccess?.();
+    },
   });
   const { mutate: bulkExportTemplates, isLoading: isBulkExporting } = useBulkExportTemplates();
-  const reportTemplateDeleted = useTemplateDeletedEBT();
 
   const selectedTemplateIds = useMemo(
     () => selectedTemplates.map((template) => template.templateId),
@@ -51,17 +58,9 @@ const TemplatesBulkActionsComponent: React.FC<TemplatesBulkActionsProps> = ({
   }, [closePopover]);
 
   const handleConfirmBulkDelete = useCallback(() => {
-    // One event for the confirmed action, whatever the number of selected templates.
-    bulkDeleteTemplates(
-      { templateIds: selectedTemplateIds },
-      {
-        onSuccess: () => {
-          reportTemplateDeleted({ entryPoint: 'templates_list', deleteScope: 'bulk' });
-        },
-      }
-    );
+    bulkDeleteTemplates({ templateIds: selectedTemplateIds });
     setIsDeleteModalVisible(false);
-  }, [bulkDeleteTemplates, selectedTemplateIds, reportTemplateDeleted]);
+  }, [bulkDeleteTemplates, selectedTemplateIds]);
 
   const handleCancelBulkDelete = useCallback(() => {
     setIsDeleteModalVisible(false);

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_bulk_actions.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_bulk_actions.tsx
@@ -13,6 +13,7 @@ import * as i18n from '../translations';
 import { useBulkDeleteTemplates } from '../hooks/use_bulk_delete_templates';
 import { useBulkExportTemplates } from '../hooks/use_bulk_export_templates';
 import { DeleteConfirmationModal } from '../../configure_cases/delete_confirmation_modal';
+import { useTemplateDeletedEBT } from '../../../analytics/templates';
 
 export interface TemplatesBulkActionsProps {
   selectedTemplates: Template[];
@@ -32,6 +33,7 @@ const TemplatesBulkActionsComponent: React.FC<TemplatesBulkActionsProps> = ({
     onSuccess: onActionSuccess,
   });
   const { mutate: bulkExportTemplates, isLoading: isBulkExporting } = useBulkExportTemplates();
+  const reportTemplateDeleted = useTemplateDeletedEBT();
 
   const selectedTemplateIds = useMemo(
     () => selectedTemplates.map((template) => template.templateId),
@@ -49,9 +51,17 @@ const TemplatesBulkActionsComponent: React.FC<TemplatesBulkActionsProps> = ({
   }, [closePopover]);
 
   const handleConfirmBulkDelete = useCallback(() => {
-    bulkDeleteTemplates({ templateIds: selectedTemplateIds });
+    // One event for the confirmed action, whatever the number of selected templates.
+    bulkDeleteTemplates(
+      { templateIds: selectedTemplateIds },
+      {
+        onSuccess: () => {
+          reportTemplateDeleted({ entryPoint: 'templates_list', deleteScope: 'bulk' });
+        },
+      }
+    );
     setIsDeleteModalVisible(false);
-  }, [bulkDeleteTemplates, selectedTemplateIds]);
+  }, [bulkDeleteTemplates, selectedTemplateIds, reportTemplateDeleted]);
 
   const handleCancelBulkDelete = useCallback(() => {
     setIsDeleteModalVisible(false);

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.test.tsx
@@ -7,8 +7,15 @@
 
 import React from 'react';
 import { renderHook, act } from '@testing-library/react';
+import type { CoreStart } from '@kbn/core/public';
+import { coreMock } from '@kbn/core/public/mocks';
 import type { Template } from '../../../../common/types/domain/template/v1';
-import { TestProviders } from '../../../common/mock';
+import {
+  CASES_TEMPLATE_CREATED_EVENT_TYPE,
+  CASES_TEMPLATE_DELETED_EVENT_TYPE,
+  CASES_TEMPLATE_UPDATED_EVENT_TYPE,
+} from '../../../../common/constants';
+import { mockedTestProvidersOwner, TestProviders } from '../../../common/mock';
 import { useTemplatesActions } from './use_templates_actions';
 import { useCasesEditTemplateNavigation } from '../../../common/navigation';
 import { useBulkDeleteTemplates } from './use_bulk_delete_templates';
@@ -36,8 +43,10 @@ const useBulkExportTemplatesMock = useBulkExportTemplates as jest.Mock;
 const useCasesToastMock = useCasesToast as jest.Mock;
 
 describe('useTemplatesActions', () => {
+  let coreStart: CoreStart;
+
   const wrapper = ({ children }: React.PropsWithChildren<{}>) => (
-    <TestProviders>{children}</TestProviders>
+    <TestProviders coreStart={coreStart}>{children}</TestProviders>
   );
 
   const mockTemplate: Template = {
@@ -66,6 +75,7 @@ describe('useTemplatesActions', () => {
   const showSuccessToastMock = jest.fn();
 
   beforeEach(() => {
+    coreStart = coreMock.createStart() as unknown as CoreStart;
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     useCasesEditTemplateNavigationMock.mockReturnValue({
       navigateToCasesEditTemplate: navigateToCasesEditTemplateMock,
@@ -292,9 +302,10 @@ describe('useTemplatesActions', () => {
       result.current.confirmDelete();
     });
 
-    expect(bulkDeleteTemplatesMock).toHaveBeenCalledWith({
-      templateIds: [mockTemplate.templateId],
-    });
+    expect(bulkDeleteTemplatesMock).toHaveBeenCalledWith(
+      { templateIds: [mockTemplate.templateId] },
+      { onSuccess: expect.any(Function) }
+    );
     expect(result.current.templateToDelete).toBeNull();
   });
 
@@ -398,5 +409,127 @@ describe('useTemplatesActions', () => {
     expect(result.current.handleDelete).toBe(firstRenderHandlers.handleDelete);
     expect(result.current.cancelDelete).toBe(firstRenderHandlers.cancelDelete);
     expect(result.current.handleIsEnabledChange).toBe(firstRenderHandlers.handleIsEnabledChange);
+  });
+
+  describe('telemetry', () => {
+    it('reports nothing when the actions are only mounted', () => {
+      renderHook(() => useTemplatesActions(), { wrapper });
+
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+    });
+
+    it('reports a created event with the clone mode once the clone is confirmed', () => {
+      const { result } = renderHook(() => useTemplatesActions(), { wrapper });
+
+      act(() => {
+        result.current.handleClone(mockTemplate);
+      });
+
+      // The mutation has been called but the server has not confirmed it yet.
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+
+      act(() => {
+        cloneTemplateMock.mock.calls[0][1].onSuccess();
+      });
+
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+        CASES_TEMPLATE_CREATED_EVENT_TYPE,
+        {
+          owner: mockedTestProvidersOwner[0],
+          entry_point: 'templates_list',
+          creation_mode: 'clone',
+        }
+      );
+    });
+
+    it('reports an updated event with the list entry point once the enabled toggle is confirmed', () => {
+      const { result } = renderHook(() => useTemplatesActions(), { wrapper });
+
+      act(() => {
+        result.current.handleIsEnabledChange({ ...mockTemplate, isEnabled: true });
+      });
+
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+
+      act(() => {
+        updateTemplateMock.mock.calls[0][1].onSuccess();
+      });
+
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+        CASES_TEMPLATE_UPDATED_EVENT_TYPE,
+        { owner: mockedTestProvidersOwner[0], entry_point: 'templates_list' }
+      );
+    });
+
+    it('reports a deleted event with the single scope once a row delete is confirmed', () => {
+      const { result } = renderHook(() => useTemplatesActions(), { wrapper });
+
+      act(() => {
+        result.current.handleDelete(mockTemplate);
+      });
+
+      act(() => {
+        result.current.confirmDelete();
+      });
+
+      // Confirming the modal only starts the delete; the event waits for the server.
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+
+      act(() => {
+        bulkDeleteTemplatesMock.mock.calls[0][1].onSuccess();
+      });
+
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+        CASES_TEMPLATE_DELETED_EVENT_TYPE,
+        {
+          owner: mockedTestProvidersOwner[0],
+          entry_point: 'templates_list',
+          delete_scope: 'single',
+        }
+      );
+    });
+
+    it('reports one deleted event even though the hook-level callback also runs', () => {
+      const onDeleteSuccessMock = jest.fn();
+      const { result } = renderHook(
+        () => useTemplatesActions({ onDeleteSuccess: onDeleteSuccessMock }),
+        { wrapper }
+      );
+
+      act(() => {
+        result.current.handleDelete(mockTemplate);
+      });
+
+      act(() => {
+        result.current.confirmDelete();
+      });
+
+      // A real success runs both callbacks: the hook-level one refreshes the list, the per-call one
+      // reports. Only one of them may report.
+      act(() => {
+        useBulkDeleteTemplatesMock.mock.calls[0][0].onSuccess();
+        bulkDeleteTemplatesMock.mock.calls[0][1].onSuccess();
+      });
+
+      expect(onDeleteSuccessMock).toHaveBeenCalledTimes(1);
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports nothing for a delete the user cancels', () => {
+      const { result } = renderHook(() => useTemplatesActions(), { wrapper });
+
+      act(() => {
+        result.current.handleDelete(mockTemplate);
+      });
+
+      act(() => {
+        result.current.cancelDelete();
+      });
+
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.test.tsx
@@ -302,23 +302,27 @@ describe('useTemplatesActions', () => {
       result.current.confirmDelete();
     });
 
-    expect(bulkDeleteTemplatesMock).toHaveBeenCalledWith(
-      { templateIds: [mockTemplate.templateId] },
-      { onSuccess: expect.any(Function) }
-    );
+    expect(bulkDeleteTemplatesMock).toHaveBeenCalledWith({
+      templateIds: [mockTemplate.templateId],
+    });
     expect(result.current.templateToDelete).toBeNull();
   });
 
-  it('passes onDeleteSuccess to useBulkDeleteTemplates hook', () => {
+  it('forwards onDeleteSuccess through the callback it gives useBulkDeleteTemplates', () => {
     const onDeleteSuccessMock = jest.fn();
     renderHook(() => useTemplatesActions({ onDeleteSuccess: onDeleteSuccessMock }), {
       wrapper,
     });
 
-    // Verify useBulkDeleteTemplates was called with the onSuccess callback
     expect(useBulkDeleteTemplatesMock).toHaveBeenCalledWith({
-      onSuccess: onDeleteSuccessMock,
+      onSuccess: expect.any(Function),
     });
+
+    act(() => {
+      useBulkDeleteTemplatesMock.mock.calls[0][0].onSuccess();
+    });
+
+    expect(onDeleteSuccessMock).toHaveBeenCalledTimes(1);
   });
 
   it('cancelDelete clears templateToDelete without calling mutation', () => {
@@ -476,9 +480,14 @@ describe('useTemplatesActions', () => {
 
       // Confirming the modal only starts the delete; the event waits for the server.
       expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+      // The report must not live in a per-call callback, which React Query skips once the caller has
+      // unsubscribed.
+      expect(bulkDeleteTemplatesMock).toHaveBeenCalledWith({
+        templateIds: [mockTemplate.templateId],
+      });
 
       act(() => {
-        bulkDeleteTemplatesMock.mock.calls[0][1].onSuccess();
+        useBulkDeleteTemplatesMock.mock.calls[0][0].onSuccess();
       });
 
       expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
@@ -492,7 +501,7 @@ describe('useTemplatesActions', () => {
       );
     });
 
-    it('reports one deleted event even though the hook-level callback also runs', () => {
+    it('reports one deleted event and still refreshes the list', () => {
       const onDeleteSuccessMock = jest.fn();
       const { result } = renderHook(
         () => useTemplatesActions({ onDeleteSuccess: onDeleteSuccessMock }),
@@ -507,11 +516,9 @@ describe('useTemplatesActions', () => {
         result.current.confirmDelete();
       });
 
-      // A real success runs both callbacks: the hook-level one refreshes the list, the per-call one
-      // reports. Only one of them may report.
+      // The report and the list refresh now share one callback, so neither may cost the other.
       act(() => {
         useBulkDeleteTemplatesMock.mock.calls[0][0].onSuccess();
-        bulkDeleteTemplatesMock.mock.calls[0][1].onSuccess();
       });
 
       expect(onDeleteSuccessMock).toHaveBeenCalledTimes(1);

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.ts
@@ -28,8 +28,19 @@ interface UseTemplatesActionsProps {
 export const useTemplatesActions = ({ onDeleteSuccess }: UseTemplatesActionsProps = {}) => {
   const { navigateToCasesEditTemplate } = useCasesEditTemplateNavigation();
   const { showSuccessToast } = useCasesToast();
+
+  const reportTemplateCreated = useTemplateCreatedEBT();
+  const reportTemplateUpdated = useTemplateUpdatedEBT();
+  const reportTemplateDeleted = useTemplateDeletedEBT();
+
   const { mutate: bulkDeleteTemplates, isLoading: isDeleting } = useBulkDeleteTemplates({
-    onSuccess: onDeleteSuccess,
+    onSuccess: () => {
+      // React Query awaits this hook-level callback whatever happens to the caller, but it runs a
+      // per-call callback only while the caller still has listeners. Report here so that navigating
+      // away mid-flight cannot drop the event. This hook instance always deletes one row.
+      reportTemplateDeleted({ entryPoint: 'templates_list', deleteScope: 'single' });
+      onDeleteSuccess?.();
+    },
   });
 
   const { mutate: cloneTemplate, isLoading: isCloning } = useCreateTemplate({
@@ -41,10 +52,6 @@ export const useTemplatesActions = ({ onDeleteSuccess }: UseTemplatesActionsProp
   const { mutate: updateTemplate, isLoading: isUpdating } = useUpdateTemplate({
     disableDefaultSuccessToast: true,
   });
-
-  const reportTemplateCreated = useTemplateCreatedEBT();
-  const reportTemplateUpdated = useTemplateUpdatedEBT();
-  const reportTemplateDeleted = useTemplateDeletedEBT();
 
   const [templateToDelete, setTemplateToDelete] = useState<Template | null>(null);
 
@@ -100,19 +107,10 @@ export const useTemplatesActions = ({ onDeleteSuccess }: UseTemplatesActionsProp
 
   const confirmDelete = useCallback(() => {
     if (templateToDelete) {
-      // A row delete reuses the bulk mutation with a single id, so the scope is only knowable here.
-      // This per-call callback is additional to the hook-level one, which refreshes the list.
-      bulkDeleteTemplates(
-        { templateIds: [templateToDelete.templateId] },
-        {
-          onSuccess: () => {
-            reportTemplateDeleted({ entryPoint: 'templates_list', deleteScope: 'single' });
-          },
-        }
-      );
+      bulkDeleteTemplates({ templateIds: [templateToDelete.templateId] });
       setTemplateToDelete(null);
     }
-  }, [templateToDelete, bulkDeleteTemplates, reportTemplateDeleted]);
+  }, [templateToDelete, bulkDeleteTemplates]);
 
   const cancelDelete = useCallback(() => {
     setTemplateToDelete(null);

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_templates_actions.ts
@@ -14,6 +14,11 @@ import { useCreateTemplate } from './use_create_template';
 import { useUpdateTemplate } from './use_update_template';
 import { useBulkExportTemplates } from './use_bulk_export_templates';
 import { useCasesToast } from '../../../common/use_cases_toast';
+import {
+  useTemplateCreatedEBT,
+  useTemplateDeletedEBT,
+  useTemplateUpdatedEBT,
+} from '../../../analytics/templates';
 import * as i18n from '../translations';
 
 interface UseTemplatesActionsProps {
@@ -36,6 +41,10 @@ export const useTemplatesActions = ({ onDeleteSuccess }: UseTemplatesActionsProp
   const { mutate: updateTemplate, isLoading: isUpdating } = useUpdateTemplate({
     disableDefaultSuccessToast: true,
   });
+
+  const reportTemplateCreated = useTemplateCreatedEBT();
+  const reportTemplateUpdated = useTemplateUpdatedEBT();
+  const reportTemplateDeleted = useTemplateDeletedEBT();
 
   const [templateToDelete, setTemplateToDelete] = useState<Template | null>(null);
 
@@ -67,12 +76,15 @@ export const useTemplatesActions = ({ onDeleteSuccess }: UseTemplatesActionsProp
         },
         {
           onSuccess: () => {
+            // A clone is a create with a copied payload, so it reports the create event with a
+            // distinct creation mode rather than an event of its own.
+            reportTemplateCreated({ entryPoint: 'templates_list', creationMode: 'clone' });
             showSuccessToast(i18n.SUCCESS_CLONING_TEMPLATE(template.name));
           },
         }
       );
     },
-    [cloneTemplate, showSuccessToast]
+    [cloneTemplate, showSuccessToast, reportTemplateCreated]
   );
 
   const handleExport = useCallback(
@@ -88,10 +100,19 @@ export const useTemplatesActions = ({ onDeleteSuccess }: UseTemplatesActionsProp
 
   const confirmDelete = useCallback(() => {
     if (templateToDelete) {
-      bulkDeleteTemplates({ templateIds: [templateToDelete.templateId] });
+      // A row delete reuses the bulk mutation with a single id, so the scope is only knowable here.
+      // This per-call callback is additional to the hook-level one, which refreshes the list.
+      bulkDeleteTemplates(
+        { templateIds: [templateToDelete.templateId] },
+        {
+          onSuccess: () => {
+            reportTemplateDeleted({ entryPoint: 'templates_list', deleteScope: 'single' });
+          },
+        }
+      );
       setTemplateToDelete(null);
     }
-  }, [templateToDelete, bulkDeleteTemplates]);
+  }, [templateToDelete, bulkDeleteTemplates, reportTemplateDeleted]);
 
   const cancelDelete = useCallback(() => {
     setTemplateToDelete(null);
@@ -106,12 +127,13 @@ export const useTemplatesActions = ({ onDeleteSuccess }: UseTemplatesActionsProp
         },
         {
           onSuccess: () => {
+            reportTemplateUpdated({ entryPoint: 'templates_list' });
             showSuccessToast(i18n.SUCCESS_UPDATING_TEMPLATE);
           },
         }
       );
     },
-    [updateTemplate, showSuccessToast]
+    [updateTemplate, showSuccessToast, reportTemplateUpdated]
   );
 
   return {

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/all_templates_page.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/all_templates_page.test.tsx
@@ -11,6 +11,8 @@ import userEvent from '@testing-library/user-event';
 
 import { APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
 import { openAppMenuOverflow } from '@kbn/app-header/test_helpers';
+import type { CoreStart } from '@kbn/core/public';
+import { coreMock } from '@kbn/core/public/mocks';
 import { AllTemplatesPage } from './all_templates_page';
 import { renderWithTestingProviders, createTestQueryClient } from '../../../common/mock';
 import { KibanaServices } from '../../../common/lib/kibana';
@@ -406,5 +408,21 @@ describe('AllTemplatesPage', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('templates-table-selected-count')).not.toBeInTheDocument();
     });
+  });
+
+  it('reports no template management event on page load alone', async () => {
+    const queryClient = createTestQueryClient();
+    const coreStart = coreMock.createStart() as unknown as CoreStart;
+
+    renderWithTestingProviders(<AllTemplatesPage />, {
+      wrapperProps: { queryClient, coreStart },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('templates-table')).toBeInTheDocument();
+    });
+
+    // Loading and listing templates is not a management action.
+    expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/all_templates_page.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/all_templates_page.test.tsx
@@ -6,16 +6,22 @@
  */
 
 import React from 'react';
-import { createEvent, fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, createEvent, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
 import { openAppMenuOverflow } from '@kbn/app-header/test_helpers';
 import type { CoreStart } from '@kbn/core/public';
 import { coreMock } from '@kbn/core/public/mocks';
+import { CASES_TEMPLATE_DELETED_EVENT_TYPE } from '../../../../common/constants';
 import { AllTemplatesPage } from './all_templates_page';
-import { renderWithTestingProviders, createTestQueryClient } from '../../../common/mock';
+import {
+  createTestQueryClient,
+  mockedTestProvidersOwner,
+  renderWithTestingProviders,
+} from '../../../common/mock';
 import { KibanaServices } from '../../../common/lib/kibana';
+import type { BulkDeleteTemplatesResponse } from '../types';
 import * as api from '../api/api';
 
 jest.mock('../api/api');
@@ -104,6 +110,9 @@ describe('AllTemplatesPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     apiMock.getTemplates.mockResolvedValue(mockTemplatesResponse);
+    // clearAllMocks keeps implementations, so reset this one: the tests below install a promise they
+    // resolve by hand, which any later test would otherwise inherit as a delete that never settles.
+    apiMock.bulkDeleteTemplates.mockResolvedValue({ success: true, deleted: [], errors: [] });
     jest
       .spyOn(KibanaServices, 'getConfig')
       .mockReturnValue({ templates: { enabled: true } } as ReturnType<
@@ -424,5 +433,208 @@ describe('AllTemplatesPage', () => {
 
     // Loading and listing templates is not a management action.
     expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+  });
+
+  it('reports exactly one deleted event for a confirmed row delete', async () => {
+    const queryClient = createTestQueryClient();
+    const coreStart = coreMock.createStart() as unknown as CoreStart;
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    apiMock.bulkDeleteTemplates.mockResolvedValue({
+      success: true,
+      deleted: ['template-1'],
+      errors: [],
+    });
+
+    renderWithTestingProviders(<AllTemplatesPage />, {
+      wrapperProps: { queryClient, coreStart },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('templates-table')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('template-action-popover-button-template-1'));
+    await user.click(await screen.findByTestId('template-action-delete-template-1'));
+    await user.click(await screen.findByTestId('confirmModalConfirmButton'));
+
+    // This drives the real mutation, so every callback React Query runs for a success runs here.
+    // A report in more than one of them would show up as a second event.
+    await waitFor(() => {
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+    });
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+      CASES_TEMPLATE_DELETED_EVENT_TYPE,
+      {
+        owner: mockedTestProvidersOwner[0],
+        entry_point: 'templates_list',
+        delete_scope: 'single',
+      }
+    );
+  });
+
+  it('reports nothing when a confirmed row delete fails', async () => {
+    const queryClient = createTestQueryClient();
+    const coreStart = coreMock.createStart() as unknown as CoreStart;
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    apiMock.bulkDeleteTemplates.mockRejectedValue(new Error('Delete failed'));
+
+    renderWithTestingProviders(<AllTemplatesPage />, {
+      wrapperProps: { queryClient, coreStart },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('templates-table')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('template-action-popover-button-template-1'));
+    await user.click(await screen.findByTestId('template-action-delete-template-1'));
+    await user.click(await screen.findByTestId('confirmModalConfirmButton'));
+
+    await waitFor(() => {
+      expect(apiMock.bulkDeleteTemplates).toHaveBeenCalled();
+    });
+
+    expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+  });
+
+  it('reports one bulk delete event and still clears the selection', async () => {
+    const queryClient = createTestQueryClient();
+    const coreStart = coreMock.createStart() as unknown as CoreStart;
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    apiMock.bulkDeleteTemplates.mockResolvedValue({
+      success: true,
+      deleted: ['template-1', 'template-2'],
+      errors: [],
+    });
+
+    renderWithTestingProviders(<AllTemplatesPage />, {
+      wrapperProps: { queryClient, coreStart },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('templates-table')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    await user.click(checkboxes[1]);
+    await user.click(checkboxes[2]);
+
+    await user.click(await screen.findByTestId('templates-bulk-actions-link-icon'));
+    await user.click(await screen.findByTestId('templates-bulk-action-delete'));
+    await user.click(await screen.findByTestId('confirmModalConfirmButton'));
+
+    // The deselect and the report share one callback now, so neither may cancel the other. This
+    // test also passes on the old per-call wiring, because the component renders null on an empty
+    // selection rather than unmounting. The two tests below are the ones that pin the fix.
+    await waitFor(() => {
+      expect(screen.queryByTestId('templates-table-selected-count')).not.toBeInTheDocument();
+    });
+
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+      CASES_TEMPLATE_DELETED_EVENT_TYPE,
+      {
+        owner: mockedTestProvidersOwner[0],
+        entry_point: 'templates_list',
+        delete_scope: 'bulk',
+      }
+    );
+  });
+
+  it('reports a row delete that the server confirms after the page unmounts', async () => {
+    const queryClient = createTestQueryClient();
+    const coreStart = coreMock.createStart() as unknown as CoreStart;
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const deferred: { resolve: (value: BulkDeleteTemplatesResponse) => void } = {
+      resolve: () => {},
+    };
+    apiMock.bulkDeleteTemplates.mockReturnValue(
+      new Promise((resolve) => {
+        deferred.resolve = resolve;
+      })
+    );
+
+    const { unmount } = renderWithTestingProviders(<AllTemplatesPage />, {
+      wrapperProps: { queryClient, coreStart },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('templates-table')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('template-action-popover-button-template-1'));
+    await user.click(await screen.findByTestId('template-action-delete-template-1'));
+    await user.click(await screen.findByTestId('confirmModalConfirmButton'));
+
+    await waitFor(() => {
+      expect(apiMock.bulkDeleteTemplates).toHaveBeenCalled();
+    });
+
+    // The user leaves the page while the delete is still in flight.
+    unmount();
+
+    await act(async () => {
+      deferred.resolve({ success: true, deleted: ['template-1'], errors: [] });
+    });
+
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+      CASES_TEMPLATE_DELETED_EVENT_TYPE,
+      {
+        owner: mockedTestProvidersOwner[0],
+        entry_point: 'templates_list',
+        delete_scope: 'single',
+      }
+    );
+  });
+
+  it('reports a bulk delete that the server confirms after the page unmounts', async () => {
+    const queryClient = createTestQueryClient();
+    const coreStart = coreMock.createStart() as unknown as CoreStart;
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const deferred: { resolve: (value: BulkDeleteTemplatesResponse) => void } = {
+      resolve: () => {},
+    };
+    apiMock.bulkDeleteTemplates.mockReturnValue(
+      new Promise((resolve) => {
+        deferred.resolve = resolve;
+      })
+    );
+
+    const { unmount } = renderWithTestingProviders(<AllTemplatesPage />, {
+      wrapperProps: { queryClient, coreStart },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('templates-table')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    await user.click(checkboxes[1]);
+    await user.click(checkboxes[2]);
+
+    await user.click(await screen.findByTestId('templates-bulk-actions-link-icon'));
+    await user.click(await screen.findByTestId('templates-bulk-action-delete'));
+    await user.click(await screen.findByTestId('confirmModalConfirmButton'));
+
+    await waitFor(() => {
+      expect(apiMock.bulkDeleteTemplates).toHaveBeenCalled();
+    });
+
+    unmount();
+
+    await act(async () => {
+      deferred.resolve({ success: true, deleted: ['template-1', 'template-2'], errors: [] });
+    });
+
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+    expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+      CASES_TEMPLATE_DELETED_EVENT_TYPE,
+      {
+        owner: mockedTestProvidersOwner[0],
+        entry_point: 'templates_list',
+        delete_scope: 'bulk',
+      }
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/create_template/page.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/create_template/page.test.tsx
@@ -10,9 +10,14 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { parse as yamlParse } from 'yaml';
 import { APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
+import type { CoreStart } from '@kbn/core/public';
+import { coreMock } from '@kbn/core/public/mocks';
 import { CreateTemplatePage } from './page';
-import { TestProviders } from '../../../../common/mock';
-import { LOCAL_STORAGE_KEYS } from '../../../../../common/constants';
+import { mockedTestProvidersOwner, TestProviders } from '../../../../common/mock';
+import {
+  CASES_TEMPLATE_CREATED_EVENT_TYPE,
+  LOCAL_STORAGE_KEYS,
+} from '../../../../../common/constants';
 import { exampleTemplateDefinition } from '../../field_types/constants';
 import * as i18n from '../../translations';
 
@@ -81,8 +86,11 @@ const nameTemplateFromPageTitle = async (name: string) => {
 };
 
 describe('CreateTemplatePage', () => {
+  let coreStart: CoreStart;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    coreStart = coreMock.createStart() as unknown as CoreStart;
     localStorage.clear();
     // Create resolves to the new template; the page then switches to edit mode for that id.
     mockMutateAsync.mockResolvedValue({ templateId: 'new-tpl-id' });
@@ -275,5 +283,52 @@ describe('CreateTemplatePage', () => {
     const storedConfig = localStorage.getItem(configKey);
     const parsedConfig = storedConfig ? JSON.parse(storedConfig) : {};
     expect(parsedConfig.settings).toEqual({ syncAlerts: true, extractObservables: true });
+  });
+
+  describe('telemetry', () => {
+    it('reports one created event with the blank mode when the save succeeds', async () => {
+      render(
+        <TestProviders coreStart={coreStart}>
+          <CreateTemplatePage />
+        </TestProviders>
+      );
+
+      // Opening the editor is not a confirmed action.
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+
+      await nameTemplateFromPageTitle('My template');
+      await userEvent.click(screen.getByTestId('saveTemplateHeaderButton'));
+
+      await waitFor(() => {
+        expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      });
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+        CASES_TEMPLATE_CREATED_EVENT_TYPE,
+        {
+          owner: mockedTestProvidersOwner[0],
+          entry_point: 'template_editor',
+          creation_mode: 'blank',
+        }
+      );
+    });
+
+    it('reports nothing when the save fails', async () => {
+      mockMutateAsync.mockRejectedValueOnce(new Error('Creation failed'));
+
+      render(
+        <TestProviders coreStart={coreStart}>
+          <CreateTemplatePage />
+        </TestProviders>
+      );
+
+      await nameTemplateFromPageTitle('My template');
+      await userEvent.click(screen.getByTestId('saveTemplateHeaderButton'));
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+      });
+
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/create_template/page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/create_template/page.tsx
@@ -17,6 +17,7 @@ import { useCasesFeatures } from '../../../../common/use_cases_features';
 import { useAvailableCasesOwners } from '../../../app/use_available_owners';
 import { getOwnerDefaultValue } from '../../../create/utils';
 import { useCasesEditTemplateNavigation } from '../../../../common/navigation';
+import { useTemplateCreatedEBT } from '../../../../analytics/templates';
 import { LOCAL_STORAGE_KEYS, SECURITY_SOLUTION_OWNER } from '../../../../../common/constants';
 import { useCasesTemplatesBreadcrumbs } from '../../../use_breadcrumbs';
 import type { TemplateMetadata } from '../../utils/template_metadata';
@@ -46,6 +47,7 @@ export const CreateTemplatePage: FC<CreateTemplatePageProps> = () => {
   const defaultOwnerValue = owner[0] ?? getOwnerDefaultValue(availableOwners);
   const { navigateToCasesEditTemplate } = useCasesEditTemplateNavigation();
   const { isExtractObservablesEnabled } = useCasesFeatures();
+  const reportTemplateCreated = useTemplateCreatedEBT();
 
   // Defaults for a new template mirror toggle visibility: extract observables on only where the
   // solution enables it, sync alerts on only for Security (the toggles are hidden otherwise).
@@ -71,11 +73,14 @@ export const CreateTemplatePage: FC<CreateTemplatePageProps> = () => {
           isEnabled,
         },
       });
+      // Reported after the write resolves, so a rejected save stays silent, and before navigating,
+      // so the report is not racing this component's unmount.
+      reportTemplateCreated({ entryPoint: 'template_editor', creationMode: 'blank' });
       // Stay in the editor after the first save: switch to edit mode for the new template so a
       // subsequent Save updates it instead of creating a duplicate.
       navigateToCasesEditTemplate({ templateId: created.templateId });
     },
-    [defaultOwnerValue, mutateAsync, navigateToCasesEditTemplate]
+    [defaultOwnerValue, mutateAsync, navigateToCasesEditTemplate, reportTemplateCreated]
   );
 
   return (

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/edit_template/page.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/edit_template/page.test.tsx
@@ -7,11 +7,16 @@
 
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import type { CoreStart } from '@kbn/core/public';
+import { coreMock } from '@kbn/core/public/mocks';
 import { EditTemplatePage } from './page';
+import { mockedTestProvidersOwner, TestProviders } from '../../../../common/mock';
+import { CASES_TEMPLATE_UPDATED_EVENT_TYPE } from '../../../../../common/constants';
 
 const mockUseTemplateViewParams = jest.fn();
 const mockNavigateToCasesTemplates = jest.fn();
 jest.mock('../../../../common/navigation', () => ({
+  ...jest.requireActual('../../../../common/navigation'),
   useTemplateViewParams: () => mockUseTemplateViewParams(),
   useCasesTemplatesNavigation: () => ({
     navigateToCasesTemplates: mockNavigateToCasesTemplates,
@@ -69,8 +74,18 @@ jest.mock('../../components/template_form_layout', () => ({
 }));
 
 describe('EditTemplatePage', () => {
+  let coreStart: CoreStart;
+
+  const renderEditTemplatePage = () =>
+    render(
+      <TestProviders coreStart={coreStart}>
+        <EditTemplatePage />
+      </TestProviders>
+    );
+
   beforeEach(() => {
     jest.clearAllMocks();
+    coreStart = coreMock.createStart() as unknown as CoreStart;
     mockMutateAsync.mockResolvedValue(undefined);
     mockTemplateFormLayout.mockImplementation(({ initialMetadata, isLoading }) => (
       <div>
@@ -100,7 +115,7 @@ describe('EditTemplatePage', () => {
       isLoading: false,
     });
 
-    render(<EditTemplatePage />);
+    renderEditTemplatePage();
 
     expect(screen.getByTestId('layout-title')).toHaveTextContent('Test Template');
     expect(screen.getByTestId('layout-loaded')).toBeInTheDocument();
@@ -111,9 +126,17 @@ describe('EditTemplatePage', () => {
     mockUseTemplateViewParams.mockReturnValue({ templateId: 'template-123' });
     mockUseGetTemplate.mockReturnValue({ data: undefined, isLoading: true });
 
-    const { container } = render(<EditTemplatePage />);
+    // Scoped to a slot of its own, because the surrounding providers render markup into the
+    // container and would defeat an assertion made on the container itself.
+    render(
+      <TestProviders coreStart={coreStart}>
+        <div data-test-subj="edit-page-slot">
+          <EditTemplatePage />
+        </div>
+      </TestProviders>
+    );
 
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByTestId('edit-page-slot')).toBeEmptyDOMElement();
   });
 
   it('sends empty description and empty tags when metadata is cleared', async () => {
@@ -136,7 +159,7 @@ describe('EditTemplatePage', () => {
       isLoading: false,
     });
 
-    render(<EditTemplatePage />);
+    renderEditTemplatePage();
 
     await capturedTemplateFormLayoutProps.onCreate?.(
       { definition: 'name: Updated\nfields: []' },
@@ -177,7 +200,7 @@ describe('EditTemplatePage', () => {
       isLoading: false,
     });
 
-    render(<EditTemplatePage />);
+    renderEditTemplatePage();
 
     // The metadata form folds undefined identity fields to '' / []. A no-op Save must NOT coerce
     // those into a persisted '' / [] via the PATCH `?? existing` fallback.
@@ -198,6 +221,66 @@ describe('EditTemplatePage', () => {
           isEnabled: true,
         },
       });
+    });
+  });
+
+  describe('telemetry', () => {
+    const loadedTemplate = {
+      data: {
+        templateId: 'template-123',
+        name: 'Test Template',
+        owner: 'cases',
+        definition: { name: 'Test Template', fields: [] },
+        definitionString: 'name: Test Template\nfields: []',
+        templateVersion: 2,
+        deletedAt: null,
+        isLatest: true,
+        latestVersion: 2,
+        isEnabled: true,
+      },
+      isLoading: false,
+    };
+
+    beforeEach(() => {
+      mockUseTemplateViewParams.mockReturnValue({ templateId: 'template-123' });
+      mockUseGetTemplate.mockReturnValue(loadedTemplate);
+    });
+
+    it('reports one updated event with the editor entry point when the save succeeds', async () => {
+      renderEditTemplatePage();
+
+      // Opening an existing template is not a confirmed action.
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
+
+      await capturedTemplateFormLayoutProps.onCreate?.(
+        { definition: 'name: Updated\nfields: []' },
+        { name: 'Test Template', description: '', tags: [] },
+        true
+      );
+
+      await waitFor(() => {
+        expect(coreStart.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      });
+      expect(coreStart.analytics.reportEvent).toHaveBeenCalledWith(
+        CASES_TEMPLATE_UPDATED_EVENT_TYPE,
+        { owner: mockedTestProvidersOwner[0], entry_point: 'template_editor' }
+      );
+    });
+
+    it('reports nothing when the save fails', async () => {
+      mockMutateAsync.mockRejectedValueOnce(new Error('Update failed'));
+
+      renderEditTemplatePage();
+
+      await expect(
+        capturedTemplateFormLayoutProps.onCreate?.(
+          { definition: 'name: Updated\nfields: []' },
+          { name: 'Test Template', description: '', tags: [] },
+          true
+        )
+      ).rejects.toThrow('Update failed');
+
+      expect(coreStart.analytics.reportEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/edit_template/page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/pages/edit_template/page.tsx
@@ -13,6 +13,7 @@ import type { YamlEditorFormValues } from '../../components/template_form';
 import { useGetTemplate } from '../../hooks/use_get_template';
 import { useUpdateTemplate } from '../../hooks/use_update_template';
 import { TemplateFormLayout } from '../../components/template_form_layout';
+import { useTemplateUpdatedEBT } from '../../../../analytics/templates';
 import { LOCAL_STORAGE_KEYS } from '../../../../../common/constants';
 import { useCasesTemplatesBreadcrumbs } from '../../../use_breadcrumbs';
 import type { TemplateMetadata } from '../../utils/template_metadata';
@@ -25,6 +26,7 @@ export const EditTemplatePage: FC<EditTemplatePageProps> = () => {
   const { templateId } = useTemplateViewParams();
   const { data: template } = useGetTemplate(templateId);
   const { mutateAsync, isLoading: isSaving } = useUpdateTemplate();
+  const reportTemplateUpdated = useTemplateUpdatedEBT();
 
   useCasesTemplatesBreadcrumbs(template?.name ?? i18n.EDIT_TEMPLATE_TITLE);
 
@@ -74,9 +76,11 @@ export const EditTemplatePage: FC<EditTemplatePageProps> = () => {
           isEnabled,
         },
       });
+      // Reported after the write resolves, so a rejected save stays silent.
+      reportTemplateUpdated({ entryPoint: 'template_editor' });
       // Stay in the editor after saving (no redirect to the list) so authoring can continue.
     },
-    [mutateAsync, templateId, template?.description, template?.tags]
+    [mutateAsync, templateId, template?.description, template?.tags, reportTemplateUpdated]
   );
 
   if (!template) {


### PR DESCRIPTION
## What & Why

The Cases server already counts every template write, but a counter cannot say where in the UI the
action started, or whether a new template began blank or as a copy. This PR registers three browser
events — `cases_template_created`, `cases_template_updated`, `cases_template_deleted` — and reports
exactly one after each confirmed write on the templates pages: a blank save, a row clone, an editor
save, the row enable switch, a row delete, and a bulk delete. Each event carries the owner plus
bounded context only (`entry_point`, and `creation_mode` on a create or `delete_scope` on a delete):
no template name, tag, author, or YAML, and nothing is sent on a page load or a failed write. The
server counters remain the totals.

Closes https://github.com/elastic/security-team/issues/18977

Gated by `xpack.cases.templates.enabled`, which defaults to `true`.


## How to Test

1. Add `telemetry.localShipper: true` to `config/kibana.dev.yml` and start Kibana. This indexes
   browser events into a local `ebt-kibana-browser` index.
2. Open Cases → Templates. Create a template in the editor, clone a row, save an edit, toggle a
   row's enable switch, delete a row, then select two rows and bulk delete them.
3. Read the events:
   `curl -u elastic:changeme -XPOST localhost:9200/ebt-kibana-browser/_refresh` then
   `curl -u elastic:changeme 'localhost:9200/ebt-kibana-browser/_search?q=event_type:cases_template_*&size=50'`
4. Confirm one event per action, `creation_mode` of `blank` or `clone` on the creates,
   `delete_scope` of `single` or `bulk` on the deletes, and a single event for the two-row bulk
   delete.
5. Confirm that loading the templates list sends no `cases_template_*` event, and that a cancelled
   delete sends none either.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->