### PR TITLE
[Significant Events] Add CPS Scout API test for stream data routing

### DIFF
--- a/.buildkite/pipelines/pull_request/cps_testing.yml
+++ b/.buildkite/pipelines/pull_request/cps_testing.yml
@@ -8,7 +8,7 @@ steps:
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
       - build
-    timeout_in_minutes: 30
+    timeout_in_minutes: 40
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -127,3 +127,4 @@ excluded_configs:
   - x-pack/platform/plugins/shared/entity_store/test/scout_cps_local/api/playwright.config.ts
   - x-pack/platform/plugins/shared/spaces/test/scout_cps_local/ui/playwright.config.ts
   - x-pack/platform/plugins/private/transform/test/scout_cps_local/api/playwright.config.ts
+  - x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/playwright.config.ts

--- a/.buildkite/scripts/steps/test/scout/cps_testing.sh
+++ b/.buildkite/scripts/steps/test/scout/cps_testing.sh
@@ -4,11 +4,15 @@ set -euo pipefail
 
 source .buildkite/scripts/steps/functional/common.sh
 
-CONFIG_PATHS=(
+SECURITY_COMPLETE_CONFIG_PATHS=(
   "x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/ui/playwright.config.ts"
   "x-pack/solutions/security/plugins/security_solution/test/scout_cps_local/api/playwright.config.ts"
   "x-pack/platform/plugins/shared/entity_store/test/scout_cps_local/api/playwright.config.ts"
   "x-pack/platform/plugins/private/transform/test/scout_cps_local/api/playwright.config.ts"
+)
+
+OBSERVABILITY_COMPLETE_CONFIG_PATHS=(
+  "x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/playwright.config.ts"
 )
 
 SPACES_CPS_CONFIG="x-pack/platform/plugins/shared/spaces/test/scout_cps_local/ui/playwright.config.ts"
@@ -37,8 +41,12 @@ run_cps_tests() {
   fi
 }
 
-for CONFIG_PATH in "${CONFIG_PATHS[@]}"; do
+for CONFIG_PATH in "${SECURITY_COMPLETE_CONFIG_PATHS[@]}"; do
   run_cps_tests "$CONFIG_PATH" "security_complete"
+done
+
+for CONFIG_PATH in "${OBSERVABILITY_COMPLETE_CONFIG_PATHS[@]}"; do
+  run_cps_tests "$CONFIG_PATH" "observability_complete"
 done
 
 # Spaces project-routing visibility/save/capability coverage across eligible and

--- a/x-pack/platform/plugins/shared/significant_events/test/scout/api/fixtures/setup_environment.ts
+++ b/x-pack/platform/plugins/shared/significant_events/test/scout/api/fixtures/setup_environment.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setTimeout as delay } from 'timers/promises';
+import type { ApiServicesFixture, KbnClient, ScoutLogger } from '@kbn/scout';
+import {
+  STREAMS_SIGNIFICANT_EVENTS_AVAILABLE_FLAG,
+  type SignificantEventsAvailabilityResponse,
+} from '../../../../common';
+import { COMMON_API_HEADERS } from './constants';
+
+const AVAILABILITY_PATH = '/internal/significant_events/availability';
+const AVAILABILITY_TIMEOUT_MS = 30_000;
+const AVAILABILITY_POLL_INTERVAL_MS = 1_000;
+
+/**
+ * Enables Streams and significant events, then waits for significant events to be observably
+ * available. Shared by the global setup hook of every Significant Events API suite.
+ */
+export async function setupSignificantEventsEnvironment({
+  apiServices,
+  kbnClient,
+  log,
+}: {
+  apiServices: ApiServicesFixture;
+  kbnClient: KbnClient;
+  log: ScoutLogger;
+}) {
+  log.debug('[setup] Enabling Streams...');
+  await apiServices.streams.enable();
+  log.debug('[setup] Streams enabled successfully');
+
+  // Significant events is gated behind the streams.significantEventsAvailable feature flag, which
+  // falls back to false. Force it on as the sole availability gate for the API tests.
+  log.debug('[setup] Enabling significant events availability feature flag...');
+  await apiServices.core.settings({
+    'feature_flags.overrides': {
+      [STREAMS_SIGNIFICANT_EVENTS_AVAILABLE_FLAG]: true,
+    },
+  });
+
+  // Gate setup on the flag being observably effective: the override applies only on the node that
+  // handles the PUT and reaches other Cloud instances on their next ~10s config poll, so specs
+  // would otherwise race that propagation window and read the `false` fallback.
+  log.debug('[setup] Waiting for significant events availability to propagate...');
+  const deadline = Date.now() + AVAILABILITY_TIMEOUT_MS;
+  let lastResponse: SignificantEventsAvailabilityResponse | undefined;
+  while (Date.now() < deadline) {
+    const { data, status } = await kbnClient.request<SignificantEventsAvailabilityResponse>({
+      path: AVAILABILITY_PATH,
+      method: 'GET',
+      headers: COMMON_API_HEADERS,
+      ignoreErrors: [404],
+    });
+    // A 404 means the plugin is unloaded for this deployment (e.g. Logs Essentials sets
+    // `xpack.significantEvents.enabled: false`), so there is no availability to wait for.
+    if (status === 404) {
+      log.debug('[setup] Significant events plugin not loaded (404); skipping availability gate');
+      return;
+    }
+    lastResponse = data;
+    if (data.available) {
+      log.debug('[setup] Significant events availability confirmed');
+      return;
+    }
+    await delay(AVAILABILITY_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(
+    `Significant events did not become available within ${AVAILABILITY_TIMEOUT_MS}ms of enabling the feature flag. Last availability response: ${JSON.stringify(
+      lastResponse
+    )}`
+  );
+}

--- a/x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/fixtures/index.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  getStreamsTestApiService,
+  type StreamsTestApiService,
+} from '@kbn/streams-plugin/test/scout/api/services/streams_api_service';
+import { significantEventsApiTest } from '../../../scout/api/fixtures';
+
+/**
+ * CPS variant of the Significant Events API test, adding the Streams API service needed to set up
+ * the query stream under test on top of the auth roles and API services of the standard suite.
+ *
+ * `streamsTest` is worker scoped so that `beforeAll`/`afterAll` hooks can use it.
+ */
+export const significantEventsCpsApiTest = significantEventsApiTest.extend<
+  {},
+  { streamsTest: StreamsTestApiService }
+>({
+  streamsTest: [
+    async ({ kbnClient, esClient, log }, use) => {
+      await use(getStreamsTestApiService({ kbnClient, esClient, log }));
+    },
+    { scope: 'worker' },
+  ],
+});
+
+export { COMMON_API_HEADERS, PUBLIC_API_HEADERS } from '../../../scout/api/fixtures';

--- a/x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/playwright.config.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+  workers: 1,
+  runGlobalSetup: true,
+});

