### PR TITLE
[One Workflow] Fix AI diffs on resumed conversations and duplicate workflow attachments

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.test.ts
@@ -43,6 +43,35 @@ const makeYamlChangedEvent = (payload: Record<string, unknown>): BrowserChatEven
     },
   } as unknown as BrowserChatEvent);
 
+/**
+ * The chat UI publishes the active conversation and exposes one event stream per
+ * conversation. It mints the id before the first request, so a bridge is always
+ * bound before events arrive.
+ */
+const createChatEvents = (initialConversationId: string | undefined = 'conv-1') => {
+  const activeConversation$ = new BehaviorSubject<ActiveConversation | null>(
+    initialConversationId ? { id: initialConversationId } : null
+  );
+  const streams = new Map<string, Subject<BrowserChatEvent>>();
+  const streamFor = (conversationId: string) => {
+    let stream = streams.get(conversationId);
+    if (!stream) {
+      stream = new Subject<BrowserChatEvent>();
+      streams.set(conversationId, stream);
+    }
+    return stream;
+  };
+
+  return {
+    activeConversation$,
+    getChatEvents$: (conversationId: string) => streamFor(conversationId).asObservable(),
+    /** Bind the bridge to another conversation, as switching chats does. */
+    bindTo: (conversationId: string) => activeConversation$.next({ id: conversationId }),
+    emit: (event: BrowserChatEvent, conversationId = initialConversationId!) =>
+      streamFor(conversationId).next(event),
+  };
+};
+
 const createMockEditor = (initialValue: string) => {
   let content = initialValue;
   return {
@@ -90,7 +119,7 @@ describe('AttachmentBridge: workflow navigation', () => {
   ].join('\n');
 
   it('event for previous workflow arriving after navigation should not corrupt the current editor', () => {
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
 
     const editedWorkflowAYaml = WORKFLOW_A_YAML.replace(
       'description: First workflow',
@@ -103,12 +132,13 @@ describe('AttachmentBridge: workflow navigation', () => {
     const { manager: managerA } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, managerA, editorRefA, trackerA, {
+    bridge.start(managerA, editorRefA, trackerA, {
+      ...events,
       attachmentId: 'workflow-a',
       workflowId: 'workflow-a',
     });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'proposal-a',
         beforeYaml: WORKFLOW_A_YAML,
@@ -131,7 +161,8 @@ describe('AttachmentBridge: workflow navigation', () => {
     const trackerB = new ProposalTracker();
     const { manager: managerB } = createMockProposalManager();
 
-    bridge.start(chat$, managerB, editorRefB, trackerB, {
+    bridge.start(managerB, editorRefB, trackerB, {
+      ...events,
       attachmentId: 'workflow-b',
       workflowId: 'workflow-b',
     });
@@ -140,7 +171,7 @@ describe('AttachmentBridge: workflow navigation', () => {
       'description: First workflow',
       'description: Another edit on A'
     );
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'proposal-a-late',
         beforeYaml: editedWorkflowAYaml,
@@ -149,7 +180,7 @@ describe('AttachmentBridge: workflow navigation', () => {
       })
     );
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'proposal-b',
         beforeYaml: WORKFLOW_B_YAML,
@@ -167,7 +198,7 @@ describe('AttachmentBridge: workflow navigation', () => {
 
 describe('AttachmentBridge: onProposalReceived workflowId', () => {
   it('passes the event workflowId through to onProposalReceived (unset when create-time)', () => {
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
     const editor = createMockEditor('yaml: content');
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
@@ -176,12 +207,13 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
     const onProposalReceived = jest.fn();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker, {
+    bridge.start(manager, editorRef, tracker, {
+      ...events,
       attachmentId: 'attachment-uuid-not-a-real-workflow-id',
       onProposalReceived,
     });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'p1',
         beforeYaml: 'yaml: content',
@@ -202,7 +234,7 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
   });
 
   it('passes real workflowId from event payload when present', () => {
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
     const editor = createMockEditor('yaml: content');
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
@@ -211,13 +243,14 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
     const onProposalReceived = jest.fn();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker, {
+    bridge.start(manager, editorRef, tracker, {
+      ...events,
       attachmentId: 'real-workflow-id',
       workflowId: 'real-workflow-id',
       onProposalReceived,
     });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'p1',
         beforeYaml: 'yaml: content',
@@ -241,19 +274,20 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
     // Simulates: user starts chat on /workflows/create (unsaved UUID X), navigates
     // to workflow B before the agent replies. B's bridge must drop the late event
     // whose attachmentId is X, not apply it to B.
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
     const editor = createMockEditor('yaml: on-B');
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker, {
+    bridge.start(manager, editorRef, tracker, {
+      ...events,
       attachmentId: 'workflow-B',
       workflowId: 'workflow-B',
     });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'late-from-create',
         beforeYaml: 'yaml: on-create',
@@ -273,19 +307,20 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
     // attachmentId, so the server mints a fresh one and echoes it back. The
     // client's unsavedWorkflowIdRef doesn't match, but the event has no
     // saved workflowId, so it belongs to this create session and must apply.
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
     const editor = createMockEditor('yaml: default');
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker, {
+    bridge.start(manager, editorRef, tracker, {
+      ...events,
       attachmentId: 'client-unsaved-uuid',
       // workflowId omitted — create-session bridge
     });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'first-gen',
         beforeYaml: 'yaml: default',
@@ -300,55 +335,35 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
     bridge.stop();
   });
 
-  it('scopes to its own conversation via getChatEvents$ and ignores broad-stream workflow events after conversation_id is known', () => {
-    // With per-conversation scoping (getChatEvents$), events from other
-    // conversations cannot reach this bridge — regardless of ordering. Covers
-    // both "B receives its own event first" and "B receives A's late event
-    // first" scenarios of the create→create leak the bot flagged.
-    const chat$ = new Subject<BrowserChatEvent>();
-    const perConversation$ = new Map<string, Subject<BrowserChatEvent>>();
-    const getChatEvents$ = jest.fn((conversationId: string) => {
-      let s = perConversation$.get(conversationId);
-      if (!s) {
-        s = new Subject<BrowserChatEvent>();
-        perConversation$.set(conversationId, s);
-      }
-      return s.asObservable();
-    });
-
+  it('ignores workflow events from another conversation', () => {
+    // Per-conversation scoping means a second create session cannot leak its
+    // edits into this editor, regardless of which event arrives first.
+    const events = createChatEvents('conv-B');
     const editor = createMockEditor('yaml: on-B');
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker, {
+    bridge.start(manager, editorRef, tracker, {
+      ...events,
       attachmentId: 'client-B-unsaved-uuid',
-      getChatEvents$,
     });
 
-    // conversation_id_set for B lands on the broad chat$ → bridge switches to
-    // getChatEvents$('conv-B') for workflow events.
-    chat$.next({
-      type: ChatEventType.conversationIdSet,
-      data: { conversation_id: 'conv-B' },
-    } as unknown as BrowserChatEvent);
-
-    // A stale workflow event on the broad chat$ (from a previous session A)
-    // must NOT be picked up — the bridge no longer listens for workflow
-    // events on chat$ once scoped.
-    chat$.next(
+    // A stale event from a previous session A must not be picked up.
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'A-late',
         beforeYaml: 'yaml: on-A',
         afterYaml: 'yaml: from-A-agent',
         attachmentId: 'server-A-id',
-      })
+      }),
+      'conv-A'
     );
     expect(manager.applyAfterYaml).not.toHaveBeenCalled();
 
-    // B's own event on the scoped stream is applied.
-    perConversation$.get('conv-B')!.next(
+    // B's own event is applied.
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'B-first',
         beforeYaml: 'yaml: on-B',
@@ -361,33 +376,29 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
     bridge.stop();
   });
 
-  it('drops workflow events arriving on the broad chat$ before conversation_id_set (deterministic stale-event guard)', () => {
-    // Reverse ordering of the create→create repro: A's late event arrives on
-    // chat$ *before* our conversation_id_set. Since our conversation hasn't
-    // started yet, any workflow:yaml_changed must be stale — drop.
-    const chat$ = new Subject<BrowserChatEvent>();
-    const scoped$ = new Subject<BrowserChatEvent>();
-    const getChatEvents$ = jest.fn(() => scoped$.asObservable());
+  it('applies nothing until the chat UI has bound a conversation', () => {
+    // No binding yet, so there is no stream to listen on and any event in
+    // flight belongs to someone else.
+    const events = createChatEvents(undefined);
     const editor = createMockEditor('yaml: on-B');
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker, {
+    bridge.start(manager, editorRef, tracker, {
+      ...events,
       attachmentId: 'client-B-unsaved-uuid',
-      getChatEvents$,
     });
 
-    // A's late event arrives on the broad chat$ before we've seen our
-    // conversation_id_set — must be ignored.
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'A-late-first',
         beforeYaml: 'yaml: on-A',
         afterYaml: 'yaml: from-A-agent',
         attachmentId: 'server-A-id',
-      })
+      }),
+      'conv-A'
     );
 
     expect(manager.applyAfterYaml).not.toHaveBeenCalled();
@@ -399,19 +410,20 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
     // User was on saved workflow A, opened a conversation, navigated to
     // /workflows/create. Late event from A lands on the new create-session
     // bridge — must be dropped, otherwise A's edits mutate the fresh /create.
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
     const editor = createMockEditor('yaml: default');
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker, {
+    bridge.start(manager, editorRef, tracker, {
+      ...events,
       attachmentId: 'new-unsaved-uuid',
       // no workflowId
     });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'late-from-A',
         beforeYaml: 'yaml: on-A',
@@ -430,16 +442,16 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
     // Older servers may emit events without attachmentId; the bridge falls back
     // to matching by workflowId so the previously-working saved→saved guard
     // does not regress.
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
     const editor = createMockEditor('yaml: on-B');
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker, { attachmentId: 'workflow-B' });
+    bridge.start(manager, editorRef, tracker, { ...events, attachmentId: 'workflow-B' });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'late-legacy',
         beforeYaml: 'yaml: on-A',
@@ -455,47 +467,36 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
 });
 
 describe('AttachmentBridge: resumed conversation', () => {
-  // `conversation_id_set` only fires for newly created conversations, so a
-  // resumed one scopes itself from the active conversation instead.
-  const setup = (activeConversation: ActiveConversation | null) => {
-    const chat$ = new Subject<BrowserChatEvent>();
-    const activeConversation$ = new BehaviorSubject<ActiveConversation | null>(activeConversation);
-    const perConversation$ = new Map<string, Subject<BrowserChatEvent>>();
-    const getChatEvents$ = jest.fn((conversationId: string) => {
-      let stream = perConversation$.get(conversationId);
-      if (!stream) {
-        stream = new Subject<BrowserChatEvent>();
-        perConversation$.set(conversationId, stream);
-      }
-      return stream.asObservable();
-    });
-
+  // The server only emits `conversation_id_set` for newly created
+  // conversations, so a resumed one is scoped from the active conversation.
+  const setup = (initialConversationId?: string) => {
+    const events = createChatEvents(initialConversationId);
     const editorRef = { current: createMockEditor('yaml: original') };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
     const bridge = new AttachmentBridge();
 
-    bridge.start(chat$, manager, editorRef, tracker, {
+    bridge.start(manager, editorRef, tracker, {
+      ...events,
       attachmentId: 'workflow-a',
       workflowId: 'workflow-a',
-      getChatEvents$,
-      activeConversation$,
     });
 
-    return { bridge, chat$, activeConversation$, perConversation$, manager };
+    return { bridge, events, manager };
   };
 
-  it('applies YAML changes without a conversation_id_set event', () => {
-    const { bridge, perConversation$, manager } = setup({ id: 'conv-restored' });
+  const yamlChange = (proposalId: string, afterYaml: string) =>
+    makeYamlChangedEvent({
+      proposalId,
+      beforeYaml: 'yaml: original',
+      afterYaml,
+      attachmentId: 'workflow-a',
+    });
 
-    perConversation$.get('conv-restored')!.next(
-      makeYamlChangedEvent({
-        proposalId: 'resumed-1',
-        beforeYaml: 'yaml: original',
-        afterYaml: 'yaml: from-agent',
-        attachmentId: 'workflow-a',
-      })
-    );
+  it('applies YAML changes on a conversation it was bound to at start', () => {
+    const { bridge, events, manager } = setup('conv-restored');
+
+    events.emit(yamlChange('resumed-1', 'yaml: from-agent'), 'conv-restored');
 
     expect(manager.applyAfterYaml).toHaveBeenCalledWith('yaml: from-agent');
 
@@ -503,18 +504,10 @@ describe('AttachmentBridge: resumed conversation', () => {
   });
 
   it('scopes to a conversation restored after start', () => {
-    const { bridge, activeConversation$, perConversation$, manager } = setup(null);
+    const { bridge, events, manager } = setup(undefined);
 
-    activeConversation$.next({ id: 'conv-restored' });
-
-    perConversation$.get('conv-restored')!.next(
-      makeYamlChangedEvent({
-        proposalId: 'resumed-2',
-        beforeYaml: 'yaml: original',
-        afterYaml: 'yaml: from-agent',
-        attachmentId: 'workflow-a',
-      })
-    );
+    events.bindTo('conv-restored');
+    events.emit(yamlChange('resumed-2', 'yaml: from-agent'), 'conv-restored');
 
     expect(manager.applyAfterYaml).toHaveBeenCalledWith('yaml: from-agent');
 
@@ -522,21 +515,10 @@ describe('AttachmentBridge: resumed conversation', () => {
   });
 
   it('keeps the current scope when the chat UI reports a new, id-less conversation', () => {
-    // A new conversation emits `{ id: undefined }` before the server mints one.
-    const { bridge, perConversation$, activeConversation$, manager } = setup({
-      id: 'conv-restored',
-    });
+    const { bridge, events, manager } = setup('conv-restored');
 
-    activeConversation$.next({ id: undefined });
-
-    perConversation$.get('conv-restored')!.next(
-      makeYamlChangedEvent({
-        proposalId: 'resumed-3',
-        beforeYaml: 'yaml: original',
-        afterYaml: 'yaml: from-agent',
-        attachmentId: 'workflow-a',
-      })
-    );
+    events.activeConversation$.next({ id: undefined });
+    events.emit(yamlChange('resumed-3', 'yaml: from-agent'), 'conv-restored');
 
     expect(manager.applyAfterYaml).toHaveBeenCalledWith('yaml: from-agent');
 
@@ -544,44 +526,26 @@ describe('AttachmentBridge: resumed conversation', () => {
   });
 
   it('re-scopes when the user switches to another conversation', () => {
-    const { bridge, activeConversation$, perConversation$, manager } = setup({
-      id: 'conv-first',
-    });
+    const { bridge, events, manager } = setup('conv-first');
 
-    activeConversation$.next({ id: 'conv-second' });
+    events.bindTo('conv-second');
 
-    perConversation$.get('conv-first')!.next(
-      makeYamlChangedEvent({
-        proposalId: 'stale',
-        beforeYaml: 'yaml: original',
-        afterYaml: 'yaml: from-first',
-        attachmentId: 'workflow-a',
-      })
-    );
+    events.emit(yamlChange('stale', 'yaml: from-first'), 'conv-first');
     expect(manager.applyAfterYaml).not.toHaveBeenCalled();
 
-    perConversation$.get('conv-second')!.next(
-      makeYamlChangedEvent({
-        proposalId: 'current',
-        beforeYaml: 'yaml: original',
-        afterYaml: 'yaml: from-second',
-        attachmentId: 'workflow-a',
-      })
-    );
+    events.emit(yamlChange('current', 'yaml: from-second'), 'conv-second');
     expect(manager.applyAfterYaml).toHaveBeenCalledWith('yaml: from-second');
 
     bridge.stop();
   });
 
   it('stops listening after stop()', () => {
-    const { bridge, activeConversation$, perConversation$, manager } = setup({
-      id: 'conv-restored',
-    });
+    const { bridge, events, manager } = setup('conv-restored');
 
     bridge.stop();
-    activeConversation$.next({ id: 'conv-later' });
+    events.bindTo('conv-later');
+    events.emit(yamlChange('after-stop', 'yaml: from-agent'), 'conv-later');
 
-    expect(perConversation$.has('conv-later')).toBe(false);
     expect(manager.applyAfterYaml).not.toHaveBeenCalled();
   });
 });
@@ -612,16 +576,16 @@ describe('AttachmentBridge: sequential events delegate to applyAfterYaml', () =>
   const V2_YAML = V1_YAML.replace('enabled: true', 'enabled: false');
 
   it('second sequential event calls applyAfterYaml with V2', () => {
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
     const editor = createMockEditor(ORIGINAL_YAML);
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker);
+    bridge.start(manager, editorRef, tracker, { ...events });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'p1',
         beforeYaml: ORIGINAL_YAML,
@@ -632,7 +596,7 @@ describe('AttachmentBridge: sequential events delegate to applyAfterYaml', () =>
 
     expect(manager.applyAfterYaml).toHaveBeenCalledWith(V1_YAML);
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'p2',
         beforeYaml: V1_YAML,
@@ -648,16 +612,16 @@ describe('AttachmentBridge: sequential events delegate to applyAfterYaml', () =>
   });
 
   it('tracker records are set for each event', () => {
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
     const editor = createMockEditor(ORIGINAL_YAML);
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker);
+    bridge.start(manager, editorRef, tracker, { ...events });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'p1',
         beforeYaml: ORIGINAL_YAML,
@@ -666,7 +630,7 @@ describe('AttachmentBridge: sequential events delegate to applyAfterYaml', () =>
       })
     );
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'p2',
         beforeYaml: V1_YAML,
@@ -682,16 +646,16 @@ describe('AttachmentBridge: sequential events delegate to applyAfterYaml', () =>
   });
 
   it('after stop/restart, new manager receives applyAfterYaml', () => {
-    const chat$ = new Subject<BrowserChatEvent>();
+    const events = createChatEvents();
     const editor = createMockEditor(ORIGINAL_YAML);
     const editorRef = { current: editor };
     const tracker = new ProposalTracker();
     const { manager } = createMockProposalManager();
 
     const bridge = new AttachmentBridge();
-    bridge.start(chat$, manager, editorRef, tracker);
+    bridge.start(manager, editorRef, tracker, { ...events });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'p1',
         beforeYaml: ORIGINAL_YAML,
@@ -704,9 +668,9 @@ describe('AttachmentBridge: sequential events delegate to applyAfterYaml', () =>
 
     const tracker2 = new ProposalTracker();
     const { manager: manager2 } = createMockProposalManager();
-    bridge.start(chat$, manager2, editorRef, tracker2);
+    bridge.start(manager2, editorRef, tracker2, { ...events });
 
-    chat$.next(
+    events.emit(
       makeYamlChangedEvent({
         proposalId: 'p2',
         beforeYaml: V1_YAML,

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.test.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Subject } from 'rxjs';
-import type { BrowserChatEvent } from '@kbn/agent-builder-browser';
+import { BehaviorSubject, Subject } from 'rxjs';
+import type { ActiveConversation, BrowserChatEvent } from '@kbn/agent-builder-browser';
 import { ChatEventType } from '@kbn/agent-builder-common';
 import { WORKFLOW_YAML_CHANGED_EVENT } from '@kbn/workflows/common/constants';
 import { AttachmentBridge, baseProposalId } from './attachment_bridge';
@@ -451,6 +451,141 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
     expect(manager.applyAfterYaml).not.toHaveBeenCalled();
 
     bridge.stop();
+  });
+});
+
+describe('AttachmentBridge: resumed conversation', () => {
+  // The server only emits `conversation_id_set` when it creates a new
+  // conversation. On a resumed one the bridge must still scope itself, using
+  // the active conversation published by the chat UI.
+  // https://github.com/elastic/security-team/issues/19002
+  const setup = (activeConversation: ActiveConversation | null) => {
+    const chat$ = new Subject<BrowserChatEvent>();
+    const activeConversation$ = new BehaviorSubject<ActiveConversation | null>(activeConversation);
+    const perConversation$ = new Map<string, Subject<BrowserChatEvent>>();
+    const getChatEvents$ = jest.fn((conversationId: string) => {
+      let stream = perConversation$.get(conversationId);
+      if (!stream) {
+        stream = new Subject<BrowserChatEvent>();
+        perConversation$.set(conversationId, stream);
+      }
+      return stream.asObservable();
+    });
+
+    const editorRef = { current: createMockEditor('yaml: original') };
+    const tracker = new ProposalTracker();
+    const { manager } = createMockProposalManager();
+    const bridge = new AttachmentBridge();
+
+    bridge.start(chat$, manager, editorRef, tracker, {
+      attachmentId: 'workflow-a',
+      workflowId: 'workflow-a',
+      getChatEvents$,
+      activeConversation$,
+    });
+
+    return { bridge, chat$, activeConversation$, perConversation$, manager };
+  };
+
+  it('applies YAML changes without a conversation_id_set event', () => {
+    const { bridge, perConversation$, manager } = setup({ id: 'conv-restored' });
+
+    perConversation$.get('conv-restored')!.next(
+      makeYamlChangedEvent({
+        proposalId: 'resumed-1',
+        beforeYaml: 'yaml: original',
+        afterYaml: 'yaml: from-agent',
+        attachmentId: 'workflow-a',
+      })
+    );
+
+    expect(manager.applyAfterYaml).toHaveBeenCalledWith('yaml: from-agent');
+
+    bridge.stop();
+  });
+
+  it('scopes to a conversation restored after start', () => {
+    const { bridge, activeConversation$, perConversation$, manager } = setup(null);
+
+    activeConversation$.next({ id: 'conv-restored' });
+
+    perConversation$.get('conv-restored')!.next(
+      makeYamlChangedEvent({
+        proposalId: 'resumed-2',
+        beforeYaml: 'yaml: original',
+        afterYaml: 'yaml: from-agent',
+        attachmentId: 'workflow-a',
+      })
+    );
+
+    expect(manager.applyAfterYaml).toHaveBeenCalledWith('yaml: from-agent');
+
+    bridge.stop();
+  });
+
+  it('keeps the current scope when the chat UI reports a new, id-less conversation', () => {
+    // A new conversation emits `{ id: undefined }` before the server mints an
+    // id. That must not tear down the scope of the conversation in flight.
+    const { bridge, perConversation$, activeConversation$, manager } = setup({
+      id: 'conv-restored',
+    });
+
+    activeConversation$.next({ id: undefined });
+
+    perConversation$.get('conv-restored')!.next(
+      makeYamlChangedEvent({
+        proposalId: 'resumed-3',
+        beforeYaml: 'yaml: original',
+        afterYaml: 'yaml: from-agent',
+        attachmentId: 'workflow-a',
+      })
+    );
+
+    expect(manager.applyAfterYaml).toHaveBeenCalledWith('yaml: from-agent');
+
+    bridge.stop();
+  });
+
+  it('re-scopes when the user switches to another conversation', () => {
+    const { bridge, activeConversation$, perConversation$, manager } = setup({
+      id: 'conv-first',
+    });
+
+    activeConversation$.next({ id: 'conv-second' });
+
+    perConversation$.get('conv-first')!.next(
+      makeYamlChangedEvent({
+        proposalId: 'stale',
+        beforeYaml: 'yaml: original',
+        afterYaml: 'yaml: from-first',
+        attachmentId: 'workflow-a',
+      })
+    );
+    expect(manager.applyAfterYaml).not.toHaveBeenCalled();
+
+    perConversation$.get('conv-second')!.next(
+      makeYamlChangedEvent({
+        proposalId: 'current',
+        beforeYaml: 'yaml: original',
+        afterYaml: 'yaml: from-second',
+        attachmentId: 'workflow-a',
+      })
+    );
+    expect(manager.applyAfterYaml).toHaveBeenCalledWith('yaml: from-second');
+
+    bridge.stop();
+  });
+
+  it('stops listening after stop()', () => {
+    const { bridge, activeConversation$, perConversation$, manager } = setup({
+      id: 'conv-restored',
+    });
+
+    bridge.stop();
+    activeConversation$.next({ id: 'conv-later' });
+
+    expect(perConversation$.has('conv-later')).toBe(false);
+    expect(manager.applyAfterYaml).not.toHaveBeenCalled();
   });
 });
 

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.test.ts
@@ -455,10 +455,8 @@ describe('AttachmentBridge: onProposalReceived workflowId', () => {
 });
 
 describe('AttachmentBridge: resumed conversation', () => {
-  // The server only emits `conversation_id_set` when it creates a new
-  // conversation. On a resumed one the bridge must still scope itself, using
-  // the active conversation published by the chat UI.
-  // https://github.com/elastic/security-team/issues/19002
+  // `conversation_id_set` only fires for newly created conversations, so a
+  // resumed one scopes itself from the active conversation instead.
   const setup = (activeConversation: ActiveConversation | null) => {
     const chat$ = new Subject<BrowserChatEvent>();
     const activeConversation$ = new BehaviorSubject<ActiveConversation | null>(activeConversation);
@@ -524,8 +522,7 @@ describe('AttachmentBridge: resumed conversation', () => {
   });
 
   it('keeps the current scope when the chat UI reports a new, id-less conversation', () => {
-    // A new conversation emits `{ id: undefined }` before the server mints an
-    // id. That must not tear down the scope of the conversation in flight.
+    // A new conversation emits `{ id: undefined }` before the server mints one.
     const { bridge, perConversation$, activeConversation$, manager } = setup({
       id: 'conv-restored',
     });

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Observable, Subscription } from 'rxjs';
-import type { BrowserChatEvent } from '@kbn/agent-builder-browser';
+import type { ActiveConversation, BrowserChatEvent } from '@kbn/agent-builder-browser';
 import { isToolUiEvent } from '@kbn/agent-builder-common';
 import { isConversationIdSetEvent } from '@kbn/agent-builder-common/chat/events';
 import type { monaco } from '@kbn/monaco';
@@ -60,6 +60,7 @@ export class AttachmentBridge {
   private workflowId: string | undefined;
   private conversationId: string | undefined;
   private broadSubscription: Subscription | null = null;
+  private activeConversationSubscription: Subscription | null = null;
   private getChatEvents$: ((conversationId: string) => Observable<BrowserChatEvent>) | undefined;
 
   start(
@@ -73,11 +74,20 @@ export class AttachmentBridge {
       /** Saved workflow id, or undefined on the `/workflows/create` route. */
       workflowId?: string;
       /**
-       * Per-conversation stream factory. Once `conversation_id_set` arrives on
-       * the broad `chat$`, we switch to `getChatEvents$(id)` so events from
-       * other conversations can't leak in.
+       * Per-conversation stream factory. Once the conversation id is known we
+       * switch to `getChatEvents$(id)` so events from other conversations
+       * can't leak in.
        */
       getChatEvents$?: (conversationId: string) => Observable<BrowserChatEvent>;
+      /**
+       * Active conversation binding published by the chat UI. This is the
+       * primary trigger for scoping, because the chat UI sets it for any
+       * conversation it renders — including a restored one. The server only
+       * emits `conversation_id_set` for newly created conversations, so
+       * relying on that event alone leaves resumed conversations unscoped and
+       * their YAML changes unapplied.
+       */
+      activeConversation$?: Observable<ActiveConversation | null>;
       onProposalReceived?: (params: {
         proposalId: string;
         toolId: string;
@@ -93,6 +103,16 @@ export class AttachmentBridge {
     this.attachmentId = options?.attachmentId;
     this.workflowId = options?.workflowId;
     this.getChatEvents$ = options?.getChatEvents$;
+
+    this.activeConversationSubscription =
+      options?.activeConversation$?.subscribe((activeConversation) => {
+        // An `undefined` id means a new conversation the server hasn't minted
+        // an id for yet. Keep the current scoped subscription until a real id
+        // arrives, either here or via `conversation_id_set`.
+        if (activeConversation?.id) {
+          this.onConversationIdKnown(activeConversation.id);
+        }
+      }) ?? null;
 
     this.broadSubscription = chat$.subscribe((event) => {
       if (isConversationIdSetEvent(event)) {
@@ -128,6 +148,15 @@ export class AttachmentBridge {
   }
 
   /**
+   * Repoint the attachment-id guard. The editor resolves the attachment it
+   * shares with the conversation only once that conversation has loaded, which
+   * can happen after `start`.
+   */
+  setAttachmentId(attachmentId: string): void {
+    this.attachmentId = attachmentId;
+  }
+
+  /**
    * Inject a simulated YAML change for testing purposes. Creates a
    * workflow:yaml_changed payload from the current model content and
    * processes it through the same pipeline as real LLM tool responses.
@@ -150,6 +179,8 @@ export class AttachmentBridge {
     this.subscription = null;
     this.broadSubscription?.unsubscribe();
     this.broadSubscription = null;
+    this.activeConversationSubscription?.unsubscribe();
+    this.activeConversationSubscription = null;
     this.proposalManager = null;
     this.tracker = null;
     this.editorRef = null;

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.ts
@@ -80,12 +80,9 @@ export class AttachmentBridge {
        */
       getChatEvents$?: (conversationId: string) => Observable<BrowserChatEvent>;
       /**
-       * Active conversation binding published by the chat UI. This is the
-       * primary trigger for scoping, because the chat UI sets it for any
-       * conversation it renders — including a restored one. The server only
-       * emits `conversation_id_set` for newly created conversations, so
-       * relying on that event alone leaves resumed conversations unscoped and
-       * their YAML changes unapplied.
+       * Active conversation binding. The chat UI sets it for any conversation
+       * it renders, including a restored one, while `conversation_id_set` only
+       * fires for newly created ones.
        */
       activeConversation$?: Observable<ActiveConversation | null>;
       onProposalReceived?: (params: {
@@ -106,9 +103,8 @@ export class AttachmentBridge {
 
     this.activeConversationSubscription =
       options?.activeConversation$?.subscribe((activeConversation) => {
-        // An `undefined` id means a new conversation the server hasn't minted
-        // an id for yet. Keep the current scoped subscription until a real id
-        // arrives, either here or via `conversation_id_set`.
+        // A new conversation has no id yet — keep the current scope until one
+        // arrives, here or via `conversation_id_set`.
         if (activeConversation?.id) {
           this.onConversationIdKnown(activeConversation.id);
         }
@@ -147,11 +143,7 @@ export class AttachmentBridge {
     });
   }
 
-  /**
-   * Repoint the attachment-id guard. The editor resolves the attachment it
-   * shares with the conversation only once that conversation has loaded, which
-   * can happen after `start`.
-   */
+  /** Repoint the guard once the conversation reveals which attachment to track. */
   setAttachmentId(attachmentId: string): void {
     this.attachmentId = attachmentId;
   }

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.ts
@@ -10,7 +10,6 @@
 import type { Observable, Subscription } from 'rxjs';
 import type { ActiveConversation, BrowserChatEvent } from '@kbn/agent-builder-browser';
 import { isToolUiEvent } from '@kbn/agent-builder-common';
-import { isConversationIdSetEvent } from '@kbn/agent-builder-common/chat/events';
 import type { monaco } from '@kbn/monaco';
 import { WORKFLOW_YAML_CHANGED_EVENT } from '@kbn/workflows/common/constants';
 import type { ProposalTracker } from './proposal_tracker';
@@ -59,32 +58,26 @@ export class AttachmentBridge {
   private attachmentId: string | undefined;
   private workflowId: string | undefined;
   private conversationId: string | undefined;
-  private broadSubscription: Subscription | null = null;
   private activeConversationSubscription: Subscription | null = null;
   private getChatEvents$: ((conversationId: string) => Observable<BrowserChatEvent>) | undefined;
 
   start(
-    chat$: Observable<BrowserChatEvent>,
     proposalManager: ProposalManager,
     editorRef: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>,
     tracker: ProposalTracker,
-    options?: {
+    options: {
+      /**
+       * Active conversation binding. The chat UI publishes it for any
+       * conversation it renders, and mints the id before the first request, so
+       * it is known before any event arrives.
+       */
+      activeConversation$: Observable<ActiveConversation | null>;
+      /** Per-conversation stream, so events from other conversations can't leak in. */
+      getChatEvents$: (conversationId: string) => Observable<BrowserChatEvent>;
       onError?: (err: unknown) => void;
       attachmentId?: string;
       /** Saved workflow id, or undefined on the `/workflows/create` route. */
       workflowId?: string;
-      /**
-       * Per-conversation stream factory. Once the conversation id is known we
-       * switch to `getChatEvents$(id)` so events from other conversations
-       * can't leak in.
-       */
-      getChatEvents$?: (conversationId: string) => Observable<BrowserChatEvent>;
-      /**
-       * Active conversation binding. The chat UI sets it for any conversation
-       * it renders, including a restored one, while `conversation_id_set` only
-       * fires for newly created ones.
-       */
-      activeConversation$?: Observable<ActiveConversation | null>;
       onProposalReceived?: (params: {
         proposalId: string;
         toolId: string;
@@ -95,35 +88,20 @@ export class AttachmentBridge {
     this.proposalManager = proposalManager;
     this.editorRef = editorRef;
     this.tracker = tracker;
-    this.onError = options?.onError ?? (() => {});
-    this.onProposalReceived = options?.onProposalReceived;
-    this.attachmentId = options?.attachmentId;
-    this.workflowId = options?.workflowId;
-    this.getChatEvents$ = options?.getChatEvents$;
+    this.onError = options.onError ?? (() => {});
+    this.onProposalReceived = options.onProposalReceived;
+    this.attachmentId = options.attachmentId;
+    this.workflowId = options.workflowId;
+    this.getChatEvents$ = options.getChatEvents$;
 
-    this.activeConversationSubscription =
-      options?.activeConversation$?.subscribe((activeConversation) => {
-        // A new conversation has no id yet — keep the current scope until one
-        // arrives, here or via `conversation_id_set`.
+    this.activeConversationSubscription = options.activeConversation$.subscribe(
+      (activeConversation) => {
+        // A conversation the UI has not minted an id for yet keeps the current scope.
         if (activeConversation?.id) {
           this.onConversationIdKnown(activeConversation.id);
         }
-      }) ?? null;
-
-    this.broadSubscription = chat$.subscribe((event) => {
-      if (isConversationIdSetEvent(event)) {
-        this.onConversationIdKnown(event.data.conversation_id);
-        return;
       }
-      // Fallback for callers that don't wire `getChatEvents$` — legacy path.
-      if (!this.getChatEvents$ && isToolUiEvent(event, WORKFLOW_YAML_CHANGED_EVENT)) {
-        try {
-          this.handleYamlChanged(event.data.data as WorkflowYamlChangedPayload);
-        } catch (err) {
-          this.onError(err);
-        }
-      }
-    });
+    );
   }
 
   private onConversationIdKnown(conversationId: string): void {
@@ -169,8 +147,6 @@ export class AttachmentBridge {
   stop(): void {
     this.subscription?.unsubscribe();
     this.subscription = null;
-    this.broadSubscription?.unsubscribe();
-    this.broadSubscription = null;
     this.activeConversationSubscription?.unsubscribe();
     this.activeConversationSubscription = null;
     this.proposalManager = null;

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_bridge.ts
@@ -191,6 +191,9 @@ export class AttachmentBridge {
 
     // Secondary guard on top of the per-conversation scope: even within one
     // conversation, a payload for a different saved workflow must be dropped.
+    // Every workflow editor shares one attachment id, so the workflow id is
+    // what tells them apart.
+    if (this.workflowId && workflowId && workflowId !== this.workflowId) return;
     if (this.workflowId) {
       const payloadAttachmentId = payload.attachmentId ?? workflowId;
       if (payloadAttachmentId && payloadAttachmentId !== this.attachmentId) return;

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.test.ts
@@ -65,17 +65,6 @@ describe('findLinkedWorkflowAttachment', () => {
     ).toBe('draft-uuid');
   });
 
-  it('matches the carried draft attachment before its origin is set', () => {
-    expect(
-      findLinkedWorkflowAttachment({
-        attachments: [workflowAttachment('draft-uuid')],
-        attachmentId: 'workflow-a',
-        workflowId: 'workflow-a',
-        carriedAttachmentId: 'draft-uuid',
-      })?.id
-    ).toBe('draft-uuid');
-  });
-
   it('ignores a workflow attachment linked to a different workflow', () => {
     expect(
       findLinkedWorkflowAttachment({

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
+import { findLinkedWorkflowAttachmentId, needsOriginLink } from './attachment_link';
+
+const workflowAttachment = (
+  id: string,
+  overrides: Partial<VersionedAttachment> = {}
+): VersionedAttachment =>
+  ({
+    id,
+    type: WORKFLOW_YAML_ATTACHMENT_TYPE,
+    versions: [],
+    ...overrides,
+  } as unknown as VersionedAttachment);
+
+const otherAttachment = (id: string): VersionedAttachment =>
+  ({ id, type: 'screen_context', versions: [] } as unknown as VersionedAttachment);
+
+describe('findLinkedWorkflowAttachmentId', () => {
+  it('returns undefined when the conversation has no attachments', () => {
+    expect(
+      findLinkedWorkflowAttachmentId({ attachments: undefined, attachmentId: 'workflow-a' })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the conversation holds no workflow attachment', () => {
+    expect(
+      findLinkedWorkflowAttachmentId({
+        attachments: [otherAttachment('screen-context')],
+        attachmentId: 'workflow-a',
+      })
+    ).toBeUndefined();
+  });
+
+  it('prefers an attachment whose id already matches this session', () => {
+    expect(
+      findLinkedWorkflowAttachmentId({
+        attachments: [workflowAttachment('draft-uuid'), workflowAttachment('workflow-a')],
+        attachmentId: 'workflow-a',
+        workflowId: 'workflow-a',
+      })
+    ).toBe('workflow-a');
+  });
+
+  it('matches the draft attachment by origin after the first save', () => {
+    // The editor would mint `workflow-a`, but the conversation already holds
+    // the create session's attachment linked to that workflow.
+    expect(
+      findLinkedWorkflowAttachmentId({
+        attachments: [workflowAttachment('draft-uuid', { origin: 'workflow-a' })],
+        attachmentId: 'workflow-a',
+        workflowId: 'workflow-a',
+      })
+    ).toBe('draft-uuid');
+  });
+
+  it('matches the carried draft attachment before its origin is set', () => {
+    expect(
+      findLinkedWorkflowAttachmentId({
+        attachments: [workflowAttachment('draft-uuid')],
+        attachmentId: 'workflow-a',
+        workflowId: 'workflow-a',
+        carriedAttachmentId: 'draft-uuid',
+      })
+    ).toBe('draft-uuid');
+  });
+
+  it('ignores a workflow attachment linked to a different workflow', () => {
+    expect(
+      findLinkedWorkflowAttachmentId({
+        attachments: [workflowAttachment('draft-uuid', { origin: 'workflow-b' })],
+        attachmentId: 'workflow-a',
+        workflowId: 'workflow-a',
+      })
+    ).toBeUndefined();
+  });
+
+  it('ignores a deleted attachment', () => {
+    expect(
+      findLinkedWorkflowAttachmentId({
+        attachments: [workflowAttachment('draft-uuid', { origin: 'workflow-a', active: false })],
+        attachmentId: 'workflow-a',
+        workflowId: 'workflow-a',
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe('needsOriginLink', () => {
+  it('is true for an attachment with no origin', () => {
+    expect(
+      needsOriginLink({
+        attachments: [workflowAttachment('draft-uuid')],
+        attachmentId: 'draft-uuid',
+        workflowId: 'workflow-a',
+      })
+    ).toBe(true);
+  });
+
+  it('is false once the origin points at the workflow', () => {
+    expect(
+      needsOriginLink({
+        attachments: [workflowAttachment('draft-uuid', { origin: 'workflow-a' })],
+        attachmentId: 'draft-uuid',
+        workflowId: 'workflow-a',
+      })
+    ).toBe(false);
+  });
+
+  it('is false when the attachment is not in the conversation yet', () => {
+    expect(
+      needsOriginLink({
+        attachments: [],
+        attachmentId: 'draft-uuid',
+        workflowId: 'workflow-a',
+      })
+    ).toBe(false);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.test.ts
@@ -9,33 +9,37 @@
 
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
-import { findLinkedWorkflowAttachmentId, needsOriginLink } from './attachment_link';
+import { findLinkedWorkflowAttachment } from './attachment_link';
 
 const workflowAttachment = (
   id: string,
   overrides: Partial<VersionedAttachment> = {}
-): VersionedAttachment =>
-  ({
-    id,
-    type: WORKFLOW_YAML_ATTACHMENT_TYPE,
-    versions: [],
-    ...overrides,
-  } as unknown as VersionedAttachment);
+): VersionedAttachment => ({
+  id,
+  type: WORKFLOW_YAML_ATTACHMENT_TYPE,
+  versions: [],
+  current_version: 1,
+  ...overrides,
+});
 
-const otherAttachment = (id: string): VersionedAttachment =>
-  ({ id, type: 'screen_context', versions: [] } as unknown as VersionedAttachment);
+const screenContextAttachment = (): VersionedAttachment => ({
+  id: 'screen-context',
+  type: 'screen_context',
+  versions: [],
+  current_version: 1,
+});
 
-describe('findLinkedWorkflowAttachmentId', () => {
+describe('findLinkedWorkflowAttachment', () => {
   it('returns undefined when the conversation has no attachments', () => {
     expect(
-      findLinkedWorkflowAttachmentId({ attachments: undefined, attachmentId: 'workflow-a' })
+      findLinkedWorkflowAttachment({ attachments: undefined, attachmentId: 'workflow-a' })
     ).toBeUndefined();
   });
 
   it('returns undefined when the conversation holds no workflow attachment', () => {
     expect(
-      findLinkedWorkflowAttachmentId({
-        attachments: [otherAttachment('screen-context')],
+      findLinkedWorkflowAttachment({
+        attachments: [screenContextAttachment()],
         attachmentId: 'workflow-a',
       })
     ).toBeUndefined();
@@ -43,40 +47,38 @@ describe('findLinkedWorkflowAttachmentId', () => {
 
   it('prefers an attachment whose id already matches this session', () => {
     expect(
-      findLinkedWorkflowAttachmentId({
+      findLinkedWorkflowAttachment({
         attachments: [workflowAttachment('draft-uuid'), workflowAttachment('workflow-a')],
         attachmentId: 'workflow-a',
         workflowId: 'workflow-a',
-      })
+      })?.id
     ).toBe('workflow-a');
   });
 
   it('matches the draft attachment by origin after the first save', () => {
-    // The editor would mint `workflow-a`, but the conversation already holds
-    // the create session's attachment linked to that workflow.
     expect(
-      findLinkedWorkflowAttachmentId({
+      findLinkedWorkflowAttachment({
         attachments: [workflowAttachment('draft-uuid', { origin: 'workflow-a' })],
         attachmentId: 'workflow-a',
         workflowId: 'workflow-a',
-      })
+      })?.id
     ).toBe('draft-uuid');
   });
 
   it('matches the carried draft attachment before its origin is set', () => {
     expect(
-      findLinkedWorkflowAttachmentId({
+      findLinkedWorkflowAttachment({
         attachments: [workflowAttachment('draft-uuid')],
         attachmentId: 'workflow-a',
         workflowId: 'workflow-a',
         carriedAttachmentId: 'draft-uuid',
-      })
+      })?.id
     ).toBe('draft-uuid');
   });
 
   it('ignores a workflow attachment linked to a different workflow', () => {
     expect(
-      findLinkedWorkflowAttachmentId({
+      findLinkedWorkflowAttachment({
         attachments: [workflowAttachment('draft-uuid', { origin: 'workflow-b' })],
         attachmentId: 'workflow-a',
         workflowId: 'workflow-a',
@@ -86,43 +88,11 @@ describe('findLinkedWorkflowAttachmentId', () => {
 
   it('ignores a deleted attachment', () => {
     expect(
-      findLinkedWorkflowAttachmentId({
+      findLinkedWorkflowAttachment({
         attachments: [workflowAttachment('draft-uuid', { origin: 'workflow-a', active: false })],
         attachmentId: 'workflow-a',
         workflowId: 'workflow-a',
       })
     ).toBeUndefined();
-  });
-});
-
-describe('needsOriginLink', () => {
-  it('is true for an attachment with no origin', () => {
-    expect(
-      needsOriginLink({
-        attachments: [workflowAttachment('draft-uuid')],
-        attachmentId: 'draft-uuid',
-        workflowId: 'workflow-a',
-      })
-    ).toBe(true);
-  });
-
-  it('is false once the origin points at the workflow', () => {
-    expect(
-      needsOriginLink({
-        attachments: [workflowAttachment('draft-uuid', { origin: 'workflow-a' })],
-        attachmentId: 'draft-uuid',
-        workflowId: 'workflow-a',
-      })
-    ).toBe(false);
-  });
-
-  it('is false when the attachment is not in the conversation yet', () => {
-    expect(
-      needsOriginLink({
-        attachments: [],
-        attachmentId: 'draft-uuid',
-        workflowId: 'workflow-a',
-      })
-    ).toBe(false);
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.test.ts
@@ -9,7 +9,7 @@
 
 import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
-import { findLinkedWorkflowAttachment } from './attachment_link';
+import { findLinkedWorkflowAttachment, WORKFLOW_EDITOR_ATTACHMENT_ID } from './attachment_link';
 
 const workflowAttachment = (
   id: string,
@@ -70,6 +70,16 @@ describe('findLinkedWorkflowAttachment', () => {
       findLinkedWorkflowAttachment({
         attachments: [workflowAttachment('draft-uuid', { origin: 'workflow-b' })],
         attachmentId: 'workflow-a',
+        workflowId: 'workflow-a',
+      })
+    ).toBeUndefined();
+  });
+
+  it('ignores the fixed-id attachment when it is linked to a different workflow', () => {
+    expect(
+      findLinkedWorkflowAttachment({
+        attachments: [workflowAttachment(WORKFLOW_EDITOR_ATTACHMENT_ID, { origin: 'workflow-b' })],
+        attachmentId: WORKFLOW_EDITOR_ATTACHMENT_ID,
         workflowId: 'workflow-a',
       })
     ).toBeUndefined();

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.ts
@@ -11,14 +11,19 @@ import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments'
 import { isAttachmentActive } from '@kbn/agent-builder-common/attachments';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 
+/**
+ * Id the editor gives its workflow attachment. Fixed, so saving a workflow
+ * cannot move it and leave the editor writing into a second attachment.
+ * `screen-context` and `ai-rule-creation` work the same way.
+ */
+export const WORKFLOW_EDITOR_ATTACHMENT_ID = 'workflow-yaml-editor';
+
 export interface FindLinkedWorkflowAttachmentParams {
   attachments: VersionedAttachment[] | undefined;
   /** Attachment id this editor session would use on its own. */
   attachmentId: string;
   /** Saved workflow id, or undefined on the `/workflows/create` route. */
   workflowId?: string;
-  /** Create-session attachment id handed over across the first save. */
-  carriedAttachmentId?: string;
 }
 
 /**
@@ -31,7 +36,6 @@ export const findLinkedWorkflowAttachment = ({
   attachments,
   attachmentId,
   workflowId,
-  carriedAttachmentId,
 }: FindLinkedWorkflowAttachmentParams): VersionedAttachment | undefined => {
   const candidates = (attachments ?? []).filter(
     (attachment) =>
@@ -40,10 +44,7 @@ export const findLinkedWorkflowAttachment = ({
 
   return (
     candidates.find((attachment) => attachment.id === attachmentId) ??
-    // Survives a reload, where the handoff state is gone.
-    (workflowId ? candidates.find((attachment) => attachment.origin === workflowId) : undefined) ??
-    (carriedAttachmentId
-      ? candidates.find((attachment) => attachment.id === carriedAttachmentId)
-      : undefined)
+    // Attachments predating the fixed id are only identifiable by origin.
+    (workflowId ? candidates.find((attachment) => attachment.origin === workflowId) : undefined)
   );
 };

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.ts
@@ -28,9 +28,9 @@ export interface FindLinkedWorkflowAttachmentParams {
 
 /**
  * Returns the workflow attachment this session must keep writing into, or
- * `undefined` when the conversation holds none. The editor's own id changes
- * when a new workflow is saved, so resolving from the conversation is what
- * keeps one attachment instead of two.
+ * `undefined` when the conversation holds none. Once set, the origin identifies
+ * the owning workflow; before the first save, the fixed editor id identifies
+ * the unowned draft attachment.
  */
 export const findLinkedWorkflowAttachment = ({
   attachments,
@@ -42,9 +42,9 @@ export const findLinkedWorkflowAttachment = ({
       attachment.type === WORKFLOW_YAML_ATTACHMENT_TYPE && isAttachmentActive(attachment)
   );
 
-  return (
-    candidates.find((attachment) => attachment.id === attachmentId) ??
-    // Attachments predating the fixed id are only identifiable by origin.
-    (workflowId ? candidates.find((attachment) => attachment.origin === workflowId) : undefined)
+  return candidates.find((attachment) =>
+    attachment.origin !== undefined
+      ? attachment.origin === workflowId
+      : attachment.id === attachmentId
   );
 };

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.ts
@@ -12,68 +12,38 @@ import { isAttachmentActive } from '@kbn/agent-builder-common/attachments';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 
 export interface FindLinkedWorkflowAttachmentParams {
-  /** Conversation-level attachments of the conversation the editor is bound to. */
   attachments: VersionedAttachment[] | undefined;
-  /** Attachment id this editor session would mint on its own. */
+  /** Attachment id this editor session would use on its own. */
   attachmentId: string;
   /** Saved workflow id, or undefined on the `/workflows/create` route. */
   workflowId?: string;
-  /**
-   * Attachment id of the create session that produced `workflowId`, handed over
-   * by {@link carryConversationToWorkflow} across the first save.
-   */
+  /** Create-session attachment id handed over across the first save. */
   carriedAttachmentId?: string;
 }
 
 /**
- * Returns the id of the workflow attachment this editor session must keep
- * writing into, or `undefined` when the conversation holds none yet.
- *
- * The editor mints its attachment id from the route: a uuid on
- * `/workflows/create`, the workflow id on a saved workflow. The id therefore
- * changes when the user saves a new workflow, and a session that syncs under
- * the new id adds a second `workflow.yaml` attachment to the same
- * conversation. Resolving the id from the conversation instead keeps one
- * attachment with a growing version list.
+ * Returns the workflow attachment this session must keep writing into, or
+ * `undefined` when the conversation holds none. The editor's own id changes
+ * when a new workflow is saved, so resolving from the conversation is what
+ * keeps one attachment instead of two.
  */
-export const findLinkedWorkflowAttachmentId = ({
+export const findLinkedWorkflowAttachment = ({
   attachments,
   attachmentId,
   workflowId,
   carriedAttachmentId,
-}: FindLinkedWorkflowAttachmentParams): string | undefined => {
+}: FindLinkedWorkflowAttachmentParams): VersionedAttachment | undefined => {
   const candidates = (attachments ?? []).filter(
     (attachment) =>
       attachment.type === WORKFLOW_YAML_ATTACHMENT_TYPE && isAttachmentActive(attachment)
   );
-  if (candidates.length === 0) return undefined;
 
-  const exact = candidates.find((attachment) => attachment.id === attachmentId);
-  if (exact) return exact.id;
-
-  // Set once the create session's attachment has been linked to the saved
-  // workflow, so it survives a page reload where the handoff state is gone.
-  const byOrigin = workflowId && candidates.find((attachment) => attachment.origin === workflowId);
-  if (byOrigin) return byOrigin.id;
-
-  const carried =
-    carriedAttachmentId && candidates.find((attachment) => attachment.id === carriedAttachmentId);
-  return carried ? carried.id : undefined;
-};
-
-/**
- * Returns true when `attachmentId` names an attachment in the conversation that
- * is not yet linked to `workflowId`, so the caller must set its origin.
- */
-export const needsOriginLink = ({
-  attachments,
-  attachmentId,
-  workflowId,
-}: {
-  attachments: VersionedAttachment[] | undefined;
-  attachmentId: string;
-  workflowId: string;
-}): boolean => {
-  const attachment = (attachments ?? []).find((candidate) => candidate.id === attachmentId);
-  return Boolean(attachment && isAttachmentActive(attachment) && attachment.origin !== workflowId);
+  return (
+    candidates.find((attachment) => attachment.id === attachmentId) ??
+    // Survives a reload, where the handoff state is gone.
+    (workflowId ? candidates.find((attachment) => attachment.origin === workflowId) : undefined) ??
+    (carriedAttachmentId
+      ? candidates.find((attachment) => attachment.id === carriedAttachmentId)
+      : undefined)
+  );
 };

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/attachment_link.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import { isAttachmentActive } from '@kbn/agent-builder-common/attachments';
+import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
+
+export interface FindLinkedWorkflowAttachmentParams {
+  /** Conversation-level attachments of the conversation the editor is bound to. */
+  attachments: VersionedAttachment[] | undefined;
+  /** Attachment id this editor session would mint on its own. */
+  attachmentId: string;
+  /** Saved workflow id, or undefined on the `/workflows/create` route. */
+  workflowId?: string;
+  /**
+   * Attachment id of the create session that produced `workflowId`, handed over
+   * by {@link carryConversationToWorkflow} across the first save.
+   */
+  carriedAttachmentId?: string;
+}
+
+/**
+ * Returns the id of the workflow attachment this editor session must keep
+ * writing into, or `undefined` when the conversation holds none yet.
+ *
+ * The editor mints its attachment id from the route: a uuid on
+ * `/workflows/create`, the workflow id on a saved workflow. The id therefore
+ * changes when the user saves a new workflow, and a session that syncs under
+ * the new id adds a second `workflow.yaml` attachment to the same
+ * conversation. Resolving the id from the conversation instead keeps one
+ * attachment with a growing version list.
+ */
+export const findLinkedWorkflowAttachmentId = ({
+  attachments,
+  attachmentId,
+  workflowId,
+  carriedAttachmentId,
+}: FindLinkedWorkflowAttachmentParams): string | undefined => {
+  const candidates = (attachments ?? []).filter(
+    (attachment) =>
+      attachment.type === WORKFLOW_YAML_ATTACHMENT_TYPE && isAttachmentActive(attachment)
+  );
+  if (candidates.length === 0) return undefined;
+
+  const exact = candidates.find((attachment) => attachment.id === attachmentId);
+  if (exact) return exact.id;
+
+  // Set once the create session's attachment has been linked to the saved
+  // workflow, so it survives a page reload where the handoff state is gone.
+  const byOrigin = workflowId && candidates.find((attachment) => attachment.origin === workflowId);
+  if (byOrigin) return byOrigin.id;
+
+  const carried =
+    carriedAttachmentId && candidates.find((attachment) => attachment.id === carriedAttachmentId);
+  return carried ? carried.id : undefined;
+};
+
+/**
+ * Returns true when `attachmentId` names an attachment in the conversation that
+ * is not yet linked to `workflowId`, so the caller must set its origin.
+ */
+export const needsOriginLink = ({
+  attachments,
+  attachmentId,
+  workflowId,
+}: {
+  attachments: VersionedAttachment[] | undefined;
+  attachmentId: string;
+  workflowId: string;
+}): boolean => {
+  const attachment = (attachments ?? []).find((candidate) => candidate.id === attachmentId);
+  return Boolean(attachment && isAttachmentActive(attachment) && attachment.origin !== workflowId);
+};

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
@@ -10,7 +10,6 @@
 import {
   carryConversationToWorkflow,
   consumeSidebarRestoreFor,
-  getCarriedAttachmentId,
   hasPersistedConversation,
   isSidebarOpen,
   requestSidebarRestore,
@@ -146,26 +145,6 @@ describe('conversation_handoff', () => {
     carryConversationToWorkflow('saved-wf-1');
 
     expect(window.localStorage.getItem('unrelated.key')).toBe('stays');
-  });
-
-  describe('carried attachment id', () => {
-    it('records the create session attachment id against the saved workflow', () => {
-      setLastCreateAttachmentId('draft-uuid');
-      carryConversationToWorkflow('workflow-a');
-
-      expect(getCarriedAttachmentId('workflow-a')).toBe('draft-uuid');
-    });
-
-    it('returns undefined for a workflow that was never carried', () => {
-      expect(getCarriedAttachmentId('never-saved-from-create')).toBeUndefined();
-    });
-
-    it('records nothing when the ids already match', () => {
-      setLastCreateAttachmentId('workflow-b');
-      carryConversationToWorkflow('workflow-b');
-
-      expect(getCarriedAttachmentId('workflow-b')).toBeUndefined();
-    });
   });
 
   describe('hasPersistedConversation', () => {

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
@@ -13,14 +13,14 @@ import {
   hasPersistedConversation,
   isSidebarOpen,
   requestSidebarRestore,
-  setLastCreateAttachmentId,
+  setLastCreateSessionId,
   setSidebarOpen,
 } from './conversation_handoff';
 
 describe('conversation_handoff', () => {
   beforeEach(() => {
     window.localStorage.clear();
-    setLastCreateAttachmentId(undefined);
+    setLastCreateSessionId(undefined);
     setSidebarOpen(false);
     // Drain any lingering restore pending from a previous test.
     consumeSidebarRestoreFor('__reset__');
@@ -40,7 +40,7 @@ describe('conversation_handoff', () => {
   });
 
   it('carries persisted conversation ids from the create session tag to the saved workflow tag', () => {
-    setLastCreateAttachmentId('unsaved-uuid-A');
+    setLastCreateSessionId('unsaved-uuid-A');
     window.localStorage.setItem(
       'agentBuilder.lastConversation.workflow-editor:unsaved-uuid-A.default',
       'conv-1'
@@ -71,7 +71,7 @@ describe('conversation_handoff', () => {
   });
 
   it('single-shot: a second carry after consume does not migrate again', () => {
-    setLastCreateAttachmentId('unsaved-uuid-A');
+    setLastCreateSessionId('unsaved-uuid-A');
     window.localStorage.setItem(
       'agentBuilder.lastConversation.workflow-editor:unsaved-uuid-A.default',
       'conv-1'
@@ -88,7 +88,7 @@ describe('conversation_handoff', () => {
   });
 
   it('is a no-op when source and target ids match (e.g. already-saved workflow re-save)', () => {
-    setLastCreateAttachmentId('saved-wf-1');
+    setLastCreateSessionId('saved-wf-1');
     window.localStorage.setItem(
       'agentBuilder.lastConversation.workflow-editor:saved-wf-1.default',
       'conv-1'
@@ -135,7 +135,7 @@ describe('conversation_handoff', () => {
   });
 
   it('does not touch localStorage keys outside the create tag prefix', () => {
-    setLastCreateAttachmentId('unsaved-uuid-A');
+    setLastCreateSessionId('unsaved-uuid-A');
     window.localStorage.setItem('unrelated.key', 'stays');
     window.localStorage.setItem(
       'agentBuilder.lastConversation.workflow-editor:unsaved-uuid-A.default',

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
@@ -10,6 +10,7 @@
 import {
   carryConversationToWorkflow,
   consumeSidebarRestoreFor,
+  getCarriedAttachmentId,
   isSidebarOpen,
   requestSidebarRestore,
   setLastCreateAttachmentId,
@@ -144,5 +145,28 @@ describe('conversation_handoff', () => {
     carryConversationToWorkflow('saved-wf-1');
 
     expect(window.localStorage.getItem('unrelated.key')).toBe('stays');
+  });
+
+  describe('carried attachment id', () => {
+    // The destination editor reuses this id so the conversation keeps one
+    // workflow attachment instead of gaining a second one on save.
+    // https://github.com/elastic/security-team/issues/18821
+    it('records the create session attachment id against the saved workflow', () => {
+      setLastCreateAttachmentId('draft-uuid');
+      carryConversationToWorkflow('workflow-a');
+
+      expect(getCarriedAttachmentId('workflow-a')).toBe('draft-uuid');
+    });
+
+    it('returns undefined for a workflow that was never carried', () => {
+      expect(getCarriedAttachmentId('never-saved-from-create')).toBeUndefined();
+    });
+
+    it('records nothing when the ids already match', () => {
+      setLastCreateAttachmentId('workflow-b');
+      carryConversationToWorkflow('workflow-b');
+
+      expect(getCarriedAttachmentId('workflow-b')).toBeUndefined();
+    });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
@@ -11,6 +11,7 @@ import {
   carryConversationToWorkflow,
   consumeSidebarRestoreFor,
   getCarriedAttachmentId,
+  hasPersistedConversation,
   isSidebarOpen,
   requestSidebarRestore,
   setLastCreateAttachmentId,
@@ -164,6 +165,35 @@ describe('conversation_handoff', () => {
       carryConversationToWorkflow('workflow-b');
 
       expect(getCarriedAttachmentId('workflow-b')).toBeUndefined();
+    });
+  });
+
+  describe('hasPersistedConversation', () => {
+    it('is true when the sidebar has a conversation stored for this session', () => {
+      window.localStorage.setItem(
+        'agentBuilder.lastConversation.workflow-editor:workflow-a.default',
+        '"conv-1"'
+      );
+
+      expect(hasPersistedConversation('workflow-a')).toBe(true);
+    });
+
+    it('is false for a session with nothing stored', () => {
+      window.localStorage.setItem(
+        'agentBuilder.lastConversation.workflow-editor:workflow-b.default',
+        '"conv-1"'
+      );
+
+      expect(hasPersistedConversation('workflow-a')).toBe(false);
+    });
+
+    it('does not match a session id that only shares a prefix', () => {
+      window.localStorage.setItem(
+        'agentBuilder.lastConversation.workflow-editor:workflow-a-extra.default',
+        '"conv-1"'
+      );
+
+      expect(hasPersistedConversation('workflow-a')).toBe(false);
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.test.ts
@@ -148,9 +148,6 @@ describe('conversation_handoff', () => {
   });
 
   describe('carried attachment id', () => {
-    // The destination editor reuses this id so the conversation keeps one
-    // workflow attachment instead of gaining a second one on save.
-    // https://github.com/elastic/security-team/issues/18821
     it('records the create session attachment id against the saved workflow', () => {
       setLastCreateAttachmentId('draft-uuid');
       carryConversationToWorkflow('workflow-a');

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
@@ -14,10 +14,13 @@
 const SESSION_TAG_PREFIX = 'workflow-editor:';
 const STORAGE_KEY_PREFIX = 'agentBuilder.lastConversation.';
 
-let lastCreateAttachmentId: string | undefined;
+// Session id of the `/workflows/create` chat, so its conversation can be moved
+// onto the saved workflow's session tag. This is the id the tag is built from,
+// not the id of the attachment the chat carries.
+let lastCreateSessionId: string | undefined;
 
-export const setLastCreateAttachmentId = (attachmentId: string | undefined): void => {
-  lastCreateAttachmentId = attachmentId;
+export const setLastCreateSessionId = (sessionId: string | undefined): void => {
+  lastCreateSessionId = sessionId;
 };
 
 let sidebarOpen = false;
@@ -64,8 +67,8 @@ export const hasPersistedConversation = (sessionId: string): boolean => {
  * was tracked or `localStorage` is unavailable.
  */
 export const carryConversationToWorkflow = (savedWorkflowId: string): void => {
-  const from = lastCreateAttachmentId;
-  lastCreateAttachmentId = undefined;
+  const from = lastCreateSessionId;
+  lastCreateSessionId = undefined;
 
   if (!from || from === savedWorkflowId) return;
   if (typeof window === 'undefined' || !window.localStorage) return;

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
@@ -42,13 +42,6 @@ export const consumeSidebarRestoreFor = (workflowId: string): boolean => {
   return true;
 };
 
-// Create-session attachment id, keyed by the workflow it was saved as. The
-// destination editor reuses it instead of starting a second attachment.
-const carriedAttachmentIds = new Map<string, string>();
-
-export const getCarriedAttachmentId = (workflowId: string): string | undefined =>
-  carriedAttachmentIds.get(workflowId);
-
 /**
  * True when the sidebar will restore a conversation for this session, which the
  * editor cannot sync into until it knows which attachment that conversation
@@ -75,9 +68,6 @@ export const carryConversationToWorkflow = (savedWorkflowId: string): void => {
   lastCreateAttachmentId = undefined;
 
   if (!from || from === savedWorkflowId) return;
-
-  carriedAttachmentIds.set(savedWorkflowId, from);
-
   if (typeof window === 'undefined' || !window.localStorage) return;
 
   const fromTag = `${SESSION_TAG_PREFIX}${from}`;

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
@@ -42,9 +42,8 @@ export const consumeSidebarRestoreFor = (workflowId: string): boolean => {
   return true;
 };
 
-// Attachment id of the create session that produced a saved workflow, keyed by
-// that workflow id. The destination editor reuses it so the conversation keeps
-// one workflow attachment instead of gaining a second one on save.
+// Create-session attachment id, keyed by the workflow it was saved as. The
+// destination editor reuses it instead of starting a second attachment.
 const carriedAttachmentIds = new Map<string, string>();
 
 export const getCarriedAttachmentId = (workflowId: string): string | undefined =>

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
@@ -42,6 +42,14 @@ export const consumeSidebarRestoreFor = (workflowId: string): boolean => {
   return true;
 };
 
+// Attachment id of the create session that produced a saved workflow, keyed by
+// that workflow id. The destination editor reuses it so the conversation keeps
+// one workflow attachment instead of gaining a second one on save.
+const carriedAttachmentIds = new Map<string, string>();
+
+export const getCarriedAttachmentId = (workflowId: string): string | undefined =>
+  carriedAttachmentIds.get(workflowId);
+
 /**
  * Rewrite persisted conversation-id localStorage entries from the create
  * session's tag onto `savedWorkflowId`'s tag. Iterates a prefix because keys
@@ -53,6 +61,9 @@ export const carryConversationToWorkflow = (savedWorkflowId: string): void => {
   lastCreateAttachmentId = undefined;
 
   if (!from || from === savedWorkflowId) return;
+
+  carriedAttachmentIds.set(savedWorkflowId, from);
+
   if (typeof window === 'undefined' || !window.localStorage) return;
 
   const fromTag = `${SESSION_TAG_PREFIX}${from}`;

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/conversation_handoff.ts
@@ -50,6 +50,21 @@ export const getCarriedAttachmentId = (workflowId: string): string | undefined =
   carriedAttachmentIds.get(workflowId);
 
 /**
+ * True when the sidebar will restore a conversation for this session, which the
+ * editor cannot sync into until it knows which attachment that conversation
+ * already holds. Mirrors the key `agent_builder` writes on open.
+ */
+export const hasPersistedConversation = (sessionId: string): boolean => {
+  if (typeof window === 'undefined' || !window.localStorage) return false;
+
+  const prefix = `${STORAGE_KEY_PREFIX}${SESSION_TAG_PREFIX}${sessionId}.`;
+  for (let i = 0; i < window.localStorage.length; i++) {
+    if (window.localStorage.key(i)?.startsWith(prefix)) return true;
+  }
+  return false;
+};
+
+/**
  * Rewrite persisted conversation-id localStorage entries from the create
  * session's tag onto `savedWorkflowId`'s tag. Iterates a prefix because keys
  * include a trailing agentId we don't know here. No-op if no create session

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
@@ -23,6 +23,7 @@ export {
   setLastCreateAttachmentId,
   carryConversationToWorkflow,
   getCarriedAttachmentId,
+  hasPersistedConversation,
   setSidebarOpen,
   isSidebarOpen,
   requestSidebarRestore,

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
@@ -17,12 +17,11 @@ export type { ProposalStatus, ProposalRecord } from './proposal_tracker';
 
 export { setActiveProposalManager, acceptAllActiveProposals } from './active_proposal_manager';
 
-export { findLinkedWorkflowAttachment } from './attachment_link';
+export { findLinkedWorkflowAttachment, WORKFLOW_EDITOR_ATTACHMENT_ID } from './attachment_link';
 
 export {
   setLastCreateAttachmentId,
   carryConversationToWorkflow,
-  getCarriedAttachmentId,
   hasPersistedConversation,
   setSidebarOpen,
   isSidebarOpen,

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
@@ -20,7 +20,7 @@ export { setActiveProposalManager, acceptAllActiveProposals } from './active_pro
 export { findLinkedWorkflowAttachment, WORKFLOW_EDITOR_ATTACHMENT_ID } from './attachment_link';
 
 export {
-  setLastCreateAttachmentId,
+  setLastCreateSessionId,
   carryConversationToWorkflow,
   hasPersistedConversation,
   setSidebarOpen,

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
@@ -17,7 +17,7 @@ export type { ProposalStatus, ProposalRecord } from './proposal_tracker';
 
 export { setActiveProposalManager, acceptAllActiveProposals } from './active_proposal_manager';
 
-export { findLinkedWorkflowAttachmentId, needsOriginLink } from './attachment_link';
+export { findLinkedWorkflowAttachment } from './attachment_link';
 
 export {
   setLastCreateAttachmentId,

--- a/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/ai_integration/index.ts
@@ -17,9 +17,12 @@ export type { ProposalStatus, ProposalRecord } from './proposal_tracker';
 
 export { setActiveProposalManager, acceptAllActiveProposals } from './active_proposal_manager';
 
+export { findLinkedWorkflowAttachmentId, needsOriginLink } from './attachment_link';
+
 export {
   setLastCreateAttachmentId,
   carryConversationToWorkflow,
+  getCarriedAttachmentId,
   setSidebarOpen,
   isSidebarOpen,
   requestSidebarRestore,

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/attachment_sync.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/attachment_sync.test.tsx
@@ -116,6 +116,10 @@ const createFakeAgentBuilder = () => {
       if (!acceptsAttachments) return;
       pending = upsert(pending, [attachment]);
     }),
+    removeAttachment: jest.fn((attachmentId: string) => {
+      if (!acceptsAttachments) return;
+      pending = pending.filter((attachment) => attachment.id !== attachmentId);
+    }),
     setChatConfig: jest.fn((config: { sessionTag?: string; attachments?: PendingAttachment[] }) => {
       sessionTag = config.sessionTag;
       if (acceptsAttachments && config.attachments) pending = upsert(pending, config.attachments);
@@ -210,6 +214,13 @@ const createFakeAgentBuilder = () => {
     window.localStorage.setItem(lastConversationKey(tag), JSON.stringify(conversationId));
   };
 
+  const publishConversation = (conversationId: string) => {
+    activeConversation$.next({
+      id: conversationId,
+      conversation: { attachments: conversations.get(conversationId) ?? [] },
+    } as ActiveConversation);
+  };
+
   const emitYamlChange = (conversationId: string, attachmentId: string, afterYaml: string) => {
     stream$(conversationId).next({
       type: ChatEventType.toolUi,
@@ -227,6 +238,11 @@ const createFakeAgentBuilder = () => {
       .filter((attachment) => attachment.type === WORKFLOW_YAML_ATTACHMENT_TYPE)
       .map((attachment) => attachment.id);
 
+  const pendingWorkflowAttachmentIds = () =>
+    pending
+      .filter((attachment) => attachment.type === WORKFLOW_YAML_ATTACHMENT_TYPE)
+      .map((attachment) => attachment.id);
+
   /** Conversation the sidebar bound to on its most recent open, if any. */
   const lastBoundConversation = () => boundConversations.at(-1);
 
@@ -237,6 +253,8 @@ const createFakeAgentBuilder = () => {
     seedConversation,
     pointSessionAtConversation,
     emitYamlChange,
+    pendingWorkflowAttachmentIds,
+    publishConversation,
     workflowAttachmentIds,
   };
 };
@@ -344,6 +362,27 @@ describe('workflow attachment sync', () => {
         'legacy-draft-uuid',
         'workflow-legacy'
       );
+    });
+
+    it('replaces an eagerly staged attachment when the legacy conversation appears later', async () => {
+      const fake = createFakeAgentBuilder();
+      setupKibana(fake.contract);
+      fake.seedConversation('conv-late', 'workflow-editor:another-workflow', [
+        { id: 'legacy-late-uuid', origin: 'workflow-late' },
+      ]);
+
+      const session = await renderEditor('workflow-late');
+      act(() => session.result.current.openAgentChat());
+
+      expect(fake.pendingWorkflowAttachmentIds()).toEqual(['workflow-yaml-editor']);
+
+      act(() => fake.publishConversation('conv-late'));
+      const [submittedAttachmentId] = fake.pendingWorkflowAttachmentIds();
+      act(() => fake.submitRound('conv-late'));
+      act(() => fake.emitYamlChange('conv-late', submittedAttachmentId, 'name: edited by agent'));
+
+      expect(fake.workflowAttachmentIds('conv-late')).toEqual(['legacy-late-uuid']);
+      expect(appliedYaml).toEqual(['name: edited by agent']);
     });
 
     it('reuses the attachment even when its origin was never linked', async () => {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/attachment_sync.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/attachment_sync.test.tsx
@@ -1,0 +1,323 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { BehaviorSubject, Subject } from 'rxjs';
+import type { ActiveConversation, BrowserChatEvent } from '@kbn/agent-builder-browser';
+import { ChatEventType } from '@kbn/agent-builder-common';
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import {
+  WORKFLOW_YAML_ATTACHMENT_TYPE,
+  WORKFLOW_YAML_CHANGED_EVENT,
+} from '@kbn/workflows/common/constants';
+import { useAgentBuilderIntegration } from './use_agent_builder_integration';
+import { carryConversationToWorkflow } from '../../../../features/ai_integration';
+import { useKibana } from '../../../../hooks/use_kibana';
+
+jest.mock('../../../../hooks/use_kibana');
+jest.mock('react-redux-v7', () => ({
+  ...jest.requireActual('react-redux-v7'),
+  useDispatch: () => jest.fn(),
+}));
+jest.mock('../../../../hooks/use_telemetry', () => ({
+  useTelemetry: () => ({
+    reportWorkflowAiChatOpened: jest.fn(),
+    reportWorkflowAiSessionCompleted: jest.fn(),
+    reportAiProposalReceived: jest.fn(),
+    reportAiProposalResolved: jest.fn(),
+  }),
+}));
+
+// Everything but the Monaco-bound proposal manager stays real: this covers the
+// attachment and event wiring between the editor and agent_builder.
+const appliedYaml: string[] = [];
+jest.mock('../../../../features/ai_integration', () => ({
+  ...jest.requireActual('../../../../features/ai_integration'),
+  ProposalManager: jest.fn().mockImplementation(() => ({
+    initialize: jest.fn(),
+    dispose: jest.fn(),
+    getDiffHunks: () => [],
+    hasPendingProposals: () => false,
+    applyAfterYaml: (yaml: string) => appliedYaml.push(yaml),
+  })),
+}));
+
+jest.mock('uuid', () => {
+  let counter = 0;
+  return { v4: () => `draft-uuid-${++counter}` };
+});
+
+const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
+
+interface PendingAttachment {
+  id: string;
+  type: string;
+  origin?: string;
+}
+
+/**
+ * Stand-in for `agent_builder`'s browser contract, keeping the behaviour this
+ * integration depends on:
+ *  - attachments upsert by id, so a changed id means an extra attachment;
+ *  - `addAttachment` is dropped until the sidebar registers its callbacks,
+ *    which happens while it renders;
+ *  - opening the sidebar restores the session's last conversation from local
+ *    storage, publishing the binding before the conversation is fetched.
+ */
+const createFakeAgentBuilder = () => {
+  const conversations = new Map<string, VersionedAttachment[]>();
+  const chat$ = new Subject<BrowserChatEvent>();
+  const perConversation$ = new Map<string, Subject<BrowserChatEvent>>();
+  const activeConversation$ = new BehaviorSubject<ActiveConversation | null>(null);
+
+  let acceptsAttachments = false;
+  let pending: PendingAttachment[] = [];
+  let sessionTag: string | undefined;
+
+  const upsert = (into: PendingAttachment[], next: PendingAttachment[]) => {
+    const merged = [...into];
+    for (const attachment of next) {
+      const at = merged.findIndex((candidate) => candidate.id === attachment.id);
+      if (at === -1) merged.push(attachment);
+      else merged[at] = attachment;
+    }
+    return merged;
+  };
+
+  const stream$ = (conversationId: string) => {
+    let stream = perConversation$.get(conversationId);
+    if (!stream) {
+      stream = new Subject<BrowserChatEvent>();
+      perConversation$.set(conversationId, stream);
+    }
+    return stream;
+  };
+
+  const lastConversationKey = (tag?: string) =>
+    `agentBuilder.lastConversation.${tag ?? 'default'}.default`;
+
+  const contract = {
+    getAgentBuilderAccess: jest
+      .fn()
+      .mockResolvedValue({ hasRequiredLicense: true, hasLlmConnector: true }),
+    events: {
+      chat$: chat$.asObservable(),
+      getChatEvents$: (conversationId: string) => stream$(conversationId).asObservable(),
+      ui: { activeConversation$: activeConversation$.asObservable() },
+    },
+    addAttachment: jest.fn((attachment: PendingAttachment) => {
+      if (!acceptsAttachments) return;
+      pending = upsert(pending, [attachment]);
+    }),
+    setChatConfig: jest.fn((config: { sessionTag?: string; attachments?: PendingAttachment[] }) => {
+      sessionTag = config.sessionTag;
+      if (acceptsAttachments && config.attachments) pending = upsert(pending, config.attachments);
+    }),
+    clearChatConfig: jest.fn(),
+    openChat: jest.fn((options: { sessionTag?: string; attachments?: PendingAttachment[] }) => {
+      sessionTag = options.sessionTag;
+      pending = [...(options.attachments ?? [])];
+
+      const stored = window.localStorage.getItem(lastConversationKey(options.sessionTag));
+      const restoredId = stored ? (JSON.parse(stored) as string) : undefined;
+
+      // The chat UI publishes the binding as it renders, before its attachment
+      // callbacks are registered and before the conversation fetch lands.
+      activeConversation$.next({ id: restoredId });
+      acceptsAttachments = true;
+      if (restoredId) {
+        activeConversation$.next({
+          id: restoredId,
+          conversation: { attachments: conversations.get(restoredId) ?? [] },
+        } as ActiveConversation);
+      }
+
+      return {
+        chatRef: {
+          close: () => {
+            acceptsAttachments = false;
+          },
+        },
+      };
+    }),
+    updateAttachmentOrigin: jest.fn(async (conversationId: string, id: string, origin: string) => {
+      const target = (conversations.get(conversationId) ?? []).find(
+        (attachment) => attachment.id === id
+      );
+      if (target) target.origin = origin;
+      return undefined;
+    }),
+  };
+
+  /** Persists whatever the input holds, the way sending a message does. */
+  const submitRound = (conversationId: string) => {
+    const stored = conversations.get(conversationId) ?? [];
+    for (const attachment of pending) {
+      const existing = stored.find((candidate) => candidate.id === attachment.id);
+      if (existing) {
+        existing.versions.push({ version: existing.versions.length + 1 } as never);
+      } else {
+        stored.push({
+          ...attachment,
+          versions: [{ version: 1 }],
+          current_version: 1,
+        } as unknown as VersionedAttachment);
+      }
+    }
+    conversations.set(conversationId, stored);
+    window.localStorage.setItem(lastConversationKey(sessionTag), JSON.stringify(conversationId));
+    activeConversation$.next({
+      id: conversationId,
+      conversation: { attachments: stored },
+    } as ActiveConversation);
+  };
+
+  /** A conversation and its attachments as a fresh page load would find them. */
+  const seedConversation = (
+    conversationId: string,
+    tag: string,
+    attachments: Array<{ id: string; origin?: string }>
+  ) => {
+    conversations.set(
+      conversationId,
+      attachments.map(
+        (attachment) =>
+          ({
+            ...attachment,
+            type: WORKFLOW_YAML_ATTACHMENT_TYPE,
+            versions: [{ version: 1 }],
+            current_version: 1,
+          } as unknown as VersionedAttachment)
+      )
+    );
+    window.localStorage.setItem(lastConversationKey(tag), JSON.stringify(conversationId));
+  };
+
+  const emitYamlChange = (conversationId: string, attachmentId: string, afterYaml: string) => {
+    stream$(conversationId).next({
+      type: ChatEventType.toolUi,
+      data: {
+        tool_id: 'generate_workflow',
+        tool_call_id: 'call-1',
+        custom_event: WORKFLOW_YAML_CHANGED_EVENT,
+        data: { proposalId: `p-${afterYaml.length}`, beforeYaml: '', afterYaml, attachmentId },
+      },
+    } as unknown as BrowserChatEvent);
+  };
+
+  const workflowAttachmentIds = (conversationId: string) =>
+    (conversations.get(conversationId) ?? [])
+      .filter((attachment) => attachment.type === WORKFLOW_YAML_ATTACHMENT_TYPE)
+      .map((attachment) => attachment.id);
+
+  return { contract, submitRound, seedConversation, emitYamlChange, workflowAttachmentIds };
+};
+
+type FakeAgentBuilder = ReturnType<typeof createFakeAgentBuilder>;
+
+const setupKibana = (agentBuilder: FakeAgentBuilder['contract']) => {
+  useKibanaMock.mockReturnValue({
+    services: {
+      workflowsManagement: { agentBuilder },
+      application: { capabilities: { agentBuilder: { show: true } } },
+    },
+  } as unknown as ReturnType<typeof useKibana>);
+};
+
+const createEditor = () =>
+  ({
+    getModel: () => ({
+      getValue: () => 'name: test',
+      onDidChangeContent: () => ({ dispose: jest.fn() }),
+    }),
+  } as never);
+
+const renderEditor = async (workflowId?: string) => {
+  const rendered = renderHook(() =>
+    useAgentBuilderIntegration({
+      editorRef: { current: createEditor() },
+      isEditorMounted: true,
+      workflowId,
+    })
+  );
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return rendered;
+};
+
+describe('workflow attachment sync', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    appliedYaml.length = 0;
+  });
+
+  it('keeps one attachment across create, save and the handed-over conversation', async () => {
+    const fake = createFakeAgentBuilder();
+    setupKibana(fake.contract);
+
+    const createSession = await renderEditor(undefined);
+    act(() => createSession.result.current.openAgentChat());
+    act(() => fake.submitRound('conv-1'));
+
+    const [draftId] = fake.workflowAttachmentIds('conv-1');
+    expect(draftId).toBeDefined();
+
+    // The save thunk hands the chat over before the app remounts the editor on
+    // the saved workflow's route.
+    carryConversationToWorkflow('workflow-a');
+    createSession.unmount();
+
+    const savedSession = await renderEditor('workflow-a');
+    act(() => savedSession.result.current.openAgentChat());
+    act(() => fake.submitRound('conv-1'));
+
+    expect(fake.workflowAttachmentIds('conv-1')).toEqual([draftId]);
+  });
+
+  describe('after a page reload', () => {
+    // The handoff state carrying the create session's attachment id lives in
+    // module scope, so a reload loses it. Only the conversation, and the
+    // local-storage pointer to it, survive.
+    it('reuses the attachment the restored conversation already holds', async () => {
+      const fake = createFakeAgentBuilder();
+      setupKibana(fake.contract);
+      fake.seedConversation('conv-2', 'workflow-editor:workflow-b', [
+        { id: 'draft-from-before-reload', origin: 'workflow-b' },
+      ]);
+
+      const session = await renderEditor('workflow-b');
+      act(() => session.result.current.openAgentChat());
+      act(() => fake.submitRound('conv-2'));
+
+      expect(fake.workflowAttachmentIds('conv-2')).toEqual(['draft-from-before-reload']);
+    });
+
+    it('applies the diff the agent sends back for that round', async () => {
+      const fake = createFakeAgentBuilder();
+      setupKibana(fake.contract);
+      fake.seedConversation('conv-3', 'workflow-editor:workflow-c', [
+        { id: 'draft-from-before-reload', origin: 'workflow-c' },
+      ]);
+
+      const session = await renderEditor('workflow-c');
+      act(() => session.result.current.openAgentChat());
+      act(() => fake.submitRound('conv-3'));
+
+      // The agent edits the workflow attachment the round carried. A second one
+      // splits the editor from the agent, whichever of the two each ends up on.
+      expect(fake.workflowAttachmentIds('conv-3')).toHaveLength(1);
+
+      const edited = fake.workflowAttachmentIds('conv-3').at(-1)!;
+      act(() => fake.emitYamlChange('conv-3', edited, 'name: edited by agent'));
+
+      expect(appliedYaml).toEqual(['name: edited by agent']);
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/attachment_sync.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/attachment_sync.test.tsx
@@ -79,6 +79,7 @@ const createFakeAgentBuilder = () => {
   let acceptsAttachments = false;
   let pending: PendingAttachment[] = [];
   let sessionTag: string | undefined;
+  const boundConversations: Array<string | undefined> = [];
 
   const upsert = (into: PendingAttachment[], next: PendingAttachment[]) => {
     const merged = [...into];
@@ -126,6 +127,7 @@ const createFakeAgentBuilder = () => {
 
       const stored = window.localStorage.getItem(lastConversationKey(options.sessionTag));
       const restoredId = stored ? (JSON.parse(stored) as string) : undefined;
+      boundConversations.push(restoredId);
 
       // The chat UI publishes the binding as it renders, before its attachment
       // callbacks are registered and before the conversation fetch lands.
@@ -221,8 +223,12 @@ const createFakeAgentBuilder = () => {
       .filter((attachment) => attachment.type === WORKFLOW_YAML_ATTACHMENT_TYPE)
       .map((attachment) => attachment.id);
 
+  /** Conversation the sidebar bound to on its most recent open, if any. */
+  const lastBoundConversation = () => boundConversations.at(-1);
+
   return {
     contract,
+    lastBoundConversation,
     submitRound,
     seedConversation,
     pointSessionAtConversation,
@@ -288,6 +294,10 @@ describe('workflow attachment sync', () => {
 
     const savedSession = await renderEditor('workflow-a');
     act(() => savedSession.result.current.openAgentChat());
+
+    // The chat must continue where it left off, not open a blank one.
+    expect(fake.lastBoundConversation()).toBe('conv-1');
+
     act(() => fake.submitRound('conv-1'));
 
     expect(fake.workflowAttachmentIds('conv-1')).toEqual([draftId]);

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/attachment_sync.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/attachment_sync.test.tsx
@@ -199,6 +199,11 @@ const createFakeAgentBuilder = () => {
     window.localStorage.setItem(lastConversationKey(tag), JSON.stringify(conversationId));
   };
 
+  /** What the save handoff leaves behind: the session tag points at the conversation. */
+  const pointSessionAtConversation = (tag: string, conversationId: string) => {
+    window.localStorage.setItem(lastConversationKey(tag), JSON.stringify(conversationId));
+  };
+
   const emitYamlChange = (conversationId: string, attachmentId: string, afterYaml: string) => {
     stream$(conversationId).next({
       type: ChatEventType.toolUi,
@@ -216,7 +221,14 @@ const createFakeAgentBuilder = () => {
       .filter((attachment) => attachment.type === WORKFLOW_YAML_ATTACHMENT_TYPE)
       .map((attachment) => attachment.id);
 
-  return { contract, submitRound, seedConversation, emitYamlChange, workflowAttachmentIds };
+  return {
+    contract,
+    submitRound,
+    seedConversation,
+    pointSessionAtConversation,
+    emitYamlChange,
+    workflowAttachmentIds,
+  };
 };
 
 type FakeAgentBuilder = ReturnType<typeof createFakeAgentBuilder>;
@@ -297,6 +309,32 @@ describe('workflow attachment sync', () => {
       act(() => fake.submitRound('conv-2'));
 
       expect(fake.workflowAttachmentIds('conv-2')).toEqual(['draft-from-before-reload']);
+    });
+
+    it('reuses the attachment even when its origin was never linked', async () => {
+      // A create session persisted its attachment, but the origin link never
+      // landed. After a reload the handoff state is gone, so the only thing
+      // that can still identify that attachment is its id.
+      const fake = createFakeAgentBuilder();
+      setupKibana(fake.contract);
+
+      const createSession = await renderEditor(undefined);
+      act(() => createSession.result.current.openAgentChat());
+      act(() => fake.submitRound('conv-4'));
+      createSession.unmount();
+
+      const [attachmentFromBeforeReload] = fake.workflowAttachmentIds('conv-4');
+      expect(attachmentFromBeforeReload).toBeDefined();
+
+      // The reload: local storage still points this workflow's chat at the
+      // conversation, but nothing in memory survives.
+      fake.pointSessionAtConversation('workflow-editor:workflow-e', 'conv-4');
+
+      const reloaded = await renderEditor('workflow-e');
+      act(() => reloaded.result.current.openAgentChat());
+      act(() => fake.submitRound('conv-4'));
+
+      expect(fake.workflowAttachmentIds('conv-4')).toEqual([attachmentFromBeforeReload]);
     });
 
     it('applies the diff the agent sends back for that round', async () => {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
@@ -118,6 +118,7 @@ const embeddableChatAccessReady = {
 
 const createMockAgentBuilder = () => ({
   addAttachment: jest.fn(),
+  removeAttachment: jest.fn(),
   setChatConfig: jest.fn(),
   clearChatConfig: jest.fn(),
   openChat: jest.fn().mockReturnValue({ chatRef: { close: jest.fn() } }),

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
@@ -54,6 +54,7 @@ jest.mock('../../../../features/ai_integration', () => ({
   setSidebarOpen: jest.fn(),
   consumeSidebarRestoreFor: jest.fn().mockReturnValue(false),
   getCarriedAttachmentId: jest.fn().mockReturnValue(undefined),
+  hasPersistedConversation: jest.fn().mockReturnValue(false),
   findLinkedWorkflowAttachment: jest.requireActual('../../../../features/ai_integration')
     .findLinkedWorkflowAttachment,
 }));
@@ -64,11 +65,13 @@ const {
   setSidebarOpen: mockSetSidebarOpen,
   consumeSidebarRestoreFor: mockConsumeSidebarRestoreFor,
   getCarriedAttachmentId: mockGetCarriedAttachmentId,
+  hasPersistedConversation: mockHasPersistedConversation,
 } = jest.requireMock('../../../../features/ai_integration') as {
   setLastCreateAttachmentId: jest.MockedFunction<AiIntegrationModule['setLastCreateAttachmentId']>;
   setSidebarOpen: jest.MockedFunction<AiIntegrationModule['setSidebarOpen']>;
   consumeSidebarRestoreFor: jest.MockedFunction<AiIntegrationModule['consumeSidebarRestoreFor']>;
   getCarriedAttachmentId: jest.MockedFunction<AiIntegrationModule['getCarriedAttachmentId']>;
+  hasPersistedConversation: jest.MockedFunction<AiIntegrationModule['hasPersistedConversation']>;
 };
 const { AttachmentBridge: mockAttachmentBridge } = jest.requireMock(
   '../../../../features/ai_integration'
@@ -188,6 +191,7 @@ describe('useAgentBuilderIntegration', () => {
     mockModel = createMockModel(INITIAL_YAML);
     mockConsumeSidebarRestoreFor.mockReturnValue(false);
     mockGetCarriedAttachmentId.mockReturnValue(undefined);
+    mockHasPersistedConversation.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -1177,6 +1181,47 @@ describe('useAgentBuilderIntegration', () => {
       );
       await flushChatAccessCheck();
     };
+
+    it('adds nothing until a restored conversation reveals its attachment', async () => {
+      // The sidebar restores this session's last conversation on open, so the
+      // editor cannot know its attachment id at mount.
+      const agentBuilder = createMockAgentBuilder();
+      mockHasPersistedConversation.mockReturnValue(true);
+      await renderSavedEditor(agentBuilder);
+
+      expect(agentBuilder.addAttachment).not.toHaveBeenCalled();
+
+      act(() => {
+        agentBuilder.events.ui.activeConversation$.next(
+          activeConversation([workflowAttachment(DRAFT_ID, 'workflow-a')])
+        );
+      });
+
+      expect(agentBuilder.addAttachment).toHaveBeenCalledTimes(1);
+      expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ id: DRAFT_ID })
+      );
+    });
+
+    it('opens the chat without an attachment while a restored conversation loads', async () => {
+      const agentBuilder = createMockAgentBuilder();
+      mockHasPersistedConversation.mockReturnValue(true);
+      setupKibanaMock(agentBuilder);
+      const { result } = renderHook(() =>
+        useAgentBuilderIntegration({
+          editorRef: { current: createMockEditor(mockModel) },
+          isEditorMounted: true,
+          workflowId: 'workflow-a',
+        })
+      );
+      await flushChatAccessCheck();
+
+      act(() => result.current.openAgentChat());
+
+      expect(agentBuilder.openChat).toHaveBeenCalledWith(
+        expect.objectContaining({ attachments: [] })
+      );
+    });
 
     it('uses the carried draft id for the very first sync after a save', async () => {
       const agentBuilder = createMockAgentBuilder();

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
@@ -1126,10 +1126,10 @@ describe('useAgentBuilderIntegration', () => {
   describe('proposal telemetry conversation id', () => {
     const getOnProposalReceived = () => {
       const bridge = mockAttachmentBridge.mock.results.at(-1)?.value;
-      return bridge.start.mock.calls.at(-1)[4].onProposalReceived;
+      return bridge.start.mock.calls.at(-1)[3].onProposalReceived;
     };
 
-    it('reports the resumed conversation id without a conversation_id_set event', async () => {
+    it('reports the conversation id on a resumed conversation', async () => {
       const agentBuilder = createMockAgentBuilder();
       setupKibanaMock(agentBuilder);
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
@@ -10,6 +10,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { BehaviorSubject, Subject } from 'rxjs';
 import type { ActiveConversation, BrowserChatEvent } from '@kbn/agent-builder-browser';
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 import { useAgentBuilderIntegration } from './use_agent_builder_integration';
@@ -53,9 +54,8 @@ jest.mock('../../../../features/ai_integration', () => ({
   setSidebarOpen: jest.fn(),
   consumeSidebarRestoreFor: jest.fn().mockReturnValue(false),
   getCarriedAttachmentId: jest.fn().mockReturnValue(undefined),
-  findLinkedWorkflowAttachmentId: jest.requireActual('../../../../features/ai_integration')
-    .findLinkedWorkflowAttachmentId,
-  needsOriginLink: jest.requireActual('../../../../features/ai_integration').needsOriginLink,
+  findLinkedWorkflowAttachment: jest.requireActual('../../../../features/ai_integration')
+    .findLinkedWorkflowAttachment,
 }));
 
 type AiIntegrationModule = typeof import('../../../../features/ai_integration');
@@ -1117,10 +1117,6 @@ describe('useAgentBuilderIntegration', () => {
   });
 
   describe('proposal telemetry conversation id', () => {
-    // The server only emits `conversation_id_set` for newly created
-    // conversations, so a resumed one must take its id from the active
-    // conversation published by the chat UI.
-    // https://github.com/elastic/security-team/issues/19002
     const getOnProposalReceived = () => {
       const bridge = mockAttachmentBridge.mock.results.at(-1)?.value;
       return bridge.start.mock.calls.at(-1)[4].onProposalReceived;
@@ -1152,19 +1148,23 @@ describe('useAgentBuilderIntegration', () => {
   });
 
   describe('attachment linking across the first save', () => {
-    // The editor mints its attachment id from the route: a uuid on
-    // /workflows/create, the workflow id once saved. Syncing under the new id
-    // adds a second workflow.yaml attachment to the same conversation.
-    // https://github.com/elastic/security-team/issues/18821
+    // The editor's own attachment id changes on save, so syncing under it adds
+    // a second workflow.yaml attachment to the same conversation.
     const DRAFT_ID = 'draft-uuid';
 
-    const workflowAttachment = (id: string, origin?: string) =>
+    const workflowAttachment = (id: string, origin?: string): VersionedAttachment => ({
+      id,
+      type: WORKFLOW_YAML_ATTACHMENT_TYPE,
+      versions: [],
+      current_version: 1,
+      origin,
+    });
+
+    const activeConversation = (attachments?: VersionedAttachment[]) =>
       ({
-        id,
-        type: WORKFLOW_YAML_ATTACHMENT_TYPE,
-        versions: [],
-        ...(origin ? { origin } : {}),
-      } as never);
+        id: 'conv-1',
+        ...(attachments ? { conversation: { attachments } } : {}),
+      } as ActiveConversation);
 
     const renderSavedEditor = async (agentBuilder: ReturnType<typeof createMockAgentBuilder>) => {
       setupKibanaMock(agentBuilder);
@@ -1179,8 +1179,6 @@ describe('useAgentBuilderIntegration', () => {
     };
 
     it('uses the carried draft id for the very first sync after a save', async () => {
-      // The editor pushes an attachment at mount, before the conversation
-      // loads, so the carried id has to be resolved during render.
       const agentBuilder = createMockAgentBuilder();
       mockGetCarriedAttachmentId.mockReturnValue(DRAFT_ID);
       await renderSavedEditor(agentBuilder);
@@ -1188,8 +1186,7 @@ describe('useAgentBuilderIntegration', () => {
       expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
         expect.objectContaining({ id: DRAFT_ID })
       );
-      // The session tag still keys off the workflow, so the conversation
-      // handoff from the create route keeps working.
+      // The session tag still keys off the workflow, so the handoff holds.
       expect(agentBuilder.setChatConfig).toHaveBeenCalledWith(
         expect.objectContaining({ sessionTag: 'workflow-editor:workflow-a' })
       );
@@ -1197,18 +1194,15 @@ describe('useAgentBuilderIntegration', () => {
 
     it('holds the sync until a bound conversation has loaded', async () => {
       const agentBuilder = createMockAgentBuilder();
-      agentBuilder.events.ui.activeConversation$.next({ id: 'conv-1' } as never);
+      agentBuilder.events.ui.activeConversation$.next(activeConversation());
       await renderSavedEditor(agentBuilder);
 
       expect(agentBuilder.addAttachment).not.toHaveBeenCalled();
 
       act(() => {
-        agentBuilder.events.ui.activeConversation$.next({
-          id: 'conv-1',
-          conversation: {
-            attachments: [workflowAttachment(DRAFT_ID, 'workflow-a')],
-          },
-        } as never);
+        agentBuilder.events.ui.activeConversation$.next(
+          activeConversation([workflowAttachment(DRAFT_ID, 'workflow-a')])
+        );
       });
 
       expect(agentBuilder.addAttachment).toHaveBeenCalledTimes(1);
@@ -1222,12 +1216,9 @@ describe('useAgentBuilderIntegration', () => {
       await renderSavedEditor(agentBuilder);
 
       act(() => {
-        agentBuilder.events.ui.activeConversation$.next({
-          id: 'conv-1',
-          conversation: {
-            attachments: [workflowAttachment(DRAFT_ID, 'workflow-a')],
-          },
-        } as never);
+        agentBuilder.events.ui.activeConversation$.next(
+          activeConversation([workflowAttachment(DRAFT_ID, 'workflow-a')])
+        );
       });
 
       agentBuilder.addAttachment.mockClear();
@@ -1248,10 +1239,9 @@ describe('useAgentBuilderIntegration', () => {
 
       act(() => {
         // Carried over by `carryConversationToWorkflow`; no origin yet.
-        agentBuilder.events.ui.activeConversation$.next({
-          id: 'conv-1',
-          conversation: { attachments: [workflowAttachment(DRAFT_ID)] },
-        } as never);
+        agentBuilder.events.ui.activeConversation$.next(
+          activeConversation([workflowAttachment(DRAFT_ID)])
+        );
       });
 
       expect(agentBuilder.updateAttachmentOrigin).toHaveBeenCalledWith(
@@ -1276,12 +1266,9 @@ describe('useAgentBuilderIntegration', () => {
       await renderSavedEditor(agentBuilder);
 
       act(() => {
-        agentBuilder.events.ui.activeConversation$.next({
-          id: 'conv-1',
-          conversation: {
-            attachments: [workflowAttachment(DRAFT_ID, 'workflow-a')],
-          },
-        } as never);
+        agentBuilder.events.ui.activeConversation$.next(
+          activeConversation([workflowAttachment(DRAFT_ID, 'workflow-a')])
+        );
       });
 
       expect(agentBuilder.updateAttachmentOrigin).not.toHaveBeenCalled();
@@ -1292,10 +1279,7 @@ describe('useAgentBuilderIntegration', () => {
       await renderSavedEditor(agentBuilder);
 
       act(() => {
-        agentBuilder.events.ui.activeConversation$.next({
-          id: 'conv-1',
-          conversation: { attachments: [] },
-        } as never);
+        agentBuilder.events.ui.activeConversation$.next(activeConversation([]));
       });
 
       agentBuilder.addAttachment.mockClear();

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
@@ -50,7 +50,7 @@ jest.mock('../../../../features/ai_integration', () => ({
     hasPendingProposals: jest.fn().mockReturnValue(false),
   })),
   setActiveProposalManager: jest.fn(),
-  setLastCreateAttachmentId: jest.fn(),
+  setLastCreateSessionId: jest.fn(),
   setSidebarOpen: jest.fn(),
   consumeSidebarRestoreFor: jest.fn().mockReturnValue(false),
   hasPersistedConversation: jest.fn().mockReturnValue(false),
@@ -62,12 +62,12 @@ jest.mock('../../../../features/ai_integration', () => ({
 
 type AiIntegrationModule = typeof import('../../../../features/ai_integration');
 const {
-  setLastCreateAttachmentId: mockSetLastCreateAttachmentId,
+  setLastCreateSessionId: mockSetLastCreateSessionId,
   setSidebarOpen: mockSetSidebarOpen,
   consumeSidebarRestoreFor: mockConsumeSidebarRestoreFor,
   hasPersistedConversation: mockHasPersistedConversation,
 } = jest.requireMock('../../../../features/ai_integration') as {
-  setLastCreateAttachmentId: jest.MockedFunction<AiIntegrationModule['setLastCreateAttachmentId']>;
+  setLastCreateSessionId: jest.MockedFunction<AiIntegrationModule['setLastCreateSessionId']>;
   setSidebarOpen: jest.MockedFunction<AiIntegrationModule['setSidebarOpen']>;
   consumeSidebarRestoreFor: jest.MockedFunction<AiIntegrationModule['consumeSidebarRestoreFor']>;
   hasPersistedConversation: jest.MockedFunction<AiIntegrationModule['hasPersistedConversation']>;
@@ -811,7 +811,7 @@ describe('useAgentBuilderIntegration', () => {
   });
 
   describe('conversation handoff registration', () => {
-    it('registers the unsaved attachment id when there is no workflowId', async () => {
+    it('registers the unsaved session id when there is no workflowId', async () => {
       const agentBuilder = createMockAgentBuilder();
       setupKibanaMock(agentBuilder);
       const editor = createMockEditor(mockModel);
@@ -825,7 +825,9 @@ describe('useAgentBuilderIntegration', () => {
 
       await flushChatAccessCheck();
 
-      expect(mockSetLastCreateAttachmentId).toHaveBeenCalledWith(ATTACHMENT_ID);
+      // The chat session tag is built from this, so it must be the session id
+      // and not the (fixed) attachment id.
+      expect(mockSetLastCreateSessionId).toHaveBeenCalledWith(MOCK_UUID);
     });
 
     it('does NOT register or clear the create-attachment when a workflowId is present', () => {
@@ -845,7 +847,7 @@ describe('useAgentBuilderIntegration', () => {
         })
       );
 
-      expect(mockSetLastCreateAttachmentId).not.toHaveBeenCalled();
+      expect(mockSetLastCreateSessionId).not.toHaveBeenCalled();
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
@@ -53,10 +53,11 @@ jest.mock('../../../../features/ai_integration', () => ({
   setLastCreateAttachmentId: jest.fn(),
   setSidebarOpen: jest.fn(),
   consumeSidebarRestoreFor: jest.fn().mockReturnValue(false),
-  getCarriedAttachmentId: jest.fn().mockReturnValue(undefined),
   hasPersistedConversation: jest.fn().mockReturnValue(false),
   findLinkedWorkflowAttachment: jest.requireActual('../../../../features/ai_integration')
     .findLinkedWorkflowAttachment,
+  WORKFLOW_EDITOR_ATTACHMENT_ID: jest.requireActual('../../../../features/ai_integration')
+    .WORKFLOW_EDITOR_ATTACHMENT_ID,
 }));
 
 type AiIntegrationModule = typeof import('../../../../features/ai_integration');
@@ -64,13 +65,11 @@ const {
   setLastCreateAttachmentId: mockSetLastCreateAttachmentId,
   setSidebarOpen: mockSetSidebarOpen,
   consumeSidebarRestoreFor: mockConsumeSidebarRestoreFor,
-  getCarriedAttachmentId: mockGetCarriedAttachmentId,
   hasPersistedConversation: mockHasPersistedConversation,
 } = jest.requireMock('../../../../features/ai_integration') as {
   setLastCreateAttachmentId: jest.MockedFunction<AiIntegrationModule['setLastCreateAttachmentId']>;
   setSidebarOpen: jest.MockedFunction<AiIntegrationModule['setSidebarOpen']>;
   consumeSidebarRestoreFor: jest.MockedFunction<AiIntegrationModule['consumeSidebarRestoreFor']>;
-  getCarriedAttachmentId: jest.MockedFunction<AiIntegrationModule['getCarriedAttachmentId']>;
   hasPersistedConversation: jest.MockedFunction<AiIntegrationModule['hasPersistedConversation']>;
 };
 const { AttachmentBridge: mockAttachmentBridge } = jest.requireMock(
@@ -162,8 +161,11 @@ const INITIAL_YAML = 'name: test-workflow';
 
 const MOCK_UUID = 'mock-uuid-1234';
 
+// The editor's attachment id is fixed; only the chat session tag follows the route.
+const ATTACHMENT_ID = 'workflow-yaml-editor';
+
 const expectedAttachment = (yaml: string, overrides?: { workflowId?: string; name?: string }) => ({
-  id: overrides?.workflowId ?? MOCK_UUID,
+  id: ATTACHMENT_ID,
   type: WORKFLOW_YAML_ATTACHMENT_TYPE,
   ...(overrides?.workflowId ? { origin: overrides.workflowId } : {}),
   data: {
@@ -190,7 +192,6 @@ describe('useAgentBuilderIntegration', () => {
     jest.useFakeTimers();
     mockModel = createMockModel(INITIAL_YAML);
     mockConsumeSidebarRestoreFor.mockReturnValue(false);
-    mockGetCarriedAttachmentId.mockReturnValue(undefined);
     mockHasPersistedConversation.mockReturnValue(false);
   });
 
@@ -347,7 +348,7 @@ describe('useAgentBuilderIntegration', () => {
       );
     });
 
-    it('uses a generated UUID as attachment id when workflowId is undefined', async () => {
+    it('uses the fixed attachment id and a generated session tag on the create route', async () => {
       const agentBuilder = createMockAgentBuilder();
       setupKibanaMock(agentBuilder);
       const editor = createMockEditor(mockModel);
@@ -364,7 +365,7 @@ describe('useAgentBuilderIntegration', () => {
       expect(agentBuilder.setChatConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           sessionTag: `workflow-editor:${MOCK_UUID}`,
-          attachments: [expect.objectContaining({ id: MOCK_UUID })],
+          attachments: [expect.objectContaining({ id: ATTACHMENT_ID })],
         })
       );
     });
@@ -824,7 +825,7 @@ describe('useAgentBuilderIntegration', () => {
 
       await flushChatAccessCheck();
 
-      expect(mockSetLastCreateAttachmentId).toHaveBeenCalledWith(MOCK_UUID);
+      expect(mockSetLastCreateAttachmentId).toHaveBeenCalledWith(ATTACHMENT_ID);
     });
 
     it('does NOT register or clear the create-attachment when a workflowId is present', () => {
@@ -1223,13 +1224,14 @@ describe('useAgentBuilderIntegration', () => {
       );
     });
 
-    it('uses the carried draft id for the very first sync after a save', async () => {
+    it('uses the fixed id for the very first sync after a save', async () => {
+      // The editor pushes an attachment at mount, before the conversation
+      // loads, so the id has to hold without consulting the conversation.
       const agentBuilder = createMockAgentBuilder();
-      mockGetCarriedAttachmentId.mockReturnValue(DRAFT_ID);
       await renderSavedEditor(agentBuilder);
 
       expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
-        expect.objectContaining({ id: DRAFT_ID })
+        expect.objectContaining({ id: ATTACHMENT_ID })
       );
       // The session tag still keys off the workflow, so the handoff holds.
       expect(agentBuilder.setChatConfig).toHaveBeenCalledWith(
@@ -1279,30 +1281,19 @@ describe('useAgentBuilderIntegration', () => {
 
     it('links the create session attachment to the workflow after the first save', async () => {
       const agentBuilder = createMockAgentBuilder();
-      mockGetCarriedAttachmentId.mockReturnValue(DRAFT_ID);
       await renderSavedEditor(agentBuilder);
 
       act(() => {
-        // Carried over by `carryConversationToWorkflow`; no origin yet.
+        // Added while the workflow was still unsaved, so it has no origin yet.
         agentBuilder.events.ui.activeConversation$.next(
-          activeConversation([workflowAttachment(DRAFT_ID)])
+          activeConversation([workflowAttachment(ATTACHMENT_ID)])
         );
       });
 
       expect(agentBuilder.updateAttachmentOrigin).toHaveBeenCalledWith(
         'conv-1',
-        DRAFT_ID,
+        ATTACHMENT_ID,
         'workflow-a'
-      );
-
-      agentBuilder.addAttachment.mockClear();
-      act(() => {
-        mockModel.simulateContentChange('name: edited');
-        jest.advanceTimersByTime(1000);
-      });
-
-      expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
-        expect.objectContaining({ id: DRAFT_ID })
       );
     });
 
@@ -1334,7 +1325,7 @@ describe('useAgentBuilderIntegration', () => {
       });
 
       expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'workflow-a', origin: 'workflow-a' })
+        expect.objectContaining({ id: ATTACHMENT_ID, origin: 'workflow-a' })
       );
     });
   });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.test.ts
@@ -8,6 +8,8 @@
  */
 
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { BehaviorSubject, Subject } from 'rxjs';
+import type { ActiveConversation, BrowserChatEvent } from '@kbn/agent-builder-browser';
 import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 import { useAgentBuilderIntegration } from './use_agent_builder_integration';
@@ -38,6 +40,7 @@ jest.mock('../../../../features/ai_integration', () => ({
   AttachmentBridge: jest.fn().mockImplementation(() => ({
     start: jest.fn(),
     stop: jest.fn(),
+    setAttachmentId: jest.fn(),
   })),
   ProposalManager: jest.fn().mockImplementation(() => ({
     initialize: jest.fn(),
@@ -49,6 +52,10 @@ jest.mock('../../../../features/ai_integration', () => ({
   setLastCreateAttachmentId: jest.fn(),
   setSidebarOpen: jest.fn(),
   consumeSidebarRestoreFor: jest.fn().mockReturnValue(false),
+  getCarriedAttachmentId: jest.fn().mockReturnValue(undefined),
+  findLinkedWorkflowAttachmentId: jest.requireActual('../../../../features/ai_integration')
+    .findLinkedWorkflowAttachmentId,
+  needsOriginLink: jest.requireActual('../../../../features/ai_integration').needsOriginLink,
 }));
 
 type AiIntegrationModule = typeof import('../../../../features/ai_integration');
@@ -56,11 +63,16 @@ const {
   setLastCreateAttachmentId: mockSetLastCreateAttachmentId,
   setSidebarOpen: mockSetSidebarOpen,
   consumeSidebarRestoreFor: mockConsumeSidebarRestoreFor,
+  getCarriedAttachmentId: mockGetCarriedAttachmentId,
 } = jest.requireMock('../../../../features/ai_integration') as {
   setLastCreateAttachmentId: jest.MockedFunction<AiIntegrationModule['setLastCreateAttachmentId']>;
   setSidebarOpen: jest.MockedFunction<AiIntegrationModule['setSidebarOpen']>;
   consumeSidebarRestoreFor: jest.MockedFunction<AiIntegrationModule['consumeSidebarRestoreFor']>;
+  getCarriedAttachmentId: jest.MockedFunction<AiIntegrationModule['getCarriedAttachmentId']>;
 };
+const { AttachmentBridge: mockAttachmentBridge } = jest.requireMock(
+  '../../../../features/ai_integration'
+) as { AttachmentBridge: jest.Mock };
 jest.mock('../../../../features/ai_integration/proposal_tracker', () => ({
   ProposalTracker: jest.fn().mockImplementation(() => ({
     onAllResolved: jest.fn().mockReturnValue(jest.fn()),
@@ -108,7 +120,12 @@ const createMockAgentBuilder = () => ({
   clearChatConfig: jest.fn(),
   openChat: jest.fn().mockReturnValue({ chatRef: { close: jest.fn() } }),
   getAgentBuilderAccess: jest.fn().mockResolvedValue(embeddableChatAccessReady),
-  events: { chat$: { subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }) } },
+  events: {
+    chat$: new Subject<BrowserChatEvent>(),
+    getChatEvents$: jest.fn(() => new Subject<BrowserChatEvent>().asObservable()),
+    ui: { activeConversation$: new BehaviorSubject<ActiveConversation | null>(null) },
+  },
+  updateAttachmentOrigin: jest.fn().mockResolvedValue(undefined),
   tools: {},
   attachments: {},
 });
@@ -145,6 +162,7 @@ const MOCK_UUID = 'mock-uuid-1234';
 const expectedAttachment = (yaml: string, overrides?: { workflowId?: string; name?: string }) => ({
   id: overrides?.workflowId ?? MOCK_UUID,
   type: WORKFLOW_YAML_ATTACHMENT_TYPE,
+  ...(overrides?.workflowId ? { origin: overrides.workflowId } : {}),
   data: {
     yaml,
     workflowId: overrides?.workflowId,
@@ -169,6 +187,7 @@ describe('useAgentBuilderIntegration', () => {
     jest.useFakeTimers();
     mockModel = createMockModel(INITIAL_YAML);
     mockConsumeSidebarRestoreFor.mockReturnValue(false);
+    mockGetCarriedAttachmentId.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -1094,6 +1113,200 @@ describe('useAgentBuilderIntegration', () => {
       await flushChatAccessCheck();
 
       expect(useUiSettingMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('proposal telemetry conversation id', () => {
+    // The server only emits `conversation_id_set` for newly created
+    // conversations, so a resumed one must take its id from the active
+    // conversation published by the chat UI.
+    // https://github.com/elastic/security-team/issues/19002
+    const getOnProposalReceived = () => {
+      const bridge = mockAttachmentBridge.mock.results.at(-1)?.value;
+      return bridge.start.mock.calls.at(-1)[4].onProposalReceived;
+    };
+
+    it('reports the resumed conversation id without a conversation_id_set event', async () => {
+      const agentBuilder = createMockAgentBuilder();
+      setupKibanaMock(agentBuilder);
+
+      renderHook(() =>
+        useAgentBuilderIntegration({
+          editorRef: { current: createMockEditor(mockModel) },
+          isEditorMounted: true,
+        })
+      );
+
+      await flushChatAccessCheck();
+
+      act(() => {
+        agentBuilder.events.ui.activeConversation$.next({ id: 'conv-resumed' });
+      });
+
+      getOnProposalReceived()({ proposalId: 'proposal-1', toolId: 'edit-tool' });
+
+      expect(mockTelemetry.reportAiProposalReceived).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: 'conv-resumed', proposalId: 'proposal-1' })
+      );
+    });
+  });
+
+  describe('attachment linking across the first save', () => {
+    // The editor mints its attachment id from the route: a uuid on
+    // /workflows/create, the workflow id once saved. Syncing under the new id
+    // adds a second workflow.yaml attachment to the same conversation.
+    // https://github.com/elastic/security-team/issues/18821
+    const DRAFT_ID = 'draft-uuid';
+
+    const workflowAttachment = (id: string, origin?: string) =>
+      ({
+        id,
+        type: WORKFLOW_YAML_ATTACHMENT_TYPE,
+        versions: [],
+        ...(origin ? { origin } : {}),
+      } as never);
+
+    const renderSavedEditor = async (agentBuilder: ReturnType<typeof createMockAgentBuilder>) => {
+      setupKibanaMock(agentBuilder);
+      renderHook(() =>
+        useAgentBuilderIntegration({
+          editorRef: { current: createMockEditor(mockModel) },
+          isEditorMounted: true,
+          workflowId: 'workflow-a',
+        })
+      );
+      await flushChatAccessCheck();
+    };
+
+    it('uses the carried draft id for the very first sync after a save', async () => {
+      // The editor pushes an attachment at mount, before the conversation
+      // loads, so the carried id has to be resolved during render.
+      const agentBuilder = createMockAgentBuilder();
+      mockGetCarriedAttachmentId.mockReturnValue(DRAFT_ID);
+      await renderSavedEditor(agentBuilder);
+
+      expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ id: DRAFT_ID })
+      );
+      // The session tag still keys off the workflow, so the conversation
+      // handoff from the create route keeps working.
+      expect(agentBuilder.setChatConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionTag: 'workflow-editor:workflow-a' })
+      );
+    });
+
+    it('holds the sync until a bound conversation has loaded', async () => {
+      const agentBuilder = createMockAgentBuilder();
+      agentBuilder.events.ui.activeConversation$.next({ id: 'conv-1' } as never);
+      await renderSavedEditor(agentBuilder);
+
+      expect(agentBuilder.addAttachment).not.toHaveBeenCalled();
+
+      act(() => {
+        agentBuilder.events.ui.activeConversation$.next({
+          id: 'conv-1',
+          conversation: {
+            attachments: [workflowAttachment(DRAFT_ID, 'workflow-a')],
+          },
+        } as never);
+      });
+
+      expect(agentBuilder.addAttachment).toHaveBeenCalledTimes(1);
+      expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ id: DRAFT_ID })
+      );
+    });
+
+    it('reuses the draft attachment id when the conversation links it to this workflow', async () => {
+      const agentBuilder = createMockAgentBuilder();
+      await renderSavedEditor(agentBuilder);
+
+      act(() => {
+        agentBuilder.events.ui.activeConversation$.next({
+          id: 'conv-1',
+          conversation: {
+            attachments: [workflowAttachment(DRAFT_ID, 'workflow-a')],
+          },
+        } as never);
+      });
+
+      agentBuilder.addAttachment.mockClear();
+      act(() => {
+        mockModel.simulateContentChange('name: edited');
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ id: DRAFT_ID })
+      );
+    });
+
+    it('links the create session attachment to the workflow after the first save', async () => {
+      const agentBuilder = createMockAgentBuilder();
+      mockGetCarriedAttachmentId.mockReturnValue(DRAFT_ID);
+      await renderSavedEditor(agentBuilder);
+
+      act(() => {
+        // Carried over by `carryConversationToWorkflow`; no origin yet.
+        agentBuilder.events.ui.activeConversation$.next({
+          id: 'conv-1',
+          conversation: { attachments: [workflowAttachment(DRAFT_ID)] },
+        } as never);
+      });
+
+      expect(agentBuilder.updateAttachmentOrigin).toHaveBeenCalledWith(
+        'conv-1',
+        DRAFT_ID,
+        'workflow-a'
+      );
+
+      agentBuilder.addAttachment.mockClear();
+      act(() => {
+        mockModel.simulateContentChange('name: edited');
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ id: DRAFT_ID })
+      );
+    });
+
+    it('does not re-link an attachment whose origin is already set', async () => {
+      const agentBuilder = createMockAgentBuilder();
+      await renderSavedEditor(agentBuilder);
+
+      act(() => {
+        agentBuilder.events.ui.activeConversation$.next({
+          id: 'conv-1',
+          conversation: {
+            attachments: [workflowAttachment(DRAFT_ID, 'workflow-a')],
+          },
+        } as never);
+      });
+
+      expect(agentBuilder.updateAttachmentOrigin).not.toHaveBeenCalled();
+    });
+
+    it('keeps its own attachment id when the conversation holds none', async () => {
+      const agentBuilder = createMockAgentBuilder();
+      await renderSavedEditor(agentBuilder);
+
+      act(() => {
+        agentBuilder.events.ui.activeConversation$.next({
+          id: 'conv-1',
+          conversation: { attachments: [] },
+        } as never);
+      });
+
+      agentBuilder.addAttachment.mockClear();
+      act(() => {
+        mockModel.simulateContentChange('name: edited');
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(agentBuilder.addAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'workflow-a', origin: 'workflow-a' })
+      );
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
@@ -300,12 +300,17 @@ export const useAgentBuilderIntegration = ({
           attachmentId,
           workflowId,
         });
+        const previousAttachmentId = syncAttachmentIdRef.current ?? attachmentId;
+        const linkedAttachmentChanged = linked !== undefined && linked.id !== previousAttachmentId;
         if (linked) {
+          if (linkedAttachmentChanged) {
+            agentBuilder.removeAttachment(previousAttachmentId);
+          }
           syncAttachmentIdRef.current = linked.id;
           bridge.setAttachmentId(linked.id);
         }
 
-        if (!attachmentTargetResolvedRef.current) {
+        if (!attachmentTargetResolvedRef.current || linkedAttachmentChanged) {
           attachmentTargetResolvedRef.current = true;
           const yaml = editorRef.current?.getModel()?.getValue();
           if (yaml !== undefined) syncAttachment(yaml);

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
@@ -18,9 +18,8 @@ import { setAiAssisted } from '../../../../entities/workflows/store/workflow_det
 import {
   AttachmentBridge,
   consumeSidebarRestoreFor,
-  findLinkedWorkflowAttachmentId,
+  findLinkedWorkflowAttachment,
   getCarriedAttachmentId,
-  needsOriginLink,
   ProposalManager,
   setActiveProposalManager,
   setLastCreateAttachmentId,
@@ -89,16 +88,13 @@ export const useAgentBuilderIntegration = ({
   workflowNameRef.current = workflowName;
   const [isChatAccessible, setIsChatAccessible] = useState(false);
 
-  // Identifies the editor session. Drives the chat session tag, which
-  // `carryConversationToWorkflow` rewrites onto the saved workflow across the
-  // first save.
+  // Drives the chat session tag, which `carryConversationToWorkflow` rewrites
+  // onto the saved workflow across the first save.
   const sessionId = workflowId ?? unsavedWorkflowIdRef.current;
 
-  // Identifies the attachment the session writes into. It follows `sessionId`
-  // except right after the first save, where the conversation already holds the
-  // create session's attachment. Reusing that id keeps one attachment with a
-  // growing version list instead of adding a second one. Resolved during render
-  // because the editor pushes an attachment before the conversation loads.
+  // Follows `sessionId` except right after the first save, where the
+  // conversation already holds the create session's attachment. Resolved during
+  // render because the editor syncs before the conversation loads.
   const attachmentId = (workflowId ? getCarriedAttachmentId(workflowId) : undefined) ?? sessionId;
 
   useEffect(() => {
@@ -282,40 +278,34 @@ export const useAgentBuilderIntegration = ({
       agentBuilder.addAttachment(attachment);
     };
 
-    // False while a bound conversation is still loading — see the subscription
-    // below.
     let attachmentTargetResolved = true;
-
-    // The server only emits `conversation_id_set` for newly created
-    // conversations, so telemetry on a resumed conversation would otherwise
-    // report `conversationId: undefined`. The same subscription resolves the
-    // attachment this session shares with the conversation.
     let originLinkRequested = false;
+
+    // `conversation_id_set` only fires for newly created conversations, so a
+    // resumed one takes both its id and its attachment from here.
     const activeConversationSub = agentBuilder.events.ui?.activeConversation$.subscribe(
       (activeConversation) => {
         if (activeConversation?.id) {
           conversationIdRef.current = activeConversation.id;
         }
 
-        // A bound conversation that has not loaded yet may already hold the
-        // attachment this session must write into. Syncing before it lands
-        // would add a second one, so hold the sync until it resolves.
+        // A conversation still loading may already hold the attachment to
+        // write into. Syncing now would add a second one.
         const isLoading = Boolean(activeConversation?.id) && !activeConversation?.conversation;
         if (isLoading) {
           attachmentTargetResolved = false;
           return;
         }
 
-        const attachments = activeConversation?.conversation?.attachments;
-        const linkedId = findLinkedWorkflowAttachmentId({
-          attachments,
+        const linked = findLinkedWorkflowAttachment({
+          attachments: activeConversation?.conversation?.attachments,
           attachmentId,
           workflowId,
           carriedAttachmentId: workflowId ? getCarriedAttachmentId(workflowId) : undefined,
         });
-        if (linkedId) {
-          syncAttachmentIdRef.current = linkedId;
-          bridge.setAttachmentId(linkedId);
+        if (linked) {
+          syncAttachmentIdRef.current = linked.id;
+          bridge.setAttachmentId(linked.id);
         }
 
         if (!attachmentTargetResolved) {
@@ -324,18 +314,15 @@ export const useAgentBuilderIntegration = ({
           if (yaml !== undefined) syncAttachment(yaml);
         }
 
-        // The create session's attachment predates the workflow, so nothing has
-        // pointed it at one yet. Link it, otherwise the next session cannot
-        // find it and starts a second attachment.
-        if (!activeConversation?.id || !workflowId || !linkedId) return;
-        if (originLinkRequested) return;
-        if (!needsOriginLink({ attachments, attachmentId: linkedId, workflowId })) return;
+        // A create-session attachment predates the workflow, so nothing has
+        // pointed it at one yet.
+        const conversationId = activeConversation?.id;
+        if (!conversationId || !workflowId || originLinkRequested) return;
+        if (!linked || linked.origin === workflowId) return;
         originLinkRequested = true;
         void agentBuilder
-          .updateAttachmentOrigin(activeConversation.id, linkedId, workflowId)
+          .updateAttachmentOrigin(conversationId, linked.id, workflowId)
           .catch(() => {
-            // Best-effort: the attachment still syncs, it just stays unlinked
-            // and the next session may add a second one.
             originLinkRequested = false;
           });
       }
@@ -524,9 +511,8 @@ const buildWorkflowAttachment = ({
 }) => ({
   id: attachmentId,
   type: WORKFLOW_YAML_ATTACHMENT_TYPE,
-  // Links the attachment to the workflow it mirrors, so a later session can
-  // find it instead of adding a second one. A workflow being created has no id
-  // yet; `updateAttachmentOrigin` links its attachment after the first save.
+  // Lets a later session find this attachment. A workflow being created has no
+  // id yet; `updateAttachmentOrigin` links it after the first save.
   ...(workflowId ? { origin: workflowId } : {}),
   data: {
     yaml,

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
@@ -20,6 +20,7 @@ import {
   consumeSidebarRestoreFor,
   findLinkedWorkflowAttachment,
   getCarriedAttachmentId,
+  hasPersistedConversation,
   ProposalManager,
   setActiveProposalManager,
   setLastCreateAttachmentId,
@@ -79,6 +80,7 @@ export const useAgentBuilderIntegration = ({
   const sessionAutoOpenedRef = useRef(false);
   const conversationIdRef = useRef<string | undefined>(undefined);
   const syncAttachmentIdRef = useRef<string | undefined>(undefined);
+  const attachmentTargetResolvedRef = useRef(true);
   const validationErrorsRef = useRef(validationErrors);
   validationErrorsRef.current = validationErrors;
   const chatRefHandle = useRef<{ close: () => void } | null>(null);
@@ -268,7 +270,7 @@ export const useAgentBuilderIntegration = ({
     });
 
     const syncAttachment = (yaml: string) => {
-      if (!attachmentTargetResolved) return;
+      if (!attachmentTargetResolvedRef.current) return;
       const attachment = buildAttachment(yaml);
       agentBuilder.setChatConfig({
         sessionTag: `workflow-editor:${sessionId}`,
@@ -278,27 +280,30 @@ export const useAgentBuilderIntegration = ({
       agentBuilder.addAttachment(attachment);
     };
 
-    let attachmentTargetResolved = true;
+    // The sidebar restores this session's last conversation, which may already
+    // hold the attachment to write into. Adding one before it loads makes a
+    // second.
+    attachmentTargetResolvedRef.current = !hasPersistedConversation(sessionId);
     let originLinkRequested = false;
 
     // `conversation_id_set` only fires for newly created conversations, so a
     // resumed one takes both its id and its attachment from here.
     const activeConversationSub = agentBuilder.events.ui?.activeConversation$.subscribe(
       (activeConversation) => {
-        if (activeConversation?.id) {
+        // `null` means no chat surface is bound, which says nothing about the
+        // conversation the sidebar will restore.
+        if (!activeConversation) return;
+        if (activeConversation.id) {
           conversationIdRef.current = activeConversation.id;
         }
 
-        // A conversation still loading may already hold the attachment to
-        // write into. Syncing now would add a second one.
-        const isLoading = Boolean(activeConversation?.id) && !activeConversation?.conversation;
-        if (isLoading) {
-          attachmentTargetResolved = false;
+        if (activeConversation.id && !activeConversation.conversation) {
+          attachmentTargetResolvedRef.current = false;
           return;
         }
 
         const linked = findLinkedWorkflowAttachment({
-          attachments: activeConversation?.conversation?.attachments,
+          attachments: activeConversation.conversation?.attachments,
           attachmentId,
           workflowId,
           carriedAttachmentId: workflowId ? getCarriedAttachmentId(workflowId) : undefined,
@@ -308,15 +313,15 @@ export const useAgentBuilderIntegration = ({
           bridge.setAttachmentId(linked.id);
         }
 
-        if (!attachmentTargetResolved) {
-          attachmentTargetResolved = true;
+        if (!attachmentTargetResolvedRef.current) {
+          attachmentTargetResolvedRef.current = true;
           const yaml = editorRef.current?.getModel()?.getValue();
           if (yaml !== undefined) syncAttachment(yaml);
         }
 
         // A create-session attachment predates the workflow, so nothing has
         // pointed it at one yet.
-        const conversationId = activeConversation?.id;
+        const conversationId = activeConversation.id;
         if (!conversationId || !workflowId || originLinkRequested) return;
         if (!linked || linked.origin === workflowId) return;
         originLinkRequested = true;
@@ -359,6 +364,7 @@ export const useAgentBuilderIntegration = ({
       sessionAutoOpenedRef.current = false;
       conversationIdRef.current = undefined;
       syncAttachmentIdRef.current = undefined;
+      attachmentTargetResolvedRef.current = true;
 
       if (debounceTimer) {
         clearTimeout(debounceTimer);
@@ -407,15 +413,20 @@ export const useAgentBuilderIntegration = ({
         greetingMessage: WORKFLOW_EDITOR_GREETING,
         initialMessage: options?.initialMessage,
         autoSendInitialMessage: options?.autoSendInitialMessage,
-        attachments: [
-          buildWorkflowAttachment({
-            yaml: currentYaml,
-            attachmentId: syncAttachmentIdRef.current ?? attachmentId,
-            workflowId,
-            workflowName,
-            diagnostics: serializeClientDiagnostics(validationErrors),
-          }),
-        ],
+        // Left empty while a restored conversation is still loading; the
+        // active-conversation subscription adds the attachment once it knows
+        // which one this session shares.
+        attachments: attachmentTargetResolvedRef.current
+          ? [
+              buildWorkflowAttachment({
+                yaml: currentYaml,
+                attachmentId: syncAttachmentIdRef.current ?? attachmentId,
+                workflowId,
+                workflowName,
+                diagnostics: serializeClientDiagnostics(validationErrors),
+              }),
+            ]
+          : [],
         onClose: () => setSidebarOpen(false),
       });
       chatRefHandle.current = chatRef;

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
@@ -10,7 +10,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux-v7';
 import { v4 } from 'uuid';
-import { isConversationIdSetEvent } from '@kbn/agent-builder-common/chat/events';
 import type { monaco } from '@kbn/code-editor';
 import { i18n } from '@kbn/i18n';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
@@ -216,11 +215,11 @@ export const useAgentBuilderIntegration = ({
     }
 
     const bridge = new AttachmentBridge();
-    bridge.start(agentBuilder.events.chat$, manager, editorRef, tracker, {
+    bridge.start(manager, editorRef, tracker, {
+      activeConversation$: agentBuilder.events.ui.activeConversation$,
+      getChatEvents$: agentBuilder.events.getChatEvents$.bind(agentBuilder.events),
       attachmentId,
       workflowId,
-      getChatEvents$: agentBuilder.events.getChatEvents$?.bind(agentBuilder.events),
-      activeConversation$: agentBuilder.events.ui?.activeConversation$,
       onProposalReceived: ({ proposalId, toolId }) => {
         telemetry.reportAiProposalReceived({
           workflowId,
@@ -232,12 +231,6 @@ export const useAgentBuilderIntegration = ({
       },
     });
     attachmentBridgeRef.current = bridge;
-
-    const conversationIdSub = agentBuilder.events.chat$.subscribe((event) => {
-      if (isConversationIdSetEvent(event)) {
-        conversationIdRef.current = event.data.conversation_id;
-      }
-    });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__wfTestBridge = {
@@ -285,9 +278,10 @@ export const useAgentBuilderIntegration = ({
     attachmentTargetResolvedRef.current = !hasPersistedConversation(sessionId);
     let originLinkRequested = false;
 
-    // `conversation_id_set` only fires for newly created conversations, so a
-    // resumed one takes both its id and its attachment from here.
-    const activeConversationSub = agentBuilder.events.ui?.activeConversation$.subscribe(
+    // The chat UI publishes the conversation for every surface it renders, and
+    // mints the id before the first request, so this covers new and resumed
+    // conversations alike.
+    const activeConversationSub = agentBuilder.events.ui.activeConversation$.subscribe(
       (activeConversation) => {
         // `null` means no chat surface is bound, which says nothing about the
         // conversation the sidebar will restore.
@@ -368,8 +362,7 @@ export const useAgentBuilderIntegration = ({
         clearTimeout(debounceTimer);
       }
       modelListener?.dispose();
-      conversationIdSub.unsubscribe();
-      activeConversationSub?.unsubscribe();
+      activeConversationSub.unsubscribe();
       // Don't close the sidebar here — this runs on every deps change
       // (including the workflowId flip after Save). Close lives in the
       // unmount-only effect below.

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
@@ -19,12 +19,12 @@ import {
   AttachmentBridge,
   consumeSidebarRestoreFor,
   findLinkedWorkflowAttachment,
-  getCarriedAttachmentId,
   hasPersistedConversation,
   ProposalManager,
   setActiveProposalManager,
   setLastCreateAttachmentId,
   setSidebarOpen,
+  WORKFLOW_EDITOR_ATTACHMENT_ID,
 } from '../../../../features/ai_integration';
 import { ProposalTracker } from '../../../../features/ai_integration/proposal_tracker';
 import type { YamlValidationResult } from '../../../../features/validate_workflow_yaml/model/types';
@@ -94,10 +94,9 @@ export const useAgentBuilderIntegration = ({
   // onto the saved workflow across the first save.
   const sessionId = workflowId ?? unsavedWorkflowIdRef.current;
 
-  // Follows `sessionId` except right after the first save, where the
-  // conversation already holds the create session's attachment. Resolved during
-  // render because the editor syncs before the conversation loads.
-  const attachmentId = (workflowId ? getCarriedAttachmentId(workflowId) : undefined) ?? sessionId;
+  // Fixed, so saving a new workflow cannot move the attachment the conversation
+  // is already writing into.
+  const attachmentId = WORKFLOW_EDITOR_ATTACHMENT_ID;
 
   useEffect(() => {
     if (!agentBuilder || !hasShowPrivilege) {
@@ -306,7 +305,6 @@ export const useAgentBuilderIntegration = ({
           attachments: activeConversation.conversation?.attachments,
           attachmentId,
           workflowId,
-          carriedAttachmentId: workflowId ? getCarriedAttachmentId(workflowId) : undefined,
         });
         if (linked) {
           syncAttachmentIdRef.current = linked.id;

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
@@ -22,7 +22,7 @@ import {
   hasPersistedConversation,
   ProposalManager,
   setActiveProposalManager,
-  setLastCreateAttachmentId,
+  setLastCreateSessionId,
   setSidebarOpen,
   WORKFLOW_EDITOR_ATTACHMENT_ID,
 } from '../../../../features/ai_integration';
@@ -212,7 +212,7 @@ export const useAgentBuilderIntegration = ({
     // workflowId presence would race that consume after setWorkflow re-fires
     // this effect.
     if (!workflowId) {
-      setLastCreateAttachmentId(attachmentId);
+      setLastCreateSessionId(sessionId);
     }
 
     const bridge = new AttachmentBridge();

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_agent_builder_integration.ts
@@ -18,6 +18,9 @@ import { setAiAssisted } from '../../../../entities/workflows/store/workflow_det
 import {
   AttachmentBridge,
   consumeSidebarRestoreFor,
+  findLinkedWorkflowAttachmentId,
+  getCarriedAttachmentId,
+  needsOriginLink,
   ProposalManager,
   setActiveProposalManager,
   setLastCreateAttachmentId,
@@ -76,6 +79,7 @@ export const useAgentBuilderIntegration = ({
   const chatOpenedReportedRef = useRef(false);
   const sessionAutoOpenedRef = useRef(false);
   const conversationIdRef = useRef<string | undefined>(undefined);
+  const syncAttachmentIdRef = useRef<string | undefined>(undefined);
   const validationErrorsRef = useRef(validationErrors);
   validationErrorsRef.current = validationErrors;
   const chatRefHandle = useRef<{ close: () => void } | null>(null);
@@ -85,7 +89,17 @@ export const useAgentBuilderIntegration = ({
   workflowNameRef.current = workflowName;
   const [isChatAccessible, setIsChatAccessible] = useState(false);
 
-  const attachmentId = workflowId ?? unsavedWorkflowIdRef.current;
+  // Identifies the editor session. Drives the chat session tag, which
+  // `carryConversationToWorkflow` rewrites onto the saved workflow across the
+  // first save.
+  const sessionId = workflowId ?? unsavedWorkflowIdRef.current;
+
+  // Identifies the attachment the session writes into. It follows `sessionId`
+  // except right after the first save, where the conversation already holds the
+  // create session's attachment. Reusing that id keeps one attachment with a
+  // growing version list instead of adding a second one. Resolved during render
+  // because the editor pushes an attachment before the conversation loads.
+  const attachmentId = (workflowId ? getCarriedAttachmentId(workflowId) : undefined) ?? sessionId;
 
   useEffect(() => {
     if (!agentBuilder || !hasShowPrivilege) {
@@ -209,6 +223,7 @@ export const useAgentBuilderIntegration = ({
       attachmentId,
       workflowId,
       getChatEvents$: agentBuilder.events.getChatEvents$?.bind(agentBuilder.events),
+      activeConversation$: agentBuilder.events.ui?.activeConversation$,
       onProposalReceived: ({ proposalId, toolId }) => {
         telemetry.reportAiProposalReceived({
           workflowId,
@@ -243,7 +258,7 @@ export const useAgentBuilderIntegration = ({
     const buildAttachment = (yaml: string) =>
       buildWorkflowAttachment({
         yaml,
-        attachmentId,
+        attachmentId: syncAttachmentIdRef.current ?? attachmentId,
         workflowId,
         workflowName: workflowNameRef.current,
         diagnostics: serializeClientDiagnostics(validationErrorsRef.current),
@@ -257,14 +272,74 @@ export const useAgentBuilderIntegration = ({
     });
 
     const syncAttachment = (yaml: string) => {
+      if (!attachmentTargetResolved) return;
       const attachment = buildAttachment(yaml);
       agentBuilder.setChatConfig({
-        sessionTag: `workflow-editor:${attachmentId}`,
+        sessionTag: `workflow-editor:${sessionId}`,
         greetingMessage: WORKFLOW_EDITOR_GREETING,
         attachments: [attachment],
       });
       agentBuilder.addAttachment(attachment);
     };
+
+    // False while a bound conversation is still loading — see the subscription
+    // below.
+    let attachmentTargetResolved = true;
+
+    // The server only emits `conversation_id_set` for newly created
+    // conversations, so telemetry on a resumed conversation would otherwise
+    // report `conversationId: undefined`. The same subscription resolves the
+    // attachment this session shares with the conversation.
+    let originLinkRequested = false;
+    const activeConversationSub = agentBuilder.events.ui?.activeConversation$.subscribe(
+      (activeConversation) => {
+        if (activeConversation?.id) {
+          conversationIdRef.current = activeConversation.id;
+        }
+
+        // A bound conversation that has not loaded yet may already hold the
+        // attachment this session must write into. Syncing before it lands
+        // would add a second one, so hold the sync until it resolves.
+        const isLoading = Boolean(activeConversation?.id) && !activeConversation?.conversation;
+        if (isLoading) {
+          attachmentTargetResolved = false;
+          return;
+        }
+
+        const attachments = activeConversation?.conversation?.attachments;
+        const linkedId = findLinkedWorkflowAttachmentId({
+          attachments,
+          attachmentId,
+          workflowId,
+          carriedAttachmentId: workflowId ? getCarriedAttachmentId(workflowId) : undefined,
+        });
+        if (linkedId) {
+          syncAttachmentIdRef.current = linkedId;
+          bridge.setAttachmentId(linkedId);
+        }
+
+        if (!attachmentTargetResolved) {
+          attachmentTargetResolved = true;
+          const yaml = editorRef.current?.getModel()?.getValue();
+          if (yaml !== undefined) syncAttachment(yaml);
+        }
+
+        // The create session's attachment predates the workflow, so nothing has
+        // pointed it at one yet. Link it, otherwise the next session cannot
+        // find it and starts a second attachment.
+        if (!activeConversation?.id || !workflowId || !linkedId) return;
+        if (originLinkRequested) return;
+        if (!needsOriginLink({ attachments, attachmentId: linkedId, workflowId })) return;
+        originLinkRequested = true;
+        void agentBuilder
+          .updateAttachmentOrigin(activeConversation.id, linkedId, workflowId)
+          .catch(() => {
+            // Best-effort: the attachment still syncs, it just stays unlinked
+            // and the next session may add a second one.
+            originLinkRequested = false;
+          });
+      }
+    );
 
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
     let modelListener: monaco.IDisposable | null = null;
@@ -296,12 +371,14 @@ export const useAgentBuilderIntegration = ({
       chatOpenedReportedRef.current = false;
       sessionAutoOpenedRef.current = false;
       conversationIdRef.current = undefined;
+      syncAttachmentIdRef.current = undefined;
 
       if (debounceTimer) {
         clearTimeout(debounceTimer);
       }
       modelListener?.dispose();
       conversationIdSub.unsubscribe();
+      activeConversationSub?.unsubscribe();
       // Don't close the sidebar here — this runs on every deps change
       // (including the workflowId flip after Save). Close lives in the
       // unmount-only effect below.
@@ -324,6 +401,7 @@ export const useAgentBuilderIntegration = ({
     hasShowPrivilege,
     isChatAccessible,
     attachmentId,
+    sessionId,
     workflowId,
     telemetry,
     dispatch,
@@ -338,14 +416,14 @@ export const useAgentBuilderIntegration = ({
       const currentYaml = editorRef.current?.getModel()?.getValue() ?? '';
 
       const { chatRef } = agentBuilder.openChat({
-        sessionTag: `workflow-editor:${attachmentId}`,
+        sessionTag: `workflow-editor:${sessionId}`,
         greetingMessage: WORKFLOW_EDITOR_GREETING,
         initialMessage: options?.initialMessage,
         autoSendInitialMessage: options?.autoSendInitialMessage,
         attachments: [
           buildWorkflowAttachment({
             yaml: currentYaml,
-            attachmentId,
+            attachmentId: syncAttachmentIdRef.current ?? attachmentId,
             workflowId,
             workflowName,
             diagnostics: serializeClientDiagnostics(validationErrors),
@@ -372,6 +450,7 @@ export const useAgentBuilderIntegration = ({
       isChatAccessible,
       editorRef,
       attachmentId,
+      sessionId,
       workflowId,
       workflowName,
       validationErrors,
@@ -445,6 +524,10 @@ const buildWorkflowAttachment = ({
 }) => ({
   id: attachmentId,
   type: WORKFLOW_YAML_ATTACHMENT_TYPE,
+  // Links the attachment to the workflow it mirrors, so a later session can
+  // find it instead of adding a second one. A workflow being created has no id
+  // yet; `updateAttachmentOrigin` links its attachment after the first save.
+  ...(workflowId ? { origin: workflowId } : {}),
   data: {
     yaml,
     workflowId,

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/attachment_types/workflow_yaml_attachment.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/attachment_types/workflow_yaml_attachment.test.ts
@@ -7,12 +7,19 @@
 
 import { registerWorkflowYamlAttachment } from './workflow_yaml_attachment';
 import { platformCoreTools } from '@kbn/agent-builder-common/tools';
+import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 import { workflowTools } from '../../common/constants';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-server';
 
 type WorkflowsManagementApi = WorkflowsServerPluginSetup['management'];
+
+interface WorkflowYamlAttachmentData {
+  yaml: string;
+  workflowId?: string;
+  name?: string;
+}
 
 interface RegisteredAttachmentType {
   id: string;
@@ -25,6 +32,13 @@ interface RegisteredAttachmentType {
     origin: string,
     context: { spaceId: string }
   ) => Promise<{ yaml: string; workflowId: string; name: string } | undefined>;
+  isStale: (
+    attachment: VersionedAttachment<
+      typeof WORKFLOW_YAML_ATTACHMENT_TYPE,
+      WorkflowYamlAttachmentData
+    >,
+    context: { spaceId: string }
+  ) => Promise<boolean>;
   format: (
     attachment: {
       data: {
@@ -53,6 +67,28 @@ const registerAndCapture = (api: Partial<WorkflowsManagementApi> = {}) => {
   registerWorkflowYamlAttachment(mockAgentBuilder, api as WorkflowsManagementApi);
   return registeredType!;
 };
+
+const createWorkflowAttachment = (
+  yaml: string,
+  overrides: Partial<
+    VersionedAttachment<typeof WORKFLOW_YAML_ATTACHMENT_TYPE, WorkflowYamlAttachmentData>
+  > = {}
+): VersionedAttachment<typeof WORKFLOW_YAML_ATTACHMENT_TYPE, WorkflowYamlAttachmentData> => ({
+  id: 'attachment-1',
+  type: WORKFLOW_YAML_ATTACHMENT_TYPE,
+  origin: 'workflow-1',
+  origin_snapshot_at: '2025-01-01T00:00:00.000Z',
+  versions: [
+    {
+      version: 1,
+      data: { yaml },
+      created_at: '2025-01-01T00:00:00.000Z',
+      content_hash: 'hash',
+    },
+  ],
+  current_version: 1,
+  ...overrides,
+});
 
 describe('workflow_yaml_attachment', () => {
   describe('getTools', () => {
@@ -106,6 +142,60 @@ describe('workflow_yaml_attachment', () => {
       getWorkflow.mockResolvedValueOnce(undefined);
       await expect(type.resolve('missing', { spaceId: 'default' })).resolves.toBeUndefined();
       expect(getWorkflow).toHaveBeenCalledWith('missing', 'default');
+    });
+  });
+
+  describe('isStale', () => {
+    it('returns false before the workflow has changed', async () => {
+      const getWorkflow = jest.fn().mockResolvedValue({
+        id: 'workflow-1',
+        name: 'Workflow',
+        yaml: 'name: Workflow',
+        lastUpdatedAt: '2025-01-01T00:00:00.000Z',
+      });
+      const type = registerAndCapture({ getWorkflow });
+
+      await expect(
+        type.isStale(createWorkflowAttachment('name: Old workflow'), { spaceId: 'default' })
+      ).resolves.toBe(false);
+    });
+
+    it('returns false when only YAML formatting has changed', async () => {
+      const getWorkflow = jest.fn().mockResolvedValue({
+        id: 'workflow-1',
+        name: 'Workflow',
+        yaml: `# Current persisted workflow
+name: Workflow
+version: '1'
+steps: [{ type: console, name: first, with: { message: hello } }]`,
+        lastUpdatedAt: '2025-01-02T00:00:00.000Z',
+      });
+      const type = registerAndCapture({ getWorkflow });
+      const attachment = createWorkflowAttachment(`version: "1"
+name: Workflow
+steps:
+  - name: first
+    type: console
+    with:
+      message: hello`);
+
+      await expect(type.isStale(attachment, { spaceId: 'default' })).resolves.toBe(false);
+    });
+
+    it('returns true when the persisted workflow YAML has changed', async () => {
+      const getWorkflow = jest.fn().mockResolvedValue({
+        id: 'workflow-1',
+        name: 'Workflow',
+        yaml: 'name: Updated workflow',
+        lastUpdatedAt: '2025-01-02T00:00:00.000Z',
+      });
+      const type = registerAndCapture({ getWorkflow });
+
+      await expect(
+        type.isStale(createWorkflowAttachment('name: Original workflow'), {
+          spaceId: 'default',
+        })
+      ).resolves.toBe(true);
     });
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder_workflows/server/attachment_types/workflow_yaml_attachment.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_workflows/server/attachment_types/workflow_yaml_attachment.ts
@@ -9,11 +9,14 @@ import type {
   AttachmentFormatContext,
   AttachmentResolveContext,
 } from '@kbn/agent-builder-server/attachments';
+import { getLatestVersion, type VersionedAttachment } from '@kbn/agent-builder-common/attachments';
 import { z } from '@kbn/zod/v4';
 import { platformCoreTools } from '@kbn/agent-builder-common/tools';
 import { WORKFLOW_YAML_ATTACHMENT_TYPE } from '@kbn/workflows/common/constants';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-server';
+import { parseYamlToJSONWithoutValidation } from '@kbn/workflows-yaml';
+import deepEqual from 'fast-deep-equal';
 import { workflowTools } from '../../common/constants';
 
 type WorkflowsManagementApi = WorkflowsServerPluginSetup['management'];
@@ -37,6 +40,22 @@ const workflowYamlDataSchema = z.object({
 type WorkflowYamlData = z.infer<typeof workflowYamlDataSchema>;
 
 const workflowYamlOriginSchema = z.string().describe('The workflow ID to resolve');
+
+const areWorkflowYamlsEquivalent = (left: string, right: string): boolean => {
+  const parsedLeft = parseYamlToJSONWithoutValidation(left);
+  const parsedRight = parseYamlToJSONWithoutValidation(right);
+
+  if (
+    parsedLeft.success &&
+    parsedLeft.document.errors.length === 0 &&
+    parsedRight.success &&
+    parsedRight.document.errors.length === 0
+  ) {
+    return deepEqual(parsedLeft.json, parsedRight.json);
+  }
+
+  return left.trim() === right.trim();
+};
 
 const createWorkflowYamlAttachmentType = (api: WorkflowsManagementApi) => ({
   id: WORKFLOW_YAML_ATTACHMENT_TYPE,
@@ -62,6 +81,29 @@ const createWorkflowYamlAttachmentType = (api: WorkflowsManagementApi) => ({
     const workflow = await api.getWorkflow(origin, context.spaceId);
     if (!workflow) return undefined;
     return { yaml: workflow.yaml, workflowId: workflow.id, name: workflow.name };
+  },
+  isStale: async (
+    attachment: VersionedAttachment<typeof WORKFLOW_YAML_ATTACHMENT_TYPE, WorkflowYamlData>,
+    context: AttachmentResolveContext
+  ): Promise<boolean> => {
+    if (!attachment.origin || !attachment.origin_snapshot_at) {
+      return false;
+    }
+
+    const workflow = await api.getWorkflow(attachment.origin, context.spaceId);
+    if (
+      !workflow ||
+      Date.parse(workflow.lastUpdatedAt) <= Date.parse(attachment.origin_snapshot_at)
+    ) {
+      return false;
+    }
+
+    const latestVersion = getLatestVersion(attachment);
+    if (!latestVersion) {
+      return false;
+    }
+
+    return !areWorkflowYamlsEquivalent(workflow.yaml, latestVersion.data.yaml);
   },
   format: (attachment: { data: WorkflowYamlData }, context: AttachmentFormatContext) => {
     const { data } = attachment;


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/19002
Closes https://github.com/elastic/security-team/issues/18821

This PR fixes the link between the AI sidebar and the workflow YAML editor. It fixes three problems.

### Resumed conversations did not update the editor

`AttachmentBridge` started its subscription after the `conversation_id_set` event. The server emits this event only for a new conversation. A resumed conversation did not start the subscription. The diff appeared in chat, but the editor did not change.

The bridge now uses `activeConversation$`. The chat UI sets this value for new and resumed conversations. Proposal telemetry uses the same value and now reports the correct conversation ID.

| Before | After |
| --- | --- |
| <img src="https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260825/vuera4m3-before-no-changes-in-editor.png" width="450"> | <img src="https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260825/2uh0azzc-after-changes-in-editor.png" width="450"> |
| The agent answers in a resumed conversation. The editor shows no diff and no **Accept** action. | The same resumed conversation applies the diff. The editor shows the change with **Accept** / **Decline**. |


### A save could create a second attachment

The editor previously used the route ID as the attachment ID. A new workflow used a UUID. The saved workflow used its workflow ID. The first save changed the attachment ID and could create a second `workflow.yaml` attachment.

The editor now uses one fixed ID:

```ts
export const WORKFLOW_EDITOR_ATTACHMENT_ID = 'workflow-yaml-editor';
```

The chat session tag still uses the route ID. The create-to-save conversation handoff is unchanged.

The attachment `origin` identifies the owning workflow:

- The editor adds `origin: workflowId` for a saved workflow.
- `updateAttachmentOrigin` links a new attachment after the first save.
- Legacy attachments still resolve by `origin`.
- An attachment for `workflow-b` cannot match the editor for `workflow-a`.

The editor also waits for a restored conversation to load before it selects an attachment.

| Before | After |
| --- | --- |
| <img src="https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260825/acumk157-before-two-attachments.png" width="450"> | <img src="https://pub-6b50802d113345dea50c783e8280b53e.r2.dev/artifacts/20260825/orkptrho-after-one-versioned-attachment.png" width="450"> |
| The conversation holds two `workflow.yaml` attachments: one under the UUID and one under the workflow ID. | The conversation holds one `workflow.yaml` attachment with the fixed id `workflow-yaml-editor`, `origin`, and 7 versions. |


### Saved workflow changes are detected

The attachment contains a YAML snapshot. The `origin` field identifies the saved workflow, but it does not update the snapshot.

The `workflow.yaml` attachment now implements `isStale`:

- It first compares `lastUpdatedAt` with `origin_snapshot_at`.
- It parses and compares both YAML documents only when the saved workflow is newer.
- Comments, whitespace, quote style, and key order do not cause a stale result.
- A semantic YAML change causes Agent Builder to offer **Use updated versions**.

The stale check does not update Monaco or the attachment canvas. Local Monaco changes continue to update the attachment through the existing editor sync.

### Verification

Automated tests cover resumed conversations, the create-to-save handoff, legacy attachments, cross-workflow isolation, and stale YAML checks.

- 1503 editor and AI integration tests pass.
- 12 `workflow_yaml_attachment` tests pass.
- Scoped type checks, ESLint, and diff checks pass.

Manual tests on the local Kibana stack confirm:

- A semantic edit in a second tab shows the stale attachment callout.
- **Use updated versions** gives the agent the new YAML.
- A formatting-only edit does not show the callout.
- Three rounds across create, save, and reload keep one attachment with five versions.



<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->