### PR TITLE
ci: Specify Buildkite settings and GitHub webhook events for merge-queue

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-merge-queue.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-merge-queue.yml
@@ -42,6 +42,11 @@ spec:
         build_tags: false
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: false
+        build_merge_group_checks_requested: true
+        cancel_when_merge_group_destroyed: true
+        use_merge_group_base_commit_for_git_diff_base: true
+      webhook_events:
+        - merge_group
       teams:
         everyone:
           access_level: BUILD_AND_READ

--- a/.buildkite/pipeline-resource-definitions/scripts/validate-pipeline-definition.sh
+++ b/.buildkite/pipeline-resource-definitions/scripts/validate-pipeline-definition.sh
@@ -20,7 +20,7 @@ FOLDER_NAME=$(dirname "$ABSOLUTE_PATH")
 # docker inspect docker.elastic.co/ci-agent-images/pipelib:latest --format '{{index .RepoDigests 0}}'
 docker run \
  --mount type=bind,source="$FOLDER_NAME",target=/home/app/ \
-  docker.elastic.co/ci-agent-images/pipelib@sha256:d1713778d27e0b6208f59ba8761f04ef033af4c4237cb2614a09d38584c5ff88 \
+  docker.elastic.co/ci-agent-images/pipelib@sha256:d79a2f81e8679788e314bdb69c074388dbc9b5d6d30f9e2e90cd40b867911bf7 \
   rre validate --backstage-entity-aware "/home/app/$FILE_NAME"
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Codifies the settings we expect to see for the merge-queue pipeline and the events that GitHub publishes to its corresponding webhook.





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->