--- a/x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/tests/cps_stream_data_routing.spec.ts
+++ b/x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/tests/cps_stream_data_routing.spec.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+import type { EsClient } from '@kbn/scout';
+import { LOG_SAMPLES_FEATURE_TYPE } from '@kbn/significant-events-schema';
+import { significantEventsCpsApiTest as apiTest, COMMON_API_HEADERS } from '../fixtures';
+
+// A `logs-*` name so CPS resolves the same unqualified name on the origin and the linked project.
+// The built-in `logs` template is data-stream-only, so this has to be created as a data stream
+// through a dedicated higher-priority template rather than as a plain index.
+const CPS_TEST_DATA_STREAM = 'logs-cps-se-ki-test';
+const CPS_TEST_TEMPLATE = 'cps-se-ki-test-template';
+// A classic parent lets the query stream `FROM` the data stream directly. Chaining an
+// intermediate `$.…` parent view under CPS is a known fragile shape; origin view over real
+// cross-project indices is the supported one.
+const QUERY_STREAM = `${CPS_TEST_DATA_STREAM}.qs`;
+
+const NOW = Date.now();
+const WINDOW_START = NOW - 10 * 60_000;
+const WINDOW_END = NOW + 60 * 60_000;
+
+/**
+ * Cross-project ES|QL resolves a field once across all projects, so leaving either copy to
+ * dynamic mapping would make `cps_se_marker` a `text` field on one side and a `keyword` on the
+ * other, and `KEEP` would then fail on the conflicting column type.
+ */
+const CPS_DATA_STREAM_MAPPINGS: estypes.MappingTypeMapping = {
+  properties: {
+    '@timestamp': { type: 'date' },
+    cps_se_marker: { type: 'keyword' },
+    message: { type: 'text' },
+    service: { properties: { name: { type: 'keyword' } } },
+  },
+};
+
+interface ComputedFeature {
+  type: string;
+  properties: Record<string, unknown>;
+}
+
+interface IdentifyComputedResponse {
+  computedFeatures: ComputedFeature[];
+  computedFeaturesCount: number;
+}
+
+async function deleteTestDataStream(esClient: EsClient) {
+  await esClient.indices.deleteDataStream({ name: CPS_TEST_DATA_STREAM }, { ignore: [404] });
+  await esClient.indices.deleteIndexTemplate({ name: CPS_TEST_TEMPLATE }, { ignore: [404] });
+}
+
+async function ensureTestDataStream(esClient: EsClient) {
+  // Recreate from scratch so a run that crashed before its teardown doesn't fail this one.
+  await deleteTestDataStream(esClient);
+  await esClient.indices.putIndexTemplate({
+    name: CPS_TEST_TEMPLATE,
+    index_patterns: [CPS_TEST_DATA_STREAM],
+    data_stream: {},
+    // Higher than the built-in `logs` template so the explicit field types win.
+    priority: 1000,
+    template: { mappings: CPS_DATA_STREAM_MAPPINGS },
+  });
+  await esClient.indices.createDataStream({ name: CPS_TEST_DATA_STREAM });
+}
+
+async function ingestMarkerOnLinked(
+  linkedEsClient: EsClient,
+  markerValue: string,
+  timestamp: string
+) {
+  await linkedEsClient.index({
+    index: CPS_TEST_DATA_STREAM,
+    refresh: 'wait_for',
+    document: {
+      '@timestamp': timestamp,
+      cps_se_marker: markerValue,
+      message: `CPS significant events marker ${markerValue}`,
+      'service.name': 'cps-se-test',
+    },
+  });
+}
+
+apiTest.describe(
+  'Significant Events CPS stream data routing (linked serverless project)',
+  { tag: tags.serverless.observability.complete },
+  () => {
+    const markerValue = `cps_marker_${Date.now()}`;
+    let cookieHeader: Record<string, string>;
+
+    apiTest.beforeAll(async ({ samlAuth, streamsTest, esClient, linkedProject }) => {
+      // Built-in admin, matching the entity_store CPS suite: this suite covers space-based
+      // stream data routing, not Streams RBAC.
+      const credentials = await samlAuth.asInteractiveUser('admin');
+      cookieHeader = credentials.cookieHeader;
+
+      await streamsTest.enableQueryStreams();
+
+      // The data stream has to exist on both projects before the query stream is created, because
+      // Kibana validates the desired stream state by running the ES|QL query against the origin
+      // project and rejects an unknown index. The origin copy deliberately stays empty: every
+      // matching document lives on the linked project, so the marker can only reach the identify
+      // response if the read fans out across projects.
+      await ensureTestDataStream(esClient);
+      await ensureTestDataStream(linkedProject.esClient);
+
+      await streamsTest.createStream(CPS_TEST_DATA_STREAM, {
+        dashboards: [],
+        rules: [],
+        stream: {
+          description: 'CPS significant events test classic stream',
+          type: 'classic',
+          ingest: {
+            lifecycle: { inherit: {} },
+            processing: { steps: [] },
+            settings: {},
+            failure_store: { inherit: {} },
+            classic: {},
+          },
+        },
+      });
+
+      await streamsTest.createQueryStream(
+        QUERY_STREAM,
+        `FROM ${CPS_TEST_DATA_STREAM} | KEEP @timestamp, cps_se_marker, message, \`service.name\``
+      );
+    });
+
+    apiTest.afterAll(async ({ streamsTest, esClient, linkedProject }) => {
+      await streamsTest.cleanupTestStreams(CPS_TEST_DATA_STREAM);
+      await streamsTest.disableQueryStreams();
+      await deleteTestDataStream(esClient);
+      await deleteTestDataStream(linkedProject.esClient);
+    });
+
+    apiTest(
+      'samples stream data from a linked CPS project during computed KI identification',
+      async ({ apiClient, esClient, linkedProject }) => {
+        await ingestMarkerOnLinked(
+          linkedProject.esClient,
+          markerValue,
+          new Date(NOW - 5 * 60_000).toISOString()
+        );
+
+        // Negative control: the origin copy of the data stream is empty, so an origin-only read
+        // cannot see the marker. This is what makes the assertions below evidence of
+        // cross-project routing rather than of the data simply being available locally.
+        const originHits = await esClient.search({
+          index: CPS_TEST_DATA_STREAM,
+          query: { term: { cps_se_marker: markerValue } },
+        });
+        expect(originHits.hits.hits).toHaveLength(0);
+
+        const { statusCode, body } = await apiClient.post(
+          `internal/streams/${QUERY_STREAM}/features/_identify/computed`,
+          {
+            headers: { ...COMMON_API_HEADERS, ...cookieHeader },
+            body: {
+              start: WINDOW_START,
+              end: WINDOW_END,
+            },
+            responseType: 'json',
+          }
+        );
+
+        expect(statusCode, `identify/computed failed: ${JSON.stringify(body)}`).toBe(200);
+
+        const response: IdentifyComputedResponse = body;
+
+        // Only the marker proves the read fanned out: every generator contributes a feature even
+        // when it sampled nothing, so the feature count stays positive for an origin-only read of
+        // the empty origin data stream and cannot tell the two cases apart.
+        expect(
+          JSON.stringify(response.computedFeatures),
+          `expected the linked project marker in the computed features; got ${JSON.stringify(
+            response.computedFeatures
+          )}`
+        ).toContain(markerValue);
+
+        const logSamples = response.computedFeatures.find(
+          (feature) => feature.type === LOG_SAMPLES_FEATURE_TYPE
+        );
+        expect(
+          logSamples,
+          `no ${LOG_SAMPLES_FEATURE_TYPE} feature in ${JSON.stringify(response.computedFeatures)}`
+        ).toBeDefined();
+        expect(
+          JSON.stringify(logSamples?.properties),
+          `expected the linked project marker in the log samples; got ${JSON.stringify(
+            logSamples?.properties
+          )}`
+        ).toContain(markerValue);
+      }
+    );
+  }
+);

