### PR TITLE
[Cases] Fix CPS metrics error

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/count.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/count.test.ts
@@ -33,7 +33,10 @@ const constructorOptions = { caseId: 'test-id', casesClient: clientMock, clientA
 describe('AlertsCount', () => {
   beforeAll(() => {
     getAuthorizationFilter.mockResolvedValue({});
-    clientMock.cases.get.mockResolvedValue({ id: 'test-id' } as unknown as Case);
+    clientMock.cases.get.mockResolvedValue({
+      id: 'test-id',
+      owner: 'securitySolution',
+    } as unknown as Case);
   });
 
   beforeEach(() => {
@@ -51,5 +54,16 @@ describe('AlertsCount', () => {
     const handler = new AlertsCount(constructorOptions);
 
     expect(await handler.compute()).toEqual({ alerts: { count: 5 } });
+  });
+
+  it('passes the case owner to the attachment service', async () => {
+    attachmentService.countAlertsAttachedToCase.mockResolvedValue(0);
+    const handler = new AlertsCount(constructorOptions);
+
+    await handler.compute();
+
+    expect(attachmentService.countAlertsAttachedToCase).toHaveBeenCalledWith(
+      expect.objectContaining({ caseId: 'test-id', owner: 'securitySolution' })
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/count.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/count.ts
@@ -42,6 +42,7 @@ export class AlertsCount extends SingleCaseBaseHandler {
       const alertsCount = await attachmentService.countAlertsAttachedToCase({
         caseId: theCase.id,
         filter: authorizationFilter,
+        owner: theCase.owner,
       });
 
       return {

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.test.ts
@@ -80,6 +80,45 @@ describe('AlertDetails', () => {
     expect(getAuthorizationFilter).toHaveBeenCalled();
   });
 
+  it('excludes linked-project alert indices from executeAggregations', async () => {
+    const linkedIndex = 'keepcps-2907-linked-99-e5ebb4:.alerts-security.alerts-default';
+    const originAlert = {
+      id: 'alert-origin',
+      index: '.alerts-security.alerts-default',
+      attached_at: '2020-01-01T00:00:00.000Z',
+    };
+    client.attachments.getAllDocumentsAttachedToCase.mockResolvedValue([
+      originAlert,
+      { id: 'alert-linked', index: linkedIndex, attached_at: '2020-01-01T00:00:00.000Z' },
+    ]);
+
+    const handler = new AlertDetails(constructorOptions);
+    handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
+    await handler.compute();
+
+    expect(mockServices.services.alertsService.executeAggregations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        alerts: [originAlert],
+      })
+    );
+  });
+
+  it('skips executeAggregations when every attached alert is a linked-project index', async () => {
+    client.attachments.getAllDocumentsAttachedToCase.mockResolvedValue([
+      {
+        id: 'alert-linked',
+        index: 'keepcps-2907-linked-99-e5ebb4:.alerts-security.alerts-default',
+        attached_at: '2020-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    const handler = new AlertDetails(constructorOptions);
+    handler.setupFeature(CaseMetricsFeature.ALERTS_HOSTS);
+    await handler.compute();
+
+    expect(mockServices.services.alertsService.executeAggregations).not.toHaveBeenCalled();
+  });
+
   it('fetches alerts and entity attachments concurrently rather than sequentially', async () => {
     let resolveAlerts: (
       value: Array<{ id: string; index: string; attached_at: string }>

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/details.ts
@@ -14,6 +14,7 @@ import { CaseMetricsFeature } from '../../../../common/types/api';
 import { Operations } from '../../../authorization';
 import { getOwnersFilter } from '../../../authorization/utils';
 import { createCaseError } from '../../../common/error';
+import { filterOriginAlerts } from '../../../common/utils';
 import type { UnifiedAttachmentAttributes } from '../../../common/types/attachments_v2';
 
 import { SingleCaseAggregationHandler } from '../single_case_aggregation_handler';
@@ -64,10 +65,13 @@ export class AlertDetails extends SingleCaseAggregationHandler {
         this.formatResponse<SingleCaseMetricsResponse>(undefined);
       let knownAlertNames: KnownAlertNames = { userNames: new Set(), hostNames: new Set() };
 
-      if (alerts.length > 0) {
+      // Linked-project indices (`cluster:index`) fail origin-only ES routing.
+      const originAlerts = filterOriginAlerts(alerts);
+
+      if (originAlerts.length > 0) {
         const aggregationsResponse = await alertsService.executeAggregations({
           aggregationBuilders: this.aggregationBuilders,
-          alerts,
+          alerts: originAlerts,
         });
         metrics = this.formatResponse<SingleCaseMetricsResponse>(aggregationsResponse);
         knownAlertNames = {

--- a/x-pack/platform/plugins/shared/cases/server/common/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/utils.ts
@@ -12,6 +12,7 @@ import type {
   SavedObjectReference,
   IBasePath,
 } from '@kbn/core/server';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { flatMap, uniqWith, xorWith } from 'lodash';
 import type { LensServerPluginSetup } from '@kbn/lens-plugin/server';
 import { addSpaceIdToPath } from '@kbn/core-spaces-common';
@@ -208,6 +209,13 @@ export const flattenAttachmentSavedObject = (
   version: savedObject.version ?? '0',
   ...savedObject.attributes,
 });
+
+/**
+ * Filters out alerts whose index belongs to a linked project (`cluster:index`),
+ * which cannot be resolved through the origin-only alerts ES client.
+ */
+export const filterOriginAlerts = <T extends { index: string }>(alerts: T[]): T[] =>
+  alerts.filter((alert) => !isNonLocalIndexName(alert.index));
 
 export const getIDsAndIndicesAsArrays = (
   comment: AttachmentRequestV2

--- a/x-pack/platform/plugins/shared/cases/server/services/alerts/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/alerts/index.test.ts
@@ -472,6 +472,45 @@ describe('updateAlertsStatus', () => {
     });
   });
 
+  describe('executeAggregations', () => {
+    const aggregationBuilders = [
+      {
+        getName: () => 'hosts',
+        build: () => ({ hosts_total: { cardinality: { field: 'host.id' } } }),
+        formatResponse: () => ({}),
+      },
+    ];
+
+    it('searches unique alert ids and indices with ignore_unavailable', async () => {
+      const aggregations = { hosts_total: { value: 2 } };
+      esClient.search.mockResolvedValue({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { hits: [] },
+        aggregations,
+      });
+
+      const res = await alertService.executeAggregations({
+        aggregationBuilders,
+        alerts: [
+          { id: 'alert-1', index: '.alerts-security.alerts-default' },
+          { id: 'alert-2', index: '.alerts-security.alerts-default' },
+          { id: 'alert-3', index: '.alerts-observability.alerts-default' },
+        ],
+      });
+
+      expect(esClient.search).toHaveBeenCalledWith({
+        index: ['.alerts-security.alerts-default', '.alerts-observability.alerts-default'],
+        ignore_unavailable: true,
+        query: { ids: { values: ['alert-1', 'alert-2', 'alert-3'] } },
+        size: 0,
+        aggregations: { hosts_total: { cardinality: { field: 'host.id' } } },
+      });
+      expect(res).toEqual(aggregations);
+    });
+  });
+
   describe('getAlerts', () => {
     const docs = [
       {

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
@@ -27,11 +27,13 @@ import { createErrorSO, createSOFindResponse, mockPointInTimeFinder } from '../t
 import {
   CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_COMMENT_SAVED_OBJECT,
+  LEGACY_ALERT_TYPE,
   LENS_ATTACHMENT_TYPE,
   LENS_SO_TYPE,
   SECURITY_ENTITY_ATTACHMENT_TYPE,
   SECURITY_SOLUTION_OWNER,
 } from '../../../common/constants';
+import { toUnifiedAttachmentType } from '../../../common/utils/attachments';
 import type { ConfigType } from '../../config';
 
 const createAttachmentServiceConfig = (attachmentsEnabled = false): ConfigType =>
@@ -2184,6 +2186,45 @@ describe('AttachmentService', () => {
         caseId: 'test-id',
         owner: SECURITY_SOLUTION_OWNER,
         originOnly: false,
+      });
+
+      expect(res).toBe(2);
+    });
+
+    it('counts unified alert attachments with a missing metadata.index instead of throwing', async () => {
+      mockFinder(
+        createSOFindResponse([
+          {
+            id: '1',
+            type: CASE_ATTACHMENT_SAVED_OBJECT,
+            attributes: {
+              type: toUnifiedAttachmentType(LEGACY_ALERT_TYPE, SECURITY_SOLUTION_OWNER),
+              attachmentId: ['a', 'b'],
+              owner: SECURITY_SOLUTION_OWNER,
+              created_at: '2019-11-25T21:55:00.177Z',
+              created_by: {
+                full_name: 'elastic',
+                email: 'testemail@elastic.co',
+                username: 'elastic',
+              },
+              pushed_at: null,
+              pushed_by: null,
+              updated_at: '2019-11-25T21:55:00.177Z',
+              updated_by: {
+                full_name: 'elastic',
+                email: 'testemail@elastic.co',
+                username: 'elastic',
+              },
+            },
+            references: [],
+            score: 0,
+          },
+        ])
+      );
+
+      const res = await service.countAlertsAttachedToCase({
+        caseId: 'test-id',
+        owner: SECURITY_SOLUTION_OWNER,
       });
 
       expect(res).toBe(2);

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
@@ -23,7 +23,7 @@ import {
   persistableStateAttachmentAttributes,
 } from '../../attachment_framework/mocks';
 import { createAlertAttachment, createUserAttachment } from './test_utils';
-import { createErrorSO, createSOFindResponse } from '../test_utils';
+import { createErrorSO, createSOFindResponse, mockPointInTimeFinder } from '../test_utils';
 import {
   CASE_ATTACHMENT_SAVED_OBJECT,
   CASE_COMMENT_SAVED_OBJECT,
@@ -2100,6 +2100,93 @@ describe('AttachmentService', () => {
 
       const filterAsString = JSON.stringify(unifiedCallArgs.filter);
       expect(filterAsString).not.toMatch(/"value":\s*"file"/);
+    });
+  });
+
+  describe('countAlertsAttachedToCase', () => {
+    const mockFinder = mockPointInTimeFinder(unsecuredSavedObjectsClient);
+
+    it('counts unique origin alert ids', async () => {
+      mockFinder(
+        createSOFindResponse([
+          { ...createAlertAttachment({ alertId: 'a', index: 'origin-index' }), score: 0 },
+          { ...createAlertAttachment({ alertId: 'a', index: 'origin-index' }), score: 0 },
+          { ...createAlertAttachment({ alertId: 'b', index: 'origin-index' }), score: 0 },
+        ])
+      );
+
+      const res = await service.countAlertsAttachedToCase({
+        caseId: 'test-id',
+        owner: SECURITY_SOLUTION_OWNER,
+      });
+
+      expect(res).toBe(2);
+    });
+
+    it('excludes alerts from linked-project indices', async () => {
+      mockFinder(
+        createSOFindResponse([
+          { ...createAlertAttachment({ alertId: 'origin', index: 'origin-index' }), score: 0 },
+          {
+            ...createAlertAttachment({
+              alertId: 'linked',
+              index: 'keepcps-2907-linked-99-e5ebb4:.alerts-security.alerts-default',
+            }),
+            score: 0,
+          },
+        ])
+      );
+
+      const res = await service.countAlertsAttachedToCase({
+        caseId: 'test-id',
+        owner: SECURITY_SOLUTION_OWNER,
+      });
+
+      expect(res).toBe(1);
+    });
+
+    it('returns 0 when every attached alert is a linked-project index', async () => {
+      mockFinder(
+        createSOFindResponse([
+          {
+            ...createAlertAttachment({
+              alertId: 'linked',
+              index: 'keepcps-2907-linked-99-e5ebb4:.alerts-security.alerts-default',
+            }),
+            score: 0,
+          },
+        ])
+      );
+
+      const res = await service.countAlertsAttachedToCase({
+        caseId: 'test-id',
+        owner: SECURITY_SOLUTION_OWNER,
+      });
+
+      expect(res).toBe(0);
+    });
+
+    it('counts linked-project alerts when originOnly is false', async () => {
+      mockFinder(
+        createSOFindResponse([
+          { ...createAlertAttachment({ alertId: 'origin', index: 'origin-index' }), score: 0 },
+          {
+            ...createAlertAttachment({
+              alertId: 'linked',
+              index: 'keepcps-2907-linked-99-e5ebb4:.alerts-security.alerts-default',
+            }),
+            score: 0,
+          },
+        ])
+      );
+
+      const res = await service.countAlertsAttachedToCase({
+        caseId: 'test-id',
+        owner: SECURITY_SOLUTION_OWNER,
+        originOnly: false,
+      });
+
+      expect(res).toBe(2);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -20,7 +20,7 @@ import { isSavedObjectErrorResult } from '@kbn/core/server';
 
 import type { estypes } from '@elastic/elasticsearch';
 import type { KueryNode } from '@kbn/es-query';
-import { fromKueryExpression } from '@kbn/es-query';
+import { fromKueryExpression, isNonLocalIndexName } from '@kbn/es-query';
 import { AttachmentType } from '../../../common/types/domain';
 import {
   UNIFIED_ALERT_TYPES_ARRAY,
@@ -49,7 +49,7 @@ import {
   resolveAttachmentSavedObjectTypes,
 } from '../../common/attachments';
 import { buildFilter, combineFilters } from '../../client/utils';
-import { defaultSortField } from '../../common/utils';
+import { defaultSortField, getIDsAndIndicesAsArrays } from '../../common/utils';
 import type { AggregationResponse } from '../../client/metrics/types';
 import {
   extractAttachmentSORefsFromAttributes,
@@ -170,17 +170,34 @@ export class AttachmentService {
    *
    * Used by the case metrics handler to display the alert count to the user.
    */
-  public async countAlertsAttachedToCase(
-    params: AlertsAttachedToCaseArgs
-  ): Promise<number | undefined> {
-    const { caseId, filter: authorizationFilter } = params;
+  public async countAlertsAttachedToCase({
+    caseId,
+    filter: authorizationFilter,
+    owner,
+    originOnly = true,
+  }: AlertsAttachedToCaseArgs): Promise<number | undefined> {
     try {
       this.context.log.debug(`Attempting to count alerts for case id ${caseId}`);
-      return this.aggregateAlertsForCase({
+
+      const documents = await this.getter.getAllDocumentsAttachedToCase({
         caseId,
-        aggType: 'cardinality',
-        extraFilter: authorizationFilter,
+        filter: authorizationFilter,
+        attachmentTypes: [AttachmentType.alert],
+        owner,
       });
+
+      const alertIds = new Set<string>();
+      for (const document of documents) {
+        const { ids, indices } = getIDsAndIndicesAsArrays(document.attributes);
+
+        ids.forEach((id, index) => {
+          if (originOnly && isNonLocalIndexName(indices[index])) {
+            alertIds.add(id);
+          }
+        });
+      }
+
+      return alertIds.size;
     } catch (error) {
       this.context.log.error(`Error while counting alerts for case id ${caseId}: ${error}`);
       throw error;
@@ -198,7 +215,7 @@ export class AttachmentService {
       this.context.log.debug(
         `Attempting to count all alerts (legacy + unified) for case ${caseId}`
       );
-      return this.aggregateAlertsForCase({ caseId, aggType: 'value_count' });
+      return this.aggregateAlertsForCase(caseId);
     } catch (error) {
       this.context.log.error(`Error while counting alerts for case ${caseId}: ${error}`);
       throw error;
@@ -206,21 +223,10 @@ export class AttachmentService {
   }
 
   /**
-   * Shared aggregation across legacy (`cases-comments.attributes.alertId`) and
-   * unified (`cases-attachments.attributes.attachmentId`) alert storage.
-   *
-   * @param aggType `'cardinality'` for unique alert ids, `'value_count'` for occurrences.
-   * @param extraFilter additional KueryNode (e.g. authorization) AND-combined onto the type filter.
+   * Aggregates alert occurrence counts across legacy (`cases-comments.attributes.alertId`)
+   * and unified (`cases-attachments.attributes.attachmentId`) alert storage.
    */
-  private async aggregateAlertsForCase({
-    caseId,
-    aggType,
-    extraFilter,
-  }: {
-    caseId: string;
-    aggType: 'cardinality' | 'value_count';
-    extraFilter?: KueryNode;
-  }): Promise<number> {
+  private async aggregateAlertsForCase(caseId: string): Promise<number> {
     const typeFilters: Array<KueryNode | undefined> = [
       buildFilter({
         filters: [AttachmentType.alert],
@@ -238,15 +244,14 @@ export class AttachmentService {
 
     const aggregations: Record<string, estypes.AggregationsAggregationContainer> = {
       legacyAlerts: {
-        [aggType]: { field: `${CASE_COMMENT_SAVED_OBJECT}.attributes.alertId` },
+        value_count: { field: `${CASE_COMMENT_SAVED_OBJECT}.attributes.alertId` },
       },
       unifiedAlerts: {
-        [aggType]: { field: `${CASE_ATTACHMENT_SAVED_OBJECT}.attributes.attachmentId` },
+        value_count: { field: `${CASE_ATTACHMENT_SAVED_OBJECT}.attributes.attachmentId` },
       },
     };
 
-    const combinedTypeFilter = combineFilters(typeFilters, 'or');
-    const combinedFilter = combineFilters([combinedTypeFilter, extraFilter]);
+    const combinedFilter = combineFilters(typeFilters, 'or');
 
     const response = await this.context.unsecuredSavedObjectsClient.find<
       unknown,

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -191,7 +191,8 @@ export class AttachmentService {
         const { ids, indices } = getIDsAndIndicesAsArrays(document.attributes);
 
         ids.forEach((id, index) => {
-          if (!originOnly || !isNonLocalIndexName(indices[index])) {
+          const alertIndex = indices[index];
+          if (!originOnly || alertIndex == null || !isNonLocalIndexName(alertIndex)) {
             alertIds.add(id);
           }
         });

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -191,7 +191,7 @@ export class AttachmentService {
         const { ids, indices } = getIDsAndIndicesAsArrays(document.attributes);
 
         ids.forEach((id, index) => {
-          if (originOnly && isNonLocalIndexName(indices[index])) {
+          if (!originOnly || !isNonLocalIndexName(indices[index])) {
             alertIds.add(id);
           }
         });

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
@@ -117,7 +117,14 @@ export interface EventIdsAggsResult {
   };
 }
 
-export type AlertsAttachedToCaseArgs = AttachedToCaseArgs;
+export type AlertsAttachedToCaseArgs = AttachedToCaseArgs & {
+  owner: string;
+  /**
+   * Excludes alerts whose index belongs to a linked project
+   * default to true
+   */
+  originOnly?: boolean;
+};
 
 export interface AttachmentsAttachedToCaseArgs extends AttachedToCaseArgs {
   attachmentType: AttachmentType;


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/283291

Added exclude linked alerts filter to metrics only. A separate PR will block adding linked alerts to the case, this fix will remove the error in cases that already have linked alerts.

How to test
- Set up linked projects with alerts
- Add some linked alerts (bulk example below) via the api in dev tools
- Observe no error toast, metric reflect correct alert count and host count
<img width="781" height="232" alt="image" src="https://github.com/user-attachments/assets/2f4a5051-4727-4835-a50b-e664e4957b44" />

```
POST kbn:/api/cases/6d786c06-27af-455a-bda4-35869a18005c/comments
{
  "type": "security.alert",
  "attachmentId": ["4c7ad8b73df560cadd0d8290c2be94963084c2b944864b5942b3ca4323909b94","82d7b7708767932f555cd95dc0991a5bb48e498c31e7c590e8efc6f25062fff5"],
  "owner": "securitySolution",
  "metadata": {
    "index": [".ds-.alerts-security.alerts-default-2026.08.19-000001", "linked_local_project:.ds-.alerts-security.alerts-default-2026.08.19-000001"],
    "rule": { "id": "b8750d4a-6dc4-45b0-8ef4-62cea815af01", "name": "Endpoint Security (Elastic Defend)" }
  }
}
```

### Checklist


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->