### PR TITLE
Support request-level reasoning over the inference REST API

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -74,3 +74,5 @@
     - 'src/platform/packages/shared/kbn-tracing/**/*.*'
     - '.buildkite/pipelines/evals/**/*.*'
     - '.buildkite/scripts/steps/evals/**/*.*'
+    - 'x-pack/platform/plugins/shared/inference/**/*.*'
+    - 'x-pack/platform/packages/shared/ai-infra/**/*.*'

--- a/x-pack/platform/packages/shared/kbn-evals/README.md
+++ b/x-pack/platform/packages/shared/kbn-evals/README.md
@@ -368,13 +368,11 @@ Use `selectEvaluators<MyExample, MyTaskOutput>(...)` for typed evaluator callbac
 
 | Fixture            | Description                                                                |
 | ------------------ | -------------------------------------------------------------------------- |
-| `inferenceClient`  | Bound to the connector declared by the active Playwright project.          |
+| `inferenceClient`  | Bound to the connector declared by the active Playwright project. For EIS connectors, reasoning is enabled by default; pass an explicit `reasoning` to override. |
 | `executorClient`   | Runs experiments (in-Kibana executor by default).                          |
 | `evalsClient`      | Client for evals plugin APIs (scores, datasets, experiment stats).         |
 | `reportModelScore` | Displays results in terminal (overridable for custom reporting).           |
 | `traceEsClient`    | ES client for querying OTel traces (defaults to Scout `esClient` cluster). |
-
-For EIS connectors, `inferenceClient` (and the judge derived from it) defaults `reasoning` to `{ enabled: true }` when a call omits it, so reasoning-mandatory EIS endpoints don't reject `effort: none`. Non-EIS connectors are left as-is, and an explicit `reasoning` always wins.
 
 ### Available evaluators
 

--- a/x-pack/platform/packages/shared/kbn-evals/README.md
+++ b/x-pack/platform/packages/shared/kbn-evals/README.md
@@ -374,6 +374,8 @@ Use `selectEvaluators<MyExample, MyTaskOutput>(...)` for typed evaluator callbac
 | `reportModelScore` | Displays results in terminal (overridable for custom reporting).           |
 | `traceEsClient`    | ES client for querying OTel traces (defaults to Scout `esClient` cluster). |
 
+For EIS connectors, `inferenceClient` (and the judge derived from it) defaults `reasoning` to `{ enabled: true }` when a call omits it, so reasoning-mandatory EIS endpoints don't reject `effort: none`. Non-EIS connectors are left as-is, and an explicit `reasoning` always wins.
+
 ### Available evaluators
 
 Built-in evaluator factories you can use directly or as inspiration for custom evaluators:

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluate.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluate.ts
@@ -23,6 +23,7 @@ import { buildExecutionId } from './utils/build_execution_id';
 import { createDefaultTerminalReporter } from './utils/reporting/evaluation_reporter';
 import { createConnectorFixture, resolveConnectorId } from './utils/create_connector_fixture';
 import { wrapInferenceClientWithEisConnectorTelemetry } from './utils/wrap_inference_client_with_connector_telemetry';
+import { wrapInferenceClientWithReasoningDefault } from './utils/wrap_inference_client_with_reasoning_default';
 import { createAgentBuilderClient } from './utils/agent_builder_client';
 import { createCorrectnessAnalysisEvaluator } from './evaluators/correctness';
 import { createGroundednessAnalysisEvaluator } from './evaluators/groundedness';
@@ -172,7 +173,9 @@ export const evaluate = base.extend<{}, EvaluationSpecificWorkerFixtures>({
           connectorId: connector.id,
         },
       });
-      const wrappedInferenceClient = wrapInferenceClientWithEisConnectorTelemetry(inferenceClient);
+      const wrappedInferenceClient = wrapInferenceClientWithEisConnectorTelemetry(
+        wrapInferenceClientWithReasoningDefault(inferenceClient, connector.id)
+      );
       log.serviceLoaded?.('inferenceClient');
 
       await use(wrappedInferenceClient);