--- a/x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/tests/global.setup.ts
+++ b/x-pack/platform/plugins/shared/significant_events/test/scout_cps_local/api/tests/global.setup.ts
@@ -6,10 +6,10 @@
  */
 
 import { globalSetupHook } from '@kbn/scout';
-import { setupSignificantEventsEnvironment } from '../fixtures/setup_environment';
+import { setupSignificantEventsEnvironment } from '../../../scout/api/fixtures/setup_environment';
 
 globalSetupHook(
-  'Setup environment for Significant Events API tests',
+  'Setup environment for Significant Events CPS API tests',
   async ({ apiServices, kbnClient, log }) => {
     await setupSignificantEventsEnvironment({ apiServices, kbnClient, log });
   }


### PR DESCRIPTION
## Summary

Supersedes #282590.

Adds a `scout_cps_local` API suite covering that Significant Events knowledge indicator extraction reads stream data across **all** CPS-linked projects.

### How the test proves cross-project routing

The suite creates `logs-cps-se-ki-test` on **both** the origin and the linked project, but ingests its marker document **only** into the linked one, leaving the origin copy empty. It then asserts the marker appears in the `_identify/computed` response, which can only happen if the read fans out past the origin. An explicit assertion that the origin copy contains no matching document keeps that negative control honest.