### PR TITLE
[9.5][security_solution/cypress] Fix elastic-agent version resolution

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
@@ -542,21 +542,22 @@ export const getAgentVersionMatchingCurrentStack = async (
     { maxTimeout: 10000 }
   );
 
-  let version =
-    semver.maxSatisfying(
-      map(agentVersions, (agentVersion) => agentVersion.split('-SNAPSHOT')[0]),
-      `<=${kbnStatus.version.number}`
-    ) ?? kbnStatus.version.number;
+  const useSnapshot =
+    kbnStatus.version.build_snapshot || kbnStatus.version.build_hash.startsWith('XXXXXXXXXXXXXXX');
+  const suffix = useSnapshot ? '-SNAPSHOT' : '';
+  const matchingAgentVersions = agentVersions.filter(
+    (version) => version.endsWith('-SNAPSHOT') === useSnapshot
+  );
+  const version = semver.maxSatisfying(
+    map(matchingAgentVersions, (agentVersion) => agentVersion.split('-SNAPSHOT')[0]),
+    `<=${kbnStatus.version.number}`
+  );
 
-  const snapshotVersion = `${version}-SNAPSHOT`;
-  if (
-    agentVersions.includes(snapshotVersion) &&
-    (kbnStatus.version.build_snapshot || kbnStatus.version.build_hash.startsWith('XXXXXXXXXXXXXXX'))
-  ) {
-    version = snapshotVersion;
+  if (!version) {
+    throw new Error(`Unable to find an Agent version compatible with ${kbnStatus.version.number}`);
   }
 
-  return version;
+  return `${version}${suffix}`;
 };
 
 // Generates a file name using system arch and an agent version.

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
@@ -537,27 +537,23 @@ export const getAgentVersionMatchingCurrentStack = async (
       return axios
         .get('https://artifacts-api.elastic.co/v1/versions')
         .catch(catchAxiosErrorFormatAndThrow)
-        .then((response) =>
-          map(
-            response.data.versions.filter(isValidArtifactVersion),
-            (version) => version.split('-SNAPSHOT')[0]
-          )
-        );
+        .then((response) => response.data.versions.filter(isValidArtifactVersion));
     },
     { maxTimeout: 10000 }
   );
 
   let version =
-    semver.maxSatisfying(agentVersions, `<=${kbnStatus.version.number}`) ??
-    kbnStatus.version.number;
+    semver.maxSatisfying(
+      map(agentVersions, (agentVersion) => agentVersion.split('-SNAPSHOT')[0]),
+      `<=${kbnStatus.version.number}`
+    ) ?? kbnStatus.version.number;
 
-  // Add `-SNAPSHOT` if version indicates it was from a snapshot or the build hash starts
-  // with `xxxxxxxxx` (value that seems to be present when running kibana from source)
+  const snapshotVersion = `${version}-SNAPSHOT`;
   if (
-    kbnStatus.version.build_snapshot ||
-    kbnStatus.version.build_hash.startsWith('XXXXXXXXXXXXXXX')
+    agentVersions.includes(snapshotVersion) &&
+    (kbnStatus.version.build_snapshot || kbnStatus.version.build_hash.startsWith('XXXXXXXXXXXXXXX'))
   ) {
-    version += '-SNAPSHOT';
+    version = snapshotVersion;
   }
 
   return version;


### PR DESCRIPTION
Version resolution currently assumes a snapshot build will always exist
for the most recent version.  That is currently not the case.

Instead match on the available versions with a -SNAPSHOT suffix.

Fixes https://buildkite.com/elastic/kibana-on-merge/builds/106957#01a01b1e-dff8-4c63-be09-9432dc8e7251