### PR TITLE
[Agent Builder] Fix copy label on the user prompt bubble

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_input.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_input.tsx
@@ -91,7 +91,7 @@ export const RoundInput = ({
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <RoundResponseActions content={input} isVisible={isHovering} />
+        <RoundResponseActions content={input} isVisible={isHovering} copyTarget="prompt" />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/round_response_actions.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/round_response_actions.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import copy from 'copy-to-clipboard';
+import { RoundResponseActions } from './round_response_actions';
+import { useToasts } from '../../../../hooks/use_toasts';
+
+jest.mock('copy-to-clipboard');
+
+jest.mock('../../../../hooks/use_toasts', () => ({
+  useToasts: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/use_conversation_stream', () => ({
+  useConversationStream: () => ({
+    regenerate: jest.fn(),
+    isRegenerating: false,
+    isResponseLoading: false,
+  }),
+}));
+
+jest.mock('../../../../hooks/use_kibana', () => ({
+  useKibana: () => ({ services: { plugins: {} } }),
+}));
+
+jest.mock('../../../../hooks/use_experimental_features', () => ({
+  useExperimentalFeatures: () => false,
+}));
+
+jest.mock('../../../../hooks/use_tracing_enabled', () => ({
+  useTracingEnabled: () => false,
+}));
+
+const copyMock = copy as jest.MockedFunction<typeof copy>;
+const useToastsMock = useToasts as jest.MockedFunction<typeof useToasts>;
+const addSuccessToast = jest.fn();
+
+describe('RoundResponseActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    copyMock.mockReturnValue(true);
+    useToastsMock.mockReturnValue({ addSuccessToast } as unknown as ReturnType<typeof useToasts>);
+  });
+
+  it('labels the copy action for the agent response by default', async () => {
+    render(<RoundResponseActions content="the answer" isVisible />);
+
+    const copyButton = screen.getByRole('button', { name: 'Copy response' });
+    await userEvent.click(copyButton);
+
+    expect(copyMock).toHaveBeenCalledWith('the answer');
+    expect(addSuccessToast).toHaveBeenCalledWith('Response copied to clipboard');
+  });
+
+  it('labels the copy action for the user prompt when copyTarget is prompt', async () => {
+    render(<RoundResponseActions content="my question" isVisible copyTarget="prompt" />);
+
+    const copyButton = screen.getByRole('button', { name: 'Copy prompt' });
+    await userEvent.click(copyButton);
+
+    expect(copyMock).toHaveBeenCalledWith('my question');
+    expect(addSuccessToast).toHaveBeenCalledWith('Prompt copied to clipboard');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/round_response_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/round_response_actions.tsx
@@ -21,13 +21,26 @@ import { useTracingEnabled } from '../../../../hooks/use_tracing_enabled';
 import { RoundMetadataPopover } from './round_metadata_popover';
 import { RoundTraceButton } from './round_trace_button';
 
+const copyLabels = {
+  response: {
+    action: i18n.translate('xpack.agentBuilder.roundResponseActions.copy', {
+      defaultMessage: 'Copy response',
+    }),
+    success: i18n.translate('xpack.agentBuilder.roundResponseActions.copySuccess', {
+      defaultMessage: 'Response copied to clipboard',
+    }),
+  },
+  prompt: {
+    action: i18n.translate('xpack.agentBuilder.roundResponseActions.copyPrompt', {
+      defaultMessage: 'Copy prompt',
+    }),
+    success: i18n.translate('xpack.agentBuilder.roundResponseActions.copyPromptSuccess', {
+      defaultMessage: 'Prompt copied to clipboard',
+    }),
+  },
+} as const;
+
 const labels = {
-  copy: i18n.translate('xpack.agentBuilder.roundResponseActions.copy', {
-    defaultMessage: 'Copy response',
-  }),
-  copySuccess: i18n.translate('xpack.agentBuilder.roundResponseActions.copySuccess', {
-    defaultMessage: 'Response copied to clipboard',
-  }),
   regenerate: i18n.translate('xpack.agentBuilder.roundResponseActions.regenerate', {
     defaultMessage: 'Regenerate response',
   }),
@@ -40,6 +53,8 @@ interface RoundResponseActionsProps {
   isVisible: boolean;
   isLastRound?: boolean;
   rawRound?: ConversationRound;
+  /** Which side of the round `content` comes from, so the copy wording matches it. */
+  copyTarget?: keyof typeof copyLabels;
 }
 
 export const RoundResponseActions: React.FC<RoundResponseActionsProps> = ({
@@ -47,6 +62,7 @@ export const RoundResponseActions: React.FC<RoundResponseActionsProps> = ({
   isVisible,
   isLastRound,
   rawRound,
+  copyTarget = 'response',
 }) => {
   const { addSuccessToast } = useToasts();
   const { regenerate, isRegenerating, isResponseLoading } = useConversationStream();
@@ -54,12 +70,14 @@ export const RoundResponseActions: React.FC<RoundResponseActionsProps> = ({
   const isExperimentalEnabled = useExperimentalFeatures();
   const isTracingEnabled = useTracingEnabled();
 
+  const { action: copyLabel, success: copySuccessLabel } = copyLabels[copyTarget];
+
   const handleCopy = useCallback(() => {
     const isSuccess = copy(content);
     if (isSuccess) {
-      addSuccessToast(labels.copySuccess);
+      addSuccessToast(copySuccessLabel);
     }
-  }, [content, addSuccessToast]);
+  }, [content, addSuccessToast, copySuccessLabel]);
 
   const handleResend = useCallback(() => {
     regenerate();
@@ -108,10 +126,10 @@ export const RoundResponseActions: React.FC<RoundResponseActionsProps> = ({
       `}
     >
       <EuiFlexItem grow={false}>
-        <EuiToolTip content={labels.copy} disableScreenReaderOutput>
+        <EuiToolTip content={copyLabel} disableScreenReaderOutput>
           <EuiButtonIcon
             iconType="copy"
-            aria-label={labels.copy}
+            aria-label={copyLabel}
             onClick={handleCopy}
             color="text"
             data-test-subj="roundResponseCopyButton"


### PR DESCRIPTION
## Summary

Fixes #280441.

The user prompt bubble in Agent Builder chat renders `RoundResponseActions`, the same component the agent response uses. Its copy button tooltip said **Copy response** and its toast said **Response copied to clipboard**, on a message the user wrote.

`RoundResponseActions` now takes a `copyTarget` prop (`'response' | 'prompt'`, default `'response'`). `RoundInput` passes `copyTarget="prompt"`, so the user bubble reads **Copy prompt** / **Prompt copied to clipboard**. The agent response side is unchanged.

The bug is generic to Agent Builder chat, not Security-only.

## Screenshots

Tooltip on the user's own message:

| Before | After |
|--------|-------|
| ![before](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260819/7ellr6kr-before.png) | ![after](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260819/uoj0k5hu-after.png) |

Toast after clicking that copy button:

| Before | After |
|--------|-------|
| ![before toast](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260819/xvk6oul4-before-toast.png) | ![after toast](https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260819/haq4bi3u-after-toast.png) |

Captured on a local Kibana, same conversation and same crop region for each pair.

## Changes

- `round_response_actions.tsx` — split copy labels into a `copyLabels` map keyed by target; add the `copyTarget` prop.
- `round_input.tsx` — pass `copyTarget="prompt"`.
- `round_response_actions.test.tsx` — new tests covering both label sets and the clipboard call.

The EBT action stays `COPY_RESPONSE` for both, so existing telemetry is not split.

## How to test

1. Open Agent Builder chat and send any prompt.
2. Hover the copy icon on your own message. Tooltip reads **Copy prompt**.
3. Click it. Toast reads **Prompt copied to clipboard**, clipboard holds your prompt.
4. Repeat on the agent response. Wording stays **Copy response** / **Response copied to clipboard**.

## Checklist

- [x] Unit tests added (`node scripts/jest x-pack/platform/plugins/shared/agent_builder/.../round_response_actions.test.tsx`)
- [x] `node scripts/i18n_check` passes
- [x] `node scripts/eslint` passes
- [x] Verified in a running Kibana (screenshots above)

## Release note

Agent Builder chat now labels the copy button on a user message "Copy prompt" instead of "Copy response".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKiKykhWZYWM3u2TE8YR8N
