### PR TITLE
[Discover] Change Point: Show a sparkline chart in the Summary column

### DIFF
--- a/src/platform/packages/shared/kbn-change-point-chart-viewer/index.ts
+++ b/src/platform/packages/shared/kbn-change-point-chart-viewer/index.ts
@@ -16,4 +16,13 @@ export {
 } from './src/utils/get_pvalue_impact';
 export type { PvalueImpactLevel } from './src/utils/get_pvalue_impact';
 export { ChangePointChartForRow } from './src/change_point_chart_for_row';
+export {
+  buildChangePointCards,
+  formatAnnotationTimestamp,
+  getCardForRow,
+  getChangePointRowTimestamp,
+  getEntityKey,
+  isChangePointTableRow,
+} from './src/utils/derive_change_point_cards';
+export type { ChangePointCardModel } from './src/utils/derive_change_point_cards';
 export type { ChangePointChartForRowProps } from './src/change_point_chart_for_row';

--- a/src/platform/packages/shared/kbn-change-point-chart-viewer/src/utils/derive_change_point_cards.test.ts
+++ b/src/platform/packages/shared/kbn-change-point-chart-viewer/src/utils/derive_change_point_cards.test.ts
@@ -12,6 +12,9 @@ import {
   buildChangePointCards,
   formatAnnotationTimestamp,
   getCardForRow,
+  getChangePointRowTimestamp,
+  getEntityKey,
+  isChangePointTableRow,
 } from './derive_change_point_cards';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -53,6 +56,63 @@ const COLUMNS_WITH_HOST = [
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('derive_change_point_cards', () => {
+  describe('getEntityKey', () => {
+    it('returns empty string when there are no entity columns', () => {
+      expect(getEntityKey({ host: 'a' }, [])).toBe('');
+    });
+
+    it('builds col=value keys joined by comma-space', () => {
+      expect(getEntityKey({ host: 'a' }, ['host'])).toBe('host=a');
+      expect(getEntityKey({ host: 'web-1', service: 'orders' }, ['host', 'service'])).toBe(
+        'host=web-1, service=orders'
+      );
+    });
+
+    it('serializes null as (null) to match Discover / card grouping', () => {
+      expect(getEntityKey({ host: null }, ['host'])).toBe('host=(null)');
+    });
+  });
+
+  describe('isChangePointTableRow', () => {
+    it('requires a non-empty type and a defined pvalue', () => {
+      expect(isChangePointTableRow({ type: 'mean_shift', pvalue: 0.01 }, 'type', 'pvalue')).toBe(
+        true
+      );
+      expect(isChangePointTableRow({ type: '', pvalue: 0.01 }, 'type', 'pvalue')).toBe(false);
+      expect(isChangePointTableRow({ type: 'mean_shift', pvalue: null }, 'type', 'pvalue')).toBe(
+        false
+      );
+    });
+  });
+
+  describe('getChangePointRowTimestamp', () => {
+    it('falls back to another date column when the ON column is null', () => {
+      const table = makeTable(
+        [
+          { id: 'bucket', name: 'bucket', meta: { type: 'date' as const } },
+          { id: 'other_date', name: 'other_date', meta: { type: 'date' as const } },
+          { id: 'avg_bytes', name: 'avg_bytes', meta: { type: 'number' as const } },
+          { id: 'type', name: 'type', meta: { type: 'string' as const } },
+          { id: 'pvalue', name: 'pvalue', meta: { type: 'number' as const } },
+        ],
+        []
+      );
+      const iso = getChangePointRowTimestamp(
+        {
+          bucket: null,
+          other_date: '2023-11-15T00:00:00.000Z',
+          avg_bytes: 14,
+          type: 'mean_shift',
+          pvalue: 0.001,
+        },
+        'bucket',
+        table,
+        new Set(['type', 'pvalue', 'avg_bytes'])
+      );
+      expect(iso).toBe('2023-11-15T00:00:00.000Z');
+    });
+  });
+
   describe('formatAnnotationTimestamp', () => {
     it('formats epoch ms as ISO', () => {
       const ms = Date.parse('2023-11-14T22:13:20.000Z');

--- a/src/platform/packages/shared/kbn-change-point-chart-viewer/src/utils/derive_change_point_cards.ts
+++ b/src/platform/packages/shared/kbn-change-point-chart-viewer/src/utils/derive_change_point_cards.ts
@@ -7,46 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Walker, Parser, isColumn } from '@elastic/esql';
-import type {
-  ESQLAstChangePointCommand,
-  ESQLCommandOption,
-  ESQLAstItem,
-} from '@elastic/esql/types';
 import {
   appendEntityFiltersToChangePointLineEsql,
   buildChangePointLineDataQuery,
+  getChangePointByColumns,
   getChangePointOutputColumnNames,
   getChangePointSeriesColumns,
 } from '@kbn/esql-utils';
-import { CommandNames } from '@kbn/esql-language';
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import { i18n } from '@kbn/i18n';
 import { CHANGE_POINT_TYPE_COLUMN, CHANGE_POINT_PVALUE_COLUMN } from '../constants';
 import { formatPvalueLabel } from './get_pvalue_impact';
-
-const isByOption = (a: ESQLAstItem): a is ESQLCommandOption =>
-  (a as { type?: string; name?: string }).type === 'option' &&
-  (a as { type?: string; name?: string }).name === 'by';
-
-const getChangePointByColumns = (esql?: string): string[] | undefined => {
-  if (!esql) return undefined;
-  try {
-    const { root } = Parser.parse(esql);
-    const changePointCommands = Walker.findAll(
-      root,
-      (node) => node.type === 'command' && node.name === CommandNames.CHANGE_POINT
-    );
-    const cp = changePointCommands[0] as ESQLAstChangePointCommand | undefined;
-    if (!cp) return undefined;
-    const byOption = cp.args.find(isByOption);
-    if (!byOption) return undefined;
-    const cols = byOption.args.filter(isColumn).map((c) => c.parts.join('.'));
-    return cols.length ? cols : undefined;
-  } catch {
-    return undefined;
-  }
-};
 
 export interface ChangePointCardModel {
   readonly id: string;
@@ -92,8 +63,20 @@ const serializeCell = (value: unknown): string => {
   return String(value);
 };
 
+/**
+ * Stable map key for which time series a row belongs to.
+ * Matches card grouping / `cp-card-${key}` ids (`col=value` joined by `, `). Empty when there is no BY.
+ */
+export const getEntityKey = (
+  row: Readonly<Record<string, unknown>>,
+  entityColumnIds: readonly string[]
+): string => {
+  if (entityColumnIds.length === 0) return '';
+  return entityColumnIds.map((id) => `${id}=${serializeCell(row[id])}`).join(', ');
+};
+
 const pickTimestampCell = (
-  row: Record<string, unknown>,
+  row: Readonly<Record<string, unknown>>,
   timeColumn: string,
   table: Datatable,
   reservedColumnIds: ReadonlySet<string>
@@ -132,9 +115,9 @@ export const formatAnnotationTimestamp = (value: unknown): string | undefined =>
   return undefined;
 };
 
-/** Change-point rows: non-empty type and a defined pvalue column. */
-const isChangePointTableRow = (
-  row: Record<string, unknown>,
+/** Change-point rows - non-empty type and a defined pvalue column. */
+export const isChangePointTableRow = (
+  row: Readonly<Record<string, unknown>>,
   typeColumnId: string,
   pvalueColumnId: string
 ): boolean => {
@@ -145,6 +128,15 @@ const isChangePointTableRow = (
   const p = row[pvalueColumnId];
   return p !== null && p !== undefined;
 };
+
+/** ISO timestamp for a row's change-point marker, with date-column fallback when ON is null. */
+export const getChangePointRowTimestamp = (
+  row: Readonly<Record<string, unknown>>,
+  timeColumn: string,
+  table: Datatable,
+  reservedColumnIds: ReadonlySet<string>
+): string | undefined =>
+  formatAnnotationTimestamp(pickTimestampCell(row, timeColumn, table, reservedColumnIds));
 
 /**
  * Builds a human-readable card title from entity columns and their values in the first row.
@@ -177,7 +169,7 @@ interface ChangePointCardsBuildContext {
   readonly pvalueColumnId: string;
   readonly timeColumn: string;
   /**
-   * Columns used to identify distinct entities. Comes from the explicit `BY` clause when present;
+   * Columns used to identify distinct entities. Comes from the explicit `BY` clause when present -
    * otherwise derived heuristically as the result columns that are not reserved (value, time,
    * type, pvalue).
    */
@@ -239,10 +231,7 @@ const getChangePointCardsBuildContext = (params: {
   const groups = new Map<string, { entityLabel: string; rows: ChangePointRow[] }>();
 
   for (const row of table.rows as ChangePointRow[]) {
-    const entityLabel =
-      entityColumnIds.length > 0
-        ? entityColumnIds.map((id: string) => `${id}=${serializeCell(row[id])}`).join(', ')
-        : '';
+    const entityLabel = getEntityKey(row, entityColumnIds);
     const existing = groups.get(entityLabel);
     if (existing) {
       existing.rows.push(row);
@@ -307,8 +296,7 @@ export const buildChangePointCards = (params: {
       // Track detection before the timestamp guard so that a change point with an unresolvable
       // timestamp (e.g. a null bucket at the edge of the time range) is still counted.
       hasDetectedChangePoint = true;
-      const timeCell = pickTimestampCell(row, timeColumn, table, timestampReservedIds);
-      const datetime = formatAnnotationTimestamp(timeCell);
+      const datetime = getChangePointRowTimestamp(row, timeColumn, table, timestampReservedIds);
       if (!datetime) continue;
 
       const label = isByMode
@@ -392,14 +380,14 @@ export const getCardForRow = (
     // actual change points (non-empty type + defined pvalue). All other rows (e.g. regular
     // time-series buckets without a detected change) should show an empty state.
     const { typeColumnId, pvalueColumnId } = firstCard;
-    if (!isChangePointTableRow(row as Record<string, unknown>, typeColumnId, pvalueColumnId)) {
+    if (!isChangePointTableRow(row, typeColumnId, pvalueColumnId)) {
       return undefined;
     }
     return firstCard;
   }
 
   const entityCols = Object.keys(firstCard.entityValues);
-  const entityLabel = entityCols.map((col) => `${col}=${serializeCell(row[col])}`).join(', ');
+  const entityLabel = getEntityKey(row, entityCols);
   const card = cards.find((c) => c.id === `cp-card-${entityLabel}`);
   if (!card) return undefined;
 
@@ -410,7 +398,7 @@ export const getCardForRow = (
     card.changePointTypes.length > 0 || card.minPvalue !== undefined;
   if (
     cardHasTypedChangePointRows &&
-    !isChangePointTableRow(row as Record<string, unknown>, card.typeColumnId, card.pvalueColumnId)
+    !isChangePointTableRow(row, card.typeColumnId, card.pvalueColumnId)
   ) {
     return undefined;
   }

--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -78,6 +78,7 @@ export {
   hasChangePointCommand,
   getChangePointOutputColumnNames,
   getChangePointSeriesColumns,
+  getChangePointByColumns,
   buildChangePointLineDataQuery,
   appendEntityFiltersToChangePointLineEsql,
   formatEsqlIdentifier,

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -37,6 +37,7 @@ export {
   hasChangePointCommand,
   getChangePointOutputColumnNames,
   getChangePointSeriesColumns,
+  getChangePointByColumns,
   buildChangePointLineDataQuery,
   appendEntityFiltersToChangePointLineEsql,
   formatEsqlIdentifier,

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/change_point_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/change_point_helpers.test.ts
@@ -10,6 +10,7 @@ import {
   hasChangePointCommand,
   getChangePointOutputColumnNames,
   getChangePointSeriesColumns,
+  getChangePointByColumns,
   buildChangePointLineDataQuery,
   appendEntityFiltersToChangePointLineEsql,
   formatEsqlIdentifier,
@@ -96,6 +97,30 @@ describe('getChangePointSeriesColumns', () => {
   ( WHERE referer == "http://a.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket )
 | WHERE type IS NOT NULL`;
     expect(getChangePointSeriesColumns(forkQuery)).toBeUndefined();
+  });
+});
+
+describe('getChangePointByColumns', () => {
+  it('returns undefined when there is no CHANGE_POINT BY', () => {
+    expect(getChangePointByColumns(undefined)).toBeUndefined();
+    expect(
+      getChangePointByColumns(
+        'FROM idx | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket'
+      )
+    ).toBeUndefined();
+  });
+
+  it('returns BY columns from the query', () => {
+    expect(
+      getChangePointByColumns(
+        'FROM idx | STATS avg_bytes = AVG(bytes) BY host, bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket BY host'
+      )
+    ).toEqual(['host']);
+    expect(
+      getChangePointByColumns(
+        'FROM idx | STATS avg_bytes = AVG(bytes) BY host, service, bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket BY host, service'
+      )
+    ).toEqual(['host', 'service']);
   });
 });
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/change_point_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/change_point_helpers.ts
@@ -6,12 +6,13 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { Parser, WrappingPrettyPrinter } from '@elastic/esql';
+import { Parser, WrappingPrettyPrinter, isColumn, isOptionNode } from '@elastic/esql';
 import { CommandNames } from '@kbn/esql-language';
 import type {
   ESQLAstChangePointCommand,
   ESQLAstQueryExpression,
   ESQLAstCommand,
+  ESQLCommandOption,
 } from '@elastic/esql/types';
 import { escapeStringValue } from './append_to_query/utils';
 import { sanitazeESQLInput } from './sanitaze_input';
@@ -75,6 +76,28 @@ export const getChangePointSeriesColumns = (
     const valueColumn = cp.value.parts.join('.');
     const timeColumn = cp.key?.parts?.length ? cp.key.parts.join('.') : '@timestamp';
     return { valueColumn, timeColumn };
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Column names from `CHANGE_POINT ... BY col[, col]` on the first top-level CHANGE_POINT command.
+ */
+export const getChangePointByColumns = (esql?: string): string[] | undefined => {
+  if (!esql) return undefined;
+  try {
+    const { root } = Parser.parse(esql);
+    const cp = root.commands.find((c) => c.name === CommandNames.CHANGE_POINT) as
+      | ESQLAstChangePointCommand
+      | undefined;
+    if (!cp) return undefined;
+    const byOption = cp.args.find((arg) => isOptionNode(arg) && arg.name === 'by') as
+      | ESQLCommandOption
+      | undefined;
+    if (!byOption) return undefined;
+    const cols = byOption.args.filter(isColumn).map((c) => c.parts.join('.'));
+    return cols.length ? cols : undefined;
   } catch {
     return undefined;
   }

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/build_esql_fetch_subscribe.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/build_esql_fetch_subscribe.test.ts
@@ -21,6 +21,7 @@ import { internalStateActions } from '../redux';
 import type { DiscoverAppState } from '../redux';
 import { dataViewAdHoc } from '../../../../__mocks__/data_view_complex';
 import type { DiscoverDataStateContainer } from '../discover_data_state_container';
+import { SOURCE_COLUMN } from '@kbn/unified-data-table';
 
 // Track resources from the last test for cleanup in afterEach
 let lastTestToolkit: InternalStateMockToolkit | undefined;
@@ -848,5 +849,140 @@ describe('buildEsqlFetchSubscribe', () => {
     });
 
     expect(replaceUrlState).toHaveBeenCalledTimes(0);
+  });
+
+  test('should show Summary when profile has it showing by default', async () => {
+    const { replaceUrlState, dataState, tabId } = await setupTest({
+      appState: { columns: ['field1', SOURCE_COLUMN, 'field2'] },
+    });
+    const documents$ = dataState.data$.documents$;
+
+    documents$.next({
+      fetchStatus: FetchStatus.PARTIAL,
+      result: [],
+      esqlQueryColumns: makeEsqlCols(['field1', 'field2', 'field3', 'field4', 'field5', 'field6']),
+      query: { esql: 'from the-data-view-title' },
+    });
+    expect(replaceUrlState).toHaveBeenCalledTimes(0);
+    replaceUrlState.mockClear();
+
+    documents$.next({
+      fetchStatus: FetchStatus.PARTIAL,
+      result: [],
+      esqlQueryColumns: makeEsqlCols(['field1', 'field3', 'field4', 'field5', 'field6', 'field7']),
+      query: { esql: 'from the-data-view-title | where field1 > 0' },
+    });
+
+    expect(replaceUrlState).toHaveBeenCalledTimes(1);
+    expect(replaceUrlState).toHaveBeenCalledWith({
+      tabId,
+      appState: { columns: ['field1', SOURCE_COLUMN] },
+    });
+  });
+
+  test('should not re-insert Summary after the user removed it', async () => {
+    const { replaceUrlState, dataState, tabId, toolkit } = await setupTest({
+      appState: { columns: ['field1', SOURCE_COLUMN, 'field2'] },
+    });
+    const documents$ = dataState.data$.documents$;
+
+    documents$.next({
+      fetchStatus: FetchStatus.PARTIAL,
+      result: [],
+      esqlQueryColumns: makeEsqlCols(['field1', 'field2', 'field3', 'field4', 'field5', 'field6']),
+      query: { esql: 'from the-data-view-title' },
+    });
+    expect(replaceUrlState).toHaveBeenCalledTimes(0);
+
+    toolkit.internalState.dispatch(
+      toolkit.injectCurrentTab(internalStateActions.updateAppState)({
+        appState: { columns: ['field1', 'field2'] },
+      })
+    );
+    replaceUrlState.mockClear();
+
+    documents$.next({
+      fetchStatus: FetchStatus.PARTIAL,
+      result: [],
+      esqlQueryColumns: makeEsqlCols(['field1', 'field3', 'field4', 'field5', 'field6', 'field7']),
+      query: { esql: 'from the-data-view-title | where field1 > 0' },
+    });
+
+    expect(replaceUrlState).toHaveBeenCalledTimes(1);
+    expect(replaceUrlState).toHaveBeenCalledWith({
+      tabId,
+      appState: { columns: ['field1'] },
+    });
+  });
+
+  test('should keep Summary when ES|QL default columns change', async () => {
+    const { replaceUrlState, dataState, tabId, toolkit } = await setupTest({
+      appState: { columns: ['field1', SOURCE_COLUMN, 'field2'] },
+    });
+    const documents$ = dataState.data$.documents$;
+
+    documents$.next(msgComplete);
+    replaceUrlState.mockClear();
+
+    toolkit.internalState.dispatch(
+      toolkit.injectCurrentTab(internalStateActions.updateAppState)({
+        appState: { columns: ['field1', SOURCE_COLUMN, 'field2'] },
+      })
+    );
+
+    documents$.next({
+      fetchStatus: FetchStatus.PARTIAL,
+      result: [
+        {
+          id: '1',
+          raw: { field1: 1 },
+          flattened: { field1: 1 },
+        } as unknown as DataTableRecord,
+      ],
+      query: { esql: 'from the-data-view-title | keep field1' },
+    });
+
+    expect(replaceUrlState).toHaveBeenCalledWith({
+      tabId,
+      appState: { columns: ['field1', SOURCE_COLUMN] },
+    });
+  });
+
+  test('should not carry Summary across a profile column reset', async () => {
+    const { replaceUrlState, dataState, tabId, toolkit } = await setupTest({
+      appState: { columns: ['field1', SOURCE_COLUMN, 'field2'] },
+    });
+    const documents$ = dataState.data$.documents$;
+
+    documents$.next(msgComplete);
+    replaceUrlState.mockClear();
+
+    toolkit.internalState.dispatch(
+      toolkit.injectCurrentTab(internalStateActions.updateAppState)({
+        appState: { columns: ['field1', SOURCE_COLUMN, 'field2'] },
+      })
+    );
+    toolkit.internalState.dispatch(
+      toolkit.injectCurrentTab(internalStateActions.setProfileAppStateDefaultFieldsToReset)({
+        fieldsToReset: 'all',
+      })
+    );
+
+    documents$.next({
+      fetchStatus: FetchStatus.PARTIAL,
+      result: [
+        {
+          id: '1',
+          raw: { field1: 1 },
+          flattened: { field1: 1 },
+        } as unknown as DataTableRecord,
+      ],
+      query: { esql: 'from the-data-view-title | keep field1' },
+    });
+
+    expect(replaceUrlState).toHaveBeenCalledWith({
+      tabId,
+      appState: { columns: ['field1'] },
+    });
   });
 });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/build_esql_fetch_subscribe.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/build_esql_fetch_subscribe.ts
@@ -9,12 +9,14 @@
 
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { getIndexPatternFromESQLQuery, hasTransformationalCommand } from '@kbn/esql-utils';
+import { SOURCE_COLUMN } from '@kbn/unified-data-table';
 import { isEqual } from 'lodash';
 import type { DataDocumentsMsg, SavedSearchData } from '../discover_data_state_container';
 import { FetchStatus } from '../../../types';
 import type { InternalStateStore, TabActionInjector, TabState } from '../redux';
 import { internalStateActions } from '../redux';
 import { getValidViewMode } from '../../utils/get_valid_view_mode';
+import { shouldResetProfileAppStateDefaultField } from './profile_app_state_defaults';
 
 const ESQL_MAX_NUM_OF_COLUMNS = 50;
 const ESQL_TABLE_VIEW_COLUMN_THRESHOLD = 5;
@@ -155,9 +157,14 @@ export const buildEsqlFetchSubscribe = ({
       indexPatternChanged || !isEqual(nextDefaultColumns, prevEsqlData.defaultColumns);
 
     const appStateColumns = getCurrentTab().appState.columns ?? [];
-    const nextSelectedColumns = appStateColumns.filter(
+    const stickSource = !shouldResetProfileAppStateDefaultField(
+      getCurrentTab().profileAppStateDefaults,
+      'columns'
+    );
+    const columnsFromResponse = appStateColumns.filter(
       (column) => responseColumns?.includes(column) ?? true
     );
+    const nextSelectedColumns = withStickySource(appStateColumns, columnsFromResponse, stickSource);
     const changeSelectedColumns = !isInitialFetch && !isEqual(nextSelectedColumns, appStateColumns);
 
     const { viewMode } = getCurrentTab().appState;
@@ -171,11 +178,12 @@ export const buildEsqlFetchSubscribe = ({
 
       // just change URL state if necessary
       if (changeDefaultColumns || changeSelectedColumns || changeViewMode) {
-        const nextColumns = changeDefaultColumns
-          ? nextDefaultColumns
-          : changeSelectedColumns
-          ? nextSelectedColumns
-          : undefined;
+        let nextColumns: string[] | undefined;
+        if (changeDefaultColumns) {
+          nextColumns = withStickySource(appStateColumns, nextDefaultColumns, stickSource);
+        } else if (changeSelectedColumns) {
+          nextColumns = nextSelectedColumns;
+        }
 
         const nextState = {
           ...(nextColumns && { columns: nextColumns }),
@@ -197,4 +205,31 @@ export const buildEsqlFetchSubscribe = ({
   };
 
   return { esqlFetchSubscribe, cleanupEsql };
+};
+
+/**
+ * Inserts Summary (`_source`) into the new ES|QL column list at its previous index
+ * when `stickSource` is true. Does not re-insert Summary if the user turned it off.
+ */
+const withStickySource = (
+  previousColumns: string[],
+  nextColumns: string[],
+  stickSource: boolean
+): string[] => {
+  if (!stickSource) {
+    return nextColumns;
+  }
+
+  const sourceIndex = previousColumns.indexOf(SOURCE_COLUMN);
+  if (sourceIndex === -1) {
+    return nextColumns;
+  }
+
+  const columnsWithoutSource = nextColumns.filter((column) => column !== SOURCE_COLUMN);
+  const insertAt = Math.min(sourceIndex, columnsWithoutSource.length);
+  return [
+    ...columnsWithoutSource.slice(0, insertAt),
+    SOURCE_COLUMN,
+    ...columnsWithoutSource.slice(insertAt),
+  ];
 };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/profile_app_state_defaults.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/profile_app_state_defaults.ts
@@ -152,7 +152,7 @@ const getDefaultState = (scopedProfilesManager: ScopedProfilesManager, dataView:
   return getDefaultAppState({ dataView });
 };
 
-const shouldResetProfileAppStateDefaultField = (
+export const shouldResetProfileAppStateDefaultField = (
   profileAppStateDefaults: TabState['profileAppStateDefaults'],
   field: ProfileAppStateDefaultField
 ) =>

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_cell.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_cell.test.tsx
@@ -219,19 +219,22 @@ describe('ChangePointSummaryCell', () => {
     expect(document.querySelector('.euiLoadingChart')).toBeInTheDocument();
   });
 
-  it('renders nothing when the shared series is in error', () => {
+  it('renders a compact error icon when the shared series is in error', () => {
     const table = makeTable([CHANGE_POINT_ROW]);
     renderCell({
       flattened: CHANGE_POINT_ROW,
       table,
       seriesState: {
         status: 'error',
-        error: new Error('failed'),
+        error: new Error('esql failed'),
         entityColumnIds: [],
         cards: buildChangePointCards({ table, esql: ESQL_NO_BY }),
       },
     });
 
+    expect(screen.getByTestId('changePointSummarySeriesError')).toBeInTheDocument();
+    expect(screen.getByText('Unable to load change point sparkline')).toBeInTheDocument();
+    expect(screen.queryByText('esql failed')).not.toBeInTheDocument();
     expect(screen.queryByTestId('changePointSummaryChartMock')).not.toBeInTheDocument();
     expect(document.querySelector('.euiLoadingChart')).not.toBeInTheDocument();
   });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_cell.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_cell.test.tsx
@@ -1,0 +1,318 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
+import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import { buildChangePointCards } from '@kbn/change-point-chart-viewer';
+import type { UnifiedChangePointGridProps } from '@kbn/change-point-chart-viewer';
+import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
+import { ChangePointSummaryCell } from './change_point_summary_cell';
+import type {
+  ChangePointChartSectionProps$,
+  ChangePointChartSectionSnapshot,
+} from './change_point_context';
+import type { ChangePointSummarySeriesState } from './change_point_summary_series';
+
+jest.mock('./change_point_summary_chart', () => ({
+  ChangePointSummaryChart: ({
+    points,
+    annotationTime,
+  }: {
+    points: Array<{ x: number; y: number }>;
+    annotationTime?: number;
+  }) => (
+    <div
+      data-test-subj="changePointSummaryChartMock"
+      data-points={points.length}
+      data-annotation={annotationTime ?? ''}
+    />
+  ),
+}));
+
+const mockUseChangePointSummarySeries = jest.fn();
+
+jest.mock('./change_point_summary_series', () => {
+  const actual = jest.requireActual('./change_point_summary_series');
+  return {
+    ...actual,
+    useChangePointSummarySeries: (...args: unknown[]) => mockUseChangePointSummarySeries(...args),
+  };
+});
+
+const ESQL_NO_BY =
+  'FROM idx | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket';
+
+const ESQL_WITH_HOST_BY =
+  'FROM idx | STATS avg_bytes = AVG(bytes) BY host, bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket BY host';
+
+const SERIES_ROW = {
+  bucket: '2023-11-14T00:00:00.000Z',
+  avg_bytes: 12,
+  type: '',
+  pvalue: null,
+};
+
+const CHANGE_POINT_ROW = {
+  bucket: '2023-11-15T00:00:00.000Z',
+  avg_bytes: 14,
+  type: 'mean_shift',
+  pvalue: 0.001,
+};
+
+const NO_BY_ROWS = [SERIES_ROW, CHANGE_POINT_ROW];
+
+const COLUMNS_NO_BY: Datatable['columns'] = [
+  { id: 'bucket', name: 'bucket', meta: { type: 'date' } },
+  { id: 'avg_bytes', name: 'avg_bytes', meta: { type: 'number' } },
+  { id: 'type', name: 'type', meta: { type: 'string' } },
+  { id: 'pvalue', name: 'pvalue', meta: { type: 'number' } },
+];
+
+const makeTable = (
+  rows: Datatable['rows'],
+  columns: Datatable['columns'] = COLUMNS_NO_BY
+): Datatable => ({
+  type: 'datatable',
+  columns,
+  rows,
+});
+
+describe('ChangePointSummaryCell', () => {
+  const charts = {
+    theme: { useChartsBaseTheme: () => ({}) },
+  } as unknown as ChartsPluginStart;
+
+  const setCellProps = jest.fn();
+
+  const seriesPoints = [
+    { x: Date.parse(SERIES_ROW.bucket), y: 12 },
+    { x: Date.parse(CHANGE_POINT_ROW.bucket), y: 14 },
+  ];
+
+  const gridProps = (flattened: Record<string, unknown>): DataGridCellValueElementProps =>
+    ({
+      row: { id: '1', raw: {}, flattened },
+      dataView: {},
+      columnId: '_source',
+      isDetails: false,
+      isExpanded: false,
+      fieldFormats: {},
+      closePopover: jest.fn(),
+      setCellProps,
+    } as unknown as DataGridCellValueElementProps);
+
+  const cellContext = (chartSectionProps$: ChangePointChartSectionProps$) => ({
+    chartSectionProps$,
+    typeColumnId: 'type',
+    pvalueColumnId: 'pvalue',
+  });
+
+  beforeEach(() => {
+    setCellProps.mockClear();
+    mockUseChangePointSummarySeries.mockClear();
+  });
+
+  const renderCell = ({
+    flattened,
+    table,
+    esql = ESQL_NO_BY,
+    seriesState,
+  }: {
+    flattened: Record<string, unknown>;
+    table: Datatable;
+    esql?: string;
+    seriesState?: ChangePointSummarySeriesState;
+  }) => {
+    mockUseChangePointSummarySeries.mockReturnValue(
+      seriesState ?? {
+        status: 'ready',
+        entityColumnIds: [],
+        timeColumn: 'bucket',
+        valueColumn: 'avg_bytes',
+        seriesByEntity: new Map([['', seriesPoints]]),
+        cards: buildChangePointCards({ table, esql }),
+      }
+    );
+
+    const fetchParams = {
+      table,
+      query: { esql },
+      dataView: { isTimeBased: () => false },
+      filters: [],
+      timeRange: { from: 'now-1d', to: 'now' },
+      searchSessionId: 's1',
+      lastReloadRequestTime: 1,
+    } as unknown as UnifiedChangePointGridProps['fetchParams'];
+
+    const chartSectionProps$ = new BehaviorSubject<ChangePointChartSectionSnapshot | undefined>({
+      fetchParams,
+      fetch$: new BehaviorSubject(undefined) as never,
+      services: { data: { search: { esql: jest.fn() } } } as never,
+      onBrushEnd: undefined,
+      onFilter: undefined,
+    });
+
+    return render(
+      <ChangePointSummaryCell
+        {...gridProps(flattened)}
+        context={cellContext(chartSectionProps$)}
+        charts={charts}
+      />
+    );
+  };
+
+  it('renders the sparkline for a change-point row', () => {
+    renderCell({ flattened: CHANGE_POINT_ROW, table: makeTable(NO_BY_ROWS) });
+
+    expect(setCellProps).not.toHaveBeenCalled();
+    const chart = screen.getByTestId('changePointSummaryChartMock');
+    expect(chart).toHaveAttribute('data-points', '2');
+    expect(chart).toHaveAttribute('data-annotation', String(Date.parse(CHANGE_POINT_ROW.bucket)));
+  });
+
+  it('does not subscribe to the series hook for a non-change-point row', () => {
+    renderCell({ flattened: SERIES_ROW, table: makeTable(NO_BY_ROWS) });
+
+    expect(mockUseChangePointSummarySeries).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('changePointSummaryChartMock')).not.toBeInTheDocument();
+  });
+
+  it('subscribes for every row when type and pvalue columns are absent from the table', () => {
+    const columns = COLUMNS_NO_BY.filter((c) => c.id !== 'type' && c.id !== 'pvalue');
+    renderCell({ flattened: SERIES_ROW, table: makeTable([SERIES_ROW], columns) });
+
+    expect(mockUseChangePointSummarySeries).toHaveBeenCalled();
+  });
+
+  it('renders nothing when the shared series is idle', () => {
+    renderCell({
+      flattened: CHANGE_POINT_ROW,
+      table: makeTable([CHANGE_POINT_ROW]),
+      seriesState: { status: 'idle' },
+    });
+
+    expect(screen.queryByTestId('changePointSummaryChartMock')).not.toBeInTheDocument();
+    expect(document.querySelector('.euiLoadingChart')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading indicator, not a chart, while the shared series is loading', () => {
+    const table = makeTable([CHANGE_POINT_ROW]);
+    renderCell({
+      flattened: CHANGE_POINT_ROW,
+      table,
+      seriesState: {
+        status: 'loading',
+        cards: buildChangePointCards({ table, esql: ESQL_NO_BY }),
+      },
+    });
+
+    expect(screen.queryByTestId('changePointSummaryChartMock')).not.toBeInTheDocument();
+    expect(document.querySelector('.euiLoadingChart')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the shared series is in error', () => {
+    const table = makeTable([CHANGE_POINT_ROW]);
+    renderCell({
+      flattened: CHANGE_POINT_ROW,
+      table,
+      seriesState: {
+        status: 'error',
+        error: new Error('failed'),
+        entityColumnIds: [],
+        cards: buildChangePointCards({ table, esql: ESQL_NO_BY }),
+      },
+    });
+
+    expect(screen.queryByTestId('changePointSummaryChartMock')).not.toBeInTheDocument();
+    expect(document.querySelector('.euiLoadingChart')).not.toBeInTheDocument();
+  });
+
+  it('looks up the BY entity series for the row', () => {
+    const row = { host: 'a', ...CHANGE_POINT_ROW };
+    const table = makeTable(
+      [row],
+      [{ id: 'host', name: 'host', meta: { type: 'string' } }, ...COLUMNS_NO_BY]
+    );
+    renderCell({
+      flattened: row,
+      table,
+      esql: ESQL_WITH_HOST_BY,
+      seriesState: {
+        status: 'ready',
+        entityColumnIds: ['host'],
+        timeColumn: 'bucket',
+        valueColumn: 'avg_bytes',
+        seriesByEntity: new Map([
+          ['host=a', seriesPoints],
+          ['host=b', [{ x: 1, y: 1 }]],
+        ]),
+        cards: buildChangePointCards({ table, esql: ESQL_WITH_HOST_BY }),
+      },
+    });
+
+    expect(screen.getByTestId('changePointSummaryChartMock')).toHaveAttribute('data-points', '2');
+  });
+
+  it('annotates using a fallback date column when the ON timestamp is null', () => {
+    const row = {
+      bucket: null,
+      other_date: '2023-11-16T00:00:00.000Z',
+      avg_bytes: 14,
+      type: 'mean_shift',
+      pvalue: 0.001,
+    };
+    const table = makeTable(
+      [row],
+      [
+        { id: 'bucket', name: 'bucket', meta: { type: 'date' } },
+        { id: 'other_date', name: 'other_date', meta: { type: 'date' } },
+        { id: 'avg_bytes', name: 'avg_bytes', meta: { type: 'number' } },
+        { id: 'type', name: 'type', meta: { type: 'string' } },
+        { id: 'pvalue', name: 'pvalue', meta: { type: 'number' } },
+      ]
+    );
+    renderCell({
+      flattened: row,
+      table,
+      seriesState: {
+        status: 'ready',
+        entityColumnIds: [],
+        timeColumn: 'bucket',
+        valueColumn: 'avg_bytes',
+        seriesByEntity: new Map([['', seriesPoints]]),
+        cards: buildChangePointCards({ table, esql: ESQL_NO_BY }),
+      },
+    });
+
+    expect(screen.getByTestId('changePointSummaryChartMock')).toHaveAttribute(
+      'data-annotation',
+      String(Date.parse(row.other_date))
+    );
+  });
+
+  it('does not subscribe when chart section props are not yet available', () => {
+    const chartSectionProps$ = new BehaviorSubject<ChangePointChartSectionSnapshot | undefined>(
+      undefined
+    );
+
+    render(
+      <ChangePointSummaryCell
+        {...gridProps(CHANGE_POINT_ROW)}
+        context={cellContext(chartSectionProps$)}
+        charts={charts}
+      />
+    );
+
+    expect(mockUseChangePointSummarySeries).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('changePointSummaryChartMock')).not.toBeInTheDocument();
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_cell.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_cell.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo } from 'react';
+import type { FC } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+import { EuiLoadingChart, mathWithUnits, useEuiTheme } from '@elastic/eui';
+import {
+  getCardForRow,
+  getChangePointRowTimestamp,
+  getEntityKey,
+  isChangePointTableRow,
+} from '@kbn/change-point-chart-viewer';
+import type { UnifiedChangePointGridProps } from '@kbn/change-point-chart-viewer';
+import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
+import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
+import { ChangePointSummaryChart } from './change_point_summary_chart';
+import type { ChangePointChartSectionProps$ } from './change_point_context';
+import { useChangePointSummarySeries } from './change_point_summary_series';
+
+export interface ChangePointSummaryCellContext {
+  chartSectionProps$: ChangePointChartSectionProps$;
+  typeColumnId: string;
+  pvalueColumnId: string;
+}
+
+interface ChangePointSummaryCellProps extends DataGridCellValueElementProps {
+  context: ChangePointSummaryCellContext;
+  charts: ChartsPluginStart;
+}
+
+const shouldRenderChangePointChart = (
+  row: Readonly<Record<string, unknown>>,
+  table: { columns: Array<{ id: string }> } | undefined,
+  typeColumnId: string,
+  pvalueColumnId: string
+): boolean => {
+  if (!table?.columns.length) return false;
+  const columnIds = new Set(table.columns.map((c) => c.id));
+  const hasTypedColumns = columnIds.has(typeColumnId) && columnIds.has(pvalueColumnId);
+  return hasTypedColumns ? isChangePointTableRow(row, typeColumnId, pvalueColumnId) : true;
+};
+
+interface ChangePointSummaryCellInnerProps {
+  row: DataGridCellValueElementProps['row'];
+  charts: ChartsPluginStart;
+  fetchParams: UnifiedChangePointGridProps['fetchParams'];
+  data: UnifiedChangePointGridProps['services']['data'];
+}
+
+/**
+ * Subscribes to the shared series snapshot. Mounted only for change-point rows.
+ */
+const ChangePointSummaryCellInner: FC<ChangePointSummaryCellInnerProps> = ({
+  row,
+  charts,
+  fetchParams,
+  data,
+}) => {
+  const seriesState = useChangePointSummarySeries(fetchParams, data);
+
+  const cards = seriesState.status === 'idle' ? undefined : seriesState.cards;
+  const card = useMemo(
+    () => (cards?.length ? getCardForRow(cards, row.flattened) : undefined),
+    [cards, row.flattened]
+  );
+
+  const annotationTime = useMemo(() => {
+    if (!card || seriesState.status !== 'ready' || !fetchParams.table) return undefined;
+    const iso = getChangePointRowTimestamp(
+      row.flattened,
+      seriesState.timeColumn,
+      fetchParams.table,
+      new Set([card.typeColumnId, card.pvalueColumnId, seriesState.valueColumn])
+    );
+    if (!iso) return undefined;
+    const ms = Date.parse(iso);
+    return Number.isNaN(ms) ? undefined : ms;
+  }, [card, fetchParams.table, row.flattened, seriesState]);
+
+  const points = useMemo(() => {
+    if (!card || seriesState.status !== 'ready') return undefined;
+    const entityKey = getEntityKey(row.flattened, seriesState.entityColumnIds);
+    return seriesState.seriesByEntity.get(entityKey);
+  }, [card, row.flattened, seriesState]);
+
+  if (seriesState.status === 'error' || seriesState.status === 'idle') {
+    return null;
+  }
+
+  if (seriesState.status === 'loading') {
+    if (cards !== undefined && !card) {
+      return null;
+    }
+    return <EuiLoadingChart size="m" />;
+  }
+
+  if (card && points && points.length > 0) {
+    return (
+      <ChangePointSummaryChart charts={charts} points={points} annotationTime={annotationTime} />
+    );
+  }
+
+  return null;
+};
+
+/**
+ * Summary-column cell: glanceable sparkline for this row's change point.
+ * Non-interactive; detail lives in the Overview flyout / top Lens charts.
+ */
+export const ChangePointSummaryCell: FC<ChangePointSummaryCellProps> = ({
+  row,
+  context,
+  charts,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const fallbackHeight = useMemo(
+    () => mathWithUnits(euiTheme.size.l, (l) => l * 2),
+    [euiTheme.size.l]
+  );
+
+  const chartSectionProps = useObservable(
+    context.chartSectionProps$,
+    context.chartSectionProps$.getValue()
+  );
+
+  const fetchParams = chartSectionProps?.fetchParams;
+  const showChart = shouldRenderChangePointChart(
+    row.flattened,
+    fetchParams?.table,
+    context.typeColumnId,
+    context.pvalueColumnId
+  );
+
+  return (
+    <div
+      css={{
+        width: '100%',
+        height: '100%',
+        minWidth: 0,
+        minHeight: fallbackHeight,
+        overflow: 'hidden',
+      }}
+    >
+      {showChart && fetchParams && chartSectionProps?.services.data ? (
+        <ChangePointSummaryCellInner
+          row={row}
+          charts={charts}
+          fetchParams={fetchParams}
+          data={chartSectionProps.services.data}
+        />
+      ) : null}
+    </div>
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_cell.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_cell.tsx
@@ -10,7 +10,14 @@
 import React, { useMemo } from 'react';
 import type { FC } from 'react';
 import useObservable from 'react-use/lib/useObservable';
-import { EuiLoadingChart, mathWithUnits, useEuiTheme } from '@elastic/eui';
+import {
+  EuiIcon,
+  EuiLoadingChart,
+  EuiScreenReaderOnly,
+  mathWithUnits,
+  useEuiTheme,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import {
   getCardForRow,
   getChangePointRowTimestamp,
@@ -54,6 +61,13 @@ interface ChangePointSummaryCellInnerProps {
   data: UnifiedChangePointGridProps['services']['data'];
 }
 
+const errorLabel = i18n.translate(
+  'discover.contextAwareness.changePointSummaryCell.seriesLoadErrorMessage',
+  {
+    defaultMessage: 'Unable to load change point sparkline',
+  }
+);
+
 /**
  * Subscribes to the shared series snapshot. Mounted only for change-point rows.
  */
@@ -90,8 +104,25 @@ const ChangePointSummaryCellInner: FC<ChangePointSummaryCellInnerProps> = ({
     return seriesState.seriesByEntity.get(entityKey);
   }, [card, row.flattened, seriesState]);
 
-  if (seriesState.status === 'error' || seriesState.status === 'idle') {
+  if (seriesState.status === 'idle') {
     return null;
+  }
+
+  if (seriesState.status === 'error') {
+    return (
+      <>
+        <EuiIcon
+          type="warning"
+          color="danger"
+          title={errorLabel}
+          aria-hidden
+          data-test-subj="changePointSummarySeriesError"
+        />
+        <EuiScreenReaderOnly>
+          <span>{errorLabel}</span>
+        </EuiScreenReaderOnly>
+      </>
+    );
   }
 
   if (seriesState.status === 'loading') {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_chart.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_chart.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getSparklineXDomain } from './change_point_summary_chart';
+
+describe('getSparklineXDomain', () => {
+  const points = [{ x: 1000 }, { x: 2000 }, { x: 3000 }];
+
+  it('returns undefined for an empty series', () => {
+    expect(getSparklineXDomain([])).toBeUndefined();
+  });
+
+  it('pads the domain so a marker at either end or outside the series is not clipped', () => {
+    const dataSpan = 3000 - 1000;
+
+    for (const annotation of [undefined, 500, 1000, 3000, 3500]) {
+      const domain = getSparklineXDomain(points, annotation)!;
+      const lo = annotation === undefined ? 1000 : Math.min(1000, annotation);
+      const hi = annotation === undefined ? 3000 : Math.max(3000, annotation);
+      expect(domain.min).toBeLessThan(lo);
+      expect(domain.max).toBeGreaterThan(hi);
+      expect(domain.max - domain.min).toBeGreaterThan(dataSpan);
+    }
+  });
+
+  it('produces a non-zero span for a single-point series', () => {
+    const domain = getSparklineXDomain([{ x: 1000 }], 1000)!;
+    expect(domain.max).toBeGreaterThan(domain.min);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_chart.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_chart.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FC } from 'react';
+import React, { memo, useMemo } from 'react';
+import type { PartialTheme } from '@elastic/charts';
+import {
+  AnnotationDomainType,
+  Chart,
+  LineAnnotation,
+  LineSeries,
+  ScaleType,
+  Settings,
+  Tooltip,
+  TooltipType,
+} from '@elastic/charts';
+import { useEuiTheme, EuiScreenReaderOnly } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
+import type { ChangePointSeriesPoint } from './change_point_summary_series';
+
+const miniChartTheme: PartialTheme = {
+  chartMargins: {
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+  },
+  chartPaddings: {
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+  },
+  background: {
+    color: 'transparent',
+  },
+};
+
+/**
+ * Widen the x-axis so a change-point marker at the start/end is not clipped
+ * (these sparklines use zero chart margins).
+ */
+export const getSparklineXDomain = (
+  points: Array<{ x: number }>,
+  annotationTime?: number
+): { min: number; max: number } | undefined => {
+  if (points.length === 0) return undefined;
+
+  let min = points[0].x;
+  let max = points[0].x;
+  for (let i = 1; i < points.length; i++) {
+    const x = points[i].x;
+    if (x < min) min = x;
+    if (x > max) max = x;
+  }
+
+  if (annotationTime !== undefined) {
+    if (annotationTime < min) min = annotationTime;
+    if (annotationTime > max) max = annotationTime;
+  }
+
+  const pad = Math.max((max - min) * 0.02, 1);
+  return { min: min - pad, max: max + pad };
+};
+
+export interface ChangePointSummaryChartProps {
+  charts: ChartsPluginStart;
+  points: ChangePointSeriesPoint[];
+  /** Epoch ms for this row's change point, when known. */
+  annotationTime?: number;
+}
+
+/** Tiny display-only sparkline: series + optional change-point marker. */
+const ChangePointSummaryChartComponent: FC<ChangePointSummaryChartProps> = ({
+  charts,
+  points,
+  annotationTime,
+}) => {
+  const chartBaseTheme = charts.theme.useChartsBaseTheme();
+  const sparklineOverrides = charts.theme.useSparklineOverrides();
+  const { euiTheme } = useEuiTheme();
+
+  const annotationData = useMemo(
+    () => (annotationTime !== undefined ? [{ dataValue: annotationTime }] : []),
+    [annotationTime]
+  );
+
+  const xDomain = useMemo(
+    () => getSparklineXDomain(points, annotationTime),
+    [points, annotationTime]
+  );
+
+  if (points.length === 0) {
+    return null;
+  }
+
+  const screenReaderSummary =
+    annotationTime !== undefined
+      ? i18n.translate(
+          'discover.contextAwareness.changePointSummaryChart.screenReaderSummaryWithMarker',
+          {
+            defaultMessage:
+              'Change point sparkline with {pointCount} {pointCount, plural, one {point} other {points}} and a change point marker.',
+            values: { pointCount: points.length },
+          }
+        )
+      : i18n.translate('discover.contextAwareness.changePointSummaryChart.screenReaderSummary', {
+          defaultMessage:
+            'Change point sparkline with {pointCount} {pointCount, plural, one {point} other {points}}.',
+          values: { pointCount: points.length },
+        });
+
+  return (
+    <div css={{ pointerEvents: 'none', width: '100%', height: '100%', minWidth: 0, minHeight: 0 }}>
+      <Chart>
+        <Tooltip type={TooltipType.None} />
+        <Settings
+          theme={[miniChartTheme, sparklineOverrides]}
+          baseTheme={chartBaseTheme}
+          showLegend={false}
+          locale={i18n.getLocale()}
+          xDomain={xDomain}
+        />
+        <LineSeries
+          id="changePointSummarySeries"
+          xScaleType={ScaleType.Time}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          data={points}
+          // Match Lens XY default series color in the main change-point view.
+          color={chartBaseTheme.colors.defaultVizColor}
+        />
+        {annotationData.length > 0 ? (
+          <LineAnnotation
+            id="changePointSummaryAnnotation"
+            hideTooltips
+            domainType={AnnotationDomainType.XDomain}
+            dataValues={annotationData}
+            style={{
+              line: {
+                strokeWidth: 1,
+                stroke: euiTheme.colors.danger,
+                opacity: 1,
+              },
+            }}
+          />
+        ) : null}
+      </Chart>
+      <EuiScreenReaderOnly>
+        <span>{screenReaderSummary}</span>
+      </EuiScreenReaderOnly>
+    </div>
+  );
+};
+
+export const ChangePointSummaryChart = memo(ChangePointSummaryChartComponent);

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_chart.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_chart.tsx
@@ -23,7 +23,7 @@ import {
 import { useEuiTheme, EuiScreenReaderOnly } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
-import type { ChangePointSeriesPoint } from './change_point_summary_series';
+import type { ChangePointSeriesPoint } from './change_point_summary_series_helpers';
 
 const miniChartTheme: PartialTheme = {
   chartMargins: {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.test.ts
@@ -23,6 +23,7 @@ import {
   partitionLineRows,
   type ChangePointSummarySeriesState,
 } from './change_point_summary_series';
+import { SPARKLINE_MAX_POINTS } from './downsample_sparkline_points';
 
 jest.mock('@kbn/data-plugin/public', () => {
   const actual = jest.requireActual('@kbn/data-plugin/public');
@@ -159,6 +160,24 @@ describe('change_point_summary_series pure helpers', () => {
       );
 
       expect(series.get('')).toEqual([{ x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 }]);
+    });
+
+    it('caps a long entity series at SPARKLINE_MAX_POINTS', () => {
+      const start = Date.parse('2023-01-01T00:00:00.000Z');
+      const rows = Array.from({ length: 500 }, (_, i) => ({
+        bucket: new Date(start + i * 60_000).toISOString(),
+        avg_bytes: i,
+      }));
+
+      const series = partitionLineRows(rows, 'bucket', 'avg_bytes', []);
+      const points = series.get('') ?? [];
+
+      expect(points).toHaveLength(SPARKLINE_MAX_POINTS);
+      expect(points[0]).toEqual({ x: start, y: 0 });
+      expect(points[points.length - 1]).toEqual({
+        x: start + 499 * 60_000,
+        y: 499,
+      });
     });
   });
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.test.ts
@@ -11,19 +11,13 @@ import type { Datatable } from '@kbn/expressions-plugin/common';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { getTime } from '@kbn/data-plugin/public';
 import type { UnifiedChangePointGridProps } from '@kbn/change-point-chart-viewer';
+import { ESQLVariableType } from '@kbn/esql-types';
 import {
-  appendDistinctEntityWhereToLineEsql,
   clearChangePointSummarySeriesCache,
-  ENTITY_WHERE_PREDICATE_CAP,
   getChangePointSummarySeries$,
-  getEarliestAnnotationTime,
-  getEntityColumnIds,
   getSeriesCacheKey,
-  getSummarySeriesTimeRange,
-  partitionLineRows,
   type ChangePointSummarySeriesState,
 } from './change_point_summary_series';
-import { SPARKLINE_MAX_POINTS } from './downsample_sparkline_points';
 
 jest.mock('@kbn/data-plugin/public', () => {
   const actual = jest.requireActual('@kbn/data-plugin/public');
@@ -62,156 +56,121 @@ const COLUMNS_WITH_HOST = [
   { id: 'pvalue', name: 'pvalue', meta: { type: 'number' as const } },
 ];
 
-describe('change_point_summary_series pure helpers', () => {
-  describe('getEntityColumnIds', () => {
-    it('returns BY columns that exist on the table', () => {
-      expect(getEntityColumnIds(ESQL_NO_BY, makeTable(COLUMNS_NO_BY, []))).toEqual([]);
-      expect(getEntityColumnIds(ESQL_WITH_HOST_BY, makeTable(COLUMNS_WITH_HOST, []))).toEqual([
-        'host',
-      ]);
-      expect(getEntityColumnIds(ESQL_WITH_HOST_BY, makeTable(COLUMNS_NO_BY, []))).toEqual([]);
+const NO_BY_ROW = {
+  bucket: '2023-11-15T00:00:00.000Z',
+  avg_bytes: 14,
+  type: 'mean_shift',
+  pvalue: 0.001,
+};
+
+const HOST_ROW = { host: 'a', ...NO_BY_ROW };
+
+const fixtures = {
+  noBy: {
+    esqlQuery: ESQL_NO_BY,
+    columns: COLUMNS_NO_BY,
+    rows: [NO_BY_ROW],
+    lineColumns: ['bucket', 'avg_bytes'],
+    lineValues: [['2023-11-15T00:00:00.000Z', 14]],
+  },
+  byHost: {
+    esqlQuery: ESQL_WITH_HOST_BY,
+    columns: COLUMNS_WITH_HOST,
+    rows: [HOST_ROW],
+    lineColumns: ['host', 'bucket', 'avg_bytes'],
+    lineValues: [
+      ['a', '2023-11-14T00:00:00.000Z', 12],
+      ['a', '2023-11-15T00:00:00.000Z', 14],
+    ],
+  },
+} as const;
+
+type LineSearchFixture = keyof typeof fixtures;
+
+const waitForTerminalState = (
+  fetchParams: ChangePointFetchParams,
+  data: DataPublicPluginStart
+): Promise<ChangePointSummarySeriesState> =>
+  new Promise((resolve, reject) => {
+    getChangePointSummarySeries$(fetchParams, data).subscribe({
+      next: (s) => {
+        if (s.status === 'ready' || s.status === 'error' || s.status === 'idle') {
+          resolve(s);
+        }
+      },
+      error: reject,
     });
   });
 
-  describe('getEarliestAnnotationTime / getSummarySeriesTimeRange', () => {
-    const inRangeTable = makeTable(COLUMNS_NO_BY, [
-      { bucket: '2023-11-14T00:00:00.000Z', avg_bytes: 12, type: '', pvalue: null },
-      { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14, type: 'mean_shift', pvalue: 0.001 },
-    ]);
+const setupLineSearch = ({
+  fixture = 'noBy',
+  esqlQuery,
+  columns,
+  rows,
+  lineColumns,
+  lineValues,
+  lineSearch = 'resolve',
+  lineError,
+  ...fetch
+}: {
+  fixture?: LineSearchFixture;
+  esqlQuery?: string;
+  columns?: Datatable['columns'];
+  rows?: Datatable['rows'];
+  lineColumns?: readonly string[];
+  lineValues?: unknown[][];
+  lineSearch?: 'resolve' | 'reject' | 'hang';
+  lineError?: Error;
+} & Omit<Partial<ChangePointFetchParams>, 'query' | 'table'> = {}) => {
+  const base = fixtures[fixture];
+  const resolvedQuery = esqlQuery ?? base.esqlQuery;
+  const resolvedColumns = columns ?? [...base.columns];
+  const resolvedRows = rows ?? [...base.rows];
+  const resolvedLineColumns = lineColumns ?? [...base.lineColumns];
+  const resolvedLineValues = lineValues ?? [...base.lineValues];
 
-    it('finds the earliest typed change-point annotation', () => {
-      expect(getEarliestAnnotationTime(inRangeTable, 'bucket', ESQL_NO_BY)).toBe(
-        Date.parse('2023-11-15T00:00:00.000Z')
-      );
+  let abortSignal: AbortSignal | undefined;
+  const esql = jest.fn();
+  if (lineSearch === 'reject') {
+    esql.mockRejectedValue(lineError ?? new Error('esql failed'));
+  } else if (lineSearch === 'hang') {
+    esql.mockImplementation((_query, opts: { abortSignal: AbortSignal }) => {
+      abortSignal = opts.abortSignal;
+      return new Promise(() => undefined);
     });
-
-    it('extends from when the annotation is before Discover from', () => {
-      const range = getSummarySeriesTimeRange(
-        { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
-        Date.parse('2023-11-10T00:00:00.000Z')
-      );
-      expect(range).toEqual({
-        from: '2023-11-10T00:00:00.000Z',
-        to: '2023-11-20T00:00:00.000Z',
-      });
+  } else {
+    esql.mockResolvedValue({
+      rawResponse: {
+        columns: resolvedLineColumns.map((name) => ({ name })),
+        values: resolvedLineValues,
+      },
     });
+  }
 
-    it('does not extend from when the annotation is inside the range', () => {
-      const timeRange = { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' };
-      expect(getSummarySeriesTimeRange(timeRange, Date.parse('2023-11-15T00:00:00.000Z'))).toEqual(
-        timeRange
-      );
-    });
-  });
+  const fetchParams: ChangePointFetchParams = {
+    searchSessionId: 'session-1',
+    lastReloadRequestTime: 1,
+    dataView: { isTimeBased: () => false } as never,
+    filters: [],
+    timeRange: { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
+    table: makeTable(resolvedColumns, resolvedRows),
+    query: { esql: resolvedQuery },
+    ...fetch,
+  } as ChangePointFetchParams;
+  const data = { search: { esql } } as unknown as DataPublicPluginStart;
 
-  describe('partitionLineRows', () => {
-    it('builds a single series with empty entity key when there is no BY', () => {
-      const series = partitionLineRows(
-        [
-          { bucket: '2023-11-14T00:00:00.000Z', avg_bytes: 12 },
-          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14 },
-        ],
-        'bucket',
-        'avg_bytes',
-        []
-      );
+  return {
+    esql,
+    get abortSignal() {
+      return abortSignal;
+    },
+    load: (fetchOverrides?: Partial<ChangePointFetchParams>) =>
+      waitForTerminalState({ ...fetchParams, ...fetchOverrides }, data),
+    subscribe: () => getChangePointSummarySeries$(fetchParams, data).subscribe(),
+  };
+};
 
-      expect([...series.keys()]).toEqual(['']);
-      expect(series.get('')).toEqual([
-        { x: Date.parse('2023-11-14T00:00:00.000Z'), y: 12 },
-        { x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 },
-      ]);
-    });
-
-    it('partitions and sorts points per entity key', () => {
-      const series = partitionLineRows(
-        [
-          { host: 'b', bucket: '2023-11-16T00:00:00.000Z', avg_bytes: 20 },
-          { host: 'a', bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14 },
-          { host: 'a', bucket: '2023-11-14T00:00:00.000Z', avg_bytes: 12 },
-          { host: 'b', bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 18 },
-        ],
-        'bucket',
-        'avg_bytes',
-        ['host']
-      );
-
-      expect(series.get('host=a')).toEqual([
-        { x: Date.parse('2023-11-14T00:00:00.000Z'), y: 12 },
-        { x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 },
-      ]);
-      expect(series.get('host=b')).toEqual([
-        { x: Date.parse('2023-11-15T00:00:00.000Z'), y: 18 },
-        { x: Date.parse('2023-11-16T00:00:00.000Z'), y: 20 },
-      ]);
-    });
-
-    it('skips rows with invalid time or non-numeric values', () => {
-      const series = partitionLineRows(
-        [
-          { bucket: 'not-a-date', avg_bytes: 12 },
-          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 'nope' },
-          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: null },
-          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14 },
-        ],
-        'bucket',
-        'avg_bytes',
-        []
-      );
-
-      expect(series.get('')).toEqual([{ x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 }]);
-    });
-
-    it('caps a long entity series at SPARKLINE_MAX_POINTS', () => {
-      const start = Date.parse('2023-01-01T00:00:00.000Z');
-      const rows = Array.from({ length: 500 }, (_, i) => ({
-        bucket: new Date(start + i * 60_000).toISOString(),
-        avg_bytes: i,
-      }));
-
-      const series = partitionLineRows(rows, 'bucket', 'avg_bytes', []);
-      const points = series.get('') ?? [];
-
-      expect(points).toHaveLength(SPARKLINE_MAX_POINTS);
-      expect(points[0]).toEqual({ x: start, y: 0 });
-      expect(points[points.length - 1]).toEqual({
-        x: start + 499 * 60_000,
-        y: 499,
-      });
-    });
-  });
-
-  describe('appendDistinctEntityWhereToLineEsql', () => {
-    const line = 'FROM idx | STATS avg_bytes = AVG(bytes) BY host, bucket';
-
-    it('appends OR predicates for distinct entity values', () => {
-      expect(
-        appendDistinctEntityWhereToLineEsql(
-          line,
-          [{ host: 'a' }, { host: 'a' }, { host: 'b' }],
-          ['host']
-        )
-      ).toBe(`${line} | WHERE host == "a" OR host == "b"`);
-    });
-
-    it('groups multi-column entities', () => {
-      expect(
-        appendDistinctEntityWhereToLineEsql(
-          line,
-          [{ host: 'a', service: 'orders' }],
-          ['host', 'service']
-        )
-      ).toBe(`${line} | WHERE (host == "a" AND service == "orders")`);
-    });
-
-    it('returns the original query when the distinct set exceeds the cap', () => {
-      const rows = Array.from({ length: ENTITY_WHERE_PREDICATE_CAP + 1 }, (_, i) => ({
-        host: `h${i}`,
-      }));
-      expect(appendDistinctEntityWhereToLineEsql(line, rows, ['host'])).toBe(line);
-    });
-  });
-
+describe('change_point_summary_series', () => {
   describe('getSeriesCacheKey', () => {
     it('changes when time range or filters change', () => {
       const table = makeTable(COLUMNS_NO_BY, []);
@@ -241,9 +200,20 @@ describe('change_point_summary_series pure helpers', () => {
       expect(
         getSeriesCacheKey({
           ...base,
-          esqlVariables: [{ key: 'env', value: 'prod', type: 'values' }],
+          esqlVariables: [{ key: 'env', value: 'prod', type: ESQLVariableType.VALUES }],
         })
       ).not.toBe(same);
+      expect(
+        getSeriesCacheKey({
+          ...base,
+          esqlVariables: [{ key: 'env', value: 'staging', type: ESQLVariableType.VALUES }],
+        })
+      ).not.toBe(
+        getSeriesCacheKey({
+          ...base,
+          esqlVariables: [{ key: 'env', value: 'prod', type: ESQLVariableType.VALUES }],
+        })
+      );
     });
   });
 
@@ -254,68 +224,20 @@ describe('change_point_summary_series pure helpers', () => {
       jest.mocked(getTime).mockReturnValue(undefined);
     });
 
-    const waitForTerminalState = (
-      fetchParams: ChangePointFetchParams,
-      data: DataPublicPluginStart
-    ): Promise<ChangePointSummarySeriesState> =>
-      new Promise((resolve, reject) => {
-        getChangePointSummarySeries$(fetchParams, data).subscribe({
-          next: (s) => {
-            if (s.status === 'ready' || s.status === 'error' || s.status === 'idle') {
-              resolve(s);
-            }
-          },
-          error: reject,
-        });
-      });
-
-    const makeFetchParams = (
-      overrides: Partial<ChangePointFetchParams> & {
-        table: Datatable;
-        query: { esql: string };
-      }
-    ): ChangePointFetchParams =>
-      ({
-        searchSessionId: 'session-1',
-        lastReloadRequestTime: 1,
-        dataView: { isTimeBased: () => false } as never,
-        filters: [],
-        timeRange: { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
-        ...overrides,
-      } as ChangePointFetchParams);
-
     it('stays idle when the table is missing', async () => {
-      const esql = jest.fn();
-      const data = { search: { esql } } as unknown as DataPublicPluginStart;
-      const idle = await waitForTerminalState(
-        makeFetchParams({
-          table: makeTable([], []),
-          query: { esql: ESQL_NO_BY },
-        }),
-        data
-      );
+      const { esql, load } = setupLineSearch({ columns: [], rows: [] });
+      const idle = await load();
 
       expect(idle.status).toBe('idle');
       expect(esql).not.toHaveBeenCalled();
     });
 
     it('emits error when the line search rejects', async () => {
-      const esql = jest.fn().mockRejectedValue(new Error('esql failed'));
-      const data = { search: { esql } } as unknown as DataPublicPluginStart;
-      const table = makeTable(COLUMNS_WITH_HOST, [
-        {
-          host: 'a',
-          bucket: '2023-11-15T00:00:00.000Z',
-          avg_bytes: 14,
-          type: 'mean_shift',
-          pvalue: 0.001,
-        },
-      ]);
-
-      const error = await waitForTerminalState(
-        makeFetchParams({ table, query: { esql: ESQL_WITH_HOST_BY } }),
-        data
-      );
+      const { load } = setupLineSearch({
+        fixture: 'byHost',
+        lineSearch: 'reject',
+      });
+      const error = await load();
 
       expect(error.status).toBe('error');
       if (error.status === 'error') {
@@ -324,29 +246,13 @@ describe('change_point_summary_series pure helpers', () => {
     });
 
     it('fetches a line series for in-range no-BY queries instead of using the Discover table', async () => {
-      const esql = jest.fn().mockResolvedValue({
-        rawResponse: {
-          columns: [{ name: 'bucket' }, { name: 'avg_bytes' }],
-          values: [
-            ['2023-11-14T00:00:00.000Z', 12],
-            ['2023-11-15T00:00:00.000Z', 14],
-          ],
-        },
+      const { esql, load } = setupLineSearch({
+        lineValues: [
+          ['2023-11-14T00:00:00.000Z', 12],
+          ['2023-11-15T00:00:00.000Z', 14],
+        ],
       });
-      const data = { search: { esql } } as unknown as DataPublicPluginStart;
-      const table = makeTable(COLUMNS_NO_BY, [
-        {
-          bucket: '2023-11-15T00:00:00.000Z',
-          avg_bytes: 14,
-          type: 'mean_shift',
-          pvalue: 0.001,
-        },
-      ]);
-
-      const ready = await waitForTerminalState(
-        makeFetchParams({ table, query: { esql: ESQL_NO_BY } }),
-        data
-      );
+      const ready = await load();
 
       expect(ready.status).toBe('ready');
       expect(esql).toHaveBeenCalledTimes(1);
@@ -359,63 +265,63 @@ describe('change_point_summary_series pure helpers', () => {
     });
 
     it('passes ?_tstart/?_tend named params so the line query can resolve Discover time parameters', async () => {
-      const esql = jest.fn().mockResolvedValue({
-        rawResponse: {
-          columns: [{ name: 'bucket' }, { name: 'avg_bytes' }],
-          values: [['2023-11-15T00:00:00.000Z', 14]],
-        },
+      const { esql, load } = setupLineSearch({
+        esqlQuery:
+          'FROM idx | WHERE @timestamp <= ?_tend AND @timestamp > ?_tstart | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket',
       });
-      const data = { search: { esql } } as unknown as DataPublicPluginStart;
-      const table = makeTable(COLUMNS_NO_BY, [
-        {
-          bucket: '2023-11-15T00:00:00.000Z',
-          avg_bytes: 14,
-          type: 'mean_shift',
-          pvalue: 0.001,
-        },
-      ]);
-      const esqlWithTimeParams =
-        'FROM idx | WHERE @timestamp <= ?_tend AND @timestamp > ?_tstart | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket';
-
-      const ready = await waitForTerminalState(
-        makeFetchParams({ table, query: { esql: esqlWithTimeParams } }),
-        data
-      );
+      const ready = await load();
 
       expect(ready.status).toBe('ready');
+      expect(getTime).toHaveBeenCalled();
       expect(esql).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.stringContaining('?_tend'),
-          params: expect.arrayContaining([{ _tstart: expect.any(String) }, { _tend: expect.any(String) }]),
+          params: expect.arrayContaining([
+            { _tstart: expect.any(String) },
+            { _tend: expect.any(String) },
+          ]),
         }),
         expect.anything()
       );
     });
 
-    it('fetches a line series with extended from when a no-BY annotation is before the range', async () => {
-      const esql = jest.fn().mockResolvedValue({
-        rawResponse: {
-          columns: [{ name: 'bucket' }, { name: 'avg_bytes' }],
-          values: [
-            ['2023-11-10T00:00:00.000Z', 10],
-            ['2023-11-15T00:00:00.000Z', 14],
-          ],
-        },
+    it('rewrites a single-? field control to ?? and passes it as a named param', async () => {
+      const { esql, load } = setupLineSearch({
+        esqlQuery:
+          'FROM idx | STATS avg_bytes = AVG(?metric) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket',
+        esqlVariables: [{ key: 'metric', value: 'bytes', type: ESQLVariableType.FIELDS }],
       });
-      const data = { search: { esql } } as unknown as DataPublicPluginStart;
-      const table = makeTable(COLUMNS_NO_BY, [
-        {
-          bucket: '2023-11-10T00:00:00.000Z',
-          avg_bytes: 14,
-          type: 'mean_shift',
-          pvalue: 0.001,
-        },
-      ]);
+      const ready = await load();
 
-      const ready = await waitForTerminalState(
-        makeFetchParams({ table, query: { esql: ESQL_NO_BY } }),
-        data
-      );
+      expect(ready.status).toBe('ready');
+      expect(esql.mock.calls[0][0].query).toContain('AVG(??metric)');
+      expect(esql.mock.calls[0][0].query).not.toContain('AVG(?metric)');
+      expect(esql.mock.calls[0][0].params).toEqual(expect.arrayContaining([{ metric: 'bytes' }]));
+    });
+
+    it('passes value-control named params without rewriting ?value to ??value', async () => {
+      const { esql, load } = setupLineSearch({
+        esqlQuery:
+          'FROM idx | WHERE host == ?env | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket',
+        esqlVariables: [{ key: 'env', value: 'prod', type: ESQLVariableType.VALUES }],
+      });
+      const ready = await load();
+
+      expect(ready.status).toBe('ready');
+      expect(esql.mock.calls[0][0].query).toContain('host == ?env');
+      expect(esql.mock.calls[0][0].query).not.toContain('??env');
+      expect(esql.mock.calls[0][0].params).toEqual(expect.arrayContaining([{ env: 'prod' }]));
+    });
+
+    it('fetches a line series with extended from when a no-BY annotation is before the range', async () => {
+      const { esql, load } = setupLineSearch({
+        rows: [{ ...NO_BY_ROW, bucket: '2023-11-10T00:00:00.000Z' }],
+        lineValues: [
+          ['2023-11-10T00:00:00.000Z', 10],
+          ['2023-11-15T00:00:00.000Z', 14],
+        ],
+      });
+      const ready = await load();
 
       expect(ready.status).toBe('ready');
       expect(esql).toHaveBeenCalledTimes(1);
@@ -431,34 +337,8 @@ describe('change_point_summary_series pure helpers', () => {
     });
 
     it('issues a single shared ES|QL line search for BY queries across subscribers', async () => {
-      const esql = jest.fn().mockResolvedValue({
-        rawResponse: {
-          columns: [{ name: 'host' }, { name: 'bucket' }, { name: 'avg_bytes' }],
-          values: [
-            ['a', '2023-11-14T00:00:00.000Z', 12],
-            ['a', '2023-11-15T00:00:00.000Z', 14],
-          ],
-        },
-      });
-      const data = { search: { esql } } as unknown as DataPublicPluginStart;
-      const table = makeTable(COLUMNS_WITH_HOST, [
-        {
-          host: 'a',
-          bucket: '2023-11-15T00:00:00.000Z',
-          avg_bytes: 14,
-          type: 'mean_shift',
-          pvalue: 0.001,
-        },
-      ]);
-      const fetchParams = makeFetchParams({
-        table,
-        query: { esql: ESQL_WITH_HOST_BY },
-      });
-
-      const readyStates = await Promise.all([
-        waitForTerminalState(fetchParams, data),
-        waitForTerminalState(fetchParams, data),
-      ]);
+      const { esql, load } = setupLineSearch({ fixture: 'byHost' });
+      const readyStates = await Promise.all([load(), load()]);
 
       expect(esql).toHaveBeenCalledTimes(1);
       expect(esql.mock.calls[0][0].query).toContain('STATS avg_bytes');
@@ -478,74 +358,48 @@ describe('change_point_summary_series pure helpers', () => {
     });
 
     it('does not reuse a cached series when the time range changes', async () => {
-      const esql = jest.fn().mockResolvedValue({
-        rawResponse: { columns: [{ name: 'bucket' }, { name: 'avg_bytes' }], values: [] },
-      });
-      const data = { search: { esql } } as unknown as DataPublicPluginStart;
-      const table = makeTable(COLUMNS_WITH_HOST, [
-        {
-          host: 'a',
-          bucket: '2023-11-15T00:00:00.000Z',
-          avg_bytes: 14,
-          type: 'mean_shift',
-          pvalue: 0.001,
-        },
-      ]);
+      const { esql, load } = setupLineSearch({ fixture: 'byHost', lineValues: [] });
 
-      await waitForTerminalState(
-        makeFetchParams({
-          table,
-          query: { esql: ESQL_WITH_HOST_BY },
-          timeRange: { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
-        }),
-        data
-      );
-      await waitForTerminalState(
-        makeFetchParams({
-          table,
-          query: { esql: ESQL_WITH_HOST_BY },
-          timeRange: { from: '2023-11-01T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
-        }),
-        data
-      );
+      await load();
+      await load({
+        timeRange: { from: '2023-11-01T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
+      });
+
+      expect(esql).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not reuse a cached series when ES|QL variable values change', async () => {
+      const { esql, load } = setupLineSearch({
+        esqlQuery:
+          'FROM idx | WHERE host == ?env | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket',
+        lineValues: [],
+        esqlVariables: [{ key: 'env', value: 'prod', type: ESQLVariableType.VALUES }],
+      });
+
+      await load();
+      await load({
+        esqlVariables: [{ key: 'env', value: 'staging', type: ESQLVariableType.VALUES }],
+      });
 
       expect(esql).toHaveBeenCalledTimes(2);
     });
 
     it('aborts an in-flight line search when the last subscriber unsubscribes', async () => {
-      let abortSignal: AbortSignal | undefined;
-      const esql = jest.fn().mockImplementation((_query, opts: { abortSignal: AbortSignal }) => {
-        abortSignal = opts.abortSignal;
-        return new Promise(() => undefined);
-      });
-      const data = { search: { esql } } as unknown as DataPublicPluginStart;
-      const table = makeTable(COLUMNS_WITH_HOST, [
-        {
-          host: 'a',
-          bucket: '2023-11-15T00:00:00.000Z',
-          avg_bytes: 14,
-          type: 'mean_shift',
-          pvalue: 0.001,
-        },
-      ]);
-      const fetchParams = makeFetchParams({
-        table,
-        query: { esql: ESQL_WITH_HOST_BY },
-      });
+      const harness = setupLineSearch({ fixture: 'byHost', lineSearch: 'hang' });
 
-      const subscription = getChangePointSummarySeries$(fetchParams, data).subscribe();
+      const subscription = harness.subscribe();
       await Promise.resolve();
       await Promise.resolve();
-      expect(esql).toHaveBeenCalled();
-      expect(abortSignal?.aborted).toBe(false);
+      expect(harness.esql).toHaveBeenCalled();
+      expect(harness.abortSignal?.aborted).toBe(false);
 
       subscription.unsubscribe();
-      expect(abortSignal?.aborted).toBe(true);
+      expect(harness.abortSignal?.aborted).toBe(true);
 
-      getChangePointSummarySeries$(fetchParams, data).subscribe();
+      harness.subscribe();
       await Promise.resolve();
       await Promise.resolve();
-      expect(esql).toHaveBeenCalledTimes(2);
+      expect(harness.esql).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.test.ts
@@ -238,6 +238,12 @@ describe('change_point_summary_series pure helpers', () => {
           filters: [{ meta: { key: 'host' } }] as never,
         })
       ).not.toBe(same);
+      expect(
+        getSeriesCacheKey({
+          ...base,
+          esqlVariables: [{ key: 'env', value: 'prod', type: 'values' }],
+        })
+      ).not.toBe(same);
     });
   });
 
@@ -350,6 +356,40 @@ describe('change_point_summary_series pure helpers', () => {
         expect(ready.seriesByEntity.get('')).toHaveLength(2);
         expect(ready.cards).toHaveLength(1);
       }
+    });
+
+    it('passes ?_tstart/?_tend named params so the line query can resolve Discover time parameters', async () => {
+      const esql = jest.fn().mockResolvedValue({
+        rawResponse: {
+          columns: [{ name: 'bucket' }, { name: 'avg_bytes' }],
+          values: [['2023-11-15T00:00:00.000Z', 14]],
+        },
+      });
+      const data = { search: { esql } } as unknown as DataPublicPluginStart;
+      const table = makeTable(COLUMNS_NO_BY, [
+        {
+          bucket: '2023-11-15T00:00:00.000Z',
+          avg_bytes: 14,
+          type: 'mean_shift',
+          pvalue: 0.001,
+        },
+      ]);
+      const esqlWithTimeParams =
+        'FROM idx | WHERE @timestamp <= ?_tend AND @timestamp > ?_tstart | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket';
+
+      const ready = await waitForTerminalState(
+        makeFetchParams({ table, query: { esql: esqlWithTimeParams } }),
+        data
+      );
+
+      expect(ready.status).toBe('ready');
+      expect(esql).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.stringContaining('?_tend'),
+          params: expect.arrayContaining([{ _tstart: expect.any(String) }, { _tend: expect.any(String) }]),
+        }),
+        expect.anything()
+      );
     });
 
     it('fetches a line series with extended from when a no-BY annotation is before the range', async () => {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.test.ts
@@ -1,0 +1,492 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { getTime } from '@kbn/data-plugin/public';
+import type { UnifiedChangePointGridProps } from '@kbn/change-point-chart-viewer';
+import {
+  appendDistinctEntityWhereToLineEsql,
+  clearChangePointSummarySeriesCache,
+  ENTITY_WHERE_PREDICATE_CAP,
+  getChangePointSummarySeries$,
+  getEarliestAnnotationTime,
+  getEntityColumnIds,
+  getSeriesCacheKey,
+  getSummarySeriesTimeRange,
+  partitionLineRows,
+  type ChangePointSummarySeriesState,
+} from './change_point_summary_series';
+
+jest.mock('@kbn/data-plugin/public', () => {
+  const actual = jest.requireActual('@kbn/data-plugin/public');
+  return {
+    ...actual,
+    getTime: jest.fn(() => undefined),
+  };
+});
+
+type ChangePointFetchParams = UnifiedChangePointGridProps['fetchParams'];
+
+const makeTable = (columns: Datatable['columns'], rows: Datatable['rows']): Datatable => ({
+  type: 'datatable',
+  columns,
+  rows,
+});
+
+const ESQL_NO_BY =
+  'FROM idx | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket';
+
+const ESQL_WITH_HOST_BY =
+  'FROM idx | STATS avg_bytes = AVG(bytes) BY host, bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket BY host';
+
+const COLUMNS_NO_BY = [
+  { id: 'bucket', name: 'bucket', meta: { type: 'date' as const } },
+  { id: 'avg_bytes', name: 'avg_bytes', meta: { type: 'number' as const } },
+  { id: 'type', name: 'type', meta: { type: 'string' as const } },
+  { id: 'pvalue', name: 'pvalue', meta: { type: 'number' as const } },
+];
+
+const COLUMNS_WITH_HOST = [
+  { id: 'host', name: 'host', meta: { type: 'string' as const } },
+  { id: 'bucket', name: 'bucket', meta: { type: 'date' as const } },
+  { id: 'avg_bytes', name: 'avg_bytes', meta: { type: 'number' as const } },
+  { id: 'type', name: 'type', meta: { type: 'string' as const } },
+  { id: 'pvalue', name: 'pvalue', meta: { type: 'number' as const } },
+];
+
+describe('change_point_summary_series pure helpers', () => {
+  describe('getEntityColumnIds', () => {
+    it('returns BY columns that exist on the table', () => {
+      expect(getEntityColumnIds(ESQL_NO_BY, makeTable(COLUMNS_NO_BY, []))).toEqual([]);
+      expect(getEntityColumnIds(ESQL_WITH_HOST_BY, makeTable(COLUMNS_WITH_HOST, []))).toEqual([
+        'host',
+      ]);
+      expect(getEntityColumnIds(ESQL_WITH_HOST_BY, makeTable(COLUMNS_NO_BY, []))).toEqual([]);
+    });
+  });
+
+  describe('getEarliestAnnotationTime / getSummarySeriesTimeRange', () => {
+    const inRangeTable = makeTable(COLUMNS_NO_BY, [
+      { bucket: '2023-11-14T00:00:00.000Z', avg_bytes: 12, type: '', pvalue: null },
+      { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14, type: 'mean_shift', pvalue: 0.001 },
+    ]);
+
+    it('finds the earliest typed change-point annotation', () => {
+      expect(getEarliestAnnotationTime(inRangeTable, 'bucket', ESQL_NO_BY)).toBe(
+        Date.parse('2023-11-15T00:00:00.000Z')
+      );
+    });
+
+    it('extends from when the annotation is before Discover from', () => {
+      const range = getSummarySeriesTimeRange(
+        { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
+        Date.parse('2023-11-10T00:00:00.000Z')
+      );
+      expect(range).toEqual({
+        from: '2023-11-10T00:00:00.000Z',
+        to: '2023-11-20T00:00:00.000Z',
+      });
+    });
+
+    it('does not extend from when the annotation is inside the range', () => {
+      const timeRange = { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' };
+      expect(getSummarySeriesTimeRange(timeRange, Date.parse('2023-11-15T00:00:00.000Z'))).toEqual(
+        timeRange
+      );
+    });
+  });
+
+  describe('partitionLineRows', () => {
+    it('builds a single series with empty entity key when there is no BY', () => {
+      const series = partitionLineRows(
+        [
+          { bucket: '2023-11-14T00:00:00.000Z', avg_bytes: 12 },
+          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14 },
+        ],
+        'bucket',
+        'avg_bytes',
+        []
+      );
+
+      expect([...series.keys()]).toEqual(['']);
+      expect(series.get('')).toEqual([
+        { x: Date.parse('2023-11-14T00:00:00.000Z'), y: 12 },
+        { x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 },
+      ]);
+    });
+
+    it('partitions and sorts points per entity key', () => {
+      const series = partitionLineRows(
+        [
+          { host: 'b', bucket: '2023-11-16T00:00:00.000Z', avg_bytes: 20 },
+          { host: 'a', bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14 },
+          { host: 'a', bucket: '2023-11-14T00:00:00.000Z', avg_bytes: 12 },
+          { host: 'b', bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 18 },
+        ],
+        'bucket',
+        'avg_bytes',
+        ['host']
+      );
+
+      expect(series.get('host=a')).toEqual([
+        { x: Date.parse('2023-11-14T00:00:00.000Z'), y: 12 },
+        { x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 },
+      ]);
+      expect(series.get('host=b')).toEqual([
+        { x: Date.parse('2023-11-15T00:00:00.000Z'), y: 18 },
+        { x: Date.parse('2023-11-16T00:00:00.000Z'), y: 20 },
+      ]);
+    });
+
+    it('skips rows with invalid time or non-numeric values', () => {
+      const series = partitionLineRows(
+        [
+          { bucket: 'not-a-date', avg_bytes: 12 },
+          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 'nope' },
+          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: null },
+          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14 },
+        ],
+        'bucket',
+        'avg_bytes',
+        []
+      );
+
+      expect(series.get('')).toEqual([{ x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 }]);
+    });
+  });
+
+  describe('appendDistinctEntityWhereToLineEsql', () => {
+    const line = 'FROM idx | STATS avg_bytes = AVG(bytes) BY host, bucket';
+
+    it('appends OR predicates for distinct entity values', () => {
+      expect(
+        appendDistinctEntityWhereToLineEsql(
+          line,
+          [{ host: 'a' }, { host: 'a' }, { host: 'b' }],
+          ['host']
+        )
+      ).toBe(`${line} | WHERE host == "a" OR host == "b"`);
+    });
+
+    it('groups multi-column entities', () => {
+      expect(
+        appendDistinctEntityWhereToLineEsql(
+          line,
+          [{ host: 'a', service: 'orders' }],
+          ['host', 'service']
+        )
+      ).toBe(`${line} | WHERE (host == "a" AND service == "orders")`);
+    });
+
+    it('returns the original query when the distinct set exceeds the cap', () => {
+      const rows = Array.from({ length: ENTITY_WHERE_PREDICATE_CAP + 1 }, (_, i) => ({
+        host: `h${i}`,
+      }));
+      expect(appendDistinctEntityWhereToLineEsql(line, rows, ['host'])).toBe(line);
+    });
+  });
+
+  describe('getSeriesCacheKey', () => {
+    it('changes when time range or filters change', () => {
+      const table = makeTable(COLUMNS_NO_BY, []);
+      const base = {
+        searchSessionId: 's',
+        lastReloadRequestTime: 1,
+        query: { esql: ESQL_NO_BY },
+        table,
+        filters: [],
+        timeRange: { from: 'now-1d', to: 'now' },
+      } as unknown as ChangePointFetchParams;
+
+      const same = getSeriesCacheKey(base);
+      expect(getSeriesCacheKey({ ...base })).toBe(same);
+      expect(
+        getSeriesCacheKey({
+          ...base,
+          timeRange: { from: 'now-2d', to: 'now' },
+        })
+      ).not.toBe(same);
+      expect(
+        getSeriesCacheKey({
+          ...base,
+          filters: [{ meta: { key: 'host' } }] as never,
+        })
+      ).not.toBe(same);
+    });
+  });
+
+  describe('getChangePointSummarySeries$', () => {
+    beforeEach(() => {
+      clearChangePointSummarySeriesCache();
+      jest.mocked(getTime).mockClear();
+      jest.mocked(getTime).mockReturnValue(undefined);
+    });
+
+    const waitForTerminalState = (
+      fetchParams: ChangePointFetchParams,
+      data: DataPublicPluginStart
+    ): Promise<ChangePointSummarySeriesState> =>
+      new Promise((resolve, reject) => {
+        getChangePointSummarySeries$(fetchParams, data).subscribe({
+          next: (s) => {
+            if (s.status === 'ready' || s.status === 'error' || s.status === 'idle') {
+              resolve(s);
+            }
+          },
+          error: reject,
+        });
+      });
+
+    const makeFetchParams = (
+      overrides: Partial<ChangePointFetchParams> & {
+        table: Datatable;
+        query: { esql: string };
+      }
+    ): ChangePointFetchParams =>
+      ({
+        searchSessionId: 'session-1',
+        lastReloadRequestTime: 1,
+        dataView: { isTimeBased: () => false } as never,
+        filters: [],
+        timeRange: { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
+        ...overrides,
+      } as ChangePointFetchParams);
+
+    it('stays idle when the table is missing', async () => {
+      const esql = jest.fn();
+      const data = { search: { esql } } as unknown as DataPublicPluginStart;
+      const idle = await waitForTerminalState(
+        makeFetchParams({
+          table: makeTable([], []),
+          query: { esql: ESQL_NO_BY },
+        }),
+        data
+      );
+
+      expect(idle.status).toBe('idle');
+      expect(esql).not.toHaveBeenCalled();
+    });
+
+    it('emits error when the line search rejects', async () => {
+      const esql = jest.fn().mockRejectedValue(new Error('esql failed'));
+      const data = { search: { esql } } as unknown as DataPublicPluginStart;
+      const table = makeTable(COLUMNS_WITH_HOST, [
+        {
+          host: 'a',
+          bucket: '2023-11-15T00:00:00.000Z',
+          avg_bytes: 14,
+          type: 'mean_shift',
+          pvalue: 0.001,
+        },
+      ]);
+
+      const error = await waitForTerminalState(
+        makeFetchParams({ table, query: { esql: ESQL_WITH_HOST_BY } }),
+        data
+      );
+
+      expect(error.status).toBe('error');
+      if (error.status === 'error') {
+        expect(error.error.message).toBe('esql failed');
+      }
+    });
+
+    it('fetches a line series for in-range no-BY queries instead of using the Discover table', async () => {
+      const esql = jest.fn().mockResolvedValue({
+        rawResponse: {
+          columns: [{ name: 'bucket' }, { name: 'avg_bytes' }],
+          values: [
+            ['2023-11-14T00:00:00.000Z', 12],
+            ['2023-11-15T00:00:00.000Z', 14],
+          ],
+        },
+      });
+      const data = { search: { esql } } as unknown as DataPublicPluginStart;
+      const table = makeTable(COLUMNS_NO_BY, [
+        {
+          bucket: '2023-11-15T00:00:00.000Z',
+          avg_bytes: 14,
+          type: 'mean_shift',
+          pvalue: 0.001,
+        },
+      ]);
+
+      const ready = await waitForTerminalState(
+        makeFetchParams({ table, query: { esql: ESQL_NO_BY } }),
+        data
+      );
+
+      expect(ready.status).toBe('ready');
+      expect(esql).toHaveBeenCalledTimes(1);
+      expect(esql.mock.calls[0][0].query).toContain('LIMIT 10000');
+      expect(esql.mock.calls[0][0].query).not.toContain('CHANGE_POINT');
+      if (ready.status === 'ready') {
+        expect(ready.seriesByEntity.get('')).toHaveLength(2);
+        expect(ready.cards).toHaveLength(1);
+      }
+    });
+
+    it('fetches a line series with extended from when a no-BY annotation is before the range', async () => {
+      const esql = jest.fn().mockResolvedValue({
+        rawResponse: {
+          columns: [{ name: 'bucket' }, { name: 'avg_bytes' }],
+          values: [
+            ['2023-11-10T00:00:00.000Z', 10],
+            ['2023-11-15T00:00:00.000Z', 14],
+          ],
+        },
+      });
+      const data = { search: { esql } } as unknown as DataPublicPluginStart;
+      const table = makeTable(COLUMNS_NO_BY, [
+        {
+          bucket: '2023-11-10T00:00:00.000Z',
+          avg_bytes: 14,
+          type: 'mean_shift',
+          pvalue: 0.001,
+        },
+      ]);
+
+      const ready = await waitForTerminalState(
+        makeFetchParams({ table, query: { esql: ESQL_NO_BY } }),
+        data
+      );
+
+      expect(ready.status).toBe('ready');
+      expect(esql).toHaveBeenCalledTimes(1);
+      expect(esql.mock.calls[0][0].query).toContain('LIMIT 10000');
+      expect(esql.mock.calls[0][0].query).not.toContain('CHANGE_POINT');
+      expect(getTime).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ from: '2023-11-10T00:00:00.000Z' })
+      );
+      if (ready.status === 'ready') {
+        expect(ready.seriesByEntity.get('')).toHaveLength(2);
+      }
+    });
+
+    it('issues a single shared ES|QL line search for BY queries across subscribers', async () => {
+      const esql = jest.fn().mockResolvedValue({
+        rawResponse: {
+          columns: [{ name: 'host' }, { name: 'bucket' }, { name: 'avg_bytes' }],
+          values: [
+            ['a', '2023-11-14T00:00:00.000Z', 12],
+            ['a', '2023-11-15T00:00:00.000Z', 14],
+          ],
+        },
+      });
+      const data = { search: { esql } } as unknown as DataPublicPluginStart;
+      const table = makeTable(COLUMNS_WITH_HOST, [
+        {
+          host: 'a',
+          bucket: '2023-11-15T00:00:00.000Z',
+          avg_bytes: 14,
+          type: 'mean_shift',
+          pvalue: 0.001,
+        },
+      ]);
+      const fetchParams = makeFetchParams({
+        table,
+        query: { esql: ESQL_WITH_HOST_BY },
+      });
+
+      const readyStates = await Promise.all([
+        waitForTerminalState(fetchParams, data),
+        waitForTerminalState(fetchParams, data),
+      ]);
+
+      expect(esql).toHaveBeenCalledTimes(1);
+      expect(esql.mock.calls[0][0].query).toContain('STATS avg_bytes');
+      expect(esql.mock.calls[0][0].query).toContain('WHERE host == "a"');
+      expect(esql.mock.calls[0][0].query).toContain('LIMIT 10000');
+      expect(esql.mock.calls[0][0].query).not.toContain('CHANGE_POINT');
+      expect(esql.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ dropNullColumns: true, sessionId: 'session-1' })
+      );
+
+      for (const ready of readyStates) {
+        expect(ready.status).toBe('ready');
+        if (ready.status === 'ready') {
+          expect(ready.seriesByEntity.get('host=a')).toHaveLength(2);
+        }
+      }
+    });
+
+    it('does not reuse a cached series when the time range changes', async () => {
+      const esql = jest.fn().mockResolvedValue({
+        rawResponse: { columns: [{ name: 'bucket' }, { name: 'avg_bytes' }], values: [] },
+      });
+      const data = { search: { esql } } as unknown as DataPublicPluginStart;
+      const table = makeTable(COLUMNS_WITH_HOST, [
+        {
+          host: 'a',
+          bucket: '2023-11-15T00:00:00.000Z',
+          avg_bytes: 14,
+          type: 'mean_shift',
+          pvalue: 0.001,
+        },
+      ]);
+
+      await waitForTerminalState(
+        makeFetchParams({
+          table,
+          query: { esql: ESQL_WITH_HOST_BY },
+          timeRange: { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
+        }),
+        data
+      );
+      await waitForTerminalState(
+        makeFetchParams({
+          table,
+          query: { esql: ESQL_WITH_HOST_BY },
+          timeRange: { from: '2023-11-01T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
+        }),
+        data
+      );
+
+      expect(esql).toHaveBeenCalledTimes(2);
+    });
+
+    it('aborts an in-flight line search when the last subscriber unsubscribes', async () => {
+      let abortSignal: AbortSignal | undefined;
+      const esql = jest.fn().mockImplementation((_query, opts: { abortSignal: AbortSignal }) => {
+        abortSignal = opts.abortSignal;
+        return new Promise(() => undefined);
+      });
+      const data = { search: { esql } } as unknown as DataPublicPluginStart;
+      const table = makeTable(COLUMNS_WITH_HOST, [
+        {
+          host: 'a',
+          bucket: '2023-11-15T00:00:00.000Z',
+          avg_bytes: 14,
+          type: 'mean_shift',
+          pvalue: 0.001,
+        },
+      ]);
+      const fetchParams = makeFetchParams({
+        table,
+        query: { esql: ESQL_WITH_HOST_BY },
+      });
+
+      const subscription = getChangePointSummarySeries$(fetchParams, data).subscribe();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(esql).toHaveBeenCalled();
+      expect(abortSignal?.aborted).toBe(false);
+
+      subscription.unsubscribe();
+      expect(abortSignal?.aborted).toBe(true);
+
+      getChangePointSummarySeries$(fetchParams, data).subscribe();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(esql).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.ts
@@ -25,6 +25,7 @@ import {
   getChangePointByColumns,
   getChangePointOutputColumnNames,
   getChangePointSeriesColumns,
+  getNamedParams,
 } from '@kbn/esql-utils';
 import type { TimeRange } from '@kbn/es-query';
 import { isOfAggregateQueryType, buildEsQuery } from '@kbn/es-query';
@@ -182,6 +183,7 @@ export const getSeriesCacheKey = (fetchParams: ChangePointFetchParams): string =
     fetchParams.timeRange?.from ?? '',
     fetchParams.timeRange?.to ?? '',
     JSON.stringify(fetchParams.filters ?? []),
+    JSON.stringify(fetchParams.esqlVariables ?? []),
     columnIds,
     String(rowCount),
   ].join('\0');
@@ -325,10 +327,13 @@ const loadLineSeries = async ({
     filter = undefined;
   }
 
+  const query = `${lineEsql} | LIMIT ${LINE_SERIES_LIMIT}`;
+  const namedParams = getNamedParams(query, timeRange, fetchParams.esqlVariables);
   const { rawResponse } = await data.search.esql(
     {
-      query: `${lineEsql} | LIMIT ${LINE_SERIES_LIMIT}`,
+      query,
       ...(filter ? { filter } : {}),
+      ...(namedParams.length ? { params: namedParams } : {}),
     },
     {
       abortSignal,

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.ts
@@ -8,42 +8,31 @@
  */
 
 import { useEffect, useState } from 'react';
-import {
-  buildChangePointCards,
-  formatAnnotationTimestamp,
-  getEntityKey,
-  isChangePointTableRow,
-  type ChangePointCardModel,
-} from '@kbn/change-point-chart-viewer';
+import { buildChangePointCards, type ChangePointCardModel } from '@kbn/change-point-chart-viewer';
 import type { UnifiedChangePointGridProps } from '@kbn/change-point-chart-viewer';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { getTime } from '@kbn/data-plugin/public';
 import {
   buildChangePointLineDataQuery,
-  formatEsqlIdentifier,
-  formatEsqlLiteral,
-  getChangePointByColumns,
-  getChangePointOutputColumnNames,
+  fixESQLQueryWithVariables,
   getChangePointSeriesColumns,
   getNamedParams,
 } from '@kbn/esql-utils';
-import type { TimeRange } from '@kbn/es-query';
 import { isOfAggregateQueryType, buildEsQuery } from '@kbn/es-query';
-import type { Datatable } from '@kbn/expressions-plugin/common';
 import { Observable, of } from 'rxjs';
 
 import { downsampleSparklinePoints } from './downsample_sparkline_points';
+import {
+  appendDistinctEntityWhereToLineEsql,
+  esqlResponseToRows,
+  getEarliestAnnotationTimeFromCards,
+  getEntityColumnIds,
+  getSummarySeriesTimeRange,
+  partitionLineRows,
+  type ChangePointSeriesByEntity,
+} from './change_point_summary_series_helpers';
 
 type ChangePointFetchParams = UnifiedChangePointGridProps['fetchParams'];
-
-export interface ChangePointSeriesPoint {
-  /** Epoch milliseconds. */
-  x: number;
-  y: number;
-}
-
-/** Entity key → series points. Empty-string key is the single no-BY series. */
-export type ChangePointSeriesByEntity = Map<string, ChangePointSeriesPoint[]>;
 
 export type ChangePointSummarySeriesState =
   | { status: 'idle' }
@@ -68,106 +57,10 @@ export type ChangePointSummarySeriesState =
 
 const LINE_SERIES_LIMIT = 10000;
 const MAX_DONE_SERIES_CACHE = 8;
-export const ENTITY_WHERE_PREDICATE_CAP = 200;
 
 type SeriesCacheEntry =
   | { kind: 'in-flight'; observable: Observable<ChangePointSummarySeriesState> }
   | { kind: 'done'; state: ChangePointSummarySeriesState };
-
-/** BY columns that actually appear on the result table (used as series split keys). */
-export const getEntityColumnIds = (
-  esql: string | undefined,
-  table: Pick<Datatable, 'columns'>
-): string[] => {
-  const byColumns = getChangePointByColumns(esql);
-  if (!byColumns?.length) return [];
-  const columnIds = new Set(table.columns.map((c) => c.id));
-  return byColumns.filter((id) => columnIds.has(id));
-};
-
-const toEpochMs = (value: unknown): number | undefined => {
-  const iso = formatAnnotationTimestamp(value);
-  if (!iso) return undefined;
-  const ms = Date.parse(iso);
-  return Number.isNaN(ms) ? undefined : ms;
-};
-
-const toFiniteNumber = (value: unknown): number | undefined => {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (typeof value === 'string' && value.length > 0) {
-    const n = Number(value);
-    if (Number.isFinite(n)) return n;
-  }
-  return undefined;
-};
-
-/** Earliest change-point time in the table (epoch ms). */
-export const getEarliestAnnotationTime = (
-  table: Datatable,
-  timeColumn: string,
-  esql: string
-): number | undefined => {
-  const outputNames = getChangePointOutputColumnNames(esql);
-  const typeColumnId = outputNames?.typeColumn ?? 'type';
-  const pvalueColumnId = outputNames?.pvalueColumn ?? 'pvalue';
-  const columnIds = new Set(table.columns.map((c) => c.id));
-  // No type/pvalue columns => every row is a change-point event (common BY shape).
-  const hasTypedColumns = columnIds.has(typeColumnId) && columnIds.has(pvalueColumnId);
-
-  let earliest: number | undefined;
-  for (const row of table.rows as Array<Record<string, unknown>>) {
-    const isAnnotation = hasTypedColumns
-      ? isChangePointTableRow(row, typeColumnId, pvalueColumnId)
-      : true;
-    if (!isAnnotation) continue;
-    const ms = toEpochMs(row[timeColumn]);
-    if (ms === undefined) continue;
-    earliest = earliest === undefined ? ms : Math.min(earliest, ms);
-  }
-  return earliest;
-};
-
-/** Pull Discover's time range back if a change point sits before `from` (same idea as Lens). */
-export const getSummarySeriesTimeRange = (
-  timeRange: TimeRange,
-  earliestAnnotationMs?: number
-): TimeRange => {
-  if (earliestAnnotationMs === undefined) return timeRange;
-  const fromMs = Date.parse(timeRange.from);
-  if (Number.isNaN(fromMs) || earliestAnnotationMs >= fromMs) return timeRange;
-  return { from: new Date(earliestAnnotationMs).toISOString(), to: timeRange.to };
-};
-
-/** Group rows into per-entity time series, sorted by time. */
-export const partitionLineRows = (
-  rows: ReadonlyArray<Readonly<Record<string, unknown>>>,
-  timeColumn: string,
-  valueColumn: string,
-  entityColumnIds: readonly string[]
-): ChangePointSeriesByEntity => {
-  const seriesByEntity: ChangePointSeriesByEntity = new Map();
-
-  for (const row of rows) {
-    const x = toEpochMs(row[timeColumn]);
-    const y = toFiniteNumber(row[valueColumn]);
-    if (x === undefined || y === undefined) continue;
-
-    const key = getEntityKey(row, entityColumnIds);
-    const existing = seriesByEntity.get(key);
-    if (existing) {
-      existing.push({ x, y });
-    } else {
-      seriesByEntity.set(key, [{ x, y }]);
-    }
-  }
-
-  for (const [key, points] of seriesByEntity) {
-    points.sort((a, b) => a.x - b.x);
-    seriesByEntity.set(key, downsampleSparklinePoints(points));
-  }
-
-  return seriesByEntity;
-};
 
 const getEsqlQuery = (query: ChangePointFetchParams['query']): string | undefined =>
   isOfAggregateQueryType(query) ? query.esql : undefined;
@@ -207,61 +100,13 @@ const evictOldestDoneEntries = (keepKey: string): void => {
   }
 };
 
-const esqlResponseToRows = (rawResponse: {
-  columns?: Array<{ name?: string }>;
-  values?: unknown[][];
-}): Array<Record<string, unknown>> => {
-  const columnNames = (rawResponse.columns ?? [])
-    .map((c) => c.name)
-    .filter((name): name is string => typeof name === 'string' && name.length > 0);
-  return (rawResponse.values ?? []).map((values) => {
-    const row: Record<string, unknown> = {};
-    for (let i = 0; i < columnNames.length; i++) {
-      row[columnNames[i]] = values[i];
-    }
-    return row;
-  });
-};
-
-/**
- * Narrows the line query to distinct entity tuples on the Discover table.
- * Returns the original query when the distinct set exceeds {@link ENTITY_WHERE_PREDICATE_CAP}.
- */
-export const appendDistinctEntityWhereToLineEsql = (
-  lineEsql: string,
-  rows: ReadonlyArray<Readonly<Record<string, unknown>>>,
-  entityColumnIds: readonly string[],
-  cap: number = ENTITY_WHERE_PREDICATE_CAP
-): string => {
-  if (!entityColumnIds.length) return lineEsql;
-
-  const seen = new Set<string>();
-  const groups: string[] = [];
-
-  for (const row of rows) {
-    const predicates: string[] = [];
-    let skip = false;
-    for (const col of entityColumnIds) {
-      const lit = formatEsqlLiteral(row[col]);
-      if (lit === undefined) {
-        skip = true;
-        break;
-      }
-      predicates.push(`${formatEsqlIdentifier(col)} == ${lit}`);
-    }
-    if (skip) continue;
-
-    const key = predicates.join(' AND ');
-    if (seen.has(key)) continue;
-    if (seen.size >= cap) {
-      return lineEsql;
-    }
-    seen.add(key);
-    groups.push(entityColumnIds.length > 1 ? `(${key})` : key);
+const downsampleSeriesByEntity = (
+  seriesByEntity: ChangePointSeriesByEntity
+): ChangePointSeriesByEntity => {
+  for (const [key, points] of seriesByEntity) {
+    seriesByEntity.set(key, downsampleSparklinePoints(points));
   }
-
-  if (!groups.length) return lineEsql;
-  return `${lineEsql} | WHERE ${groups.join(' OR ')}`;
+  return seriesByEntity;
 };
 
 /**
@@ -294,7 +139,7 @@ const loadLineSeries = async ({
   }
 
   const { timeColumn, valueColumn } = seriesColumns;
-  const earliestAnnotationMs = getEarliestAnnotationTime(table, timeColumn, esql);
+  const earliestAnnotationMs = getEarliestAnnotationTimeFromCards(cards);
 
   let lineEsql = buildChangePointLineDataQuery(esql);
   if (!lineEsql) {
@@ -349,7 +194,9 @@ const loadLineSeries = async ({
   const rows = esqlResponseToRows(rawResponse);
   return {
     status: 'ready',
-    seriesByEntity: partitionLineRows(rows, timeColumn, valueColumn, entityColumnIds),
+    seriesByEntity: downsampleSeriesByEntity(
+      partitionLineRows(rows, timeColumn, valueColumn, entityColumnIds)
+    ),
     entityColumnIds,
     timeColumn,
     valueColumn,
@@ -378,7 +225,10 @@ export const getChangePointSummarySeries$ = (
     return cached.observable;
   }
 
-  const esql = getEsqlQuery(fetchParams.query);
+  const rawEsql = getEsqlQuery(fetchParams.query);
+  const esql = rawEsql
+    ? fixESQLQueryWithVariables(rawEsql, fetchParams.esqlVariables ?? [])
+    : undefined;
   const table = fetchParams.table;
   const entityColumnIds = esql && table?.columns?.length ? getEntityColumnIds(esql, table) : [];
   const cards = esql && table?.columns?.length ? buildChangePointCards({ table, esql }) : undefined;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.ts
@@ -31,6 +31,8 @@ import { isOfAggregateQueryType, buildEsQuery } from '@kbn/es-query';
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import { Observable, of } from 'rxjs';
 
+import { downsampleSparklinePoints } from './downsample_sparkline_points';
+
 type ChangePointFetchParams = UnifiedChangePointGridProps['fetchParams'];
 
 export interface ChangePointSeriesPoint {
@@ -158,8 +160,9 @@ export const partitionLineRows = (
     }
   }
 
-  for (const points of seriesByEntity.values()) {
+  for (const [key, points] of seriesByEntity) {
     points.sort((a, b) => a.x - b.x);
+    seriesByEntity.set(key, downsampleSparklinePoints(points));
   }
 
   return seriesByEntity;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series.ts
@@ -1,0 +1,457 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  buildChangePointCards,
+  formatAnnotationTimestamp,
+  getEntityKey,
+  isChangePointTableRow,
+  type ChangePointCardModel,
+} from '@kbn/change-point-chart-viewer';
+import type { UnifiedChangePointGridProps } from '@kbn/change-point-chart-viewer';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { getTime } from '@kbn/data-plugin/public';
+import {
+  buildChangePointLineDataQuery,
+  formatEsqlIdentifier,
+  formatEsqlLiteral,
+  getChangePointByColumns,
+  getChangePointOutputColumnNames,
+  getChangePointSeriesColumns,
+} from '@kbn/esql-utils';
+import type { TimeRange } from '@kbn/es-query';
+import { isOfAggregateQueryType, buildEsQuery } from '@kbn/es-query';
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import { Observable, of } from 'rxjs';
+
+type ChangePointFetchParams = UnifiedChangePointGridProps['fetchParams'];
+
+export interface ChangePointSeriesPoint {
+  /** Epoch milliseconds. */
+  x: number;
+  y: number;
+}
+
+/** Entity key → series points. Empty-string key is the single no-BY series. */
+export type ChangePointSeriesByEntity = Map<string, ChangePointSeriesPoint[]>;
+
+export type ChangePointSummarySeriesState =
+  | { status: 'idle' }
+  | {
+      status: 'loading';
+      cards: ChangePointCardModel[] | undefined;
+    }
+  | {
+      status: 'ready';
+      seriesByEntity: ChangePointSeriesByEntity;
+      entityColumnIds: string[];
+      timeColumn: string;
+      valueColumn: string;
+      cards: ChangePointCardModel[] | undefined;
+    }
+  | {
+      status: 'error';
+      error: Error;
+      entityColumnIds: string[];
+      cards: ChangePointCardModel[] | undefined;
+    };
+
+const LINE_SERIES_LIMIT = 10000;
+const MAX_DONE_SERIES_CACHE = 8;
+export const ENTITY_WHERE_PREDICATE_CAP = 200;
+
+type SeriesCacheEntry =
+  | { kind: 'in-flight'; observable: Observable<ChangePointSummarySeriesState> }
+  | { kind: 'done'; state: ChangePointSummarySeriesState };
+
+/** BY columns that actually appear on the result table (used as series split keys). */
+export const getEntityColumnIds = (
+  esql: string | undefined,
+  table: Pick<Datatable, 'columns'>
+): string[] => {
+  const byColumns = getChangePointByColumns(esql);
+  if (!byColumns?.length) return [];
+  const columnIds = new Set(table.columns.map((c) => c.id));
+  return byColumns.filter((id) => columnIds.has(id));
+};
+
+const toEpochMs = (value: unknown): number | undefined => {
+  const iso = formatAnnotationTimestamp(value);
+  if (!iso) return undefined;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? undefined : ms;
+};
+
+const toFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.length > 0) {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+};
+
+/** Earliest change-point time in the table (epoch ms). */
+export const getEarliestAnnotationTime = (
+  table: Datatable,
+  timeColumn: string,
+  esql: string
+): number | undefined => {
+  const outputNames = getChangePointOutputColumnNames(esql);
+  const typeColumnId = outputNames?.typeColumn ?? 'type';
+  const pvalueColumnId = outputNames?.pvalueColumn ?? 'pvalue';
+  const columnIds = new Set(table.columns.map((c) => c.id));
+  // No type/pvalue columns => every row is a change-point event (common BY shape).
+  const hasTypedColumns = columnIds.has(typeColumnId) && columnIds.has(pvalueColumnId);
+
+  let earliest: number | undefined;
+  for (const row of table.rows as Array<Record<string, unknown>>) {
+    const isAnnotation = hasTypedColumns
+      ? isChangePointTableRow(row, typeColumnId, pvalueColumnId)
+      : true;
+    if (!isAnnotation) continue;
+    const ms = toEpochMs(row[timeColumn]);
+    if (ms === undefined) continue;
+    earliest = earliest === undefined ? ms : Math.min(earliest, ms);
+  }
+  return earliest;
+};
+
+/** Pull Discover's time range back if a change point sits before `from` (same idea as Lens). */
+export const getSummarySeriesTimeRange = (
+  timeRange: TimeRange,
+  earliestAnnotationMs?: number
+): TimeRange => {
+  if (earliestAnnotationMs === undefined) return timeRange;
+  const fromMs = Date.parse(timeRange.from);
+  if (Number.isNaN(fromMs) || earliestAnnotationMs >= fromMs) return timeRange;
+  return { from: new Date(earliestAnnotationMs).toISOString(), to: timeRange.to };
+};
+
+/** Group rows into per-entity time series, sorted by time. */
+export const partitionLineRows = (
+  rows: ReadonlyArray<Readonly<Record<string, unknown>>>,
+  timeColumn: string,
+  valueColumn: string,
+  entityColumnIds: readonly string[]
+): ChangePointSeriesByEntity => {
+  const seriesByEntity: ChangePointSeriesByEntity = new Map();
+
+  for (const row of rows) {
+    const x = toEpochMs(row[timeColumn]);
+    const y = toFiniteNumber(row[valueColumn]);
+    if (x === undefined || y === undefined) continue;
+
+    const key = getEntityKey(row, entityColumnIds);
+    const existing = seriesByEntity.get(key);
+    if (existing) {
+      existing.push({ x, y });
+    } else {
+      seriesByEntity.set(key, [{ x, y }]);
+    }
+  }
+
+  for (const points of seriesByEntity.values()) {
+    points.sort((a, b) => a.x - b.x);
+  }
+
+  return seriesByEntity;
+};
+
+const getEsqlQuery = (query: ChangePointFetchParams['query']): string | undefined =>
+  isOfAggregateQueryType(query) ? query.esql : undefined;
+
+export const getSeriesCacheKey = (fetchParams: ChangePointFetchParams): string => {
+  const table = fetchParams.table;
+  const columnIds = table?.columns.map((c) => c.id).join(',') ?? '';
+  const rowCount = table?.rows.length ?? 0;
+  return [
+    fetchParams.searchSessionId ?? '',
+    String(fetchParams.lastReloadRequestTime),
+    getEsqlQuery(fetchParams.query) ?? '',
+    fetchParams.timeRange?.from ?? '',
+    fetchParams.timeRange?.to ?? '',
+    JSON.stringify(fetchParams.filters ?? []),
+    columnIds,
+    String(rowCount),
+  ].join('\0');
+};
+
+// One shared series load per Discover refetch; many Summary cells reuse it.
+const seriesCache = new Map<string, SeriesCacheEntry>();
+
+/** Clears the shared series cache (tests only). */
+export const clearChangePointSummarySeriesCache = (): void => {
+  seriesCache.clear();
+};
+
+const evictOldestDoneEntries = (keepKey: string): void => {
+  if (seriesCache.size <= MAX_DONE_SERIES_CACHE) return;
+  for (const [key, entry] of seriesCache) {
+    if (seriesCache.size <= MAX_DONE_SERIES_CACHE) break;
+    if (key !== keepKey && entry.kind === 'done') {
+      seriesCache.delete(key);
+    }
+  }
+};
+
+const esqlResponseToRows = (rawResponse: {
+  columns?: Array<{ name?: string }>;
+  values?: unknown[][];
+}): Array<Record<string, unknown>> => {
+  const columnNames = (rawResponse.columns ?? [])
+    .map((c) => c.name)
+    .filter((name): name is string => typeof name === 'string' && name.length > 0);
+  return (rawResponse.values ?? []).map((values) => {
+    const row: Record<string, unknown> = {};
+    for (let i = 0; i < columnNames.length; i++) {
+      row[columnNames[i]] = values[i];
+    }
+    return row;
+  });
+};
+
+/**
+ * Narrows the line query to distinct entity tuples on the Discover table.
+ * Returns the original query when the distinct set exceeds {@link ENTITY_WHERE_PREDICATE_CAP}.
+ */
+export const appendDistinctEntityWhereToLineEsql = (
+  lineEsql: string,
+  rows: ReadonlyArray<Readonly<Record<string, unknown>>>,
+  entityColumnIds: readonly string[],
+  cap: number = ENTITY_WHERE_PREDICATE_CAP
+): string => {
+  if (!entityColumnIds.length) return lineEsql;
+
+  const seen = new Set<string>();
+  const groups: string[] = [];
+
+  for (const row of rows) {
+    const predicates: string[] = [];
+    let skip = false;
+    for (const col of entityColumnIds) {
+      const lit = formatEsqlLiteral(row[col]);
+      if (lit === undefined) {
+        skip = true;
+        break;
+      }
+      predicates.push(`${formatEsqlIdentifier(col)} == ${lit}`);
+    }
+    if (skip) continue;
+
+    const key = predicates.join(' AND ');
+    if (seen.has(key)) continue;
+    if (seen.size >= cap) {
+      return lineEsql;
+    }
+    seen.add(key);
+    groups.push(entityColumnIds.length > 1 ? `(${key})` : key);
+  }
+
+  if (!groups.length) return lineEsql;
+  return `${lineEsql} | WHERE ${groups.join(' OR ')}`;
+};
+
+/**
+ * Loads the pre-CHANGE_POINT line series (same ES|QL Lens uses).
+ * Delete when a dedicated change-point command returns series in the response.
+ */
+const loadLineSeries = async ({
+  fetchParams,
+  data,
+  esql,
+  entityColumnIds,
+  abortSignal,
+  cards,
+}: {
+  fetchParams: ChangePointFetchParams;
+  data: DataPublicPluginStart;
+  esql: string | undefined;
+  entityColumnIds: string[];
+  abortSignal: AbortSignal;
+  cards: ChangePointCardModel[] | undefined;
+}): Promise<ChangePointSummarySeriesState> => {
+  const table = fetchParams.table;
+  if (!esql || !table?.columns?.length) {
+    return { status: 'idle' };
+  }
+
+  const seriesColumns = getChangePointSeriesColumns(esql);
+  if (!seriesColumns) {
+    return { status: 'idle' };
+  }
+
+  const { timeColumn, valueColumn } = seriesColumns;
+  const earliestAnnotationMs = getEarliestAnnotationTime(table, timeColumn, esql);
+
+  let lineEsql = buildChangePointLineDataQuery(esql);
+  if (!lineEsql) {
+    return {
+      status: 'error',
+      error: new Error('Unable to build change point line query'),
+      entityColumnIds,
+      cards,
+    };
+  }
+
+  if (entityColumnIds.length > 0 && table.rows) {
+    lineEsql = appendDistinctEntityWhereToLineEsql(
+      lineEsql,
+      table.rows as Array<Record<string, unknown>>,
+      entityColumnIds
+    );
+  }
+
+  const timeRange = getSummarySeriesTimeRange(fetchParams.timeRange, earliestAnnotationMs);
+  const timeFilter = getTime(fetchParams.dataView, timeRange);
+  let filter: ReturnType<typeof buildEsQuery> | undefined;
+  try {
+    filter = buildEsQuery(
+      fetchParams.dataView,
+      [],
+      [...(fetchParams.filters ?? []), ...(timeFilter ? [timeFilter] : [])]
+    );
+  } catch {
+    filter = undefined;
+  }
+
+  const { rawResponse } = await data.search.esql(
+    {
+      query: `${lineEsql} | LIMIT ${LINE_SERIES_LIMIT}`,
+      ...(filter ? { filter } : {}),
+    },
+    {
+      abortSignal,
+      sessionId: fetchParams.searchSessionId,
+      dropNullColumns: true,
+      executionContext: {
+        type: 'discover',
+        name: 'change_point_summary_series',
+      },
+    }
+  );
+
+  const rows = esqlResponseToRows(rawResponse);
+  return {
+    status: 'ready',
+    seriesByEntity: partitionLineRows(rows, timeColumn, valueColumn, entityColumnIds),
+    entityColumnIds,
+    timeColumn,
+    valueColumn,
+    cards,
+  };
+};
+
+const isAbortError = (err: unknown): boolean =>
+  (err instanceof DOMException && err.name === 'AbortError') ||
+  (err instanceof Error && err.name === 'AbortError');
+
+/**
+ * Shared series stream for Summary cells.
+ * N cells subscribe. At most, one line ES|QL fetch runs per Discover refetch.
+ */
+export const getChangePointSummarySeries$ = (
+  fetchParams: ChangePointFetchParams,
+  data: DataPublicPluginStart
+): Observable<ChangePointSummarySeriesState> => {
+  const cacheKey = getSeriesCacheKey(fetchParams);
+  const cached = seriesCache.get(cacheKey);
+  if (cached?.kind === 'done') {
+    return of(cached.state);
+  }
+  if (cached?.kind === 'in-flight') {
+    return cached.observable;
+  }
+
+  const esql = getEsqlQuery(fetchParams.query);
+  const table = fetchParams.table;
+  const entityColumnIds = esql && table?.columns?.length ? getEntityColumnIds(esql, table) : [];
+  const cards = esql && table?.columns?.length ? buildChangePointCards({ table, esql }) : undefined;
+
+  const abortController = new AbortController();
+  const subscribers = new Set<{
+    next: (value: ChangePointSummarySeriesState) => void;
+    complete: () => void;
+  }>();
+  let current: ChangePointSummarySeriesState = {
+    status: 'loading',
+    cards,
+  };
+
+  const finish = (state: ChangePointSummarySeriesState): void => {
+    current = state;
+    seriesCache.set(cacheKey, { kind: 'done', state });
+    evictOldestDoneEntries(cacheKey);
+    for (const subscriber of subscribers) {
+      subscriber.next(state);
+      subscriber.complete();
+    }
+  };
+
+  const observable = new Observable<ChangePointSummarySeriesState>((subscriber) => {
+    subscribers.add(subscriber);
+    subscriber.next(current);
+    return () => {
+      subscribers.delete(subscriber);
+      if (subscribers.size === 0 && seriesCache.get(cacheKey)?.kind === 'in-flight') {
+        abortController.abort();
+        seriesCache.delete(cacheKey);
+      }
+    };
+  });
+
+  seriesCache.set(cacheKey, { kind: 'in-flight', observable });
+
+  loadLineSeries({
+    fetchParams,
+    data,
+    esql,
+    entityColumnIds,
+    abortSignal: abortController.signal,
+    cards,
+  })
+    .then((state) => {
+      if (abortController.signal.aborted) return;
+      finish(state);
+    })
+    .catch((err) => {
+      if (abortController.signal.aborted || isAbortError(err)) {
+        return;
+      }
+      finish({
+        status: 'error',
+        error: err instanceof Error ? err : new Error(String(err)),
+        entityColumnIds,
+        cards,
+      });
+    });
+
+  return observable;
+};
+
+/** Hook for Summary cells to read the shared series map. */
+export const useChangePointSummarySeries = (
+  fetchParams: ChangePointFetchParams | undefined,
+  data: DataPublicPluginStart | undefined
+): ChangePointSummarySeriesState => {
+  const [state, setState] = useState<ChangePointSummarySeriesState>({ status: 'idle' });
+
+  useEffect(() => {
+    if (!fetchParams || !data) {
+      setState({ status: 'idle' });
+      return;
+    }
+
+    const subscription = getChangePointSummarySeries$(fetchParams, data).subscribe(setState);
+    return () => subscription.unsubscribe();
+  }, [fetchParams, data]);
+
+  return state;
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series_helpers.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series_helpers.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ChangePointCardModel } from '@kbn/change-point-chart-viewer';
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import {
+  appendDistinctEntityWhereToLineEsql,
+  ENTITY_WHERE_PREDICATE_CAP,
+  getEarliestAnnotationTimeFromCards,
+  getEntityColumnIds,
+  getSummarySeriesTimeRange,
+  partitionLineRows,
+} from './change_point_summary_series_helpers';
+
+const makeTable = (columns: Datatable['columns'], rows: Datatable['rows']): Datatable => ({
+  type: 'datatable',
+  columns,
+  rows,
+});
+
+const ESQL_NO_BY =
+  'FROM idx | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket';
+
+const ESQL_WITH_HOST_BY =
+  'FROM idx | STATS avg_bytes = AVG(bytes) BY host, bucket = BUCKET(@timestamp, 1 day) | CHANGE_POINT avg_bytes ON bucket BY host';
+
+const COLUMNS_NO_BY = [
+  { id: 'bucket', name: 'bucket', meta: { type: 'date' as const } },
+  { id: 'avg_bytes', name: 'avg_bytes', meta: { type: 'number' as const } },
+  { id: 'type', name: 'type', meta: { type: 'string' as const } },
+  { id: 'pvalue', name: 'pvalue', meta: { type: 'number' as const } },
+];
+
+const COLUMNS_WITH_HOST = [
+  { id: 'host', name: 'host', meta: { type: 'string' as const } },
+  { id: 'bucket', name: 'bucket', meta: { type: 'date' as const } },
+  { id: 'avg_bytes', name: 'avg_bytes', meta: { type: 'number' as const } },
+  { id: 'type', name: 'type', meta: { type: 'string' as const } },
+  { id: 'pvalue', name: 'pvalue', meta: { type: 'number' as const } },
+];
+
+const stubCards = (datetimes: string[]): ChangePointCardModel[] =>
+  [
+    {
+      annotationEvents: datetimes.map((datetime) => ({ name: 'mean_shift', datetime })),
+    },
+  ] as ChangePointCardModel[];
+
+describe('change_point_summary_series_helpers', () => {
+  describe('getEntityColumnIds', () => {
+    it('returns BY columns that exist on the table', () => {
+      expect(getEntityColumnIds(ESQL_NO_BY, makeTable(COLUMNS_NO_BY, []))).toEqual([]);
+      expect(getEntityColumnIds(ESQL_WITH_HOST_BY, makeTable(COLUMNS_WITH_HOST, []))).toEqual([
+        'host',
+      ]);
+      expect(getEntityColumnIds(ESQL_WITH_HOST_BY, makeTable(COLUMNS_NO_BY, []))).toEqual([]);
+    });
+  });
+
+  describe('getEarliestAnnotationTimeFromCards / getSummarySeriesTimeRange', () => {
+    it('finds the earliest valid annotation datetime across cards', () => {
+      expect(
+        getEarliestAnnotationTimeFromCards(
+          stubCards(['2023-11-15T00:00:00.000Z', '2023-11-10T00:00:00.000Z'])
+        )
+      ).toBe(Date.parse('2023-11-10T00:00:00.000Z'));
+    });
+
+    it('skips invalid datetimes and returns undefined when none are valid', () => {
+      expect(getEarliestAnnotationTimeFromCards(stubCards(['not-a-date']))).toBeUndefined();
+      expect(getEarliestAnnotationTimeFromCards(undefined)).toBeUndefined();
+      expect(getEarliestAnnotationTimeFromCards([])).toBeUndefined();
+    });
+
+    it('extends from when the annotation is before Discover from', () => {
+      const range = getSummarySeriesTimeRange(
+        { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' },
+        Date.parse('2023-11-10T00:00:00.000Z')
+      );
+      expect(range).toEqual({
+        from: '2023-11-10T00:00:00.000Z',
+        to: '2023-11-20T00:00:00.000Z',
+      });
+    });
+
+    it('does not extend from when the annotation is inside the range', () => {
+      const timeRange = { from: '2023-11-14T00:00:00.000Z', to: '2023-11-20T00:00:00.000Z' };
+      expect(getSummarySeriesTimeRange(timeRange, Date.parse('2023-11-15T00:00:00.000Z'))).toEqual(
+        timeRange
+      );
+    });
+  });
+
+  describe('partitionLineRows', () => {
+    it('builds a single series with empty entity key when there is no BY', () => {
+      const series = partitionLineRows(
+        [
+          { bucket: '2023-11-14T00:00:00.000Z', avg_bytes: 12 },
+          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14 },
+        ],
+        'bucket',
+        'avg_bytes',
+        []
+      );
+
+      expect([...series.keys()]).toEqual(['']);
+      expect(series.get('')).toEqual([
+        { x: Date.parse('2023-11-14T00:00:00.000Z'), y: 12 },
+        { x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 },
+      ]);
+    });
+
+    it('partitions and sorts points per entity key', () => {
+      const series = partitionLineRows(
+        [
+          { host: 'b', bucket: '2023-11-16T00:00:00.000Z', avg_bytes: 20 },
+          { host: 'a', bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14 },
+          { host: 'a', bucket: '2023-11-14T00:00:00.000Z', avg_bytes: 12 },
+          { host: 'b', bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 18 },
+        ],
+        'bucket',
+        'avg_bytes',
+        ['host']
+      );
+
+      expect(series.get('host=a')).toEqual([
+        { x: Date.parse('2023-11-14T00:00:00.000Z'), y: 12 },
+        { x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 },
+      ]);
+      expect(series.get('host=b')).toEqual([
+        { x: Date.parse('2023-11-15T00:00:00.000Z'), y: 18 },
+        { x: Date.parse('2023-11-16T00:00:00.000Z'), y: 20 },
+      ]);
+    });
+
+    it('skips rows with invalid time or non-numeric values', () => {
+      const series = partitionLineRows(
+        [
+          { bucket: 'not-a-date', avg_bytes: 12 },
+          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 'nope' },
+          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: null },
+          { bucket: '2023-11-15T00:00:00.000Z', avg_bytes: 14 },
+        ],
+        'bucket',
+        'avg_bytes',
+        []
+      );
+
+      expect(series.get('')).toEqual([{ x: Date.parse('2023-11-15T00:00:00.000Z'), y: 14 }]);
+    });
+  });
+
+  describe('appendDistinctEntityWhereToLineEsql', () => {
+    const line = 'FROM idx | STATS avg_bytes = AVG(bytes) BY host, bucket';
+
+    it('appends OR predicates for distinct entity values', () => {
+      expect(
+        appendDistinctEntityWhereToLineEsql(
+          line,
+          [{ host: 'a' }, { host: 'a' }, { host: 'b' }],
+          ['host']
+        )
+      ).toBe(`${line} | WHERE host == "a" OR host == "b"`);
+    });
+
+    it('groups multi-column entities', () => {
+      expect(
+        appendDistinctEntityWhereToLineEsql(
+          line,
+          [{ host: 'a', service: 'orders' }],
+          ['host', 'service']
+        )
+      ).toBe(`${line} | WHERE (host == "a" AND service == "orders")`);
+    });
+
+    it('returns the original query when the distinct set exceeds the cap', () => {
+      const rows = Array.from({ length: ENTITY_WHERE_PREDICATE_CAP + 1 }, (_, i) => ({
+        host: `h${i}`,
+      }));
+      expect(appendDistinctEntityWhereToLineEsql(line, rows, ['host'])).toBe(line);
+    });
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series_helpers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_summary_series_helpers.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  formatAnnotationTimestamp,
+  getEntityKey,
+  type ChangePointCardModel,
+} from '@kbn/change-point-chart-viewer';
+import { formatEsqlIdentifier, formatEsqlLiteral, getChangePointByColumns } from '@kbn/esql-utils';
+import type { TimeRange } from '@kbn/es-query';
+import type { Datatable } from '@kbn/expressions-plugin/common';
+
+export interface ChangePointSeriesPoint {
+  /** Epoch milliseconds. */
+  x: number;
+  y: number;
+}
+
+/** Entity key → series points. Empty-string key is the single no-BY series. */
+export type ChangePointSeriesByEntity = Map<string, ChangePointSeriesPoint[]>;
+
+export const ENTITY_WHERE_PREDICATE_CAP = 200;
+
+/** BY columns that actually appear on the result table (used as series split keys). */
+export const getEntityColumnIds = (
+  esql: string | undefined,
+  table: Pick<Datatable, 'columns'>
+): string[] => {
+  const byColumns = getChangePointByColumns(esql);
+  if (!byColumns?.length) return [];
+  const columnIds = new Set(table.columns.map((c) => c.id));
+  return byColumns.filter((id) => columnIds.has(id));
+};
+
+const toEpochMs = (value: unknown): number | undefined => {
+  const iso = formatAnnotationTimestamp(value);
+  if (!iso) return undefined;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? undefined : ms;
+};
+
+const toFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.length > 0) {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+};
+
+/** Earliest valid annotation datetime across cards (epoch ms). */
+export const getEarliestAnnotationTimeFromCards = (
+  cards: ChangePointCardModel[] | undefined
+): number | undefined => {
+  if (!cards?.length) return undefined;
+
+  let earliest: number | undefined;
+  for (const card of cards) {
+    for (const event of card.annotationEvents) {
+      const ms = Date.parse(event.datetime);
+      if (Number.isNaN(ms)) continue;
+      earliest = earliest === undefined ? ms : Math.min(earliest, ms);
+    }
+  }
+  return earliest;
+};
+
+/** Pull Discover's time range back if a change point sits before `from` (same idea as Lens). */
+export const getSummarySeriesTimeRange = (
+  timeRange: TimeRange,
+  earliestAnnotationMs?: number
+): TimeRange => {
+  if (earliestAnnotationMs === undefined) return timeRange;
+  const fromMs = Date.parse(timeRange.from);
+  if (Number.isNaN(fromMs) || earliestAnnotationMs >= fromMs) return timeRange;
+  return { from: new Date(earliestAnnotationMs).toISOString(), to: timeRange.to };
+};
+
+/** Group rows into per-entity time series, sorted by time. */
+export const partitionLineRows = (
+  rows: ReadonlyArray<Readonly<Record<string, unknown>>>,
+  timeColumn: string,
+  valueColumn: string,
+  entityColumnIds: readonly string[]
+): ChangePointSeriesByEntity => {
+  const seriesByEntity: ChangePointSeriesByEntity = new Map();
+
+  for (const row of rows) {
+    const x = toEpochMs(row[timeColumn]);
+    const y = toFiniteNumber(row[valueColumn]);
+    if (x === undefined || y === undefined) continue;
+
+    const key = getEntityKey(row, entityColumnIds);
+    const existing = seriesByEntity.get(key);
+    if (existing) {
+      existing.push({ x, y });
+    } else {
+      seriesByEntity.set(key, [{ x, y }]);
+    }
+  }
+
+  for (const points of seriesByEntity.values()) {
+    points.sort((a, b) => a.x - b.x);
+  }
+
+  return seriesByEntity;
+};
+
+export const esqlResponseToRows = (rawResponse: {
+  columns?: Array<{ name?: string }>;
+  values?: unknown[][];
+}): Array<Record<string, unknown>> => {
+  const columnNames = (rawResponse.columns ?? [])
+    .map((c) => c.name)
+    .filter((name): name is string => typeof name === 'string' && name.length > 0);
+  return (rawResponse.values ?? []).map((values) => {
+    const row: Record<string, unknown> = {};
+    for (let i = 0; i < columnNames.length; i++) {
+      row[columnNames[i]] = values[i];
+    }
+    return row;
+  });
+};
+
+/**
+ * Narrows the line query to distinct entity tuples on the Discover table.
+ * Returns the original query when the distinct set exceeds {@link ENTITY_WHERE_PREDICATE_CAP}.
+ */
+export const appendDistinctEntityWhereToLineEsql = (
+  lineEsql: string,
+  rows: ReadonlyArray<Readonly<Record<string, unknown>>>,
+  entityColumnIds: readonly string[],
+  cap: number = ENTITY_WHERE_PREDICATE_CAP
+): string => {
+  if (!entityColumnIds.length) return lineEsql;
+
+  const seen = new Set<string>();
+  const groups: string[] = [];
+
+  for (const row of rows) {
+    const predicates: string[] = [];
+    let skip = false;
+    for (const col of entityColumnIds) {
+      const lit = formatEsqlLiteral(row[col]);
+      if (lit === undefined) {
+        skip = true;
+        break;
+      }
+      predicates.push(`${formatEsqlIdentifier(col)} == ${lit}`);
+    }
+    if (skip) continue;
+
+    const key = predicates.join(' AND ');
+    if (seen.has(key)) continue;
+    if (seen.size >= cap) {
+      return lineEsql;
+    }
+    seen.add(key);
+    groups.push(entityColumnIds.length > 1 ? `(${key})` : key);
+  }
+
+  if (!groups.length) return lineEsql;
+  return `${lineEsql} | WHERE ${groups.join(' OR ')}`;
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/downsample_sparkline_points.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/downsample_sparkline_points.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { downsampleSparklinePoints, SPARKLINE_MAX_POINTS } from './downsample_sparkline_points';
+
+describe('downsampleSparklinePoints', () => {
+  it('returns the original array when the series is already short', () => {
+    const points = Array.from({ length: 10 }, (_, i) => ({ x: i, y: i }));
+    expect(downsampleSparklinePoints(points)).toBe(points);
+  });
+
+  it('keeps first and last points and remains x-sorted', () => {
+    const points = Array.from({ length: 500 }, (_, i) => ({ x: i, y: Math.sin(i / 10) }));
+    const sampled = downsampleSparklinePoints(points);
+
+    expect(sampled).toHaveLength(SPARKLINE_MAX_POINTS);
+    expect(sampled[0]).toEqual(points[0]);
+    expect(sampled[sampled.length - 1]).toEqual(points[points.length - 1]);
+    for (let i = 1; i < sampled.length; i++) {
+      expect(sampled[i].x).toBeGreaterThan(sampled[i - 1].x);
+    }
+  });
+
+  it('retains a single-point spike', () => {
+    const points = Array.from({ length: 500 }, (_, i) => ({ x: i, y: 0 }));
+    points[250] = { x: 250, y: 100 };
+
+    const sampled = downsampleSparklinePoints(points);
+    expect(sampled.some((point) => point.y === 100 && point.x === 250)).toBe(true);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/downsample_sparkline_points.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/downsample_sparkline_points.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ChangePointSeriesPoint } from './change_point_summary_series';
+import type { ChangePointSeriesPoint } from './change_point_summary_series_helpers';
 
 export const SPARKLINE_MAX_POINTS = 100;
 
@@ -30,11 +30,8 @@ const averagePoint = (
 };
 
 /**
- * Downsamples a sparkline with Largest Triangle Three Buckets (LTTB).
- * Always keeps first and last points, then one point per bucket: the one that
- * forms the largest triangle with the previous pick and the next bucket average.
- * Best fit here: O(n), no extra dependency, and it keeps spikes and trend that
- * even-index sampling would drop — enough shape for a tiny chart.
+ * Largest Triangle Three Buckets (LTTB) downsample: O(n), keeps first/last points
+ * and spikes that even-index sampling would drop.
  */
 export const downsampleSparklinePoints = (
   points: ChangePointSeriesPoint[]

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/downsample_sparkline_points.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/downsample_sparkline_points.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ChangePointSeriesPoint } from './change_point_summary_series';
+
+export const SPARKLINE_MAX_POINTS = 100;
+
+const averagePoint = (
+  points: ChangePointSeriesPoint[],
+  start: number,
+  end: number
+): ChangePointSeriesPoint => {
+  const count = end - start;
+  if (count <= 0) {
+    return points[points.length - 1];
+  }
+  let x = 0;
+  let y = 0;
+  for (let i = start; i < end; i++) {
+    x += points[i].x;
+    y += points[i].y;
+  }
+  return { x: x / count, y: y / count };
+};
+
+/**
+ * Downsamples a sparkline with Largest Triangle Three Buckets (LTTB).
+ * Always keeps first and last points, then one point per bucket: the one that
+ * forms the largest triangle with the previous pick and the next bucket average.
+ * Best fit here: O(n), no extra dependency, and it keeps spikes and trend that
+ * even-index sampling would drop — enough shape for a tiny chart.
+ */
+export const downsampleSparklinePoints = (
+  points: ChangePointSeriesPoint[]
+): ChangePointSeriesPoint[] => {
+  const { length } = points;
+  if (length <= SPARKLINE_MAX_POINTS) {
+    return points;
+  }
+
+  const sampled: ChangePointSeriesPoint[] = [points[0]];
+  const bucketSize = (length - 2) / (SPARKLINE_MAX_POINTS - 2);
+  let previousIndex = 0;
+
+  for (let i = 0; i < SPARKLINE_MAX_POINTS - 2; i++) {
+    const { x: avgX, y: avgY } = averagePoint(
+      points,
+      Math.floor((i + 1) * bucketSize) + 1,
+      Math.min(Math.floor((i + 2) * bucketSize) + 1, length)
+    );
+    const { x: prevX, y: prevY } = points[previousIndex];
+    const bucketStart = Math.floor(i * bucketSize) + 1;
+    const bucketEnd = Math.floor((i + 1) * bucketSize) + 1;
+
+    let maxArea = -1;
+    let nextIndex = bucketStart;
+    for (let j = bucketStart; j < bucketEnd; j++) {
+      const { x, y } = points[j];
+      const area = Math.abs((prevX - avgX) * (y - prevY) - (prevX - x) * (avgY - prevY));
+      if (area > maxArea) {
+        maxArea = area;
+        nextIndex = j;
+      }
+    }
+
+    sampled.push(points[nextIndex]);
+    previousIndex = nextIndex;
+  }
+
+  sampled.push(points[length - 1]);
+  return sampled;
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.test.ts
@@ -9,12 +9,15 @@
 
 import { BehaviorSubject } from 'rxjs';
 import React from 'react';
+import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/common';
+import { SOURCE_COLUMN } from '@kbn/unified-data-table';
 import { DataSourceType } from '../../../../../common/data_sources';
 import type { ContextWithProfileId } from '../../../profile_service';
 import type { DataSourceProfileProviderParams, RootContext } from '../../../profiles';
 import { DataSourceCategory, SolutionType } from '../../../profiles';
 import type { DocViewsRegistry } from '@kbn/unified-doc-viewer';
+import type { ProfileProviderServices } from '../../profile_provider_services';
 import {
   CHANGE_POINT_DATA_SOURCE_PROFILE_ID,
   type ChangePointChartSectionSnapshot,
@@ -41,11 +44,20 @@ describe('createChangePointDataSourceProfileProvider', () => {
     ...overrides,
   });
 
-  const provider = createChangePointDataSourceProfileProvider();
+  const mockServices = {
+    charts: {
+      theme: {
+        useChartsBaseTheme: () => ({}),
+      },
+    } as unknown as ChartsPluginStart,
+  } as unknown as ProfileProviderServices;
+
+  const provider = createChangePointDataSourceProfileProvider(mockServices);
 
   /** Builds a minimal resolved context for use in profile accessor tests. */
   const buildContext = (overrides: Record<string, unknown> = {}) => ({
     category: DataSourceCategory.Default,
+    typeColumnId: 'type',
     pvalueColumnId: 'pvalue',
     chartSectionProps$: new BehaviorSubject<ChangePointChartSectionSnapshot | undefined>(undefined),
     ...overrides,
@@ -73,21 +85,18 @@ describe('createChangePointDataSourceProfileProvider', () => {
 
   describe('resolve', () => {
     describe('matches', () => {
-      it('returns isMatch true with category and pvalueColumnId for a query with top-level CHANGE_POINT', async () => {
+      it('returns isMatch true with category, column ids, and chartSectionProps$ for a top-level CHANGE_POINT query', async () => {
         const context = await resolveMatch();
         expect(context).toMatchObject({
           category: DataSourceCategory.Default,
+          typeColumnId: 'type',
           pvalueColumnId: 'pvalue',
         });
-      });
-
-      it('includes a BehaviorSubject as chartSectionProps$ in the context', async () => {
-        const context = await resolveMatch();
         expect(context.chartSectionProps$).toBeInstanceOf(BehaviorSubject);
         expect((context.chartSectionProps$ as BehaviorSubject<unknown>).getValue()).toBeUndefined();
       });
 
-      it('picks up a custom pvalue AS alias', async () => {
+      it('picks up custom type and pvalue AS aliases', async () => {
         const context = await resolveMatch({
           query: {
             esql: 'FROM logs-* | STATS avg_val = AVG(bytes) BY bucket = BUCKET(@timestamp, 1h) | CHANGE_POINT avg_val ON bucket AS change_type, p_value',
@@ -95,13 +104,9 @@ describe('createChangePointDataSourceProfileProvider', () => {
         });
         expect(context).toMatchObject({
           category: DataSourceCategory.Default,
+          typeColumnId: 'change_type',
           pvalueColumnId: 'p_value',
         });
-      });
-
-      it('context does not include typeColumnId', async () => {
-        const context = await resolveMatch();
-        expect(context).not.toHaveProperty('typeColumnId');
       });
     });
 
@@ -157,22 +162,76 @@ describe('createChangePointDataSourceProfileProvider', () => {
     });
   });
 
+  describe('getDefaultAppState', () => {
+    it('defaults to type, pvalue, and Summary columns', () => {
+      const getDefaultAppState = provider.profile.getDefaultAppState!(() => ({}), {
+        context: buildContext(),
+        toolkit: EMPTY_CONTEXT_AWARENESS_TOOLKIT,
+      });
+      expect(getDefaultAppState({ dataView: {} as DataView })).toEqual({
+        columns: [{ name: 'type' }, { name: SOURCE_COLUMN, width: 200 }, { name: 'pvalue' }],
+      });
+    });
+
+    it('uses type and pvalue aliases from context', () => {
+      const getDefaultAppState = provider.profile.getDefaultAppState!(() => ({}), {
+        context: buildContext({ typeColumnId: 'change_type', pvalueColumnId: 'p_value' }),
+        toolkit: EMPTY_CONTEXT_AWARENESS_TOOLKIT,
+      });
+      expect(getDefaultAppState({ dataView: {} as DataView })).toEqual({
+        columns: [
+          { name: 'change_type' },
+          { name: SOURCE_COLUMN, width: 200 },
+          { name: 'p_value' },
+        ],
+      });
+    });
+  });
+
   describe('getColumnsConfiguration', () => {
-    it('customises the pvalue column when pvalueColumnId is present', () => {
+    it('customises the pvalue header and Summary column width', () => {
       const getColumns = provider.profile.getColumnsConfiguration!(() => ({}), {
         context: buildContext({ pvalueColumnId: 'my_pvalue' }),
         toolkit: EMPTY_CONTEXT_AWARENESS_TOOLKIT,
       });
-      expect(getColumns()).toHaveProperty('my_pvalue');
+      const config = getColumns();
+      expect(config).toHaveProperty('my_pvalue');
+      expect(
+        config[SOURCE_COLUMN]!({
+          column: { id: SOURCE_COLUMN } as never,
+          headerRowHeight: 1,
+        }).initialWidth
+      ).toBe(200);
+      expect(
+        config[SOURCE_COLUMN]!({
+          column: { id: SOURCE_COLUMN, initialWidth: 400 } as never,
+          headerRowHeight: 1,
+        }).initialWidth
+      ).toBe(400);
+      expect(
+        config[SOURCE_COLUMN]!({
+          column: { id: SOURCE_COLUMN, cellActions: [jest.fn()] } as never,
+          headerRowHeight: 1,
+        })
+      ).toEqual(
+        expect.objectContaining({
+          isExpandable: false,
+        })
+      );
     });
 
-    it('returns base config when pvalueColumnId is absent', () => {
-      const base = { existing: {} as never };
-      const getColumns = provider.profile.getColumnsConfiguration!(() => base, {
-        context: buildContext({ pvalueColumnId: '' }),
-        toolkit: EMPTY_CONTEXT_AWARENESS_TOOLKIT,
-      });
-      expect(getColumns()).toBe(base);
+    it('keeps Summary config and previous columns when pvalueColumnId is empty', () => {
+      const getColumns = provider.profile.getColumnsConfiguration!(
+        () => ({ existing: {} as never }),
+        {
+          context: buildContext({ pvalueColumnId: '' }),
+          toolkit: EMPTY_CONTEXT_AWARENESS_TOOLKIT,
+        }
+      );
+      const result = getColumns();
+      expect(result).toHaveProperty('existing');
+      expect(result).toHaveProperty(SOURCE_COLUMN);
+      expect(result).not.toHaveProperty('');
     });
   });
 
@@ -189,13 +248,13 @@ describe('createChangePointDataSourceProfileProvider', () => {
       });
     };
 
-    it('registers a function renderer for the pvalue column', () => {
+    it('registers pvalue and Summary renderers', () => {
       const renderers = buildRenderers('pvalue');
-      expect(renderers).toHaveProperty('pvalue');
       expect(renderers.pvalue).toBeInstanceOf(Function);
+      expect(renderers[SOURCE_COLUMN]).toBeInstanceOf(Function);
     });
 
-    it('falls through to prev when pvalueColumnId is empty', () => {
+    it('keeps Summary and prev renderers when pvalueColumnId is empty', () => {
       const existingRenderer = jest.fn();
       const prevRenderers = { some_col: existingRenderer };
       const getCellRenderers = provider.profile.getCellRenderers!(() => prevRenderers, {
@@ -207,7 +266,9 @@ describe('createChangePointDataSourceProfileProvider', () => {
         dataView: {} as DataView,
         density: undefined,
       });
-      expect(renderers).toBe(prevRenderers);
+      expect(renderers.some_col).toBe(existingRenderer);
+      expect(renderers[SOURCE_COLUMN]).toBeInstanceOf(Function);
+      expect(renderers).not.toHaveProperty('');
     });
   });
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.test.ts
@@ -186,7 +186,6 @@ describe('createChangePointDataSourceProfileProvider', () => {
 
   describe('getColumnsConfiguration', () => {
     it('customises the pvalue header and keeps Summary non-expandable', () => {
-      const cellAction = jest.fn();
       const getColumns = provider.profile.getColumnsConfiguration!(() => ({}), {
         context: buildContext({ pvalueColumnId: 'my_pvalue' }),
         toolkit: EMPTY_CONTEXT_AWARENESS_TOOLKIT,
@@ -195,13 +194,13 @@ describe('createChangePointDataSourceProfileProvider', () => {
       expect(config).toHaveProperty('my_pvalue');
       expect(
         config[SOURCE_COLUMN]!({
-          column: { id: SOURCE_COLUMN, cellActions: [cellAction] } as never,
+          column: { id: SOURCE_COLUMN, cellActions: [jest.fn()] } as never,
           headerRowHeight: 1,
         })
       ).toEqual(
         expect.objectContaining({
           isExpandable: false,
-          cellActions: [cellAction],
+          cellActions: [],
         })
       );
     });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.ts
@@ -16,12 +16,15 @@ import type {
   DataGridCellValueElementProps,
   CustomGridColumnsConfiguration,
   CustomGridColumnProps,
+  CustomCellRenderer,
 } from '@kbn/unified-data-table';
+import { SOURCE_COLUMN } from '@kbn/unified-data-table';
 import { DataSourceType, isDataSourceType } from '../../../../../common/data_sources';
 import type { DataSourceProfileProvider } from '../../../profiles';
 import { DataSourceCategory } from '../../../profiles';
 import { ChangePointPvalueCell } from './change_point_pvalue_cell';
 import { ChangePointPvalueColumnHeader } from './change_point_pvalue_column_header';
+import { ChangePointSummaryCell } from './change_point_summary_cell';
 import {
   CHANGE_POINT_DATA_SOURCE_PROFILE_ID,
   type ChangePointChartSectionProps$,
@@ -30,8 +33,10 @@ import {
 import type { ChangePointPvalueCellContext } from './change_point_pvalue_cell';
 import { ChangePointChartSectionSync } from './change_point_chart_section_sync';
 import { ChangePointDocViewerPanel } from './change_point_doc_viewer_panel';
+import type { ProfileProviderServices } from '../../profile_provider_services';
 
 const CHANGE_POINT_CHART_LOCAL_STORAGE_KEY = 'discover:changePointExperience';
+const CHANGE_POINT_SUMMARY_COLUMN_WIDTH = 200;
 
 /**
  * Extends the p-value cell context with the chart section props subject needed
@@ -42,115 +47,149 @@ const CHANGE_POINT_CHART_LOCAL_STORAGE_KEY = 'discover:changePointExperience';
  * must NOT be included here.
  */
 interface ChangePointDataSourceProfileContext extends ChangePointPvalueCellContext {
+  typeColumnId: string;
   chartSectionProps$: ChangePointChartSectionProps$;
 }
 
-export const createChangePointDataSourceProfileProvider =
-  (): DataSourceProfileProvider<ChangePointDataSourceProfileContext> => ({
-    profileId: CHANGE_POINT_DATA_SOURCE_PROFILE_ID,
-    profile: {
-      getChartSectionConfiguration:
-        (prev, { context, toolkit }) =>
-        () => ({
-          ...prev(),
-          renderChartSection: (props) =>
-            React.createElement(ChangePointChartSectionSync, {
-              gridProps: props,
-              actions: toolkit.actions,
-              chartSectionProps$: context.chartSectionProps$,
+export const createChangePointDataSourceProfileProvider = (
+  services: ProfileProviderServices
+): DataSourceProfileProvider<ChangePointDataSourceProfileContext> => ({
+  profileId: CHANGE_POINT_DATA_SOURCE_PROFILE_ID,
+  profile: {
+    getDefaultAppState:
+      (prev, { context }) =>
+      (params) => ({
+        ...prev(params),
+        columns: [
+          { name: context.typeColumnId },
+          { name: SOURCE_COLUMN, width: CHANGE_POINT_SUMMARY_COLUMN_WIDTH },
+          { name: context.pvalueColumnId },
+        ],
+      }),
+    getChartSectionConfiguration:
+      (prev, { context, toolkit }) =>
+      () => ({
+        ...prev(),
+        renderChartSection: (props) =>
+          React.createElement(ChangePointChartSectionSync, {
+            gridProps: props,
+            actions: toolkit.actions,
+            chartSectionProps$: context.chartSectionProps$,
+          }),
+        replaceDefaultChart: true as const,
+        localStorageKeyPrefix: CHANGE_POINT_CHART_LOCAL_STORAGE_KEY,
+        defaultTopPanelHeight: 'max-content',
+      }),
+    getColumnsConfiguration:
+      (prev, { context }) =>
+      (): CustomGridColumnsConfiguration => {
+        const base = prev ? prev() : {};
+        const { pvalueColumnId } = context ?? {};
+        const config: CustomGridColumnsConfiguration = {
+          ...base,
+          [SOURCE_COLUMN]: ({ column }: CustomGridColumnProps) => ({
+            ...column,
+            // Keep a default width so Summary is not the last unconstrained column
+            // (EUI's resize handle belongs to the column on the left of the divider).
+            // Do not overwrite a width the user already set.
+            initialWidth: column.initialWidth ?? CHANGE_POINT_SUMMARY_COLUMN_WIDTH,
+            isExpandable: false,
+            cellActions: [],
+          }),
+        };
+
+        if (pvalueColumnId) {
+          config[pvalueColumnId] = ({ column, headerRowHeight }: CustomGridColumnProps) => ({
+            ...column,
+            // Prevents EUI from right-aligning the header as a numeric column.
+            schema: undefined,
+            display: React.createElement(ChangePointPvalueColumnHeader, {
+              columnDisplayName: column.displayAsText,
+              headerRowHeight,
             }),
-          replaceDefaultChart: true as const,
-          localStorageKeyPrefix: CHANGE_POINT_CHART_LOCAL_STORAGE_KEY,
-          defaultTopPanelHeight: 'max-content',
-        }),
-      getColumnsConfiguration:
-        (prev, { context }) =>
-        (): CustomGridColumnsConfiguration => {
-          const base = prev ? prev() : {};
-          const { pvalueColumnId } = context ?? {};
-          if (!pvalueColumnId) return base;
-          return {
-            ...base,
-            [pvalueColumnId]: ({ column, headerRowHeight }: CustomGridColumnProps) => ({
-              ...column,
-              // Prevents EUI from right-aligning the header as a numeric column.
-              schema: undefined,
-              display: React.createElement(ChangePointPvalueColumnHeader, {
-                columnDisplayName: column.displayAsText,
-                headerRowHeight,
-              }),
+          });
+        }
+
+        return config;
+      },
+    getCellRenderers:
+      (prev, { context }) =>
+      (params) => {
+        const { pvalueColumnId } = context;
+        const renderers: CustomCellRenderer = {
+          ...prev(params),
+          [SOURCE_COLUMN]: (props: DataGridCellValueElementProps) =>
+            React.createElement(ChangePointSummaryCell, {
+              ...props,
+              context,
+              charts: services.charts,
             }),
-          };
-        },
-      getCellRenderers:
-        (prev, { context }) =>
-        (params) => {
-          const { pvalueColumnId } = context;
-          if (!pvalueColumnId) {
-            return prev(params);
-          }
-          const pvalueRenderer = (props: DataGridCellValueElementProps) =>
+        };
+
+        if (pvalueColumnId) {
+          renderers[pvalueColumnId] = (props: DataGridCellValueElementProps) =>
             React.createElement(ChangePointPvalueCell, { ...props, context });
-          return {
-            ...prev(params),
-            [pvalueColumnId]: pvalueRenderer,
-          };
-        },
-      getDocViewer:
-        (prev, { context, toolkit }) =>
-        (params) => {
-          const prevDocViewer = prev(params);
-          return {
-            ...prevDocViewer,
-            docViewsRegistry: (registry) => {
-              registry.add({
-                id: 'doc_view_change_point_chart',
-                title: i18n.translate('discover.docViews.changePoint.title', {
-                  defaultMessage: 'Overview',
+        }
+
+        return renderers;
+      },
+    getDocViewer:
+      (prev, { context, toolkit }) =>
+      (params) => {
+        const prevDocViewer = prev(params);
+        return {
+          ...prevDocViewer,
+          docViewsRegistry: (registry) => {
+            registry.add({
+              id: 'doc_view_change_point_chart',
+              title: i18n.translate('discover.docViews.changePoint.title', {
+                defaultMessage: 'Overview',
+              }),
+              order: 0,
+              render: () =>
+                // DocViewRenderProps.hit === params.record; use the closure value
+                // so the panel does not need to accept DocViewRenderProps itself.
+                React.createElement(ChangePointDocViewerPanel, {
+                  record: params.record,
+                  context,
+                  actions: toolkit.actions,
                 }),
-                order: 0,
-                render: () =>
-                  // DocViewRenderProps.hit === params.record; use the closure value
-                  // so the panel does not need to accept DocViewRenderProps itself.
-                  React.createElement(ChangePointDocViewerPanel, {
-                    record: params.record,
-                    context,
-                    actions: toolkit.actions,
-                  }),
-              });
-              return prevDocViewer.docViewsRegistry(registry);
-            },
-          };
-        },
-    },
-    resolve: (params) => {
-      if (!isDataSourceType(params.dataSource, DataSourceType.Esql)) {
-        return { isMatch: false };
-      }
+            });
+            return prevDocViewer.docViewsRegistry(registry);
+          },
+        };
+      },
+  },
+  resolve: (params) => {
+    if (!isDataSourceType(params.dataSource, DataSourceType.Esql)) {
+      return { isMatch: false };
+    }
 
-      const query = params.query;
-      if (!isOfAggregateQueryType(query) || !query.esql) {
-        return { isMatch: false };
-      }
+    const query = params.query;
+    if (!isOfAggregateQueryType(query) || !query.esql) {
+      return { isMatch: false };
+    }
 
-      if (!hasChangePointCommand(query.esql)) {
-        return { isMatch: false };
-      }
+    if (!hasChangePointCommand(query.esql)) {
+      return { isMatch: false };
+    }
 
-      const columnNames = getChangePointOutputColumnNames(query.esql);
-      const pvalueColumnId = columnNames?.pvalueColumn ?? 'pvalue';
+    const columnNames = getChangePointOutputColumnNames(query.esql);
+    const typeColumnId = columnNames?.typeColumn ?? 'type';
+    const pvalueColumnId = columnNames?.pvalueColumn ?? 'pvalue';
 
-      const chartSectionProps$ = new BehaviorSubject<ChangePointChartSectionSnapshot | undefined>(
-        undefined
-      );
+    const chartSectionProps$ = new BehaviorSubject<ChangePointChartSectionSnapshot | undefined>(
+      undefined
+    );
 
-      return {
-        isMatch: true,
-        context: {
-          category: DataSourceCategory.Default,
-          pvalueColumnId,
-          chartSectionProps$,
-        },
-      };
-    },
-  });
+    return {
+      isMatch: true,
+      context: {
+        category: DataSourceCategory.Default,
+        typeColumnId,
+        pvalueColumnId,
+        chartSectionProps$,
+      },
+    };
+  },
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
@@ -122,7 +122,7 @@ const createRootProfileProviders = (providerServices: ProfileProviderServices) =
 const createDataSourceProfileProviders = (providerServices: ProfileProviderServices) => [
   createExampleDataSourceProfileProvider(),
   createPatternsDataSourceProfileProvider(providerServices),
-  createChangePointDataSourceProfileProvider(),
+  createChangePointDataSourceProfileProvider(providerServices),
   createMetricsDataSourceProfileProvider(),
   createDeprecationLogsDataSourceProfileProvider(),
   createSparklineDataSourceProfileProvider(providerServices),


### PR DESCRIPTION
## Summary
- For CHANGE_POINT ES|QL results, the Summary column now shows a small sparkline for that row, with a marker at the change point.
- The chart sits in the cell’s normal layout (no EUI internal class overrides) and can be resized like other columns.
Default columns are type, Summary, then p-value (so Summary is not last and can be resized). It starts at 200px but persists the user selected width if it is updated.
- The Summary cell is not expandable, so the “click or hit enter to interact” control is off. Detail still lives in the Overview flyout and the charts above the table.
- Summary sparklines downsample dense series with LTTB (Largest Triangle Three Buckets)  (max 100 points). Each change-point Summary cell uses Elastic Charts, but long lines are thinned after the shared fetch so charts keep spikes and trend without plotting thousands of points. Short series are unchanged. 

<img width="1927" height="1184" alt="image" src="https://github.com/user-attachments/assets/40ee964b-2573-4180-a337-053edf7b8f13" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



