### PR TITLE
[Alerting] Suppress noisy CPS warning when local dev ES lacks /_project_routing

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/resolve_cps_data.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/resolve_cps_data.test.ts
@@ -50,6 +50,24 @@ describe('resolveCpsData', () => {
     });
   });
 
+  it('falls back to PROJECT_ROUTING_ALL on 400', async () => {
+    internalUserEsClient.transport.request.mockRejectedValueOnce({ statusCode: 400 });
+    currentUserEsClient.transport.request.mockResolvedValueOnce({ linked_projects: {} });
+
+    const result = await resolveCpsData(
+      internalUserEsClient,
+      currentUserEsClient,
+      'default',
+      logger
+    );
+
+    expect(result).toEqual({
+      resolvedExpression: PROJECT_ROUTING_ALL,
+      linkedProjects: [],
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it('falls back to PROJECT_ROUTING_ALL on 404', async () => {
     internalUserEsClient.transport.request.mockRejectedValueOnce({ statusCode: 404 });
     currentUserEsClient.transport.request.mockResolvedValueOnce({ linked_projects: {} });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/resolve_cps_data.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/resolve_cps_data.ts
@@ -42,9 +42,10 @@ export const resolveCpsData = async (
       })
       .then((res) => res.expression ?? PROJECT_ROUTING_ALL)
       .catch((error: { statusCode?: number }) => {
-        // A missing routing expression (404) is a legitimate "no routing configured" case: fall
+        // A missing routing expression (404) or unknown route (400, e.g. local dev ES that does
+        // not implement /_project_routing) is a legitimate "no routing configured" case: fall
         // back to the default "all projects" scope silently.
-        if (error?.statusCode === 404) {
+        if (error?.statusCode === 404 || error?.statusCode === 400) {
           return PROJECT_ROUTING_ALL;
         }
         // The internal user should always be authorized for this operator-only endpoint, so a 403


### PR DESCRIPTION
## Summary

When running a serverless-mode Kibana against a local `yarn es serverless` Docker container, every APM `transaction_duration` alerting rule execution logs:

```
[WARN][plugins.alerting.apm.transaction_duration] Failed to resolve CPS data: {"error":"no handler found for uri [/_project_routing/kibana_space_default_default] and method [GET]"}
```

The `/_project_routing` endpoint is a serverless-only Elasticsearch operator API. The local Docker ES container doesn't implement it, so it responds with a **400** ("no handler found") instead of a **404**. The existing error handler only caught 404 and 403 — the 400 slipped through to the outer catch, which logs a warning on every rule execution cycle (~every minute).

**Fix:** treat 400 the same as 404 — fall back to `PROJECT_ROUTING_ALL` silently. Both mean "this cluster has no routing configured for this space."

## Testing

Run Kibana against `yarn es serverless` with an APM `transaction_duration` alerting rule active. The `Failed to resolve CPS data` warning should no longer appear in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)