### PR TITLE
[9.4] [ResponseOps][Task Manager] allow updates to task documents while the task is running - take 2 (#281668)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/buffered_task_store.mock.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/buffered_task_store.mock.ts
@@ -13,6 +13,7 @@ const createBufferedTaskStoreMock = () => {
     update: jest.fn(),
     partialUpdate: jest.fn(),
     remove: jest.fn(),
+    get: jest.fn(),
   };
   return mocked;
 };

--- a/x-pack/platform/plugins/shared/task_manager/server/buffered_task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/buffered_task_store.ts
@@ -93,4 +93,8 @@ export class BufferedTaskStore implements Updatable {
   public async remove(id: string): Promise<void> {
     await unwrapPromise(this.bufferedRemove({ id }));
   }
+
+  public async get(id: string): Promise<ConcreteTaskInstance> {
+    return this.taskStore.get(id);
+  }
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/resolve_so_conflicts.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/resolve_so_conflicts.test.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockLogger } from '../test_utils';
+import { bufferedTaskStoreMock } from '../buffered_task_store.mock';
+import type { ConcreteTaskInstance, PartialConcreteTaskInstance } from '../task';
+import { TaskStatus } from '../task';
+import { resolveTaskDocumentConflicts } from './resolve_so_conflicts';
+import type { Updatable } from './task_runner';
+
+const LOG_META = { tags: ['task-1', 'bar', 'task-doc-resolve-conflict'] };
+
+const createTask = (overrides: Partial<ConcreteTaskInstance> = {}): ConcreteTaskInstance => ({
+  id: 'task-1',
+  taskType: 'bar',
+  scheduledAt: new Date('2020-01-01T00:00:00.000Z'),
+  runAt: new Date('2020-01-01T00:00:00.000Z'),
+  startedAt: new Date('2020-01-01T00:00:00.000Z'),
+  retryAt: null,
+  attempts: 0,
+  status: TaskStatus.Running,
+  params: {},
+  state: {},
+  ownerId: 'kibana-node-1',
+  schedule: { interval: '1m' },
+  version: 'WzEsMV0=',
+  ...overrides,
+});
+
+describe('resolveTaskDocumentConflicts', () => {
+  const logger = mockLogger();
+  let store: jest.Mocked<Updatable>;
+  let originalTask: ConcreteTaskInstance;
+  let partialTask: PartialConcreteTaskInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    store = bufferedTaskStoreMock.create();
+    originalTask = createTask();
+    partialTask = {
+      id: originalTask.id,
+      status: TaskStatus.Idle,
+      startedAt: null,
+      retryAt: null,
+      ownerId: null,
+      state: { foo: 'bar' },
+      runAt: new Date('2020-01-01T00:01:00.000Z'),
+      schedule: { interval: '1m' },
+    };
+  });
+
+  const resolve = () =>
+    resolveTaskDocumentConflicts({
+      taskId: originalTask.id,
+      partialTask,
+      originalTask,
+      bufferedTaskStore: store,
+      logger,
+      pRetryOptions: { minTimeout: 0, factor: 1 },
+    });
+
+  test('merges partial updates onto the current task and preserves its version', async () => {
+    const currentTask = createTask({
+      version: 'WzIsMV0=',
+      state: { existing: true },
+      startedAt: originalTask.startedAt,
+    });
+    store.get.mockResolvedValue(currentTask);
+    store.partialUpdate.mockResolvedValue(currentTask);
+
+    await resolve();
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Resolving task document conflict for task "bar:task-1" (attempt 1/3).',
+      LOG_META
+    );
+    expect(logger.warn).toHaveBeenNthCalledWith(
+      1,
+      'Resolving task document version conflict after task run for task "bar:task-1"',
+      LOG_META
+    );
+    expect(logger.warn).toHaveBeenNthCalledWith(
+      2,
+      'Resolved task document version conflict after task run for task "bar:task-1"',
+      LOG_META
+    );
+
+    expect(store.get).toHaveBeenCalledWith('task-1');
+    expect(store.partialUpdate).toHaveBeenCalledTimes(1);
+    expect(store.partialUpdate).toHaveBeenCalledWith(
+      {
+        ...currentTask,
+        ...partialTask,
+        version: 'WzIsMV0=',
+      },
+      { validate: false, doc: currentTask }
+    );
+  });
+
+  test('keeps the current schedule when it changed while the task was running', async () => {
+    const currentTask = createTask({
+      version: 'WzIsMV0=',
+      schedule: { interval: '5m' },
+      startedAt: originalTask.startedAt,
+    });
+    store.get.mockResolvedValue(currentTask);
+    store.partialUpdate.mockResolvedValue(currentTask);
+
+    await resolve();
+
+    expect(store.partialUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schedule: { interval: '5m' },
+        version: 'WzIsMV0=',
+      }),
+      { validate: false, doc: currentTask }
+    );
+  });
+
+  test('keeps the current runAt when it changed while the task was running', async () => {
+    const currentRunAt = new Date('2020-01-01T00:10:00.000Z');
+    const currentTask = createTask({
+      version: 'WzIsMV0=',
+      runAt: currentRunAt,
+      startedAt: originalTask.startedAt,
+    });
+    store.get.mockResolvedValue(currentTask);
+    store.partialUpdate.mockResolvedValue(currentTask);
+
+    await resolve();
+
+    expect(store.partialUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runAt: currentRunAt,
+        version: 'WzIsMV0=',
+      }),
+      { validate: false, doc: currentTask }
+    );
+  });
+
+  test('retries when partialUpdate fails and succeeds on a later attempt', async () => {
+    const currentTask = createTask({
+      version: 'WzIsMV0=',
+      startedAt: originalTask.startedAt,
+    });
+    store.get.mockResolvedValue(currentTask);
+    store.partialUpdate
+      .mockRejectedValueOnce(new Error('temporary conflict'))
+      .mockResolvedValueOnce(currentTask);
+
+    await resolve();
+
+    expect(store.get).toHaveBeenCalledTimes(2);
+    expect(store.partialUpdate).toHaveBeenCalledTimes(2);
+    expect(logger.debug).toHaveBeenNthCalledWith(
+      2,
+      'Resolving task document conflict for task "bar:task-1" (attempt 2/3).',
+      LOG_META
+    );
+  });
+
+  test('retries when the task is not found and logs error after exhausting retries', async () => {
+    store.get.mockRejectedValue(new Error('task not found'));
+
+    await resolve();
+
+    expect(store.partialUpdate).not.toHaveBeenCalled();
+    expect(store.get).toHaveBeenCalledTimes(3);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error resolving task document version conflict after task run: Unable to resolve task document conflicts for task "bar:task-1": task not found',
+      LOG_META
+    );
+  });
+
+  test('retries when partialUpdate fails all attempts and logs error after exhausting retries', async () => {
+    const currentTask = createTask({ version: 'WzIsMV0=', startedAt: originalTask.startedAt });
+    store.get.mockResolvedValue(currentTask);
+    store.partialUpdate.mockRejectedValue(new Error('persistent conflict'));
+
+    await resolve();
+
+    expect(store.get).toHaveBeenCalledTimes(3);
+    expect(store.partialUpdate).toHaveBeenCalledTimes(3);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error resolving task document version conflict after task run: persistent conflict',
+      LOG_META
+    );
+  });
+
+  test('does not retry when the task was claimed by another worker', async () => {
+    store.get.mockResolvedValue(
+      createTask({ ownerId: 'kibana-node-2', startedAt: originalTask.startedAt })
+    );
+
+    await resolve();
+
+    expect(store.get).toHaveBeenCalledTimes(1);
+    expect(store.partialUpdate).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Skipping resolving task document version conflict after task run: Unable to resolve task document conflicts for task "bar:task-1": task has been claimed by another worker',
+      LOG_META
+    );
+  });
+
+  test('does not retry when attempts were updated by another worker', async () => {
+    store.get.mockResolvedValue(createTask({ attempts: 1, startedAt: originalTask.startedAt }));
+
+    await resolve();
+
+    expect(store.get).toHaveBeenCalledTimes(1);
+    expect(store.partialUpdate).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Skipping resolving task document version conflict after task run: Unable to resolve task document conflicts for task "bar:task-1": task attempts has been updated by another worker',
+      LOG_META
+    );
+  });
+
+  test('does not retry when startedAt was updated by another worker', async () => {
+    store.get.mockResolvedValue(createTask({ startedAt: new Date('2020-01-01T00:00:30.000Z') }));
+
+    await resolve();
+
+    expect(store.get).toHaveBeenCalledTimes(1);
+    expect(store.partialUpdate).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenNthCalledWith(
+      1,
+      'Resolving task document version conflict after task run for task "bar:task-1"',
+      LOG_META
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'Skipping resolving task document version conflict after task run: Unable to resolve task document conflicts for task "bar:task-1": task startedAt has been updated by another worker',
+      LOG_META
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/resolve_so_conflicts.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/resolve_so_conflicts.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { isEqual } from 'lodash';
+import pRetry, { type Options as PRetryOptions } from 'p-retry';
+import type { ConcreteTaskInstance, PartialConcreteTaskInstance } from '../task';
+import type { Updatable } from './task_runner';
+
+/** Total attempts = 1 initial + (MAX_ATTEMPTS - 1) retries */
+const MAX_ATTEMPTS = 3;
+
+export async function resolveTaskDocumentConflicts(
+  opts: ResolveTaskDocumentConflictsOpts
+): Promise<void> {
+  const label = `${opts.originalTask.taskType}:${opts.taskId}`;
+  const tags = [opts.taskId, opts.originalTask.taskType, 'task-doc-resolve-conflict'];
+  opts.logger.warn(`Resolving task document version conflict after task run for task "${label}"`, {
+    tags,
+  });
+
+  try {
+    await pRetry(
+      (attempt) =>
+        resolveTaskDocumentConflictsOnce({
+          ...opts,
+          attempt,
+          maxAttempts: MAX_ATTEMPTS,
+          label,
+          tags,
+        }),
+      { retries: MAX_ATTEMPTS - 1, ...opts.pRetryOptions }
+    );
+  } catch (error) {
+    if (error instanceof NotRetryableError) {
+      opts.logger.error(
+        `Skipping resolving task document version conflict after task run: ${error.message}`,
+        { tags }
+      );
+    } else {
+      opts.logger.error(
+        `Error resolving task document version conflict after task run: ${error.message}`,
+        { tags }
+      );
+    }
+
+    return;
+  }
+
+  opts.logger.warn(`Resolved task document version conflict after task run for task "${label}"`, {
+    tags,
+  });
+}
+
+async function resolveTaskDocumentConflictsOnce({
+  taskId,
+  partialTask,
+  originalTask,
+  bufferedTaskStore,
+  logger,
+  attempt,
+  maxAttempts,
+  label,
+  tags,
+}: ResolveTaskDocumentConflictsOnceOpts): Promise<void> {
+  logger.debug(
+    `Resolving task document conflict for task "${label}" (attempt ${attempt}/${maxAttempts}).`,
+    { tags }
+  );
+
+  // if current task is not found, consider transient and retry
+  let currentTask: ConcreteTaskInstance;
+  try {
+    currentTask = await bufferedTaskStore.get(taskId);
+  } catch (error) {
+    throw Error(`Unable to resolve task document conflicts for task "${label}": ${error.message}`);
+  }
+
+  // A number of "permanent" conditions can occur that mean we should not retry,
+  // so we need to check for those and not retry.
+
+  if (currentTask.ownerId !== originalTask.ownerId) {
+    throwNotRetryableError(
+      `Unable to resolve task document conflicts for task "${label}": task has been claimed by another worker`
+    );
+  }
+
+  if (currentTask.attempts !== originalTask.attempts) {
+    throwNotRetryableError(
+      `Unable to resolve task document conflicts for task "${label}": task attempts has been updated by another worker`
+    );
+  }
+
+  if (currentTask.startedAt?.valueOf() !== originalTask.startedAt?.valueOf()) {
+    throwNotRetryableError(
+      `Unable to resolve task document conflicts for task "${label}": task startedAt has been updated by another worker`
+    );
+  }
+
+  const updatedTask: PartialConcreteTaskInstance = {
+    ...currentTask,
+    ...partialTask,
+    version: currentTask.version,
+    // use the current task's schedule if it has changed from original
+    ...(!isEqual(originalTask.schedule, currentTask.schedule)
+      ? { schedule: currentTask.schedule }
+      : {}),
+    // use the current task's runAt if it has changed from original
+    ...(originalTask.runAt.valueOf() !== currentTask.runAt.valueOf()
+      ? { runAt: currentTask.runAt }
+      : {}),
+  };
+
+  // we've already validated the current task, so we can skip validation
+  await bufferedTaskStore.partialUpdate(updatedTask, {
+    validate: false,
+    doc: currentTask,
+  });
+}
+
+interface ResolveTaskDocumentConflictsOpts {
+  taskId: string;
+  partialTask: PartialConcreteTaskInstance;
+  originalTask: ConcreteTaskInstance;
+  bufferedTaskStore: Updatable;
+  logger: Logger;
+  pRetryOptions?: PRetryOptions;
+}
+
+interface ResolveTaskDocumentConflictsOnceOpts extends ResolveTaskDocumentConflictsOpts {
+  attempt: number;
+  maxAttempts: number;
+  label: string;
+  tags: string[];
+}
+
+function throwNotRetryableError(message: string): never {
+  const error = new NotRetryableError(message);
+  throw new pRetry.AbortError(error);
+}
+class NotRetryableError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -3431,6 +3431,183 @@ describe('TaskManagerRunner', () => {
       });
     });
 
+    test('handles a version conflict gracefully when an expired recurring task is reclaimed while running and schedule is greater than timeout', async () => {
+      const id = _.random(1, 20).toString();
+      const onTaskEvent = jest.fn();
+      const { runner, store, logger } = await readyToRunStageSetup({
+        onTaskEvent,
+        instance: {
+          id,
+          startedAt: moment().subtract(5, 'm').toDate(),
+          schedule: { interval: '30s' },
+        },
+        definitions: {
+          bar: {
+            title: 'Bar!',
+            timeout: '15s',
+            createTaskRunner: () => ({
+              async run() {
+                const promise = new Promise((r) => setTimeout(r, 20000));
+                jest.advanceTimersByTime(20000);
+                await promise;
+              },
+            }),
+          },
+        },
+      });
+
+      // another Kibana reclaimed and updated the task
+      store.partialUpdate.mockRejectedValueOnce({
+        type: 'task',
+        id,
+        status: 409,
+        error: {
+          type: 'version_conflict_engine_exception',
+          reason: `[task:${id}]: version conflict, required seqNo [1], primary term [1]. current document has seqNo [64000] and primary term [1]`,
+        },
+      });
+
+      const promise = runner.run();
+      await Promise.resolve();
+      await runner.cancel();
+      await promise;
+
+      expect(store.partialUpdate).toHaveBeenCalledTimes(1);
+
+      const frameworkErrorLogs = logger.error.mock.calls.filter(([, meta]) =>
+        ((meta as { tags?: string[] })?.tags ?? []).includes('task-run-failed')
+      );
+      expect(frameworkErrorLogs).toEqual([]);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Skipping the update of expired/cancelled task bar:${id} because it was reclaimed by another Kibana while running.`,
+        { tags: [id, 'bar'] }
+      );
+    });
+
+    test('resolves a version conflict when updating a recurring task after a successful run', async () => {
+      const id = 'conflict-success';
+      const startedAt = new Date();
+      const { runner, store, logger, instance } = await readyToRunStageSetup({
+        instance: {
+          id,
+          schedule: { interval: '1m' },
+          startedAt,
+          ownerId: 'kibana-node-1',
+          version: 'WzEsMV0=',
+        },
+        definitions: {
+          bar: {
+            title: 'Bar!',
+            createTaskRunner: () => ({
+              async run() {
+                return { state: { foo: 'bar' } };
+              },
+            }),
+          },
+        },
+      });
+
+      const currentTask = {
+        ...instance,
+        version: 'WzIsMV0=',
+        schedule: { interval: '5m' },
+        runAt: minutesFromNow(5),
+      };
+
+      store.partialUpdate
+        .mockRejectedValueOnce(
+          SavedObjectsErrorHelpers.decorateConflictError(new Error('Saved object conflict'))
+        )
+        .mockResolvedValueOnce(currentTask);
+      store.get.mockResolvedValue(currentTask);
+
+      await runner.run();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Resolving task document version conflict after task run for task "bar:${id}"`,
+        {
+          tags: [id, 'bar', 'task-doc-resolve-conflict'],
+        }
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Resolved task document version conflict after task run for task "bar:${id}"`,
+        {
+          tags: [id, 'bar', 'task-doc-resolve-conflict'],
+        }
+      );
+      expect(store.get).toHaveBeenCalledWith(id);
+      expect(store.partialUpdate).toHaveBeenCalledTimes(2);
+      expect(store.partialUpdate).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          version: 'WzIsMV0=',
+          schedule: { interval: '5m' },
+          runAt: currentTask.runAt,
+          state: { foo: 'bar' },
+        }),
+        { validate: false, doc: currentTask }
+      );
+    });
+
+    test('resolves a version_conflict_engine_exception when updating a recurring task', async () => {
+      const id = 'conflict-engine';
+      const startedAt = new Date();
+      const { runner, store, logger, instance } = await readyToRunStageSetup({
+        instance: {
+          id,
+          schedule: { interval: '1m' },
+          startedAt,
+          ownerId: 'kibana-node-1',
+          version: 'WzEsMV0=',
+        },
+        definitions: {
+          bar: {
+            title: 'Bar!',
+            createTaskRunner: () => ({
+              async run() {
+                return { state: {} };
+              },
+            }),
+          },
+        },
+      });
+
+      const currentTask = {
+        ...instance,
+        version: 'WzMsMV0=',
+      };
+
+      store.partialUpdate
+        .mockRejectedValueOnce({
+          type: 'task',
+          id,
+          status: 409,
+          error: {
+            type: 'version_conflict_engine_exception',
+            reason: `[task:${id}]: version conflict`,
+          },
+        })
+        .mockResolvedValueOnce(currentTask);
+      store.get.mockResolvedValue(currentTask);
+
+      await runner.run();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Resolving task document version conflict after task run for task "bar:${id}"`,
+        {
+          tags: [id, 'bar', 'task-doc-resolve-conflict'],
+        }
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Resolved task document version conflict after task run for task "bar:${id}"`,
+        {
+          tags: [id, 'bar', 'task-doc-resolve-conflict'],
+        }
+      );
+      expect(store.get).toHaveBeenCalledWith(id);
+      expect(store.partialUpdate).toHaveBeenCalledTimes(2);
+    });
+
     test('Prints debug logs on task start/end', async () => {
       const { runner, logger } = await readyToRunStageSetup({
         definitions: {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -68,6 +68,7 @@ import { isFailedRunResult, TaskStatus, TaskCost, getTaskCostFromInstance } from
 import type { TaskTypeDictionary } from '../task_type_dictionary';
 import { isUnrecoverableError, isUserError, type DecoratedError } from './errors';
 import { CLAIM_STRATEGY_MGET, type TaskManagerConfig } from '../config';
+import { resolveTaskDocumentConflicts } from './resolve_so_conflicts';
 import { TaskValidator } from '../task_validator';
 import { getRetryAt, getRetryDate, getTimeout } from '../lib/get_retry_at';
 import { getNextRunAt } from '../lib/get_next_run_at';
@@ -121,6 +122,7 @@ export interface Updatable {
     options: { validate: boolean; doc: ConcreteTaskInstance }
   ): Promise<ConcreteTaskInstance>;
   remove(id: string): Promise<void>;
+  get(id: string): Promise<ConcreteTaskInstance>;
 }
 
 type Opts = {
@@ -825,6 +827,7 @@ export class TaskManagerRunner implements TaskRunner {
       const { shouldValidate = true } = unwrap(result);
 
       let shouldUpdateTask: boolean = false;
+      const originalTask = this.instance.task;
       let partialTask: PartialConcreteTaskInstance = {
         id: this.instance.task.id,
         version: this.instance.task.version,
@@ -874,12 +877,38 @@ export class TaskManagerRunner implements TaskRunner {
       }
 
       if (shouldUpdateTask) {
-        this.instance = asRan(
-          await this.bufferedTaskStore.partialUpdate(partialTask, {
-            validate: shouldValidate,
-            doc: this.instance.task,
-          })
-        );
+        try {
+          this.instance = asRan(
+            await this.bufferedTaskStore.partialUpdate(partialTask, {
+              validate: shouldValidate,
+              doc: this.instance.task,
+            })
+          );
+        } catch (error) {
+          const isVersionConflict =
+            SavedObjectsErrorHelpers.isConflictError(error) ||
+            error.status === 409 ||
+            error.statusCode === 409 ||
+            error.error?.type === 'version_conflict_engine_exception';
+
+          if ((this.isExpired || this.isCancelled) && isVersionConflict) {
+            const label = `${this.taskType}:${this.instance.task.id}`;
+            this.logger.warn(
+              `Skipping the update of expired/cancelled task ${label} because it was reclaimed by another Kibana while running.`,
+              { tags: [this.id, this.taskType] }
+            );
+          } else if (isVersionConflict) {
+            await resolveTaskDocumentConflicts({
+              taskId: this.id,
+              partialTask,
+              originalTask,
+              bufferedTaskStore: this.bufferedTaskStore,
+              logger: this.logger,
+            });
+          } else {
+            throw error;
+          }
+        }
       }
     }
 

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/index.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/index.ts
@@ -14,6 +14,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./metrics_route'));
     loadTestFile(require.resolve('./health_route'));
     loadTestFile(require.resolve('./task_management'));
+    loadTestFile(require.resolve('./task_management_version_conflicts'));
     loadTestFile(require.resolve('./task_management_scheduled_at'));
     loadTestFile(require.resolve('./task_management_removed_types'));
     loadTestFile(require.resolve('./check_registered_task_types'));

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/task_management_version_conflicts.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/task_management_version_conflicts.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { estypes } from '@elastic/elasticsearch';
+import { taskMappings as TaskManagerMapping } from '@kbn/task-manager-plugin/server/saved_objects/mappings';
+import type { FtrProviderContext } from '../../ftr_provider_context';
+import type { RawDoc, SearchResults, SerializedConcreteTaskInstance } from './test_utils';
+import { scheduleTask, currentTasks } from './test_utils';
+
+const { properties: taskManagerIndexMapping } = TaskManagerMapping;
+
+export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const retry = getService('retry');
+  const supertest = getService('supertest');
+  const testHistoryIndex = '.kibana_task_manager_test_result';
+
+  describe('task document version conflicts while running', () => {
+    beforeEach(async () => {
+      await supertest.delete('/api/sample_tasks').set('kbn-xsrf', 'xxx').expect(200);
+      const exists = await es.indices.exists({ index: testHistoryIndex });
+      if (exists) {
+        await es.deleteByQuery({
+          index: testHistoryIndex,
+          refresh: true,
+          query: { term: { type: 'task' } },
+        });
+      } else {
+        await es.indices.create({
+          index: testHistoryIndex,
+          mappings: {
+            properties: {
+              type: {
+                type: 'keyword',
+              },
+              taskId: {
+                type: 'keyword',
+              },
+              params: taskManagerIndexMapping.params,
+              state: taskManagerIndexMapping.state,
+              runAt: taskManagerIndexMapping.runAt,
+            } as Record<string, estypes.MappingProperty>,
+          },
+        });
+      }
+    });
+
+    after(async () => {
+      await supertest.delete('/api/sample_tasks').set('kbn-xsrf', 'xxx').expect(200);
+    });
+
+    function currentTask<State = unknown, Params = unknown>(
+      taskId: string
+    ): Promise<SerializedConcreteTaskInstance<State, Params>> {
+      return supertest
+        .get(`/api/sample_tasks/task/${taskId}`)
+        .expect((response) => {
+          expect(response.status).to.eql(200);
+          expect(typeof JSON.parse(response.text).id).to.eql('string');
+        })
+        .then((response) => response.body);
+    }
+
+    function getTaskById<State = unknown, Params = unknown>(
+      tasks: Array<SerializedConcreteTaskInstance<State, Params>>,
+      id: string
+    ) {
+      return tasks.filter((task) => task.id === id)[0];
+    }
+
+    async function historyDocs(taskId?: string): Promise<RawDoc[]> {
+      return es
+        .search({
+          index: testHistoryIndex,
+          query: {
+            term: { type: 'task' },
+          },
+        })
+        .then((result) =>
+          (result as unknown as SearchResults).hits.hits.filter((task) =>
+            taskId ? task._source?.taskId === taskId : true
+          )
+        );
+    }
+
+    function releaseTasksWaitingForEventToComplete(event: string) {
+      return supertest
+        .post('/api/sample_tasks/event')
+        .set('kbn-xsrf', 'xxx')
+        .send({ event })
+        .expect(200);
+    }
+
+    async function provideParamsToTasksWaitingForParams(
+      taskId: string,
+      data: Record<string, unknown> = {}
+    ) {
+      await retry.try(async () => {
+        const tasks = (await currentTasks(supertest)).docs;
+        expect(getTaskById(tasks, taskId).status).to.eql('running');
+      });
+
+      return supertest
+        .post('/api/sample_tasks/event')
+        .set('kbn-xsrf', 'xxx')
+        .send({ event: taskId, data })
+        .expect(200);
+    }
+
+    async function updateRunningTaskDocument(
+      taskId: string,
+      fields: Record<string, unknown>
+    ): Promise<void> {
+      await es.update({
+        id: `task:${taskId}`,
+        index: '.kibana_task_manager',
+        refresh: true,
+        doc: {
+          task: fields,
+        },
+      });
+    }
+
+    async function scheduleLongRunningSampleTask(releaseEvent: string) {
+      const scheduled = await scheduleTask(supertest, {
+        taskType: 'sampleTask',
+        schedule: { interval: '1h' },
+        params: {
+          waitForParams: true,
+        },
+      });
+
+      await provideParamsToTasksWaitingForParams(scheduled.id, {
+        waitForEvent: releaseEvent,
+      });
+
+      await retry.try(async () => {
+        const docs = await historyDocs(scheduled.id);
+        expect(docs.length).to.eql(1);
+
+        const task = await currentTask(scheduled.id);
+        expect(task.status).to.eql('running');
+      });
+
+      return scheduled;
+    }
+
+    it('retains schedule updated while running and writes the rest of the task-run fields', async () => {
+      const releaseEvent = 'releaseScheduleConflict';
+      const scheduled = await scheduleLongRunningSampleTask(releaseEvent);
+
+      const newSchedule = { interval: '3h' };
+      const newRunAt = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
+
+      // Concurrent update while the task is still running: bump schedule/runAt and
+      // poke state so we can prove the completed run's state wins on conflict resolve.
+      await updateRunningTaskDocument(scheduled.id, {
+        schedule: newSchedule,
+        runAt: newRunAt,
+        state: JSON.stringify({ count: 999 }),
+      });
+
+      await releaseTasksWaitingForEventToComplete(releaseEvent);
+
+      await retry.try(async () => {
+        const task = await currentTask<{ count: number }>(scheduled.id);
+
+        expect(task.status).to.eql('idle');
+        expect(task.schedule).to.eql(newSchedule);
+        expect(task.runAt).to.eql(newRunAt);
+        expect(task.state.count).to.eql(1);
+        expect(task.startedAt).to.be(null);
+        expect(task.retryAt).to.be(null);
+        expect(task.ownerId).to.be(null);
+        expect(task.attempts).to.eql(0);
+      });
+    });
+
+    it('retains runAt updated while running and writes the rest of the task-run fields', async () => {
+      const releaseEvent = 'releaseRunAtConflict';
+      const scheduled = await scheduleLongRunningSampleTask(releaseEvent);
+
+      const originalSchedule = { interval: '1h' };
+      const newRunAt = new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString();
+
+      await updateRunningTaskDocument(scheduled.id, {
+        runAt: newRunAt,
+        state: JSON.stringify({ count: 999 }),
+      });
+
+      await releaseTasksWaitingForEventToComplete(releaseEvent);
+
+      await retry.try(async () => {
+        const task = await currentTask<{ count: number }>(scheduled.id);
+
+        expect(task.status).to.eql('idle');
+        expect(task.schedule).to.eql(originalSchedule);
+        expect(task.runAt).to.eql(newRunAt);
+        expect(task.state.count).to.eql(1);
+        expect(task.startedAt).to.be(null);
+        expect(task.retryAt).to.be(null);
+        expect(task.ownerId).to.be(null);
+        expect(task.attempts).to.eql(0);
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ResponseOps][Task Manager] allow updates to task documents while the task is running - take 2 (#281668)](https://github.com/elastic/kibana/pull/281668)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2026-08-19T12:48:37Z","message":"[ResponseOps][Task Manager] allow updates to task documents while the task is running - take 2 (#281668)\n\nresolves https://github.com/elastic/kibana/issues/274007\n\n## Summary\n\nWhen a task comples and updates the task document, a conflict can occur\nif the task document has been updated since it started running.\n\nThis PR resolves the conflict by applying the task-run updates to the\ndocument against the current version of the document, with some\noverrides for scheduling and checks to see if the task has been\ncancelled and re-started.","sha":"0eb7433a609619e19fe1e6b9e9b846ec38eb305c","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Task Manager","Team:ResponseOps","backport:all-open","v9.6.0"],"title":"[ResponseOps][Task Manager] allow updates to task documents while the task is running - take 2","number":281668,"url":"https://github.com/elastic/kibana/pull/281668","mergeCommit":{"message":"[ResponseOps][Task Manager] allow updates to task documents while the task is running - take 2 (#281668)\n\nresolves https://github.com/elastic/kibana/issues/274007\n\n## Summary\n\nWhen a task comples and updates the task document, a conflict can occur\nif the task document has been updated since it started running.\n\nThis PR resolves the conflict by applying the task-run updates to the\ndocument against the current version of the document, with some\noverrides for scheduling and checks to see if the task has been\ncancelled and re-started.","sha":"0eb7433a609619e19fe1e6b9e9b846ec38eb305c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/281668","number":281668,"mergeCommit":{"message":"[ResponseOps][Task Manager] allow updates to task documents while the task is running - take 2 (#281668)\n\nresolves https://github.com/elastic/kibana/issues/274007\n\n## Summary\n\nWhen a task comples and updates the task document, a conflict can occur\nif the task document has been updated since it started running.\n\nThis PR resolves the conflict by applying the task-run updates to the\ndocument against the current version of the document, with some\noverrides for scheduling and checks to see if the task has been\ncancelled and re-started.","sha":"0eb7433a609619e19fe1e6b9e9b846ec38eb305c"}}]}] BACKPORT-->