### PR TITLE
Add an edit affordance to editable app header titles

### DIFF
--- a/src/core/packages/chrome/app-header/src/app_header/title_area/README.md
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area/README.md
@@ -59,16 +59,23 @@ user types, feed the typed value into the sizer; do not measure.
 - Edit mode sizes to `draft` (or `placeholder` while the draft is empty).
 - The `<input>` has `size={1}` so its intrinsic width can't inflate the track.
 
-### The hover/edit affordance bleeds via pseudo-elements, not layout
+### The edit affordance
+
+Editable titles include a subdued pencil inside the title button. The text and icon are
+one control and one keyboard tab stop; the icon is decorative and hidden from assistive
+technology. Read and edit mode both reserve the icon column so badges do not shift when
+the input replaces the title.
+
+The hover background and focus border bleed via pseudo-elements rather than adding
+padding around the control.
 
 The grey background and the border are drawn by `::before` (background, `z-index: -1`)
 and `::after` (border, on top) on `titleFrame`. They are absolutely positioned and
 **bleed outward** (negative `inset`) past the text on every side. They never enter
 layout, so:
 
-- A resting title keeps the exact position and trailing spacing of a plain heading —
-  no extra gap before the badges. (Do not add margins/padding to create the hover box;
-  that reintroduces the gap and the layout shift.)
+- A resting title keeps the exact leading position of a plain heading. (Do not add
+  margins/padding to create the hover box; that reintroduces layout shift.)
 - `::after` paints above the status-icon scrim so the invalid red border is never
   hidden by the gradient.
 

--- a/src/core/packages/chrome/app-header/src/app_header/title_area/title.tsx
+++ b/src/core/packages/chrome/app-header/src/app_header/title_area/title.tsx
@@ -8,6 +8,7 @@
  */
 
 import {
+  EuiIcon,
   EuiIconTip,
   EuiLoadingSpinner,
   EuiScreenReaderOnly,
@@ -116,6 +117,8 @@ const useTitleStyles = () => {
 
     const readModeTrigger = css`
       ${titleFrame};
+      grid-template-columns: minmax(0, max-content) ${euiTheme.size.base};
+      column-gap: ${euiTheme.size.xs};
       cursor: text;
       appearance: none;
 
@@ -137,12 +140,20 @@ const useTitleStyles = () => {
       }
     `;
 
+    const editIcon = css`
+      grid-area: 1 / 2;
+      align-self: center;
+      color: ${euiTheme.colors.textSubdued};
+    `;
+
     // Edit mode keeps a reasonable minimum width so a short or empty title still gives a
     // comfortable click/typing target instead of collapsing to the content (or to nothing
     // when empty). Long titles exceed the floor and size to content as usual.
     const editingTitleFrame = css`
       ${titleFrame};
-      grid-template-columns: minmax(calc(${euiTheme.size.base} * 8), max-content);
+      grid-template-columns: minmax(calc(${euiTheme.size.base} * 8), max-content) ${euiTheme.size
+          .base};
+      column-gap: ${euiTheme.size.xs};
 
       &::after {
         border-width: ${euiTheme.border.width.thin};
@@ -251,6 +262,7 @@ const useTitleStyles = () => {
       editingTitleFrame,
       invalidTitleFrame,
       readModeTrigger,
+      editIcon,
       input,
       statusIcon,
       titleSizer,
@@ -493,6 +505,7 @@ export const Title = React.memo<TitleProps>(({ title, titleOffset, size = 's' })
               onClick={(event) => startEditing(event.detail === 0)}
             >
               {readContent}
+              <EuiIcon type="pencil" size="m" css={styles.editIcon} aria-hidden="true" />
             </button>
           ) : (
             // Non-editable title: shares the same frame as the editable read view (its


### PR DESCRIPTION
Design discussion: https://elastic.slack.com/archives/C0ANQ2123J4/p1787134682803109
Original editable-title discussion: https://elastic.slack.com/archives/C0ANQ2123J4/p1779878840466569

## Summary

Adds a persistent, subdued pencil to editable app header titles so editability is discoverable without relying on hover. The pencil remains part of the existing title control, and its space is reserved in edit mode to prevent badges from shifting.