### PR TITLE
[kbn-es] Handle already-stopped containers in teardownServerlessClusterSync

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -1339,7 +1339,11 @@ export function teardownServerlessClusterSync(log: ToolingLog, options: Serverle
   if (runningNodes.length) {
     log.info('Killing running serverless containers.');
 
-    execa.commandSync(`docker kill ${runningNodes.join(' ')}`);
+    try {
+      execa.commandSync(`docker kill ${runningNodes.join(' ')}`);
+    } catch {
+      log.debug('Some containers had already stopped before kill completed.');
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

`teardownServerlessClusterSync` queries `docker ps --filter status=running` then calls `docker kill` on the result. If a container stops between those two calls, `docker kill` exits non-zero and the error propagates as an unhandled exception.

This wraps the `docker kill` call in a try/catch so the race condition is logged at debug level instead of crashing.

## Test plan

- Run `yarn es serverless` to start the ES serverless cluster
- Kill the Docker containers manually: `docker kill $(docker ps -q)`
- Run `yarn es serverless --kill` again — previously this would throw; now it logs a debug message and continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)