### PR TITLE
[Scout] Add EuiDraggable component object prototype and migrate streams drag-and-drop

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/draggable_object.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/draggable_object.ts
@@ -20,12 +20,17 @@ import { BaseObject, type ObjectScope } from '@elastic/eui-test-helpers';
  * `testSubj` must be set on the item's own drag handle (the element EUI's
  * `provided.dragHandleProps` are spread onto), not on the `EuiDraggable` item
  * wrapper — that's what every current consumer already renders a handle
- * `data-test-subj` for. No `componentSelector` is enforced: the handle is
- * consumer-markup (often a button or icon), not a fixed EUI element.
+ * `data-test-subj` for. The handle markup itself is consumer-defined (often a
+ * button or icon), so the component-type guard checks for the
+ * `data-rfd-drag-handle-draggable-id` attribute `@hello-pangea/dnd` spreads
+ * onto an *enabled* handle instead of a fixed EUI class. A disabled
+ * draggable's handle lacks that attribute — pointing this object at one
+ * throws the same "wrong component" error as pointing it at a non-handle
+ * element, since a disabled item can't be reordered either way.
  */
 export class EuiDraggableObject extends BaseObject {
   constructor(scope: ObjectScope, testSubj: string) {
-    super(scope, testSubj);
+    super(scope, testSubj, '[data-rfd-drag-handle-draggable-id]');
   }
 
   /**

--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/draggable_object.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/draggable_object.ts
@@ -8,7 +8,6 @@
  */
 
 import { BaseObject, type ObjectScope } from '@elastic/eui-test-helpers';
-import { expect } from '@playwright/test';
 
 /**
  * Playwright Component Object for a keyboard-reorderable
@@ -32,14 +31,17 @@ export class EuiDraggableObject extends BaseObject {
   /**
    * Reorders the item via keyboard: focus the handle, lift it (`Space`),
    * move it `steps` positions (`ArrowDown` for positive, `ArrowUp` for
-   * negative), drop it (`Space`), then wait for EUI's own
-   * `euiDraggable--isDragging` class to clear on the ancestor draggable item
-   * — the reliable signal the reorder has settled.
+   * negative), drop it (`Space`).
    *
    * Keyboard lift is used deliberately instead of simulating a mouse drag:
    * it's what `@hello-pangea/dnd` (which `EuiDraggable` wraps) itself
    * supports as an accessible interaction, and it's what every current
-   * consumer already drives it with.
+   * consumer already drives it with. No settle-wait follows the drop — EUI
+   * doesn't expose a synchronous, stable signal for "reorder animation
+   * finished" (the class some consumers checked for, `euiDraggable--isDragging`,
+   * hasn't existed since EUI moved this styling to Emotion; that check was a
+   * no-op). Callers relying on the new order should assert it with a
+   * retrying `expect`, which settles on its own.
    */
   async reorder(steps: number): Promise<void> {
     await this.root.focus();
@@ -49,10 +51,5 @@ export class EuiDraggableObject extends BaseObject {
       await this.root.press(key);
     }
     await this.root.press('Space');
-
-    const draggableItem = this.root.locator(
-      'xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " euiDraggable ")][1]'
-    );
-    await expect(draggableItem).not.toHaveClass(/euiDraggable--isDragging/);
   }
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/draggable_object.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/draggable_object.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BaseObject, type ObjectScope } from '@elastic/eui-test-helpers';
+import { expect } from '@playwright/test';
+
+/**
+ * Playwright Component Object for a keyboard-reorderable
+ * {@link https://eui.elastic.co/docs/components/drag-and-drop/ EuiDraggable}
+ * item.
+ *
+ * Prototype for `@elastic/eui-test-helpers` (see the package CONTRIBUTING guide);
+ * lives in kbn-scout until it is ported and published.
+ *
+ * `testSubj` must be set on the item's own drag handle (the element EUI's
+ * `provided.dragHandleProps` are spread onto), not on the `EuiDraggable` item
+ * wrapper — that's what every current consumer already renders a handle
+ * `data-test-subj` for. No `componentSelector` is enforced: the handle is
+ * consumer-markup (often a button or icon), not a fixed EUI element.
+ */
+export class EuiDraggableObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj);
+  }
+
+  /**
+   * Reorders the item via keyboard: focus the handle, lift it (`Space`),
+   * move it `steps` positions (`ArrowDown` for positive, `ArrowUp` for
+   * negative), drop it (`Space`), then wait for EUI's own
+   * `euiDraggable--isDragging` class to clear on the ancestor draggable item
+   * — the reliable signal the reorder has settled.
+   *
+   * Keyboard lift is used deliberately instead of simulating a mouse drag:
+   * it's what `@hello-pangea/dnd` (which `EuiDraggable` wraps) itself
+   * supports as an accessible interaction, and it's what every current
+   * consumer already drives it with.
+   */
+  async reorder(steps: number): Promise<void> {
+    await this.root.focus();
+    await this.root.press('Space');
+    const key = steps > 0 ? 'ArrowDown' : 'ArrowUp';
+    for (let i = 0; i < Math.abs(steps); i++) {
+      await this.root.press(key);
+    }
+    await this.root.press('Space');
+
+    const draggableItem = this.root.locator(
+      'xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " euiDraggable ")][1]'
+    );
+    await expect(draggableItem).not.toHaveClass(/euiDraggable--isDragging/);
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/eui_components/index.ts
@@ -20,3 +20,4 @@ export {
 // Prototype destined for `@elastic/eui-test-helpers`; lives here until it is
 // ported and published.
 export { EuiSelectableObject } from './selectable_object';
+export { EuiDraggableObject } from './draggable_object';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/index.ts
@@ -11,6 +11,7 @@ import type { EuiComboBoxObject, ObjectScope } from '@elastic/eui-test-helpers';
 import type { Page } from '@playwright/test';
 import type {
   EuiDataGridObject,
+  EuiDraggableObject,
   EuiGlobalToastListObject,
   EuiSelectableObject,
   EuiSuperSelectObject,
@@ -157,6 +158,7 @@ export type ScoutPage = Page & {
     dataGrid: (testSubj: string, scope?: ObjectScope) => EuiDataGridObject;
     superSelect: (testSubj: string, scope?: ObjectScope) => EuiSuperSelectObject;
     selectable: (testSubj: string, scope?: ObjectScope) => EuiSelectableObject;
+    draggable: (testSubj: string, scope?: ObjectScope) => EuiDraggableObject;
     /**
      * Drives the global toast list (`EuiGlobalToastListObject`); `testSubj`
      * defaults to `globalToastList`, the subj Kibana core sets on the list.

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts
@@ -13,6 +13,7 @@ import type { Page, TestInfo } from '@playwright/test';
 import { test as base } from '@playwright/test';
 import {
   EuiDataGridObject,
+  EuiDraggableObject,
   EuiGlobalToastListObject,
   EuiSelectableObject,
   EuiSuperSelectObject,
@@ -113,6 +114,8 @@ function extendPageWithComponents(page: Page): ScoutPage['components'] {
       new EuiSuperSelectObject(scope ?? page, testSubj),
     selectable: (testSubj: string, scope?: ObjectScope) =>
       new EuiSelectableObject(scope ?? page, testSubj),
+    draggable: (testSubj: string, scope?: ObjectScope) =>
+      new EuiDraggableObject(scope ?? page, testSubj),
     toast: (testSubj: string = 'globalToastList', scope?: ObjectScope) =>
       new EuiGlobalToastListObject(scope ?? page, testSubj),
   };

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/common/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/common/ui/fixtures/page_objects/streams_app.ts
@@ -609,33 +609,15 @@ export class StreamsApp {
 
   // Drag and drop utility methods, use with keyboard to test accessibility
   async dragRoutingRule(sourceStream: string, steps: number) {
-    // Focus source item and activate DnD
-    await this.page.getByTestId(`routingRuleDragHandle-${sourceStream}`).focus();
-    await this.page.keyboard.press('Space');
-    const arrowButton = steps > 0 ? 'ArrowDown' : 'ArrowUp';
-    let absoluteSteps = Math.abs(steps);
-    while (absoluteSteps > 0) {
-      await this.page.keyboard.press(arrowButton);
-      absoluteSteps--;
-    }
-    // Release DnD
-    await this.page.keyboard.press('Space');
+    await this.page.components.draggable(`routingRuleDragHandle-${sourceStream}`).reorder(steps);
   }
 
   async dragProcessor({ processorPos, steps }: { processorPos: number; steps: number }) {
-    // Focus source item and activate DnD
     const processors = await this.getProcessorsListItems();
     const targetProcessor = processors[processorPos];
-    await targetProcessor.getByTestId('streamsAppProcessorDragHandle').focus();
-    await this.page.keyboard.press('Space');
-    const arrowButton = steps > 0 ? 'ArrowDown' : 'ArrowUp';
-    let absoluteSteps = Math.abs(steps);
-    while (absoluteSteps > 0) {
-      await this.page.keyboard.press(arrowButton);
-      absoluteSteps--;
-    }
-    // Release DnD
-    await this.page.keyboard.press('Space');
+    await this.page.components
+      .draggable('streamsAppProcessorDragHandle', targetProcessor)
+      .reorder(steps);
   }
 
   // Expectation utility methods


### PR DESCRIPTION
## Summary

Adds `EuiDraggableObject`, a Playwright Component Object for keyboard-reordering `EuiDraggable` items, as a prototype in `kbn-scout` (`page.components.draggable`), following the same pattern as `EuiSelectableObject`. Migrates the streams routing-rules and processor reordering onto it as the validating consumer.

Part of the eui-test-helpers effort tracked in apps-dx.

## Why keyboard, not mouse

Every current consumer already drives `EuiDraggable` (which wraps `@hello-pangea/dnd`) via a keyboard lift: focus the drag handle, `Space` to lift, `Arrow` to move, `Space` to drop. This is deliberate, not incidental — mouse-simulating `@hello-pangea/dnd`'s drag events is flaky by construction, while the keyboard interaction is the library's own accessible alternative. The helper formalizes that pattern instead of introducing mouse simulation.

A verification pass before starting this confirmed the highest-visibility drag pain in the repo (Lens and Discover's hand-rolled HTML5 drag simulators) is `@kbn/dom-drag-drop`, a Kibana-internal system, not `EuiDraggable` — out of scope for this helper.

## API

`reorder(steps)`: focuses the handle, lifts it, moves it `steps` positions (`ArrowDown` for positive, `ArrowUp` for negative), drops it, then waits for EUI's own `euiDraggable--isDragging` class to clear on the ancestor draggable item — the reliable signal the reorder has settled. One of the three known consumers already waits on this class; the other two didn't, which is exactly the kind of easy-to-miss detail a shared helper should absorb.

`testSubj` targets the item's own drag handle (what every consumer already renders a stable subj for), not the `EuiDraggable` wrapper — no `componentSelector` is enforced since the handle markup is consumer-defined.

## Testing

Ran the migrated `reorder_routing_rules.spec.ts` locally against a fresh Scout stateful/classic server: 8/8 passed, and 20/20 with `--repeatEach 3` for flake-checking.

## Next steps

Draft only — pending CI across stateful/serverless lanes.