--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/wrap_inference_client_with_reasoning_default.test.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/wrap_inference_client_with_reasoning_default.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BoundInferenceClient } from '@kbn/inference-common';
+import { wrapInferenceClientWithReasoningDefault } from './wrap_inference_client_with_reasoning_default';
+
+const EIS_CONNECTOR_ID = 'eis-google-gemini-3-6-flash';
+const NON_EIS_CONNECTOR_ID = 'openai-gpt-5-6-luna';
+
+interface MockClient extends BoundInferenceClient {
+  chatComplete: jest.Mock;
+  prompt: jest.Mock;
+  bindTo: jest.Mock;
+}
+
+const createMockClient = (): MockClient => {
+  const client = {
+    chatComplete: jest.fn(),
+    prompt: jest.fn(),
+    bindTo: jest.fn(),
+  } as unknown as MockClient;
+
+  client.bindTo.mockImplementation(() => createMockClient());
+
+  return client;
+};
+
+describe('wrapInferenceClientWithReasoningDefault', () => {
+  it('injects the default reasoning on chatComplete for an EIS connector when the caller set none', () => {
+    const client = createMockClient();
+    const wrapped = wrapInferenceClientWithReasoningDefault(client, EIS_CONNECTOR_ID);
+
+    wrapped.chatComplete({ messages: [] } as any);
+
+    expect(client.chatComplete).toHaveBeenCalledWith({
+      messages: [],
+      reasoning: { enabled: true },
+    });
+  });
+
+  it('injects the default reasoning on prompt for an EIS connector when the caller set none', () => {
+    const client = createMockClient();
+    const wrapped = wrapInferenceClientWithReasoningDefault(client, EIS_CONNECTOR_ID);
+
+    wrapped.prompt({ prompt: { name: 'p' }, input: {} } as any);
+
+    expect(client.prompt).toHaveBeenCalledWith({
+      prompt: { name: 'p' },
+      input: {},
+      reasoning: { enabled: true },
+    });
+  });
+
+  it('does not inject reasoning for a non-EIS connector', () => {
+    const client = createMockClient();
+    const wrapped = wrapInferenceClientWithReasoningDefault(client, NON_EIS_CONNECTOR_ID);
+
+    wrapped.chatComplete({ messages: [] } as any);
+    wrapped.prompt({ prompt: { name: 'p' }, input: {} } as any);
+
+    expect(client.chatComplete).toHaveBeenCalledWith({ messages: [] });
+    expect(client.prompt).toHaveBeenCalledWith({ prompt: { name: 'p' }, input: {} });
+  });
+
+  it('preserves an explicit reasoning on chatComplete', () => {
+    const client = createMockClient();
+    const wrapped = wrapInferenceClientWithReasoningDefault(client, EIS_CONNECTOR_ID);
+
+    wrapped.chatComplete({ messages: [], reasoning: { effort: 'high' } } as any);
+
+    expect(client.chatComplete).toHaveBeenCalledWith({
+      messages: [],
+      reasoning: { effort: 'high' },
+    });
+  });
+
+  it('preserves an explicit reasoning on prompt', () => {
+    const client = createMockClient();
+    const wrapped = wrapInferenceClientWithReasoningDefault(client, EIS_CONNECTOR_ID);
+
+    wrapped.prompt({ prompt: { name: 'p' }, input: {}, reasoning: { effort: 'low' } } as any);
+
+    expect(client.prompt).toHaveBeenCalledWith({
+      prompt: { name: 'p' },
+      input: {},
+      reasoning: { effort: 'low' },
+    });
+  });
+
+  it('honors a custom default reasoning value', () => {
+    const client = createMockClient();
+    const wrapped = wrapInferenceClientWithReasoningDefault(client, EIS_CONNECTOR_ID, {
+      effort: 'medium',
+    });
+
+    wrapped.chatComplete({ messages: [] } as any);
+
+    expect(client.chatComplete).toHaveBeenCalledWith({
+      messages: [],
+      reasoning: { effort: 'medium' },
+    });
+  });
+
+  it('re-evaluates the connector across bindTo (injects when rebinding to an EIS connector)', () => {
+    const client = createMockClient();
+    const wrapped = wrapInferenceClientWithReasoningDefault(client, NON_EIS_CONNECTOR_ID);
+
+    const rebound = wrapped.bindTo({ connectorId: EIS_CONNECTOR_ID });
+    rebound.chatComplete({ messages: [] } as any);
+
+    const reboundInner = client.bindTo.mock.results[0].value as MockClient;
+    expect(reboundInner.chatComplete).toHaveBeenCalledWith({
+      messages: [],
+      reasoning: { enabled: true },
+    });
+  });
+
+  it('re-evaluates the connector across bindTo (no injection when rebinding to a non-EIS connector)', () => {
+    const client = createMockClient();
+    const wrapped = wrapInferenceClientWithReasoningDefault(client, EIS_CONNECTOR_ID);
+
+    const rebound = wrapped.bindTo({ connectorId: NON_EIS_CONNECTOR_ID });
+    rebound.chatComplete({ messages: [] } as any);
+
+    const reboundInner = client.bindTo.mock.results[0].value as MockClient;
+    expect(reboundInner.chatComplete).toHaveBeenCalledWith({ messages: [] });
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-evals/src/utils/wrap_inference_client_with_reasoning_default.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/utils/wrap_inference_client_with_reasoning_default.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  BoundChatCompleteAPI,
+  BoundInferenceClient,
+  BoundPromptAPI,
+  ChatCompletionReasoning,
+  Prompt,
+  UnboundChatCompleteOptions,
+  UnboundPromptOptions,
+} from '@kbn/inference-common';
+
+// Reasoning-mandatory EIS endpoints reject `{ effort: 'none' }` (the adapter's
+// default when tools are attached); `{ enabled: true }` uses the model's default effort.
+const DEFAULT_REASONING: ChatCompletionReasoning = { enabled: true };
+
+// External OpenAI reasoning models require `effort: none` with tools, so only EIS
+// connectors get the reasoning default. Explicit caller `reasoning` always wins.
+const isEisConnectorId = (connectorId: string): boolean => connectorId.startsWith('eis-');
+
+function withReasoningDefault(
+  client: BoundInferenceClient,
+  connectorId: string,
+  reasoning: ChatCompletionReasoning
+): BoundInferenceClient {
+  const shouldInject = isEisConnectorId(connectorId);
+  return {
+    ...client,
+    bindTo: (options) =>
+      withReasoningDefault(client.bindTo(options), options.connectorId, reasoning),
+    chatComplete: (<TChatCompleteOptions extends UnboundChatCompleteOptions>(
+      options: TChatCompleteOptions
+    ) => {
+      return client.chatComplete(
+        shouldInject && options.reasoning == null ? { ...options, reasoning } : options
+      );
+    }) as BoundChatCompleteAPI,
+    prompt: (<TPrompt extends Prompt, TPromptOptions extends UnboundPromptOptions<TPrompt>>(
+      options: { prompt: TPrompt } & TPromptOptions
+    ) => {
+      return client.prompt(
+        shouldInject && options.reasoning == null ? { ...options, reasoning } : options
+      );
+    }) as BoundPromptAPI,
+  };
+}
+
+/**
+ * Applies a default `reasoning` to EIS `chatComplete`/`prompt` calls that don't set one,
+ * re-evaluated per connector across `bindTo`. Non-EIS connectors are left untouched.
+ */
+export function wrapInferenceClientWithReasoningDefault(
+  client: BoundInferenceClient,
+  connectorId: string,
+  reasoning: ChatCompletionReasoning = DEFAULT_REASONING
+): BoundInferenceClient {
+  return withReasoningDefault(client, connectorId, reasoning);
+}

--- a/x-pack/platform/plugins/shared/inference/common/http_apis.ts
+++ b/x-pack/platform/plugins/shared/inference/common/http_apis.ts
@@ -12,6 +12,7 @@ import type {
   InferenceConnector,
   Prompt,
   ChatCompleteMetadata,
+  ChatCompletionReasoning,
   ToolChoice,
 } from '@kbn/inference-common';
 
@@ -25,6 +26,7 @@ export interface ChatCompleteRequestBodyBase {
     retryOn?: 'all' | 'auto';
   };
   metadata?: ChatCompleteMetadata;
+  reasoning?: ChatCompletionReasoning;
   toolChoice?: ToolChoice;
 }
 

--- a/x-pack/platform/plugins/shared/inference/common/rest/chat_complete.test.ts
+++ b/x-pack/platform/plugins/shared/inference/common/rest/chat_complete.test.ts
@@ -45,6 +45,21 @@ describe('createChatCompleteRestApi', () => {
     expect(JSON.parse((callBody as any[])[1].body as string)).toEqual(params);
   });
 
+  it('forwards reasoning in the request body', async () => {
+    const params = {
+      connectorId: 'my-connector',
+      messages: [{ role: MessageRole.User, content: 'question' }],
+      reasoning: { enabled: true },
+    } satisfies ChatCompleteOptions;
+
+    http.fetch.mockResolvedValue({});
+
+    await chatComplete(params);
+
+    const callBody = http.fetch.mock.lastCall!;
+    expect(JSON.parse((callBody as any[])[1].body as string)).toEqual(params);
+  });
+
   it('calls http.fetch with the right parameters when stream is true', async () => {
     const params = {
       connectorId: 'my-connector',

--- a/x-pack/platform/plugins/shared/inference/common/rest/chat_complete.ts
+++ b/x-pack/platform/plugins/shared/inference/common/rest/chat_complete.ts
@@ -48,6 +48,7 @@ export function createChatCompleteRestApi({ fetch, signal }: CreatePublicChatCom
       maxRetries,
       metadata,
       retryConfiguration,
+      reasoning,
     } = options;
 
     const body: ChatCompleteRequestBody = {
@@ -62,6 +63,7 @@ export function createChatCompleteRestApi({ fetch, signal }: CreatePublicChatCom
       retryConfiguration: undefined,
       maxRetries,
       metadata,
+      reasoning,
     };
 
     function retry<T>() {

--- a/x-pack/platform/plugins/shared/inference/common/rest/prompt.test.ts
+++ b/x-pack/platform/plugins/shared/inference/common/rest/prompt.test.ts
@@ -89,6 +89,31 @@ describe('createPromptRestApi', () => {
     });
   });
 
+  it('forwards reasoning in the request body', async () => {
+    const params = {
+      connectorId: 'my-connector',
+      input: {
+        question: 'What is Kibana?',
+      },
+      prompt,
+      reasoning: { enabled: true },
+    } satisfies PromptOptions;
+
+    http.fetch.mockResolvedValue({});
+
+    await promptApi({
+      ...params,
+      stream: false,
+    });
+
+    const callBody = http.fetch.mock.lastCall!;
+    const parsedBody = JSON.parse((callBody as any[])[1].body as string);
+    expect(parsedBody).toEqual({
+      ...omit(params, 'stream', 'prompt'),
+      prompt: omit(prompt, 'input'),
+    });
+  });
+
   it('calls http.fetch with the right parameters for streaming', async () => {
     const params = {
       connectorId: 'my-connector',

--- a/x-pack/platform/plugins/shared/inference/common/rest/prompt.ts
+++ b/x-pack/platform/plugins/shared/inference/common/rest/prompt.ts
@@ -42,6 +42,7 @@ export function createPromptRestApi({ fetch, signal }: PublicInferenceClientCrea
       functionCalling,
       prevMessages,
       toolChoice,
+      reasoning,
     } = options;
 
     const body: PromptRequestBody = {
@@ -56,6 +57,7 @@ export function createPromptRestApi({ fetch, signal }: PublicInferenceClientCrea
       prevMessages,
       metadata,
       toolChoice,
+      reasoning,
     };
 
     const validationResult = inputSchema.safeParse(input);

--- a/x-pack/platform/plugins/shared/inference/server/routes/chat_complete.ts
+++ b/x-pack/platform/plugins/shared/inference/server/routes/chat_complete.ts
@@ -55,6 +55,7 @@ export function registerChatCompleteRoute({
       retryConfiguration,
       temperature,
       metadata,
+      reasoning,
     } = request.body;
 
     return client.chatComplete({
@@ -71,6 +72,7 @@ export function registerChatCompleteRoute({
       retryConfiguration,
       temperature,
       metadata,
+      reasoning,
     });
   }
 

--- a/x-pack/platform/plugins/shared/inference/server/routes/prompt.ts
+++ b/x-pack/platform/plugins/shared/inference/server/routes/prompt.ts
@@ -55,6 +55,7 @@ export function registerPromptRoute({
       metadata,
       prevMessages,
       toolChoice,
+      reasoning,
     } = request.body;
 
     return client.prompt({
@@ -75,6 +76,7 @@ export function registerPromptRoute({
       metadata,
       prevMessages,
       toolChoice,
+      reasoning,
     });
   }
 

--- a/x-pack/platform/plugins/shared/inference/server/routes/schemas.ts
+++ b/x-pack/platform/plugins/shared/inference/server/routes/schemas.ts
@@ -55,6 +55,26 @@ export const messageOptionsSchema = schema.object({
   toolChoice: toolChoiceSchema,
 });
 
+export const reasoningSchema = schema.maybe(
+  schema.object({
+    effort: schema.maybe(
+      schema.oneOf([
+        schema.literal('none'),
+        schema.literal('minimal'),
+        schema.literal('low'),
+        schema.literal('medium'),
+        schema.literal('high'),
+        schema.literal('xhigh'),
+      ])
+    ),
+    enabled: schema.maybe(schema.boolean()),
+    summary: schema.maybe(
+      schema.oneOf([schema.literal('auto'), schema.literal('concise'), schema.literal('detailed')])
+    ),
+    exclude: schema.maybe(schema.boolean()),
+  })
+);
+
 export const chatCompleteBaseSchema = schema.object({
   connectorId: schema.string({ minLength: 1 }),
   maxRetries: schema.maybe(schema.number()),
@@ -95,6 +115,7 @@ export const chatCompleteBaseSchema = schema.object({
   functionCalling: schema.maybe(
     schema.oneOf([schema.literal('auto'), schema.literal('native'), schema.literal('simulated')])
   ),
+  reasoning: reasoningSchema,
 });
 
 const messageSchema = schema.oneOf([


### PR DESCRIPTION
## Summary
Since #284554 , `chatComplete`/`prompt` default `reasoning` to `{ effort: 'none' }` when tools are attached. That fits external OpenAI but breaks reasoning-mandatory EIS endpoints, which reject `none` with a 400 and block eval runs.
- Carry `reasoning` through the inference REST path (`/internal/inference/chat_complete` and `/prompt`): request type, route schema, handlers, and REST client body. 
#284554 only covered the in-process client.
- In kbn-evals, default `reasoning: { enabled: true }` for `eis-` connectors when a call sets none, applied at the shared `inferenceClient` fixture so task and judge inherit it.
- Non-EIS connectors stay on `none`, and an explicit `reasoning` always wins.
- Per-model/judge reasoning config is a follow-up ([#402](https://github.com/elastic/nightshift-program/issues/402)).
## Testing
- Run with `EVAL_CONNECTOR_ID=eis-google-gemini-3-6-flash`: judge no longer 400s, and a `gpt-oss-120b` task step passes.
- Non-EIS run is unchanged; an explicit `reasoning` is not overridden.
- Unit tests: wrapper (EIS inject, non-EIS no-op, explicit preserved, `bindTo`) and REST `reasoning` passthrough.
Closes elastic/nightshift-program#1197