### PR TITLE
[VectorDB] Hide trial-only onboarding pills for non-trial users

### DIFF
--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/api_step.test.tsx
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/api_step.test.tsx
@@ -53,15 +53,19 @@ const hybridTab: ApiStepTab = {
   consoleRequest: 'POST my-vectors/_search\n{ "hybrid": true }',
 };
 
-const services = {
-  application: {},
-  share: {},
-  console: {},
-} as unknown as OnboardingServices;
+const isInTrial = jest.fn();
+
+const makeServices = () =>
+  ({
+    application: {},
+    share: {},
+    console: {},
+    cloud: { isInTrial },
+  } as unknown as OnboardingServices);
 
 const renderComponent = (props: Partial<React.ComponentProps<typeof ApiStep>> = {}) =>
   render(
-    <KibanaContextProvider services={services}>
+    <KibanaContextProvider services={makeServices()}>
       <ApiStep
         tabs={[semanticTab, hybridTab]}
         consoleComment="Test console comment"
@@ -89,6 +93,45 @@ describe('ApiStep', () => {
       elasticsearchUrl: null,
       apiKey: null,
       isLoading: false,
+    });
+    isInTrial.mockReturnValue(false);
+  });
+
+  describe('pills', () => {
+    const trialPill = {
+      id: 'freeTrialEmbeddings',
+      label: 'Free trial embeddings',
+      content: 'Trial content',
+      trialOnly: true,
+    };
+    const standardPill = {
+      id: 'jinaModels',
+      label: 'Jina embedding models',
+      content: 'Jina content',
+    };
+
+    it('shows trial pills while the project is in trial', () => {
+      isInTrial.mockReturnValue(true);
+
+      renderComponent({ pills: [trialPill, standardPill] });
+
+      expect(screen.getByTestId('vectordbWizardPill-freeTrialEmbeddings')).toBeInTheDocument();
+      expect(screen.getByTestId('vectordbWizardPill-jinaModels')).toBeInTheDocument();
+    });
+
+    it('hides trial pills outside of a trial', () => {
+      renderComponent({ pills: [trialPill, standardPill] });
+
+      expect(
+        screen.queryByTestId('vectordbWizardPill-freeTrialEmbeddings')
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('vectordbWizardPill-jinaModels')).toBeInTheDocument();
+    });
+
+    it('hides the pill group when every pill is trial only', () => {
+      renderComponent({ pills: [trialPill] });
+
+      expect(screen.queryByTestId('vectordbWizardPills')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/api_step.tsx
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/api_step.tsx
@@ -56,7 +56,7 @@ interface ApiStepProps {
 
 export const ApiStep = ({ tabs, consoleComment, docsPanel, pills, step, path }: ApiStepProps) => {
   const {
-    services: { application, share, console: consolePlugin },
+    services: { application, share, console: consolePlugin, cloud },
   } = useKibana();
   const { elasticsearchUrl, apiKey } = useOnboardingCredentials();
   const [language, setLanguage] = useState<Language>(DEFAULT_LANGUAGE);
@@ -75,6 +75,9 @@ export const ApiStep = ({ tabs, consoleComment, docsPanel, pills, step, path }: 
   );
 
   const telemetryPrefix = `vectordbOnboarding-${step}-${path}`;
+
+  const isInTrial = cloud?.isInTrial() ?? false;
+  const visiblePills = isInTrial ? pills : pills.filter(({ trialOnly }) => !trialOnly);
 
   const languageMenuItems = LANGUAGES.map((lang) => (
     <EuiContextMenuItem
@@ -104,10 +107,10 @@ export const ApiStep = ({ tabs, consoleComment, docsPanel, pills, step, path }: 
   return (
     <>
       <EuiPanel paddingSize="s" hasBorder={false} hasShadow={false} color="subdued">
-        {pills.length > 0 && (
+        {visiblePills.length > 0 && (
           <>
             <EuiPanel paddingSize="s" color="transparent">
-              <OnboardingPills pills={pills} telemetryPrefix={telemetryPrefix} />
+              <OnboardingPills pills={visiblePills} telemetryPrefix={telemetryPrefix} />
             </EuiPanel>
             <EuiSpacer size="s" />
           </>

--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/onboarding_data.tsx
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/components/onboarding_data.tsx
@@ -69,6 +69,7 @@ export const getStepContent = (docLinks: DocLinksStart) => {
               defaultMessage:
                 "Your trial includes up to 30,000 embedding requests or 100 million tokens, whichever comes first. You'll only be billed once you're on a paid plan.",
             }),
+            trialOnly: true,
           },
           {
             id: 'jinaModels',

--- a/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/types.ts
+++ b/x-pack/solutions/vectordb/packages/kbn-vectordb-onboarding/src/onboarding/types.ts
@@ -22,4 +22,5 @@ export interface OnboardingPill {
   id: string;
   label: string;
   content: ReactNode;
+  trialOnly?: boolean;
 }


### PR DESCRIPTION
## Summary

The **Free trial embeddings** pill in the Vector DB onboarding wizard describes trial allowances ("up to 30,000 embedding requests or 100 million tokens"), but it was shown to every user, including those already on a paid plan.

Pills can now be marked `trialOnly`, and `ApiStep` filters those out unless `cloud.isInTrial()` reports an active trial.


### Testing
You can test this locally by adding the following to `xpack.cloud` in `config/serverless.vectordb.dev.yml`:

```
xpack.cloud:
  serverless:
    in_trial: true
  trial_end_date: '2027-01-01T00:00:00.000Z'
  ```

Without adding settings for a trial, you should not see the pill. If you the trial settings in your config, then you should see the pill.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


Made with [Cursor](https://cursor.com)