### PR TITLE
[9.5] [Cases] Harden templates-v2 extended-field key names with split read/write validation (#285423)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -233,6 +233,70 @@ export const MAX_FIELDS_PER_TEMPLATE = 200 as const;
  * non-ASCII input) so this maps directly onto Lucene's limit.
  */
 export const MAX_EXTENDED_FIELD_VALUE_BYTES = 30000 as const;
+
+/**
+ * Single source of truth for the allowed character sets in templates-v2 extended-field keys.
+ *
+ * The key stored for a field is `${name}_as_${type}` (see `getFieldSnakeKey` in
+ * `common/utils/template_fields.ts`). Because this key is interpolated verbatim into Painless
+ * string literals (search-time scripts and data-view runtime fields), the set of safe characters
+ * must exclude anything that could break Painless source or push the compiled script over
+ * Elasticsearch's 65,535-byte bytecode limit.
+ *
+ * Two guards, deliberately not independent:
+ *
+ *   AUTHORABLE_SNAKE_KEY  — what a user may newly create (strict).
+ *   SAFE_SNAKE_KEY        — what we are willing to read back / publish (lenient superset).
+ *
+ * The lenient guard exists because keys already in the index may contain characters that
+ * predate the strict rule (e.g. hyphens written by the v1→v2 migration task). We must be
+ * able to read and surface those fields without breaking anything, even though we now refuse
+ * to create new ones with the same shape.
+ *
+ * **NEVER add a character to AUTHORABLE_SNAKE_KEY without also ensuring it is in
+ * SAFE_SNAKE_KEY** — the containment is validated by the unit tests in
+ * `common/constants/snake_key_guards.test.ts`. The deliberate delta between the two
+ * (READ_TOLERATED_KEY_CHARS) is the only place to add characters that apply to reads only.
+ */
+
+/** The base character class — written down once. Both regexes are derived from this string. */
+const AUTHORABLE_KEY_CHARS = 'A-Za-z0-9_';
+
+/**
+ * Characters permitted in keys already in the index but NOT in newly-authored names.
+ * Hyphens are here because the v1→v2 migration wrote UUID field names (hex + hyphens) and
+ * some hand-authored hyphenated names already exist; on the authoring path a hyphen is
+ * refused because it camel-folds identically to `_` and reads as KQL negation.
+ * Anything added here widens reads only — by construction it cannot widen authoring.
+ */
+const READ_TOLERATED_KEY_CHARS = '-';
+
+/**
+ * Authoring guard — what a user may newly create.
+ * Must stay a strict subset of SAFE_SNAKE_KEY; enforced by unit tests.
+ */
+export const AUTHORABLE_SNAKE_KEY = new RegExp(`^[${AUTHORABLE_KEY_CHARS}]+$`);
+
+/**
+ * Read / storage guard — what we will accept when reading back keys from the index and
+ * interpolating them into Painless literals. A superset of AUTHORABLE_SNAKE_KEY by
+ * construction (shares AUTHORABLE_KEY_CHARS, adds READ_TOLERATED_KEY_CHARS).
+ */
+export const SAFE_SNAKE_KEY = new RegExp(`^[${AUTHORABLE_KEY_CHARS}${READ_TOLERATED_KEY_CHARS}]+$`);
+
+/**
+ * The longest `type` literal that any inline field can carry (the second half of the
+ * `${name}_as_${type}` key). Used when validating `$ref` aliases that have no locally-known
+ * type — checking against this value guarantees the derived key fits MAX_SNAKE_KEY_LENGTH
+ * regardless of which type the referenced field uses.
+ *
+ * A unit test ("LONGEST_STORAGE_TYPE is the longest type literal in the field schemas")
+ * in `strict_fields.test.ts` compares this against `ALL_TEMPLATE_TYPE_SUFFIXES` from the
+ * server analytics module. If a longer type literal is added to the field schemas that test
+ * will fail, prompting an update here.
+ */
+export const LONGEST_STORAGE_TYPE = 'unsigned_long' as const;
+
 /**
  * Maximum length of a full `${name}_as_${type}` extended-field storage key.
  * Shared by the friendly-name generator (which reserves room for the longest

--- a/x-pack/platform/plugins/shared/cases/common/constants/snake_key_guards.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/snake_key_guards.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SAFE_SNAKE_KEY, AUTHORABLE_SNAKE_KEY, MAX_SNAKE_KEY_LENGTH } from '.';
+import { isSafeExtendedFieldKey, isAuthorableExtendedFieldKey } from '../utils/template_fields';
+
+/**
+ * Structural tests for the two snake-key guards.
+ *
+ * These tests defend the guarantee that AUTHORABLE_SNAKE_KEY ⊆ SAFE_SNAKE_KEY, that the
+ * delta between them is exactly the characters we intend to tolerate on read only (hyphens),
+ * and that both share the same length cap. They catch regressions where someone widens one
+ * regex without intending to widen the other, or where a new character slips into one without
+ * the other being updated to match.
+ *
+ * They are NOT an exhaustive charset test — they are a drift-detector for the relationship
+ * between the two regexes. If you need to allow a new character, update both regexes (or
+ * deliberately add it to READ_TOLERATED_KEY_CHARS only) and update the "delta is exactly"
+ * test below to reflect the new intent.
+ */
+describe('snake-key guard invariants', () => {
+  // Probe the regexes at every code point in the Latin-1 range plus a few non-ASCII samples.
+  // This is wide enough to catch any accidental widening without being exhaustive over all
+  // Unicode. Non-ASCII characters are expected to fail both guards.
+  const sampleCodePoints = [
+    ...Array.from({ length: 0x2ff + 1 }, (_, i) => i),
+    0x4e2d, // 中 — CJK
+    0x00e9, // é — Latin Extended-A
+    0x1f600, // 😀 — emoji (surrogate pair in JS; str.length === 2)
+  ];
+
+  const acceptedByAuth = new Set<string>();
+  const acceptedBySafe = new Set<string>();
+
+  beforeAll(() => {
+    for (const cp of sampleCodePoints) {
+      // String.fromCodePoint handles surrogate pairs, unlike String.fromCharCode
+      const ch = String.fromCodePoint(cp);
+      if (AUTHORABLE_SNAKE_KEY.test(ch)) acceptedByAuth.add(ch);
+      if (SAFE_SNAKE_KEY.test(ch)) acceptedBySafe.add(ch);
+    }
+  });
+
+  it('every key the authoring guard accepts is also accepted by the read guard', () => {
+    // AUTHORABLE_SNAKE_KEY ⊆ SAFE_SNAKE_KEY — breaking this would let authors create
+    // keys the reader then rejects, silently dropping those fields from analytics.
+    for (const ch of acceptedByAuth) {
+      expect(SAFE_SNAKE_KEY.test(ch)).toBe(true);
+    }
+  });
+
+  it('a hyphen is accepted by the read guard but rejected by the authoring guard', () => {
+    // This is the single-sentence behavioural contract of the split. Pin it so the intent
+    // survives future refactors: if someone moves `-` into AUTHORABLE_KEY_CHARS, this test
+    // fails and they have to make that an intentional decision.
+    expect(SAFE_SNAKE_KEY.test('-')).toBe(true);
+    expect(AUTHORABLE_SNAKE_KEY.test('-')).toBe(false);
+  });
+
+  it('the delta between the read guard and the authoring guard is exactly the intended tolerated set', () => {
+    // Characters accepted by SAFE_SNAKE_KEY but not by AUTHORABLE_SNAKE_KEY should be exactly
+    // the characters in READ_TOLERATED_KEY_CHARS — currently just hyphens. If this test fails,
+    // either the delta grew (a new character was added to SAFE_SNAKE_KEY only) or shrank
+    // (a character was removed from SAFE_SNAKE_KEY, making some stored keys unreadable).
+    const delta = [...acceptedBySafe].filter((ch) => !acceptedByAuth.has(ch)).sort();
+    // Update this list if READ_TOLERATED_KEY_CHARS is intentionally changed.
+    expect(delta).toEqual(['-']);
+  });
+
+  it('both guards share the same length cap via their wrapper helpers', () => {
+    const exactLen = 'a'.repeat(MAX_SNAKE_KEY_LENGTH);
+    const overLen = 'a'.repeat(MAX_SNAKE_KEY_LENGTH + 1);
+
+    expect(isSafeExtendedFieldKey(exactLen)).toBe(true);
+    expect(isSafeExtendedFieldKey(overLen)).toBe(false);
+
+    expect(isAuthorableExtendedFieldKey(exactLen)).toBe(true);
+    expect(isAuthorableExtendedFieldKey(overLen)).toBe(false);
+  });
+
+  it('empty string is rejected by both guards', () => {
+    expect(isSafeExtendedFieldKey('')).toBe(false);
+    expect(isAuthorableExtendedFieldKey('')).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/strict_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/strict_fields.test.ts
@@ -1,0 +1,375 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LONGEST_STORAGE_TYPE } from '../../../constants';
+import {
+  ALL_TEMPLATE_TYPE_SUFFIXES,
+  splitSnakeKey,
+} from '../../../../server/cases_analytics_v2/data_view/runtime_fields';
+import { getFieldSnakeKey } from '../../../utils/template_fields';
+import {
+  StrictInlineFieldSchema,
+  StrictFieldSchema,
+  StrictFieldsArraySchema,
+  buildStrictFieldsArraySchema,
+  collectExistingFieldNames,
+} from './strict_fields';
+import type { Field } from './fields';
+
+/**
+ * Tests for strict_fields.ts.
+ *
+ * The load-bearing test is the round-trip: for any name `StrictInlineFieldSchema` accepts,
+ * `splitSnakeKey(getFieldSnakeKey(name, type))` is non-null for every type suffix. That
+ * asserts the invariant "every name a user can author produces a key that `splitSnakeKey`
+ * accepts" — which is the whole point of this module.
+ */
+describe('LONGEST_STORAGE_TYPE', () => {
+  it('is the longest type literal in ALL_TEMPLATE_TYPE_SUFFIXES', () => {
+    // If a longer type literal is added to the field schemas, this test fails so that
+    // LONGEST_STORAGE_TYPE in common/constants/index.ts can be updated. Without this
+    // test, $ref alias validation would silently over-permit names that produce keys
+    // longer than MAX_SNAKE_KEY_LENGTH when paired with the new longer type.
+    const longest = ALL_TEMPLATE_TYPE_SUFFIXES.reduce(
+      (max, s) => (s.length > max.length ? s : max),
+      ''
+    );
+    expect(LONGEST_STORAGE_TYPE).toBe(longest);
+  });
+});
+
+describe('StrictInlineFieldSchema', () => {
+  const validInlineField = {
+    control: 'INPUT_TEXT',
+    name: 'risk_score',
+    type: 'keyword',
+  };
+
+  describe('accepts', () => {
+    it('names with letters, digits, and underscores', () => {
+      const result = StrictInlineFieldSchema.safeParse({
+        ...validInlineField,
+        name: 'risk_score_2024',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('names with uppercase letters', () => {
+      const result = StrictInlineFieldSchema.safeParse({ ...validInlineField, name: 'RiskScore' });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('rejects', () => {
+    it('names with hyphens', () => {
+      const result = StrictInlineFieldSchema.safeParse({ ...validInlineField, name: 'risk-score' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('name');
+        expect(result.error.issues[0].message).toContain('risk-score');
+      }
+    });
+
+    it('names with spaces', () => {
+      const result = StrictInlineFieldSchema.safeParse({ ...validInlineField, name: 'Risk Score' });
+      expect(result.success).toBe(false);
+    });
+
+    it('names with dots', () => {
+      const result = StrictInlineFieldSchema.safeParse({ ...validInlineField, name: 'risk.score' });
+      expect(result.success).toBe(false);
+    });
+
+    it('names with apostrophes (Painless-injection vector)', () => {
+      const result = StrictInlineFieldSchema.safeParse({ ...validInlineField, name: "risk'score" });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('round-trip invariant', () => {
+    it('every accepted name produces a key that splitSnakeKey parses for all type suffixes', () => {
+      const candidateNames = [
+        'risk_score',
+        'MyField',
+        'field_123',
+        'A',
+        'z',
+        '0',
+        '_leading_underscore',
+        'a'.repeat(50),
+      ];
+
+      for (const name of candidateNames) {
+        for (const suffix of ALL_TEMPLATE_TYPE_SUFFIXES) {
+          // The field's control and type must be consistent — use INPUT_TEXT (keyword)
+          // for the non-numeric suffix, INPUT_NUMBER for a numeric one. For this invariant
+          // test we only need to confirm the derived key is parseable, not that it maps to
+          // a real control. Construct a minimal valid field with the right `type`:
+          const field = {
+            control: suffix === 'keyword' ? 'INPUT_TEXT' : 'INPUT_NUMBER',
+            name,
+            type: suffix,
+          };
+          const parsed = StrictInlineFieldSchema.safeParse(field);
+          // type may be invalid for the control (e.g. 'long' with INPUT_TEXT) — skip those
+          if (parsed.success) {
+            const snakeKey = getFieldSnakeKey(name, suffix);
+            const split = splitSnakeKey(snakeKey);
+            expect(split).not.toBeNull();
+            if (split !== null) {
+              expect(split.name).toBe(name);
+              expect(split.suffix).toBe(suffix);
+            }
+          }
+        }
+      }
+    });
+  });
+});
+
+describe('StrictFieldSchema', () => {
+  describe('$ref entries', () => {
+    it('accepts a $ref without a name alias', () => {
+      const result = StrictFieldSchema.safeParse({ $ref: 'my_library_field' });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a $ref with a valid name alias', () => {
+      const result = StrictFieldSchema.safeParse({ $ref: 'my_field', name: 'my_alias' });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a $ref alias with a hyphen', () => {
+      const result = StrictFieldSchema.safeParse({ $ref: 'my_field', name: 'my-alias' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('name');
+      }
+    });
+
+    it('accepts a UUID-style $ref target (no alias) even though it contains hyphens', () => {
+      // The $ref target is a library-definition name — we intentionally never validate it here.
+      // UUID targets from the v1->v2 migration must remain readable.
+      const uuid = '550e8400-e29b-41d4-a716-446655440000';
+      const result = StrictFieldSchema.safeParse({ $ref: uuid });
+      expect(result.success).toBe(true);
+    });
+  });
+});
+
+describe('StrictFieldsArraySchema', () => {
+  it('rejects a fields array containing a field with an invalid name', () => {
+    const fields = [{ control: 'INPUT_TEXT', name: 'bad name!', type: 'keyword' }];
+    const result = StrictFieldsArraySchema.safeParse(fields);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a fields array with duplicate names', () => {
+    const fields = [
+      { control: 'INPUT_TEXT', name: 'risk_score', type: 'keyword' },
+      { control: 'INPUT_TEXT', name: 'risk_score', type: 'keyword' },
+    ];
+    const result = StrictFieldsArraySchema.safeParse(fields);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/unique/i);
+    }
+  });
+
+  it('accepts a valid fields array', () => {
+    const fields = [
+      { control: 'INPUT_TEXT', name: 'risk_score', type: 'keyword' },
+      { control: 'INPUT_NUMBER', name: 'severity_count', type: 'long' },
+    ];
+    const result = StrictFieldsArraySchema.safeParse(fields);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('collectExistingFieldNames', () => {
+  it('collects inline field names', () => {
+    const fields = [
+      { control: 'INPUT_TEXT', name: 'legacy-field', type: 'keyword' },
+      { control: 'INPUT_NUMBER', name: 'severity_count', type: 'long' },
+    ] as Field[];
+    expect(collectExistingFieldNames(fields)).toEqual(new Set(['legacy-field', 'severity_count']));
+  });
+
+  it('collects $ref aliases but not $ref targets', () => {
+    const fields = [
+      { $ref: 'my_library_field', name: 'legacy-alias' },
+      { $ref: 'other-library-field' },
+    ] as Field[];
+    expect(collectExistingFieldNames(fields)).toEqual(new Set(['legacy-alias']));
+  });
+
+  it('returns an empty set for an empty fields array', () => {
+    expect(collectExistingFieldNames([])).toEqual(new Set());
+  });
+
+  it('excludes display-only (MARKDOWN) names — they are exempt, not grandfathered', () => {
+    const fields = [
+      { control: 'MARKDOWN', name: 'Triage instructions!', metadata: { content: 'Read me' } },
+      { control: 'INPUT_TEXT', name: 'legacy-field', type: 'keyword' },
+    ] as Field[];
+    expect(collectExistingFieldNames(fields)).toEqual(new Set(['legacy-field']));
+  });
+});
+
+describe('buildStrictFieldsArraySchema — grandfathering', () => {
+  it('with no grandfathered names, behaves identically to StrictFieldsArraySchema', () => {
+    const fields = [{ control: 'INPUT_TEXT', name: 'bad name!', type: 'keyword' }];
+    expect(buildStrictFieldsArraySchema().safeParse(fields).success).toBe(false);
+    expect(buildStrictFieldsArraySchema(new Set()).safeParse(fields).success).toBe(false);
+  });
+
+  it('accepts an untouched field whose name predates the authoring-charset rule', () => {
+    const fields = [
+      { control: 'INPUT_TEXT', name: 'legacy-field', type: 'keyword' },
+      { control: 'INPUT_TEXT', name: 'new_valid_field', type: 'keyword' },
+    ];
+    const schema = buildStrictFieldsArraySchema(new Set(['legacy-field']));
+    const result = schema.safeParse(fields);
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects a brand-new field with an invalid name alongside a grandfathered one', () => {
+    const fields = [
+      { control: 'INPUT_TEXT', name: 'legacy-field', type: 'keyword' },
+      { control: 'INPUT_TEXT', name: 'brand new field', type: 'keyword' },
+    ];
+    const schema = buildStrictFieldsArraySchema(new Set(['legacy-field']));
+    const result = schema.safeParse(fields);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('brand new field');
+    }
+  });
+
+  it('does NOT grandfather a rename to a different invalid name (byte-exact match only)', () => {
+    // "legacy-field" was grandfathered; renaming it to "legacy-field-2" is a NEW name that
+    // happens to also be invalid, and must be rejected like any other new invalid name.
+    const fields = [{ control: 'INPUT_TEXT', name: 'legacy-field-2', type: 'keyword' }];
+    const schema = buildStrictFieldsArraySchema(new Set(['legacy-field']));
+    const result = schema.safeParse(fields);
+    expect(result.success).toBe(false);
+  });
+
+  it('grandfathers a $ref alias the same way as an inline name', () => {
+    const fields = [{ $ref: 'my_field', name: 'legacy-alias' }];
+    const schema = buildStrictFieldsArraySchema(new Set(['legacy-alias']));
+    expect(schema.safeParse(fields).success).toBe(true);
+  });
+
+  it('grandfathering a display-only (MARKDOWN) field name is a no-op (already exempt)', () => {
+    const fields = [
+      {
+        control: 'MARKDOWN',
+        name: 'legacy label with spaces',
+        metadata: { content: 'Some instructions' },
+      },
+    ];
+    expect(buildStrictFieldsArraySchema().safeParse(fields).success).toBe(true);
+  });
+});
+
+describe('buildStrictFieldsArraySchema — folded-twin collisions', () => {
+  const parseWithExisting = (name: string, existingNames: string[]) =>
+    buildStrictFieldsArraySchema(new Set(existingNames)).safeParse([
+      { control: 'INPUT_TEXT', name, type: 'keyword' },
+    ]);
+
+  it('rejects an underscore twin of an existing hyphenated name', () => {
+    const result = parseWithExisting('my_field', ['my-field']);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('my_field');
+      expect(result.error.issues[0].message).toContain('my-field');
+    }
+  });
+
+  it('rejects a camelCase twin of an existing snake_case name', () => {
+    const result = parseWithExisting('myField', ['my_field']);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a new name whose folded form matches no existing name', () => {
+    const result = parseWithExisting('unrelated_name', ['my-field']);
+    expect(result.success).toBe(true);
+  });
+
+  it('does not twin-reject the grandfathered name itself (byte-exact match wins)', () => {
+    const result = parseWithExisting('my-field', ['my-field']);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a $ref alias that folds onto an existing name', () => {
+    const result = buildStrictFieldsArraySchema(new Set(['my-field'])).safeParse([
+      { $ref: 'library_field', name: 'my_field' },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  it('applies no twin check on create (no existing names)', () => {
+    const result = buildStrictFieldsArraySchema().safeParse([
+      { control: 'INPUT_TEXT', name: 'my_field', type: 'keyword' },
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects turning a stored MARKDOWN entry into a value-bearing field with its exempt name', () => {
+    // The markdown label was exempt (not grandfathered) — see `collectExistingFieldNames` —
+    // so switching the control to an input must re-run the full name checks and fail.
+    const storedFields = [
+      { control: 'MARKDOWN', name: 'Triage instructions!', metadata: { content: 'Read me' } },
+    ] as Field[];
+    const schema = buildStrictFieldsArraySchema(collectExistingFieldNames(storedFields));
+    const result = schema.safeParse([
+      { control: 'INPUT_TEXT', name: 'Triage instructions!', type: 'keyword' },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  it('does not twin-reject a valid new name that folds onto a stored MARKDOWN label', () => {
+    // Markdown fields hold no value, so a fold collision with their label is harmless.
+    const storedFields = [
+      { control: 'MARKDOWN', name: 'triage instructions', metadata: { content: 'Read me' } },
+    ] as Field[];
+    const schema = buildStrictFieldsArraySchema(collectExistingFieldNames(storedFields));
+    const result = schema.safeParse([
+      { control: 'INPUT_TEXT', name: 'triage_instructions', type: 'keyword' },
+    ]);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('StrictFieldsArraySchema — length failures get a length message', () => {
+  it('reports the length limit, not the charset rule, for an over-long clean name', () => {
+    // Clean snake_case, but the derived `<name>_as_keyword` key exceeds MAX_SNAKE_KEY_LENGTH.
+    const longName = 'a'.repeat(300);
+    const result = StrictFieldsArraySchema.safeParse([
+      { control: 'INPUT_TEXT', name: longName, type: 'keyword' },
+    ]);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('too long');
+      expect(result.error.issues[0].message).toContain('256');
+      expect(result.error.issues[0].message).not.toContain('must contain only letters');
+    }
+  });
+
+  it('keeps the charset message for a charset failure', () => {
+    const result = StrictFieldsArraySchema.safeParse([
+      { control: 'INPUT_TEXT', name: 'bad name', type: 'keyword' },
+    ]);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('must contain only letters');
+      expect(result.error.issues[0].message).not.toContain('too long');
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/strict_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/strict_fields.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { InlineFieldSchema, FieldSchema, isRefField, isDisplayOnlyField } from './fields';
+import type { Field, InlineField, RefField } from './fields';
+import {
+  getAuthorableFieldNameViolation,
+  getFoldedFieldName,
+} from '../../../utils/template_fields';
+import type { AuthorableKeyViolation } from '../../../utils/template_fields';
+import { LONGEST_STORAGE_TYPE, MAX_SNAKE_KEY_LENGTH } from '../../../constants';
+
+/**
+ * Error message for a field `name` or `$ref` alias with a character outside the authoring
+ * charset (`AUTHORABLE_SNAKE_KEY`). Names the offending field, states the expected format,
+ * and warns that renaming to fix it orphans values already stored under the old name.
+ * Shared with the template editor's inline markers — see `createInvalidNameMarkers`.
+ */
+export const charsetNameMessage = (name: string): string =>
+  `Field name "${name}" must contain only letters (A-Z, a-z), digits, and underscores. ` +
+  `Renaming a field doesn't move values already stored under the old name.`;
+
+/**
+ * Error message for a field `name` or `$ref` alias whose derived storage key exceeds
+ * `MAX_SNAKE_KEY_LENGTH`. Kept separate from {@link charsetNameMessage} because a long,
+ * clean snake_case name already satisfies the charset rule — telling its author to remove
+ * special characters would be misleading.
+ */
+export const nameTooLongMessage = (name: string): string =>
+  `Field name "${name}" is too long. The storage key built from the name and field type ` +
+  `can't exceed ${MAX_SNAKE_KEY_LENGTH} characters. Use a shorter name.`;
+
+/**
+ * Error message for a new field `name` whose camelCase-folded form matches an existing
+ * field's folded form (see {@link getFoldedFieldName}). The case list and case view read
+ * values through the folded key, so such twins silently show each other's values.
+ */
+export const foldedNameCollisionMessage = (name: string, existingName: string): string =>
+  `Field name "${name}" conflicts with the existing field "${existingName}". ` +
+  `Kibana reads both names as the same key, so the two fields would show each other's values. ` +
+  `Use a name that differs by more than hyphens, underscores, or capitalization.`;
+
+const violationMessage = (violation: AuthorableKeyViolation, name: string): string =>
+  violation === 'length' ? nameTooLongMessage(name) : charsetNameMessage(name);
+
+/**
+ * The stored names an update validates against: `grandfatheredNames` for the byte-exact
+ * skip (requirement: don't lock legacy names out of unrelated edits) and `foldedNameIndex`
+ * (folded form → stored name) for the twin check on names that are genuinely new.
+ */
+interface ExistingNamesContext {
+  readonly grandfatheredNames: ReadonlySet<string>;
+  readonly foldedNameIndex: ReadonlyMap<string, string>;
+}
+
+/** The create-path default: nothing stored yet, so nothing to grandfather or collide with. */
+const EMPTY_EXISTING_NAMES: ExistingNamesContext = {
+  grandfatheredNames: new Set(),
+  foldedNameIndex: new Map(),
+};
+
+const buildExistingNamesContext = (
+  grandfatheredNames?: ReadonlySet<string>
+): ExistingNamesContext => {
+  if (grandfatheredNames === undefined || grandfatheredNames.size === 0) {
+    return EMPTY_EXISTING_NAMES;
+  }
+  const foldedNameIndex = new Map<string, string>();
+  for (const name of grandfatheredNames) {
+    foldedNameIndex.set(getFoldedFieldName(name), name);
+  }
+  return { grandfatheredNames, foldedNameIndex };
+};
+
+/**
+ * Validates one candidate name against the authoring rules, in precedence order:
+ * 1. Byte-exact match with a stored name — grandfathered, no checks. A rename, even to
+ *    another invalid name, is treated as new.
+ * 2. Charset / length violation on the derived `<name>_as_<type>` key.
+ * 3. Folded-form collision with a stored name (`my_field` vs stored `my-field`) — the UI
+ *    reads values through the camelCase-folded key, so such twins show each other's values.
+ */
+const assertAuthorableName = (
+  name: string,
+  type: string,
+  { grandfatheredNames, foldedNameIndex }: ExistingNamesContext,
+  ctx: z.RefinementCtx
+): void => {
+  if (grandfatheredNames.has(name)) return;
+
+  const violation = getAuthorableFieldNameViolation(name, type);
+  if (violation !== null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['name'],
+      message: violationMessage(violation, name),
+    });
+    return;
+  }
+
+  // The byte-exact grandfather above already returned for a name identical to a stored one,
+  // so any hit here is a genuine twin — a different spelling folding onto a stored name.
+  const collidingName = foldedNameIndex.get(getFoldedFieldName(name));
+  if (collidingName !== undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['name'],
+      message: foldedNameCollisionMessage(name, collidingName),
+    });
+  }
+};
+
+const assertInlineFieldName = (
+  field: InlineField,
+  existingNames: ExistingNamesContext,
+  ctx: z.RefinementCtx
+): void => {
+  // Display-only fields (MARKDOWN) hold no value and are excluded from `extended_fields` and
+  // from the analytics data-view — their `name` never becomes a storage key or reaches a Painless
+  // literal, so the charset restriction has no safety benefit there and would unnecessarily
+  // reject template entries whose markdown label contains spaces, hyphens, etc.
+  if (isDisplayOnlyField(field)) return;
+
+  assertAuthorableName(field.name, field.type, existingNames, ctx);
+};
+
+const assertRefFieldAlias = (
+  field: RefField,
+  existingNames: ExistingNamesContext,
+  ctx: z.RefinementCtx
+): void => {
+  const alias = field.name;
+  if (alias == null) return; // optional — absent aliases are fine
+
+  // A $ref alias has no locally-known type at the authoring stage, so validate against the
+  // worst-case type (longest suffix, LONGEST_STORAGE_TYPE from common/constants) to guarantee
+  // the result fits MAX_SNAKE_KEY_LENGTH for any field type. A unit test asserts
+  // LONGEST_STORAGE_TYPE is actually the longest literal in the field schemas, so this cannot
+  // drift silently.
+  assertAuthorableName(alias, LONGEST_STORAGE_TYPE, existingNames, ctx);
+};
+
+/**
+ * Strict variant of `InlineFieldSchema` — adds authoring-charset validation on `name`.
+ * Use this at write time; use the lenient `InlineFieldSchema` for reads and previews.
+ *
+ * Authoring charset: letters (A-Z, a-z), digits, and underscores — no hyphens, spaces, dots,
+ * or quotes. Enforced by `AUTHORABLE_SNAKE_KEY` in `common/constants/index.ts`.
+ */
+export const StrictInlineFieldSchema = InlineFieldSchema.superRefine(
+  (field: InlineField, ctx: z.RefinementCtx) =>
+    assertInlineFieldName(field, EMPTY_EXISTING_NAMES, ctx)
+);
+
+/**
+ * Strict variant of `FieldSchema` (inline + ref), grandfathering the given set of names/aliases.
+ * For inline entries the `name` must pass the authoring charset; for `$ref` entries the optional
+ * `name` alias is checked against the worst-case type. A name in `grandfatheredNames` skips the
+ * checks when it matches byte-exactly (see `collectExistingFieldNames`); a name that instead
+ * camelCase-folds onto one of them is rejected as a twin — see `foldedNameCollisionMessage`.
+ *
+ * Use this at write time; use the lenient `FieldSchema` for reads and previews.
+ */
+export const buildStrictFieldSchema = (grandfatheredNames?: ReadonlySet<string>) => {
+  const existingNames = buildExistingNamesContext(grandfatheredNames);
+  return FieldSchema.superRefine((field: Field, ctx: z.RefinementCtx) => {
+    if (isRefField(field)) {
+      assertRefFieldAlias(field, existingNames, ctx);
+    } else {
+      assertInlineFieldName(field, existingNames, ctx);
+    }
+  });
+};
+
+/** Strict `FieldSchema` with no grandfathered names — the create-path default. */
+export const StrictFieldSchema = buildStrictFieldSchema();
+
+export type StrictField = z.infer<typeof StrictFieldSchema>;
+
+/**
+ * Strict `fields` array: each entry must pass the authoring-charset check (unless grandfathered)
+ * AND all names must be unique. Uniqueness logic mirrors `ParsedTemplateDefinitionSchema` in
+ * `v1.ts`.
+ *
+ * `grandfatheredNames` — typically the names/aliases already present in a template's
+ * currently-stored definition (see `collectExistingFieldNames`) — lets an UPDATE keep an
+ * untouched field whose name predates the authoring-charset rule, while still rejecting a
+ * brand-new or renamed field with a name that fails the checks, including one that merely
+ * camelCase-folds onto a stored name. Omit for CREATE, where there is no existing definition
+ * to grandfather against.
+ */
+export const buildStrictFieldsArraySchema = (grandfatheredNames?: ReadonlySet<string>) =>
+  z.array(buildStrictFieldSchema(grandfatheredNames)).refine(
+    (fields) => {
+      const fieldNames = new Set(
+        fields.map((field) => (isRefField(field) ? field.name ?? field.$ref : field.name))
+      );
+      return fieldNames.size === fields.length;
+    },
+    { message: 'Field names must be unique.' }
+  );
+
+/** Strict fields-array schema with no grandfathered names — the create-path default. */
+export const StrictFieldsArraySchema = buildStrictFieldsArraySchema();
+
+/**
+ * Collects the field names (inline) and `$ref` aliases already present in a template's
+ * currently-stored definition, for grandfathering on update (see `buildStrictFieldsArraySchema`).
+ * Byte-exact strings only — no normalization — so a rename, even to another invalid name, is
+ * treated as new rather than silently grandfathered.
+ *
+ * Display-only (MARKDOWN) names are excluded: their labels legitimately contain any characters
+ * because they never become storage keys, so `assertInlineFieldName` exempts them without
+ * grandfathering. Including them here would let an update that switches such an entry to a
+ * value-bearing control carry an arbitrary-charset name past every check, and would make the
+ * twin check falsely reject a valid new name that folds onto a markdown label.
+ */
+export const collectExistingFieldNames = (fields: readonly Field[]): ReadonlySet<string> => {
+  const names = new Set<string>();
+  for (const field of fields) {
+    if (field.name != null && !isDisplayOnlyField(field)) {
+      names.add(field.name);
+    }
+  }
+  return names;
+};

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.test.ts
@@ -12,8 +12,10 @@ import {
   buildExtendedFieldsDefaults,
   collectNormalizedRefNames,
   excludeRefFieldsToDefinitions,
+  getAuthorableFieldNameViolation,
   getFieldCamelKey,
   getFieldSnakeKey,
+  getFoldedFieldName,
   getV2FieldType,
   getYamlDefaultAsString,
   normalizeFieldDefinitionName,
@@ -59,6 +61,39 @@ describe('template field key utils', () => {
       expect(getFieldCamelKey(name, type)).toBe(
         snakeKey.replace(/_([a-z])/g, (_, c) => c.toUpperCase())
       );
+    });
+  });
+
+  describe('getFoldedFieldName', () => {
+    it('folds hyphen, underscore, and camelCase spellings onto the same form', () => {
+      expect(getFoldedFieldName('my-field')).toBe('myField');
+      expect(getFoldedFieldName('my_field')).toBe('myField');
+      expect(getFoldedFieldName('myField')).toBe('myField');
+    });
+
+    it('names with equal folds produce equal camel read keys for the same type', () => {
+      // The load-bearing claim behind the twin check: if two names fold together, the UI
+      // reads their values through the same camel key.
+      expect(getFieldCamelKey('my-field', 'keyword')).toBe(getFieldCamelKey('my_field', 'keyword'));
+    });
+  });
+
+  describe('getAuthorableFieldNameViolation', () => {
+    it('returns null for a clean snake_case name', () => {
+      expect(getAuthorableFieldNameViolation('risk_score', 'keyword')).toBeNull();
+    });
+
+    it('returns "charset" for a name with characters outside the authoring charset', () => {
+      expect(getAuthorableFieldNameViolation('risk-score', 'keyword')).toBe('charset');
+      expect(getAuthorableFieldNameViolation('bad name', 'keyword')).toBe('charset');
+    });
+
+    it('returns "length" when the derived key exceeds the maximum', () => {
+      expect(getAuthorableFieldNameViolation('a'.repeat(300), 'keyword')).toBe('length');
+    });
+
+    it('reports charset before length when both are violated', () => {
+      expect(getAuthorableFieldNameViolation(`${'a'.repeat(300)}-x`, 'keyword')).toBe('charset');
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/utils/template_fields.ts
@@ -16,8 +16,58 @@ import {
 import type { Field, InlineField, RefField, Validation } from '../types/domain/template/fields';
 import type { FieldDefinition } from '../types/domain/field_definition/latest';
 import { CustomFieldTypes } from '../types/domain/custom_field/v1';
+import { SAFE_SNAKE_KEY, AUTHORABLE_SNAKE_KEY, MAX_SNAKE_KEY_LENGTH } from '../constants';
 
 export const getFieldSnakeKey = (name: string, type: string): string => `${name}_as_${type}`;
+
+/**
+ * Returns true if `key` is safe to interpolate into a Painless string literal (read / storage
+ * path). Uses the lenient charset — hyphens and other index-legacy characters are allowed.
+ */
+export const isSafeExtendedFieldKey = (key: string): boolean =>
+  key.length > 0 && key.length <= MAX_SNAKE_KEY_LENGTH && SAFE_SNAKE_KEY.test(key);
+
+/**
+ * Why an authoring-time key check failed: `'charset'` — a character outside
+ * `AUTHORABLE_SNAKE_KEY`; `'length'` — the derived key exceeds `MAX_SNAKE_KEY_LENGTH`.
+ * Distinguished so error messages can tell the author what to actually fix — a 300-character
+ * clean snake_case name satisfies the charset rule and would be misled by a charset message.
+ */
+export type AuthorableKeyViolation = 'charset' | 'length';
+
+/**
+ * Checks `key` against the **authoring** rules (strict charset + max length) and returns the
+ * first violation, or `null` when the key is authorable. Charset is reported before length:
+ * fixing the charset can change the author's intended name, so it's the more actionable error.
+ */
+export const getAuthorableKeyViolation = (key: string): AuthorableKeyViolation | null => {
+  if (key.length === 0 || !AUTHORABLE_SNAKE_KEY.test(key)) return 'charset';
+  if (key.length > MAX_SNAKE_KEY_LENGTH) return 'length';
+  return null;
+};
+
+/**
+ * Returns true if `key` satisfies the **authoring** charset (strict subset of
+ * `isSafeExtendedFieldKey` — no hyphens). Use this when validating a new field name at write
+ * time; use `isSafeExtendedFieldKey` when reading back keys that may predate the strict rule.
+ */
+export const isAuthorableExtendedFieldKey = (key: string): boolean =>
+  getAuthorableKeyViolation(key) === null;
+
+/**
+ * Derives the storage key for `(name, type)` and returns the first authoring violation, or
+ * `null` when the name is authorable — see {@link getAuthorableKeyViolation}. This is the
+ * canonical way to validate a field name before writing it: derive first, check once, rather
+ * than maintaining a separate per-name rule.
+ */
+export const getAuthorableFieldNameViolation = (
+  name: string,
+  type: string
+): AuthorableKeyViolation | null => getAuthorableKeyViolation(getFieldSnakeKey(name, type));
+
+/** Boolean convenience over {@link getAuthorableFieldNameViolation}. */
+export const isAuthorableExtendedFieldName = (name: string, type: string): boolean =>
+  getAuthorableFieldNameViolation(name, type) === null;
 
 /**
  * Normalizes a field definition name for case-insensitive lookup and uniqueness.
@@ -32,6 +82,14 @@ export const normalizeFieldDefinitionName = (name: string): string => name.trim(
 
 export const getFieldCamelKey = (name: string, type: string): string =>
   camelCase(getFieldSnakeKey(name, type));
+
+/**
+ * Folds a field name the same way {@link getFieldCamelKey} folds the full storage key —
+ * lodash `camelCase`, under which `my-field`, `my_field`, and `myField` are all `myField`.
+ * Two names with equal folds and equal types collide on the UI's camel read key, silently
+ * showing each other's values; write-time validation uses this to reject such twins.
+ */
+export const getFoldedFieldName = (name: string): string => camelCase(name);
 
 /**
  * Collects the normalized (case-insensitive) `$ref` names from a template's fields array.

--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/components/field_definition_flyout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/components/field_definition_flyout.tsx
@@ -35,6 +35,7 @@ import {
   InlineFieldSchema,
   UserPickerDefaultSchema,
 } from '../../../../common/types/domain/template/fields';
+import { StrictInlineFieldSchema } from '../../../../common/types/domain/template/strict_fields';
 import {
   type FieldDefaultValue,
   updateFieldDefinitionDefault,
@@ -87,7 +88,16 @@ export const FieldDefinitionFlyout: React.FC<FieldDefinitionFlyoutProps> = ({
     }
   }, [definition]);
 
-  const isDefinitionValid = parsedDefinition?.success === true;
+  // On create the server enforces the authoring charset (strict); on update the server uses the
+  // lenient schema because the name is immutable anyway. Mirror that split in the UI so the Save
+  // button only enables when the definition matches what the server will accept.
+  const isDefinitionValid = useMemo(() => {
+    if (!parsedDefinition?.success) return false;
+    if (!isEditing) {
+      return StrictInlineFieldSchema.safeParse(parsedDefinition.data).success;
+    }
+    return true;
+  }, [parsedDefinition, isEditing]);
 
   // A definition's name and (YAML) type are its permanent identity: they form the
   // storage key for case values and the Cases analytics field. Editing them is

--- a/x-pack/platform/plugins/shared/cases/public/components/field_library/components/field_definition_yaml_editor.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/field_library/components/field_definition_yaml_editor.tsx
@@ -9,7 +9,7 @@ import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { EuiPanel } from '@elastic/eui';
 import { parse as parseYaml } from 'yaml';
-import { InlineFieldSchema } from '../../../../common/types/domain/template/fields';
+import { StrictInlineFieldSchema } from '../../../../common/types/domain/template/strict_fields';
 import { TemplateYamlEditorBase } from '../../templates_v2/components/template_yaml_editor';
 import { TemplateActionsMenu } from '../../templates_v2/components/template_actions_menu';
 import {
@@ -55,12 +55,15 @@ const validationFooterCss = css({
 
 const getDefinitionValidationErrors = (value: string): ValidationError[] => {
   try {
-    const result = InlineFieldSchema.safeParse(parseYaml(value));
+    const result = StrictInlineFieldSchema.safeParse(parseYaml(value));
     if (result.success) return [];
 
+    // Surface the first issue's message so the author sees which character is invalid,
+    // rather than the blanket "invalid field definition YAML" fallback.
+    const message = result.error.issues[0]?.message ?? i18n.FIELD_DEFINITION_YAML_INVALID;
     return [
       {
-        message: i18n.FIELD_DEFINITION_YAML_INVALID,
+        message,
         severity: 'error',
         startLineNumber: 1,
         startColumn: 1,

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form.test.tsx
@@ -82,11 +82,24 @@ describe('TemplateFormFields', () => {
     expect(status).toHaveTextContent('Draft saved');
   });
 
-  it('calls useFieldNameValidation hook with editor and value', () => {
+  it('calls useFieldNameValidation hook with editor, value, and savedValue', () => {
     const yamlValue = 'fields:\n  - name: field1\n    type: keyword';
     renderFields(yamlValue);
 
-    expect(mockUseFieldNameValidation).toHaveBeenCalledWith(null, yamlValue);
+    // savedValue is undefined here — the test harness never passes it (create-mode default).
+    expect(mockUseFieldNameValidation).toHaveBeenCalledWith(null, yamlValue, undefined);
+  });
+
+  it('calls useFieldNameValidation hook with editor, value, and savedValue for grandfathering', () => {
+    const yamlValue = 'fields:\n  - name: field1\n    type: keyword';
+    const savedValue = 'fields:\n  - name: legacy-field\n    type: keyword';
+    render(
+      <TestProviders>
+        <TemplateYamlEditor value={yamlValue} onChange={mockOnChange} savedValue={savedValue} />
+      </TestProviders>
+    );
+
+    expect(mockUseFieldNameValidation).toHaveBeenCalledWith(null, yamlValue, savedValue);
   });
 
   it('calls useFieldNameValidation hook when value changes', async () => {
@@ -96,7 +109,7 @@ describe('TemplateFormFields', () => {
       </TestProviders>
     );
 
-    expect(mockUseFieldNameValidation).toHaveBeenCalledWith(null, 'initial: value');
+    expect(mockUseFieldNameValidation).toHaveBeenCalledWith(null, 'initial: value', undefined);
 
     rerender(
       <TestProviders>
@@ -105,7 +118,7 @@ describe('TemplateFormFields', () => {
     );
 
     await waitFor(() => {
-      expect(mockUseFieldNameValidation).toHaveBeenCalledWith(null, 'updated: value');
+      expect(mockUseFieldNameValidation).toHaveBeenCalledWith(null, 'updated: value', undefined);
     });
   });
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form.tsx
@@ -104,7 +104,7 @@ export const TemplateYamlEditor = ({
     handleErrorClick,
   } = useValidationAccordionPositioning();
 
-  useFieldNameValidation(editorRef.current, value);
+  useFieldNameValidation(editorRef.current, value, savedValue);
   useUserPickerValidation(editorRef.current, value, security);
   useSemanticValidation(editorRef.current, value);
   useRefFieldCompletion(editorRef.current, owner[0]);

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.tsx
@@ -328,8 +328,12 @@ export const TemplateFormLayout: React.FC<TemplateFormLayoutProps> = ({
   ]);
 
   const yamlValidationResult = useMemo(
-    () => validateTemplateDefinitionYaml(normalizedYamlValue),
-    [normalizedYamlValue]
+    () =>
+      validateTemplateDefinitionYaml(
+        normalizedYamlValue,
+        isEdit ? initialDefinitionYaml : undefined
+      ),
+    [normalizedYamlValue, isEdit, initialDefinitionYaml]
   );
   const isYamlDefinitionValid = yamlValidationResult.success;
 
@@ -485,7 +489,10 @@ export const TemplateFormLayout: React.FC<TemplateFormLayoutProps> = ({
       { settings: settingsRef.current, connector: connectorRef.current }
     );
 
-    const validationResult = validateTemplateDefinitionYaml(mergedDefinition);
+    const validationResult = validateTemplateDefinitionYaml(
+      mergedDefinition,
+      isEdit ? initialDefinitionYaml : undefined
+    );
     if (
       !validationResult.success ||
       hasTemplateMetadataErrors(validateTemplateMetadata(normalizedMetadata))
@@ -523,6 +530,7 @@ export const TemplateFormLayout: React.FC<TemplateFormLayoutProps> = ({
     onCreate,
     isEnabled,
     isEdit,
+    initialDefinitionYaml,
     clearDraft,
     setStoredMetadataState,
     setStoredConfigState,

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_field_name_validation.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_field_name_validation.test.ts
@@ -12,6 +12,7 @@ import {
   useFieldNameValidation,
   collectFieldNames,
   createDuplicateFieldMarkers,
+  createInvalidNameMarkers,
 } from './use_field_name_validation';
 
 jest.mock('@kbn/monaco', () => ({
@@ -116,6 +117,70 @@ describe('createDuplicateFieldMarkers', () => {
     const markers = createDuplicateFieldMarkers(fieldInfos);
 
     expect(markers).toHaveLength(0);
+  });
+});
+
+describe('createInvalidNameMarkers', () => {
+  const invalidFieldInfo = {
+    name: 'legacy-field',
+    startLineNumber: 3,
+    startColumn: 11,
+    endLineNumber: 3,
+    endColumn: 25,
+  };
+  const rawFields = [{ name: 'legacy-field', control: 'INPUT_TEXT', type: 'keyword' }];
+
+  it('creates a marker for a field name that fails the authoring charset', () => {
+    const markers = createInvalidNameMarkers([invalidFieldInfo], rawFields);
+
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      severity: 8,
+      message: expect.stringContaining('legacy-field'),
+      source: 'field-name-validation',
+    });
+  });
+
+  it('does not create a marker for a grandfathered field name', () => {
+    const markers = createInvalidNameMarkers(
+      [invalidFieldInfo],
+      rawFields,
+      new Set(['legacy-field'])
+    );
+
+    expect(markers).toHaveLength(0);
+  });
+
+  it('still flags an invalid name that is NOT in the grandfathered set', () => {
+    const markers = createInvalidNameMarkers(
+      [invalidFieldInfo],
+      rawFields,
+      new Set(['some-other-field'])
+    );
+
+    expect(markers).toHaveLength(1);
+  });
+
+  it('flags an underscore twin of a grandfathered hyphenated name', () => {
+    const twinInfo = { ...invalidFieldInfo, name: 'legacy_field' };
+    const twinRawFields = [{ name: 'legacy_field', control: 'INPUT_TEXT', type: 'keyword' }];
+
+    const markers = createInvalidNameMarkers([twinInfo], twinRawFields, new Set(['legacy-field']));
+
+    expect(markers).toHaveLength(1);
+    expect(markers[0].message).toContain('conflicts with the existing field "legacy-field"');
+  });
+
+  it('uses the length message, not the charset message, for an over-long clean name', () => {
+    const longName = 'a'.repeat(300);
+    const longInfo = { ...invalidFieldInfo, name: longName };
+    const longRawFields = [{ name: longName, control: 'INPUT_TEXT', type: 'keyword' }];
+
+    const markers = createInvalidNameMarkers([longInfo], longRawFields);
+
+    expect(markers).toHaveLength(1);
+    expect(markers[0].message).toContain('too long');
+    expect(markers[0].message).not.toContain('must contain only letters');
   });
 });
 
@@ -271,5 +336,65 @@ fields:
     jest.runAllTimers();
 
     expect(mockSetModelMarkers).toHaveBeenCalledWith(mockModel, 'field-name-validation', []);
+  });
+
+  describe('authoring-charset grandfathering (existingDefinition)', () => {
+    const yamlWithLegacyField = `name: Test Template
+fields:
+  - name: legacy-field
+    control: INPUT_TEXT
+    type: keyword`;
+
+    it('flags an invalid field name with no existingDefinition', () => {
+      renderHook(() => useFieldNameValidation(mockEditor, yamlWithLegacyField));
+
+      jest.runAllTimers();
+
+      const markers = mockSetModelMarkers.mock.calls[0][2];
+      expect(markers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.stringContaining('legacy-field') }),
+        ])
+      );
+    });
+
+    it('does not flag an untouched field name already present in existingDefinition', () => {
+      renderHook(() =>
+        useFieldNameValidation(mockEditor, yamlWithLegacyField, yamlWithLegacyField)
+      );
+
+      jest.runAllTimers();
+
+      expect(mockSetModelMarkers).toHaveBeenCalledWith(mockModel, 'field-name-validation', []);
+    });
+
+    it('still flags a brand-new invalid field name even with an existingDefinition', () => {
+      const yamlWithBrandNewField = `name: Test Template
+fields:
+  - name: legacy-field
+    control: INPUT_TEXT
+    type: keyword
+  - name: brand-new field
+    control: INPUT_TEXT
+    type: keyword`;
+
+      renderHook(() =>
+        useFieldNameValidation(mockEditor, yamlWithBrandNewField, yamlWithLegacyField)
+      );
+
+      jest.runAllTimers();
+
+      const markers = mockSetModelMarkers.mock.calls[0][2];
+      expect(markers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.stringContaining('brand-new field') }),
+        ])
+      );
+      expect(markers).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.stringContaining('"legacy-field"') }),
+        ])
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_field_name_validation.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/hooks/use_field_name_validation.ts
@@ -8,6 +8,16 @@
 import { useEffect, useRef } from 'react';
 import { parse } from 'yaml';
 import { monaco } from '@kbn/monaco';
+import {
+  getAuthorableFieldNameViolation,
+  getFoldedFieldName,
+} from '../../../../common/utils/template_fields';
+import {
+  charsetNameMessage,
+  nameTooLongMessage,
+  foldedNameCollisionMessage,
+} from '../../../../common/types/domain/template/strict_fields';
+import { getExistingFieldNames } from '../utils/validate_template_definition';
 
 interface FieldNameInfo {
   name: string;
@@ -19,9 +29,17 @@ interface FieldNameInfo {
 
 const FIELD_NAME_VALIDATION_OWNER = 'field-name-validation';
 
+/**
+ * `existingDefinition` — the template's currently-stored definition when editing an existing
+ * template (undefined when creating) — grandfathers field names that predate the
+ * authoring-charset rule, so an untouched legacy field doesn't show a squiggle (and, via
+ * `validateTemplateDefinitionYaml`, doesn't disable Save) on every edit. Mirrors the server-side
+ * grandfathering in `TemplatesService.updateTemplate`.
+ */
 export const useFieldNameValidation = (
   editor: monaco.editor.IStandaloneCodeEditor | null,
-  value: string
+  value: string,
+  existingDefinition?: string
 ) => {
   const validationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -40,7 +58,7 @@ export const useFieldNameValidation = (
     }
 
     validationTimeoutRef.current = setTimeout(() => {
-      validateFieldNames(model, value);
+      validateFieldNames(model, value, existingDefinition);
     }, 300);
 
     return () => {
@@ -48,10 +66,14 @@ export const useFieldNameValidation = (
         clearTimeout(validationTimeoutRef.current);
       }
     };
-  }, [editor, value]);
+  }, [editor, value, existingDefinition]);
 };
 
-function validateFieldNames(model: monaco.editor.ITextModel, yamlContent: string) {
+function validateFieldNames(
+  model: monaco.editor.ITextModel,
+  yamlContent: string,
+  existingDefinition?: string
+) {
   try {
     const parsed = parse(yamlContent);
     const fields = parsed?.fields;
@@ -62,7 +84,12 @@ function validateFieldNames(model: monaco.editor.ITextModel, yamlContent: string
     }
 
     const fieldInfos = collectFieldNames(yamlContent, fields);
-    const markers = createDuplicateFieldMarkers(fieldInfos);
+    const grandfatheredNames =
+      existingDefinition !== undefined ? getExistingFieldNames(existingDefinition) : undefined;
+    const markers = [
+      ...createDuplicateFieldMarkers(fieldInfos),
+      ...createInvalidNameMarkers(fieldInfos, fields, grandfatheredNames),
+    ];
 
     monaco.editor.setModelMarkers(model, FIELD_NAME_VALIDATION_OWNER, markers);
   } catch (error) {
@@ -121,6 +148,78 @@ export function collectFieldNames(yamlContent: string, fields: unknown[]): Field
   }
 
   return fieldInfos;
+}
+
+/**
+ * Places a Monaco error marker on every field name that fails the authoring rules — charset
+ * (`AUTHORABLE_SNAKE_KEY`), derived-key length, or a camelCase-folded collision with a name in
+ * `grandfatheredNames` — using the same message builders as the strict write schema so the
+ * squiggle text matches the Save-gate footer and the server error. A name that byte-exactly
+ * matches an entry in `grandfatheredNames` (already present in the currently-stored definition
+ * — see `getExistingFieldNames`) is left unmarked, so editing a template that predates the
+ * rules doesn't show a permanent squiggle.
+ * Runs alongside `createDuplicateFieldMarkers` so the editor shows inline squiggles before Save.
+ */
+export function createInvalidNameMarkers(
+  fieldInfos: FieldNameInfo[],
+  rawFields: unknown[],
+  grandfatheredNames?: ReadonlySet<string>
+): monaco.editor.IMarkerData[] {
+  const markers: monaco.editor.IMarkerData[] = [];
+  const foldedNameIndex = new Map<string, string>();
+  for (const name of grandfatheredNames ?? []) {
+    foldedNameIndex.set(getFoldedFieldName(name), name);
+  }
+
+  for (let i = 0; i < fieldInfos.length; i++) {
+    const info = fieldInfos[i];
+    const rawField = rawFields[i];
+
+    if (info && !grandfatheredNames?.has(info.name)) {
+      const type =
+        typeof rawField === 'object' && rawField !== null && 'type' in rawField
+          ? (rawField as { type: unknown }).type
+          : undefined;
+
+      // Only inline (non-$ref) fields have a type; $ref aliases are rare in the template editor
+      // and are validated by the strict schema on save, so we skip them here.
+      if (typeof type === 'string') {
+        const message = getInvalidNameMessage(info.name, type, foldedNameIndex);
+        if (message !== undefined) {
+          markers.push({
+            startLineNumber: info.startLineNumber,
+            startColumn: info.startColumn,
+            endLineNumber: info.endLineNumber,
+            endColumn: info.endColumn,
+            severity: 8, // Error
+            message,
+            source: FIELD_NAME_VALIDATION_OWNER,
+          });
+        }
+      }
+    }
+  }
+
+  return markers;
+}
+
+/**
+ * The marker message for a name, or `undefined` when the name is fine. Mirrors the precedence
+ * in the strict schema's `assertAuthorableName`: charset/length first, then the folded-twin
+ * check (only reachable for names that are not byte-exactly grandfathered — the caller skips
+ * those before getting here).
+ */
+function getInvalidNameMessage(
+  name: string,
+  type: string,
+  foldedNameIndex: ReadonlyMap<string, string>
+): string | undefined {
+  const violation = getAuthorableFieldNameViolation(name, type);
+  if (violation === 'length') return nameTooLongMessage(name);
+  if (violation === 'charset') return charsetNameMessage(name);
+
+  const collidingName = foldedNameIndex.get(getFoldedFieldName(name));
+  return collidingName !== undefined ? foldedNameCollisionMessage(name, collidingName) : undefined;
 }
 
 export function createDuplicateFieldMarkers(

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/validate_template_definition.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/validate_template_definition.test.ts
@@ -69,6 +69,85 @@ describe('validateTemplateDefinitionYaml', () => {
     expect(result.success).toBe(false);
   });
 
+  describe('authoring-charset check', () => {
+    it('rejects a field name that produces an invalid storage key', () => {
+      const result = validateTemplateDefinitionYaml(
+        COMPLETE_DEFINITION.replace('name: effort', 'name: bad-name')
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.message).toContain('bad-name');
+      }
+    });
+
+    describe('grandfathering (existingDefinition)', () => {
+      const LEGACY_DEFINITION = COMPLETE_DEFINITION.replace('name: effort', 'name: legacy-field');
+
+      const WITH_BRAND_NEW_FIELD = `name: Case default title
+description: ""
+severity: low
+category: ""
+tags: []
+assignees: []
+settings:
+  syncAlerts: false
+  extractObservables: false
+connector:
+  type: .none
+  id: none
+  fields: null
+fields:
+  - name: legacy-field
+    control: INPUT_NUMBER
+    label: Effort
+    type: integer
+  - name: brand-new field
+    control: INPUT_TEXT
+    label: Brand New
+    type: keyword
+`;
+
+      it('accepts an untouched field whose name predates the authoring-charset rule', () => {
+        // Same definition, unchanged — editing a template with a pre-existing invalid name must
+        // not permanently disable Save for edits that never touch the offending field.
+        const result = validateTemplateDefinitionYaml(LEGACY_DEFINITION, LEGACY_DEFINITION);
+        expect(result.success).toBe(true);
+      });
+
+      it('still rejects a brand-new invalid field name even with an existingDefinition', () => {
+        const result = validateTemplateDefinitionYaml(WITH_BRAND_NEW_FIELD, LEGACY_DEFINITION);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.message).toContain('brand-new field');
+        }
+      });
+
+      it('rejects the same invalid name when creating (no existingDefinition to grandfather against)', () => {
+        const result = validateTemplateDefinitionYaml(LEGACY_DEFINITION);
+        expect(result.success).toBe(false);
+      });
+
+      it('rejects an underscore twin of a stored hyphenated field name', () => {
+        const withUnderscoreTwin = WITH_BRAND_NEW_FIELD.replace(
+          'name: brand-new field',
+          'name: legacy_field'
+        );
+        const result = validateTemplateDefinitionYaml(withUnderscoreTwin, LEGACY_DEFINITION);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.message).toContain('legacy_field');
+          expect(result.message).toContain('legacy-field');
+        }
+      });
+
+      it('falls back to fully strict when existingDefinition fails to parse', () => {
+        const result = validateTemplateDefinitionYaml(LEGACY_DEFINITION, 'not: valid: yaml: [');
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
   describe('completeness (editor-only)', () => {
     it('rejects a definition missing the fields block', () => {
       const withoutFields = COMPLETE_DEFINITION.replace(

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/validate_template_definition.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/validate_template_definition.ts
@@ -8,6 +8,10 @@
 import { parse as parseYaml } from 'yaml';
 import { ParsedTemplateDefinitionSchema } from '../../../../common/types/domain/template/v1';
 import {
+  buildStrictFieldsArraySchema,
+  collectExistingFieldNames,
+} from '../../../../common/types/domain/template/strict_fields';
+import {
   TEMPLATE_DEFINITION_EMPTY,
   INVALID_YAML_NON_OBJECT,
   INVALID_YAML_DEFINITION,
@@ -31,8 +35,32 @@ export type TemplateDefinitionValidationResult =
 export const getMissingRequiredKeys = (definition: Record<string, unknown>): string[] =>
   REQUIRED_TEMPLATE_ROOT_KEYS.filter((key) => !(key in definition));
 
+/**
+ * Best-effort: the field names/aliases already present in the template's currently-stored
+ * definition, for grandfathering the authoring-charset check on update (mirrors the server-side
+ * `TemplatesService.getExistingFieldNames`). Falls back to an empty set — no grandfathering, fully
+ * strict — if the stored YAML fails to parse; that can only make the check MORE restrictive.
+ */
+export const getExistingFieldNames = (existingDefinition: string): ReadonlySet<string> => {
+  try {
+    const parsed = ParsedTemplateDefinitionSchema.parse(
+      normalizeTemplateCaseDefaultsForValidation(parseYaml(existingDefinition))
+    );
+    return collectExistingFieldNames(parsed.fields);
+  } catch {
+    return new Set();
+  }
+};
+
+/**
+ * `existingDefinition` — the template's currently-stored definition when editing an existing
+ * template (undefined when creating) — grandfathers field names that predate the
+ * authoring-charset rule, so editing a legacy-named template doesn't permanently disable Save.
+ * Mirrors the server-side grandfathering in `TemplatesService.updateTemplate`.
+ */
 export const validateTemplateDefinitionYaml = (
-  definition: string
+  definition: string,
+  existingDefinition?: string
 ): TemplateDefinitionValidationResult => {
   try {
     if (!definition || definition.trim() === '') {
@@ -49,6 +77,22 @@ export const validateTemplateDefinitionYaml = (
     const result = ParsedTemplateDefinitionSchema.safeParse(normalizedDefinition);
     if (!result.success) {
       return { success: false, message: result.error.message };
+    }
+
+    // After the lenient structural parse, apply the authoring-charset check so the Save button
+    // disables and the footer names the offending field before the user hits the server.
+    // Read and preview paths keep the lenient schema — this function is only called at write time.
+    const grandfatheredNames =
+      existingDefinition !== undefined ? getExistingFieldNames(existingDefinition) : undefined;
+    const strictFieldsResult = buildStrictFieldsArraySchema(grandfatheredNames).safeParse(
+      result.data.fields
+    );
+    if (!strictFieldsResult.success) {
+      return {
+        success: false,
+        message:
+          strictFieldsResult.error.issues[0]?.message ?? 'One or more field names are invalid.',
+      };
     }
 
     const missingKeys = getMissingRequiredKeys(normalizedDefinition as Record<string, unknown>);

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.test.ts
@@ -43,16 +43,12 @@ describe('splitSnakeKey', () => {
   });
 
   /**
-   * Templates accept arbitrary `name: z.string()` upstream, so the
-   * analytics layer cannot trust the charset. A template field whose
-   * name contains a single quote, backslash, or newline would
-   * otherwise be concatenated verbatim into a Painless string
-   * literal, breaking the script or — worst case — opening a
-   * Painless-injection path. The defensive drop silently skips such
-   * fields; once the template is fixed, the next refresh publishes
-   * the runtime field normally.
+   * Uses the lenient read charset (SAFE_SNAKE_KEY = /^[A-Za-z0-9_-]+$/).
+   * Characters that would break a Painless string literal are still rejected; hyphens are now
+   * accepted so keys pre-existing in the index (including UUID-shaped migration output) resolve
+   * to a runtime field rather than being silently dropped.
    */
-  it('rejects snake-keys containing characters outside [A-Za-z0-9_]', () => {
+  it('rejects snake-keys with characters that are unsafe in a Painless string literal', () => {
     expect(splitSnakeKey('evil\'); script("x"_as_long')).toBeNull();
     expect(splitSnakeKey('with space_as_long')).toBeNull();
     expect(splitSnakeKey('quote\u0027_as_long')).toBeNull();
@@ -64,6 +60,15 @@ describe('splitSnakeKey', () => {
   it('rejects snake-keys exceeding the length cap', () => {
     const longName = 'a'.repeat(300);
     expect(splitSnakeKey(`${longName}_as_long`)).toBeNull();
+  });
+
+  it('accepts hyphenated snake-keys (e.g. UUID names written by the v1→v2 migration)', () => {
+    // SAFE_SNAKE_KEY now includes hyphens so UUID-shaped field-definition names and any
+    // hand-authored hyphenated names produce a runtime field instead of being silently dropped.
+    const result = splitSnakeKey('my-field-name_as_keyword');
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('my-field-name');
+    expect(result?.suffix).toBe('keyword');
   });
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_v2/data_view/runtime_fields.ts
@@ -7,7 +7,7 @@
 
 import { createHash } from 'crypto';
 import type { RuntimeFieldSpec, RuntimeType } from '@kbn/data-views-plugin/common';
-import { MAX_SNAKE_KEY_LENGTH } from '../../../common/constants';
+import { SAFE_SNAKE_KEY, MAX_SNAKE_KEY_LENGTH } from '../../../common/constants';
 
 /**
  * Prefix on every fingerprint produced by `computeRuntimeFieldsFingerprint`.
@@ -16,7 +16,7 @@ import { MAX_SNAKE_KEY_LENGTH } from '../../../common/constants';
  * cached fingerprint and forces all spaces to re-run the diff path on
  * their next ensure.
  */
-export const RUNTIME_FIELDS_BUILD_VERSION = 1;
+export const RUNTIME_FIELDS_BUILD_VERSION = 2;
 
 /**
  * Cases-template type suffixes (the second half of `<name>_as_<type>`
@@ -70,23 +70,16 @@ export const suffixToRuntimeType = (suffix: string): RuntimeType | undefined => 
 };
 
 /**
- * Charset and length cap enforced by `splitSnakeKey`. The snake-key is
- * concatenated verbatim into a Painless string literal in
- * `buildPainlessSource`, so any quote, backslash, or newline would either
- * break the script or open a script-injection path. Template field names
- * are validated upstream in `common/types/domain/template/fields.ts`, but
- * that schema accepts any string today, so this guard runs independently.
- * The length cap keeps Painless compile budgets bounded.
- */
-const SAFE_SNAKE_KEY = /^[A-Za-z0-9_]+$/;
-
-/**
  * Splits a snake-key into `{ name, suffix }`, or returns `null` if the key
  * has no `_as_<suffix>` segment, exceeds the length cap, or contains any
- * character outside `[A-Za-z0-9_]`.
+ * character outside the lenient read charset (`SAFE_SNAKE_KEY`).
  *
  * Splits on the last `_as_` so user-chosen names with underscores
  * (e.g. `risk_score_as_long`) recover the correct suffix.
+ *
+ * Uses the lenient `SAFE_SNAKE_KEY` (allows hyphens) rather than the strict
+ * authoring guard, so keys already in the index — including the UUID-shaped
+ * names written by the v1→v2 migration — resolve to a runtime field.
  */
 export const splitSnakeKey = (snakeKey: string): { name: string; suffix: string } | null => {
   if (snakeKey.length === 0 || snakeKey.length > MAX_SNAKE_KEY_LENGTH) return null;

--- a/x-pack/platform/plugins/shared/cases/server/client/templates/client.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/templates/client.test.ts
@@ -285,6 +285,7 @@ describe('templates client', () => {
       expect(clientArgs.services.templatesService.validateWriteInput).toHaveBeenCalledWith(input, {
         excludeTemplateId: 'template-1',
         currentOwner: 'securitySolution',
+        existingDefinition: template.attributes.definition,
       });
       expect(clientArgs.services.templatesService.updateTemplate).not.toHaveBeenCalled();
     });

--- a/x-pack/platform/plugins/shared/cases/server/client/templates/client.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/templates/client.ts
@@ -188,6 +188,7 @@ export const createTemplatesSubClient = (clientArgs: CasesClientArgs): Templates
       await templatesService.validateWriteInput(input, {
         excludeTemplateId: template.attributes.templateId,
         currentOwner: template.attributes.owner,
+        existingDefinition: template.attributes.definition,
       });
     },
 

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/templates/patch_template_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/templates/patch_template_route.ts
@@ -6,17 +6,14 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { parse as yamlParse } from 'yaml';
 import { isBoom } from '@hapi/boom';
-import {
-  PatchTemplateInputSchema,
-  ParsedTemplateDefinitionSchema,
-} from '../../../../common/types/domain/template/v1';
+import { PatchTemplateInputSchema } from '../../../../common/types/domain/template/v1';
 import { INTERNAL_TEMPLATE_DETAILS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 import { parseTemplate } from './parse_template';
+import { validateTemplateStructure } from './validate_template_input';
 
 /**
  * PATCH /internal/cases/templates/{template_id}
@@ -59,27 +56,13 @@ export const patchTemplateRoute = createCasesRoute({
         });
       }
 
-      // Validate YAML definition if provided
+      // Validate YAML definition if provided — structural check only. The authoring-charset check
+      // runs inside `updateTemplate`, which (unlike this route) has the existing template needed
+      // to grandfather field names that predate the rule. See `validateTemplateStructure`'s doc.
       if (input.definition) {
-        let parsedYaml: unknown;
-        try {
-          parsedYaml = yamlParse(input.definition);
-        } catch (yamlError) {
-          return response.badRequest({
-            body: { message: `Invalid YAML definition: ${yamlError}` },
-          });
-        }
-
-        // Validate parsed definition against the field schema
-        const definitionResult = ParsedTemplateDefinitionSchema.safeParse(parsedYaml);
-        if (!definitionResult.success) {
-          return response.badRequest({
-            body: {
-              message: `Invalid template definition: ${JSON.stringify(
-                definitionResult.error.issues
-              )}`,
-            },
-          });
+        const definitionValidation = validateTemplateStructure(input.definition);
+        if (!definitionValidation.valid) {
+          return response.badRequest({ body: { message: definitionValidation.message } });
         }
       }
 

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/templates/put_public_template_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/templates/put_public_template_route.ts
@@ -13,7 +13,7 @@ import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 import { parseTemplate } from './parse_template';
-import { validateTemplateDefinition } from './validate_template_input';
+import { validateTemplateStructure } from './validate_template_input';
 import { PublicTemplateWriteBodySchema } from './public_template_write_body';
 
 /**
@@ -53,7 +53,10 @@ export const putPublicTemplateRoute = createCasesRoute({
       }
       const input = bodyResult.data;
 
-      const definitionValidation = validateTemplateDefinition(input.definition);
+      // Structural check only — the authoring-charset check runs inside `updateTemplate` /
+      // `validateUpdateTemplate`, which (unlike this route) have the existing template needed to
+      // grandfather field names that predate the rule. See `validateTemplateStructure`'s doc.
+      const definitionValidation = validateTemplateStructure(input.definition);
       if (!definitionValidation.valid) {
         return response.badRequest({ body: { message: definitionValidation.message } });
       }

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/templates/put_template_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/templates/put_template_route.ts
@@ -13,7 +13,7 @@ import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 import { parseTemplate } from './parse_template';
-import { validateTemplateDefinition } from './validate_template_input';
+import { validateTemplateStructure } from './validate_template_input';
 
 /**
  * PUT /internal/cases/templates/{template_id}
@@ -48,7 +48,10 @@ export const putTemplateRoute = createCasesRoute({
         });
       }
 
-      const definitionValidation = validateTemplateDefinition(input.definition);
+      // Structural check only — the authoring-charset check runs inside `updateTemplate`, which
+      // (unlike this route) has the existing template needed to grandfather field names that
+      // predate the rule. See `validateTemplateStructure`'s doc.
+      const definitionValidation = validateTemplateStructure(input.definition);
       if (!definitionValidation.valid) {
         return response.badRequest({ body: { message: definitionValidation.message } });
       }

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/templates/validate_template_input.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/templates/validate_template_input.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { stringify as yamlStringify } from 'yaml';
+import { validateTemplateDefinition, validateTemplateStructure } from './validate_template_input';
+
+const buildDefinition = (fieldNames: string[]): string =>
+  yamlStringify({
+    name: 'A Template',
+    fields: fieldNames.map((fieldName) => ({
+      control: 'INPUT_TEXT',
+      name: fieldName,
+      type: 'keyword',
+    })),
+  });
+
+describe('validateTemplateStructure', () => {
+  it('accepts a structurally valid definition with an invalid (non-authorable) field name', () => {
+    // Unlike validateTemplateDefinition, this never checks the authoring charset — UPDATE
+    // routes rely on it, since only TemplatesService has the existing template needed to
+    // grandfather legacy names.
+    const result = validateTemplateStructure(buildDefinition(['legacy-field']));
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects invalid YAML', () => {
+    const result = validateTemplateStructure('not: valid: yaml: [');
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.message).toContain('Invalid YAML definition');
+    }
+  });
+
+  it('rejects a definition that fails the structural schema', () => {
+    const result = validateTemplateStructure(yamlStringify({ fields: 'not-an-array' }));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.message).toContain('Invalid template definition');
+    }
+  });
+});
+
+describe('validateTemplateDefinition', () => {
+  it('accepts a definition with only authorable field names', () => {
+    const result = validateTemplateDefinition(buildDefinition(['risk_score']));
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a definition with a non-authorable field name, naming the offending field', () => {
+    const result = validateTemplateDefinition(buildDefinition(['bad name!']));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.message).toContain('bad name!');
+    }
+  });
+
+  it('rejects invalid YAML the same way as validateTemplateStructure', () => {
+    const result = validateTemplateDefinition('not: valid: yaml: [');
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.message).toContain('Invalid YAML definition');
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/templates/validate_template_input.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/templates/validate_template_input.ts
@@ -6,7 +6,9 @@
  */
 
 import { parse as yamlParse } from 'yaml';
+import type { ParsedTemplateDefinition } from '../../../../common/types/domain/template/v1';
 import { ParsedTemplateDefinitionSchema } from '../../../../common/types/domain/template/v1';
+import { StrictFieldsArraySchema } from '../../../../common/types/domain/template/strict_fields';
 
 interface DefinitionValidationSuccess {
   valid: true;
@@ -19,13 +21,12 @@ interface DefinitionValidationFailure {
 
 export type DefinitionValidationResult = DefinitionValidationSuccess | DefinitionValidationFailure;
 
-/**
- * Validates a template write body's YAML `definition`: parseable YAML, then schema-valid against
- * `ParsedTemplateDefinitionSchema`. Single source of truth shared by the internal and public
- * template write routes (and the public `dry_run` preflight) so their acceptance criteria cannot
- * drift.
- */
-export const validateTemplateDefinition = (definition: string): DefinitionValidationResult => {
+type StructuralParseResult =
+  | { valid: true; data: ParsedTemplateDefinition }
+  | DefinitionValidationFailure;
+
+/** Shared parse step: parseable YAML, then schema-valid against `ParsedTemplateDefinitionSchema`. */
+const parseAndValidateStructure = (definition: string): StructuralParseResult => {
   let parsedYaml: unknown;
   try {
     parsedYaml = yamlParse(definition);
@@ -38,6 +39,47 @@ export const validateTemplateDefinition = (definition: string): DefinitionValida
     return {
       valid: false,
       message: `Invalid template definition: ${JSON.stringify(definitionResult.error.issues)}`,
+    };
+  }
+
+  return { valid: true, data: definitionResult.data };
+};
+
+/**
+ * Validates a template write body's YAML `definition`: parseable YAML, then schema-valid against
+ * `ParsedTemplateDefinitionSchema`. Does NOT check the authoring charset — use this for UPDATE
+ * routes, where only `TemplatesService` (via `assertFieldNamesAreAuthorable`) has the existing
+ * template needed to grandfather field names that predate the authoring-charset rule; re-running
+ * an ungrandfathered strict check here would permanently lock a legacy-named template out of
+ * every future edit, including ones that never touch the offending field.
+ */
+export const validateTemplateStructure = (definition: string): DefinitionValidationResult => {
+  const result = parseAndValidateStructure(definition);
+  return result.valid ? { valid: true } : result;
+};
+
+/**
+ * Validates a template write body's YAML `definition`: structure (see `validateTemplateStructure`)
+ * plus the authoring-charset check on every field name. Single source of truth shared by the
+ * internal and public template CREATE routes (and the public create `dry_run` preflight) so their
+ * acceptance criteria cannot drift. UPDATE routes use `validateTemplateStructure` instead — see
+ * its doc for why the strict check can't be grandfather-aware at this layer.
+ */
+export const validateTemplateDefinition = (definition: string): DefinitionValidationResult => {
+  const structuralResult = parseAndValidateStructure(definition);
+  if (!structuralResult.valid) {
+    return structuralResult;
+  }
+
+  // Check field names against the authoring charset (strict subset of the lenient read schema).
+  // Runs separately from the structural check above so the error message names the offending
+  // field rather than surfacing as a generic schema failure.
+  const strictFieldsResult = StrictFieldsArraySchema.safeParse(structuralResult.data.fields);
+  if (!strictFieldsResult.success) {
+    const firstIssue = strictFieldsResult.error.issues[0];
+    return {
+      valid: false,
+      message: firstIssue?.message ?? 'One or more field names are invalid.',
     };
   }
 

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/extended_field_search_utils.ts
@@ -14,7 +14,7 @@ import {
 import type { Template } from '../../../common/types/domain/template/v1';
 import type { InlineField } from '../../../common/types/domain/template/fields';
 import { FieldType } from '../../../common/types/domain/template/fields';
-import { getFieldSnakeKey } from '../../../common/utils/template_fields';
+import { getFieldSnakeKey, isSafeExtendedFieldKey } from '../../../common/utils/template_fields';
 
 export interface ExtendedFieldFilter {
   label: string;
@@ -432,6 +432,15 @@ const buildLabelToMetasIndex = (
   }) => {
     const labelKey = label.toLowerCase();
     const storageKey = getFieldSnakeKey(name, type);
+
+    // Guard the Painless literal: if the derived key is not safe to interpolate (wrong charset
+    // or over the length cap) skip this meta entirely. This closes the unguarded literal at
+    // `buildPainlessScript` and keeps `buildExtendedFieldRuntimeMappings` / `buildFieldLabelRuntimeMappings`
+    // consistent. Uses the lenient read guard — not the strict authoring guard — so keys that
+    // predate the strict rule (hyphenated, UUID-shaped migration output) are still handled.
+    if (!isSafeExtendedFieldKey(storageKey)) {
+      return;
+    }
 
     let byStorageKey = labelToMetas.get(labelKey);
     if (byStorageKey == null) {

--- a/x-pack/platform/plugins/shared/cases/server/services/field_definitions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/field_definitions/index.ts
@@ -21,6 +21,7 @@ import type {
   UpdateFieldDefinitionInput,
 } from '../../../common/types/domain/field_definition/v1';
 import { InlineFieldSchema } from '../../../common/types/domain/template/fields';
+import { StrictInlineFieldSchema } from '../../../common/types/domain/template/strict_fields';
 import { validateExtendedFieldValueSizes } from '../../../common/types/domain/template/validate_extended_fields';
 import {
   CASE_FIELD_DEFINITION_SAVED_OBJECT,
@@ -198,7 +199,7 @@ export class FieldDefinitionsService {
     input: CreateFieldDefinitionInput,
     serverManaged: { id?: string; legacyKey?: string } = {}
   ): Promise<SavedObject<FieldDefinition>> {
-    this.assertFieldDefinitionIsValid(input.definition);
+    this.assertFieldDefinitionIsValid(input.definition, /* strict= */ true);
 
     const id = serverManaged.id ?? uuidv4();
     const globalFieldDefinitions = input.isGlobal
@@ -314,8 +315,14 @@ export class FieldDefinitionsService {
    * A field-library default is copied into a case's `extended_fields` when a
    * template references it. Validate the persisted representation here as the
    * definition is written, rather than waiting until a case is created.
+   *
+   * When `strict` is true (create path only), also validates the field `name`
+   * against the authoring charset. Updates keep the lenient schema because the
+   * name cannot change after creation (identity guard in the sub-client) and
+   * re-applying the strict rule would strand pre-existing definitions as
+   * permanently uneditable with no compensating benefit.
    */
-  private assertFieldDefinitionIsValid(definition: string): void {
+  private assertFieldDefinitionIsValid(definition: string, strict = false): void {
     let yamlDefinition: unknown;
     try {
       yamlDefinition = parseYaml(definition);
@@ -323,7 +330,8 @@ export class FieldDefinitionsService {
       throw Boom.badRequest('Invalid YAML definition');
     }
 
-    const parsedDefinition = InlineFieldSchema.safeParse(yamlDefinition);
+    const schema = strict ? StrictInlineFieldSchema : InlineFieldSchema;
+    const parsedDefinition = schema.safeParse(yamlDefinition);
     if (!parsedDefinition.success) {
       const validationErrors = parsedDefinition.error.issues
         .map(({ path, message }) => (path.length > 0 ? `${path.join('.')}: ${message}` : message))

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.test.ts
@@ -1528,6 +1528,113 @@ describe('TemplatesService', () => {
         expect.any(Object)
       );
     });
+
+    describe('authoring-charset grandfathering', () => {
+      const buildDefinitionWithFields = (
+        name: string,
+        fields: Array<{ name: string; type?: string }>
+      ) =>
+        yamlStringify({
+          name,
+          fields: fields.map((field) => ({
+            control: 'INPUT_TEXT',
+            name: field.name,
+            type: field.type ?? 'keyword',
+          })),
+        });
+
+      const mockCurrentTemplate = (definition: string) => {
+        const service = createService();
+        jest
+          .spyOn(
+            service as unknown as Record<'_getTemplate', typeof service.getTemplate>,
+            '_getTemplate'
+          )
+          .mockResolvedValue({
+            id: 'template-so-id',
+            attributes: {
+              templateId: 'template-id',
+              name: 'Existing Template',
+              owner: 'securitySolution',
+              definition,
+              templateVersion: 1,
+              deletedAt: null,
+            },
+          } as SavedObject<Template>);
+        unsecuredSavedObjectsClient.create.mockResolvedValue({
+          id: 'template-new-so-id',
+          attributes: {} as Template,
+        } as SavedObject<Template>);
+        return service;
+      };
+
+      it('accepts an unrelated edit to a template with a pre-existing invalid field name', async () => {
+        const service = mockCurrentTemplate(
+          buildDefinitionWithFields('Existing Template', [{ name: 'legacy-field' }])
+        );
+
+        // Same field, untouched; only the template name changes.
+        await expect(
+          service.updateTemplate('template-id', {
+            name: 'Renamed Template',
+            owner: 'securitySolution',
+            definition: buildDefinitionWithFields('Renamed Template', [{ name: 'legacy-field' }]),
+          })
+        ).resolves.toBeDefined();
+      });
+
+      it('rejects a brand-new invalid field name added alongside a grandfathered one', async () => {
+        const service = mockCurrentTemplate(
+          buildDefinitionWithFields('Existing Template', [{ name: 'legacy-field' }])
+        );
+
+        await expect(
+          service.updateTemplate('template-id', {
+            name: 'Existing Template',
+            owner: 'securitySolution',
+            definition: buildDefinitionWithFields('Existing Template', [
+              { name: 'legacy-field' },
+              { name: 'brand new field' },
+            ]),
+          })
+        ).rejects.toThrow(/brand new field/);
+      });
+
+      it('rejects renaming a grandfathered invalid field to a different invalid name', async () => {
+        const service = mockCurrentTemplate(
+          buildDefinitionWithFields('Existing Template', [{ name: 'legacy-field' }])
+        );
+
+        await expect(
+          service.updateTemplate('template-id', {
+            name: 'Existing Template',
+            owner: 'securitySolution',
+            definition: buildDefinitionWithFields('Existing Template', [
+              { name: 'legacy-field-2' },
+            ]),
+          })
+        ).rejects.toThrow(/legacy-field-2/);
+      });
+
+      it('rejects a new underscore twin of an existing hyphenated field name', async () => {
+        // `legacy_field` and the stored `legacy-field` camelCase-fold to the same display key,
+        // so the case list and case view would show each other's values.
+        const service = mockCurrentTemplate(
+          buildDefinitionWithFields('Existing Template', [{ name: 'legacy-field' }])
+        );
+
+        await expect(
+          service.updateTemplate('template-id', {
+            name: 'Existing Template',
+            owner: 'securitySolution',
+            definition: buildDefinitionWithFields('Existing Template', [
+              { name: 'legacy-field' },
+              { name: 'legacy_field' },
+            ]),
+          })
+        ).rejects.toThrow(/conflicts with the existing field "legacy-field"/);
+      });
+    });
   });
 
   describe('resource limits', () => {
@@ -1948,6 +2055,73 @@ describe('TemplatesService', () => {
             definition: buildDefinitionWithFields('Too Many Fields', MAX_FIELDS_PER_TEMPLATE + 1),
           })
         ).rejects.toThrow(`A template cannot define more than ${MAX_FIELDS_PER_TEMPLATE} fields.`);
+      });
+
+      describe('authoring-charset grandfathering', () => {
+        const buildDefinitionWithNamedFields = (name: string, fieldNames: string[]): string =>
+          yamlStringify({
+            name,
+            fields: fieldNames.map((fieldName) => ({
+              control: 'INPUT_TEXT',
+              name: fieldName,
+              type: 'keyword',
+            })),
+          });
+
+        it('rejects a create dry_run preflight with no existingDefinition to grandfather against', async () => {
+          const service = createService();
+
+          await expect(
+            service.validateWriteInput({
+              name: 'New Template',
+              owner: 'securitySolution',
+              definition: buildDefinitionWithNamedFields('New Template', ['legacy-field']),
+            })
+          ).rejects.toThrow(/legacy-field/);
+        });
+
+        it('accepts an update dry_run preflight for an untouched pre-existing invalid field name', async () => {
+          const service = createService();
+
+          await expect(
+            service.validateWriteInput(
+              {
+                name: 'Renamed Template',
+                owner: 'securitySolution',
+                definition: buildDefinitionWithNamedFields('Renamed Template', ['legacy-field']),
+              },
+              {
+                excludeTemplateId: 'template-id',
+                existingDefinition: buildDefinitionWithNamedFields('Existing Template', [
+                  'legacy-field',
+                ]),
+              }
+            )
+          ).resolves.toBeUndefined();
+        });
+
+        it('rejects an update dry_run preflight for a brand-new invalid field name', async () => {
+          const service = createService();
+
+          await expect(
+            service.validateWriteInput(
+              {
+                name: 'Existing Template',
+                owner: 'securitySolution',
+                definition: buildDefinitionWithNamedFields('Existing Template', [
+                  'legacy-field',
+                  'brand new field',
+                ]),
+              },
+              {
+                excludeTemplateId: 'template-id',
+                existingDefinition: buildDefinitionWithNamedFields('Existing Template', [
+                  'legacy-field',
+                ]),
+              }
+            )
+          ).rejects.toThrow(/brand new field/);
+        });
       });
 
       it('rejects the dry_run preflight when a template default exceeds the maximum byte size', async () => {

--- a/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/templates/index.ts
@@ -25,6 +25,10 @@ import type {
 import { ParsedTemplateDefinitionSchema } from '../../../common/types/domain/template/v1';
 import type { FieldDefinition } from '../../../common/types/domain/field_definition/v1';
 import { isRefField } from '../../../common/types/domain/template/fields';
+import {
+  buildStrictFieldsArraySchema,
+  collectExistingFieldNames,
+} from '../../../common/types/domain/template/strict_fields';
 import { getYamlDefaultAsString, normalizeFieldDefinitionName } from '../../../common/utils';
 import { toFieldDefinitions, trimFieldDefaults } from './utils';
 import {
@@ -370,6 +374,7 @@ export class TemplatesService {
       );
     }
 
+    this.assertFieldNamesAreAuthorable(parsedDefinition.fields);
     this.assertFieldCountWithinLimit(parsedDefinition.fields.length);
     this.assertTemplateDefaultValuesWithinLimit(parsedDefinition.fields);
     this.assertDefinitionLengthWithinLimit(normalizedDefinition);
@@ -433,6 +438,10 @@ export class TemplatesService {
       );
     }
 
+    this.assertFieldNamesAreAuthorable(
+      parsedDefinition.fields,
+      this.getExistingFieldNames(currentTemplate.attributes.definition)
+    );
     this.assertFieldCountWithinLimit(parsedDefinition.fields.length);
     this.assertTemplateDefaultValuesWithinLimit(parsedDefinition.fields);
     this.assertDefinitionLengthWithinLimit(normalizedDefinition);
@@ -614,18 +623,28 @@ export class TemplatesService {
    * Parses through the zod schema (not a raw `parseYaml` cast) for the same reason `createTemplate`
    * /`updateTemplate` do: field-level defaults must be resolved identically so the default-value
    * size check below sees what the real write would persist. Safe to re-parse here — the route
-   * layer already ran the input through `ParsedTemplateDefinitionSchema` via
-   * `validateTemplateDefinition` before calling into this preflight.
+   * layer already ran the input through `ParsedTemplateDefinitionSchema` (via
+   * `validateTemplateDefinition` for create, `validateTemplateStructure` for update) before
+   * calling into this preflight; the authoring-charset check for update is enforced here, not at
+   * the route, because only this method's caller has the existing template to grandfather names
+   * against (see `existingDefinition`).
    *
    * `excludeTemplateId` is passed for the update preflight (it excludes the template being edited
    * from the uniqueness check); its presence also marks this as an update. `currentOwner` — the
    * template's owner before this write — is passed alongside it so an owner-changing update can be
    * detected. The per-owner count cap is asserted on the target owner whenever this is a create, or
    * an update that changes owner, matching which cap each real write path enforces.
+   *
+   * `existingDefinition` — the update preflight's current stored definition — grandfathers field
+   * names that predate the authoring-charset rule, mirroring `updateTemplate`. Omitted on create.
    */
   async validateWriteInput(
     input: Pick<CreateTemplateInput, 'name' | 'owner' | 'definition'>,
-    { excludeTemplateId, currentOwner }: { excludeTemplateId?: string; currentOwner?: string } = {}
+    {
+      excludeTemplateId,
+      currentOwner,
+      existingDefinition,
+    }: { excludeTemplateId?: string; currentOwner?: string; existingDefinition?: string } = {}
   ): Promise<void> {
     const normalizedDefinition = trimFieldDefaults(input.definition);
     const parsedDefinition = ParsedTemplateDefinitionSchema.parse(parseYaml(normalizedDefinition));
@@ -638,6 +657,10 @@ export class TemplatesService {
 
     // Keep dry_run faithful to the real write: mirror the same resource-limit assertions each write
     // path runs (including the SO `definition` maxLength, which otherwise only surfaces on apply).
+    this.assertFieldNamesAreAuthorable(
+      parsedDefinition.fields,
+      existingDefinition !== undefined ? this.getExistingFieldNames(existingDefinition) : undefined
+    );
     this.assertFieldCountWithinLimit(parsedDefinition.fields.length);
     this.assertTemplateDefaultValuesWithinLimit(parsedDefinition.fields);
     this.assertDefinitionLengthWithinLimit(normalizedDefinition);
@@ -664,6 +687,47 @@ export class TemplatesService {
       throw Boom.badRequest(
         `Template definition exceeds the maximum length of ${MAX_TEMPLATE_DEFINITION_LENGTH} characters.`
       );
+    }
+  }
+
+  /**
+   * Rejects field names whose derived `<name>_as_<type>` storage key falls outside the authoring
+   * charset (`AUTHORABLE_SNAKE_KEY`), unless the name is in `grandfatheredNames`. Enforced on
+   * every write path — create, update, and the `dry_run` preflight — but never on read, so a
+   * template stored before this rule still loads. Runs after the lenient
+   * `ParsedTemplateDefinitionSchema` parse so the message names the offending field instead of
+   * surfacing as a generic schema failure.
+   *
+   * `grandfatheredNames` is omitted on create (nothing to grandfather) and set on update to the
+   * names already present in the template's currently-stored definition (see
+   * `getExistingFieldNames`), so editing a template that predates this rule doesn't lock it —
+   * only a genuinely new or renamed invalid name is rejected.
+   */
+  private assertFieldNamesAreAuthorable(
+    fields: ParsedTemplate['definition']['fields'],
+    grandfatheredNames?: ReadonlySet<string>
+  ): void {
+    const result = buildStrictFieldsArraySchema(grandfatheredNames).safeParse(fields);
+    if (!result.success) {
+      throw Boom.badRequest(
+        result.error.issues[0]?.message ?? 'One or more field names are invalid.'
+      );
+    }
+  }
+
+  /**
+   * Best-effort: the field names/aliases already present in a template's currently-stored
+   * `definition`, for grandfathering on update (see `assertFieldNamesAreAuthorable`). Falls back
+   * to an empty set (no grandfathering — fully strict) if the stored YAML fails to parse against
+   * the lenient schema; that can only make the check MORE restrictive, never let a genuinely new
+   * invalid name through unnoticed.
+   */
+  private getExistingFieldNames(definition: string): ReadonlySet<string> {
+    try {
+      const parsed = ParsedTemplateDefinitionSchema.parse(parseYaml(definition));
+      return collectExistingFieldNames(parsed.fields);
+    } catch {
+      return new Set();
     }
   }
 

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/internal/field_definitions.ts
@@ -483,10 +483,12 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('returns 409 when a template references the field via $ref with a local name alias', async () => {
-        // FAILURE SCENARIO: The template uses { $ref: 'priority', name: 'Custom Label' }.
-        // The `fieldDefinitions` keyword cache stores "Custom Label" as the resolved name.
+        // FAILURE SCENARIO: The template uses { $ref: 'priority', name: 'custom_priority' }.
+        // The `fieldDefinitions` keyword cache stores "custom_priority" as the resolved name.
         // A query against the cache would miss this ref. The hybrid approach (match_phrase
         // pre-filter + YAML parse) finds the $ref: priority value correctly regardless.
+        // The alias must satisfy the authoring charset (letters, digits, underscores) — it
+        // replaces the library field's name and becomes part of the storage key.
         await supertest
           .post(`${getSpaceUrlPrefix('space1')}${TEMPLATES_URL}`)
           .set('kbn-xsrf', 'true')
@@ -495,7 +497,7 @@ export default ({ getService }: FtrProviderContext): void => {
             owner: 'securitySolutionFixture',
             definition: stringify({
               name: 'Aliased Ref Template',
-              fields: [{ $ref: 'priority', name: 'Custom Priority Label' }],
+              fields: [{ $ref: 'priority', name: 'custom_priority' }],
             }),
             isEnabled: true,
           })


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Cases] Harden templates-v2 extended-field key names with split read/write validation (#285423)](https://github.com/elastic/kibana/pull/285423)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"lgestc","email":"11671118+lgestc@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-19T01:13:47Z","message":"[Cases] Harden templates-v2 extended-field key names with split read/write validation (#285423)\n\n## Summary\n\nHardens the cases templates v2 extended-field `name` so every derived\n`<name>_as_<type>` storage key is safe for ES `flattened` mapping,\ndata-view runtime fields, and Painless interpolation.\n\n### Why this matters\n\nA template field `name` was unconstrained (`z.string()`). The derived\nstorage key `<name>_as_<type>` ends up in two dangerous places:\n\n- **Painless string literal** — an apostrophe in the name corrupts the\nPainless source at search time.\n- **`splitSnakeKey` charset guard** — anything outside `[A-Za-z0-9_-]`\ncauses the key to be silently dropped, so the field never appears in\nDiscover or Lens with no error anywhere.\n\n### Two-guard split\n\n| | Constant | Charset | Used by |\n|---|---|---|---|\n| **Lenient (read)** | `SAFE_SNAKE_KEY` | `[A-Za-z0-9_-]` |\n`splitSnakeKey`, analytics runtime fields, Painless literal guard |\n| **Strict (write)** | `AUTHORABLE_SNAKE_KEY` | `[A-Za-z0-9_]` | All\ntemplate and field-definition write paths |\n\nContainment is structural: one base charset string\n(`AUTHORABLE_KEY_CHARS`) plus an explicit tolerated-extras string\n(`READ_TOLERATED_KEY_CHARS = '-'`). A unit test pins the delta to\nexactly `['-']` so the two guards can never drift silently.\n\nThe lenient read guard keeps already-stored data and v1→v2 migration\noutput (UUID names with hyphens) working, including making them\nanalytics-visible for the first time. The strict write guard stops new\ninvalid names at the point of authoring with a message that names the\noffending field.\n\n### Changes\n\n**Server**\n\n- `TemplatesService` — new private `assertFieldNamesAreAuthorable`\nmethod (same pattern as `assertFieldCountWithinLimit`). Runs\n`StrictFieldsArraySchema.safeParse` and throws `Boom.badRequest` naming\nthe offending field. Called from `createTemplate`, `updateTemplate`, and\n`validateWriteInput` so every write path is gated regardless of which\nroute the client uses.\n- `patch_template_route.ts` — replaced duplicated inline YAML validation\nwith the shared `validateTemplateDefinition` helper, bringing PATCH in\nline with POST and PUT.\n- `extended_field_search_utils.ts` — added `isSafeExtendedFieldKey`\nguard before interpolating a key into the Painless literal, closing the\ninjection vector.\n\n**Client**\n\n- `validate_template_definition.ts` — after the structural parse, runs\n`StrictFieldsArraySchema` and returns the first issue message so the\nSave button disables and the footer names the offending field before the\nrequest is sent.\n- `field_definition_yaml_editor.tsx` — uses `StrictInlineFieldSchema`\nand surfaces the specific issue message instead of the generic \"invalid\nfield definition YAML\".\n- `field_definition_flyout.tsx` — `isDefinitionValid` uses\n`StrictInlineFieldSchema` on create (lenient on edit, since name is\nimmutable and the server also uses the lenient schema for updates).\n- `use_field_name_validation.ts` — new `createInvalidNameMarkers` places\nan inline Monaco squiggle on the offending name in the template YAML\neditor, alongside the existing duplicate-name markers.\n\n### What stays lenient (intentional)\n\n- Read and preview paths (`use_resolved_fields.ts`,\n`template_preview.tsx`, `field_definition_preview.tsx`) — stored data\nmust always render regardless of when it was authored.\n- `updateFieldDefinition` (field library) — name is immutable once\ncreated (409 `FIELD_IDENTITY_IMMUTABLE`), so applying the strict rule on\nupdate would permanently strand pre-existing definitions.\n- v1→v2 migration — writes via `repo.create`, bypassing service\nvalidation. UUID names (hex + hyphens) now produce runtime fields for\nthe first time thanks to the lenient read guard and the\n`RUNTIME_FIELDS_BUILD_VERSION` bump.\n\n### Out of scope\n\n- `$ref` target string (library definition names — UUID-shaped by\nmigration, intentionally not validated here).\n- `extended_fields` key-allowlist gap for no-template cases\n(`server/client/cases/validators.ts:297`).\n\n## Test plan\n\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/common/constants\nx-pack/platform/plugins/shared/cases/common/types/domain/template` —\ndrift guards and round-trip invariant\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/server/services/templates` —\ncreate/update reject invalid names; dry-run and real write agree\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/server/routes/api/templates/template_routes.test.ts`\n— PATCH with an invalid field name returns 400\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/public/components/templates_v2\nx-pack/platform/plugins/shared/cases/public/components/field_library`\n- [ ] Manual: edit an existing template, change a field name to `bad\nname` — confirm Save button disables with an inline squiggle before the\nrequest is sent. Then save `snake_name` and confirm it works.\n- [ ] Manual: open the field-library flyout for a new definition, enter\n`name: risk-score` — confirm charset error shown inline.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: Michael Olorunnisola <michael.olorunnisola@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"014d21819ed495802c6865ab4ea2003f7e68f513","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Team:Cases","Cases: Templates","Feature - improved case templates","v9.6.0","v9.5.2"],"title":"[Cases] Harden templates-v2 extended-field key names with split read/write validation","number":285423,"url":"https://github.com/elastic/kibana/pull/285423","mergeCommit":{"message":"[Cases] Harden templates-v2 extended-field key names with split read/write validation (#285423)\n\n## Summary\n\nHardens the cases templates v2 extended-field `name` so every derived\n`<name>_as_<type>` storage key is safe for ES `flattened` mapping,\ndata-view runtime fields, and Painless interpolation.\n\n### Why this matters\n\nA template field `name` was unconstrained (`z.string()`). The derived\nstorage key `<name>_as_<type>` ends up in two dangerous places:\n\n- **Painless string literal** — an apostrophe in the name corrupts the\nPainless source at search time.\n- **`splitSnakeKey` charset guard** — anything outside `[A-Za-z0-9_-]`\ncauses the key to be silently dropped, so the field never appears in\nDiscover or Lens with no error anywhere.\n\n### Two-guard split\n\n| | Constant | Charset | Used by |\n|---|---|---|---|\n| **Lenient (read)** | `SAFE_SNAKE_KEY` | `[A-Za-z0-9_-]` |\n`splitSnakeKey`, analytics runtime fields, Painless literal guard |\n| **Strict (write)** | `AUTHORABLE_SNAKE_KEY` | `[A-Za-z0-9_]` | All\ntemplate and field-definition write paths |\n\nContainment is structural: one base charset string\n(`AUTHORABLE_KEY_CHARS`) plus an explicit tolerated-extras string\n(`READ_TOLERATED_KEY_CHARS = '-'`). A unit test pins the delta to\nexactly `['-']` so the two guards can never drift silently.\n\nThe lenient read guard keeps already-stored data and v1→v2 migration\noutput (UUID names with hyphens) working, including making them\nanalytics-visible for the first time. The strict write guard stops new\ninvalid names at the point of authoring with a message that names the\noffending field.\n\n### Changes\n\n**Server**\n\n- `TemplatesService` — new private `assertFieldNamesAreAuthorable`\nmethod (same pattern as `assertFieldCountWithinLimit`). Runs\n`StrictFieldsArraySchema.safeParse` and throws `Boom.badRequest` naming\nthe offending field. Called from `createTemplate`, `updateTemplate`, and\n`validateWriteInput` so every write path is gated regardless of which\nroute the client uses.\n- `patch_template_route.ts` — replaced duplicated inline YAML validation\nwith the shared `validateTemplateDefinition` helper, bringing PATCH in\nline with POST and PUT.\n- `extended_field_search_utils.ts` — added `isSafeExtendedFieldKey`\nguard before interpolating a key into the Painless literal, closing the\ninjection vector.\n\n**Client**\n\n- `validate_template_definition.ts` — after the structural parse, runs\n`StrictFieldsArraySchema` and returns the first issue message so the\nSave button disables and the footer names the offending field before the\nrequest is sent.\n- `field_definition_yaml_editor.tsx` — uses `StrictInlineFieldSchema`\nand surfaces the specific issue message instead of the generic \"invalid\nfield definition YAML\".\n- `field_definition_flyout.tsx` — `isDefinitionValid` uses\n`StrictInlineFieldSchema` on create (lenient on edit, since name is\nimmutable and the server also uses the lenient schema for updates).\n- `use_field_name_validation.ts` — new `createInvalidNameMarkers` places\nan inline Monaco squiggle on the offending name in the template YAML\neditor, alongside the existing duplicate-name markers.\n\n### What stays lenient (intentional)\n\n- Read and preview paths (`use_resolved_fields.ts`,\n`template_preview.tsx`, `field_definition_preview.tsx`) — stored data\nmust always render regardless of when it was authored.\n- `updateFieldDefinition` (field library) — name is immutable once\ncreated (409 `FIELD_IDENTITY_IMMUTABLE`), so applying the strict rule on\nupdate would permanently strand pre-existing definitions.\n- v1→v2 migration — writes via `repo.create`, bypassing service\nvalidation. UUID names (hex + hyphens) now produce runtime fields for\nthe first time thanks to the lenient read guard and the\n`RUNTIME_FIELDS_BUILD_VERSION` bump.\n\n### Out of scope\n\n- `$ref` target string (library definition names — UUID-shaped by\nmigration, intentionally not validated here).\n- `extended_fields` key-allowlist gap for no-template cases\n(`server/client/cases/validators.ts:297`).\n\n## Test plan\n\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/common/constants\nx-pack/platform/plugins/shared/cases/common/types/domain/template` —\ndrift guards and round-trip invariant\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/server/services/templates` —\ncreate/update reject invalid names; dry-run and real write agree\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/server/routes/api/templates/template_routes.test.ts`\n— PATCH with an invalid field name returns 400\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/public/components/templates_v2\nx-pack/platform/plugins/shared/cases/public/components/field_library`\n- [ ] Manual: edit an existing template, change a field name to `bad\nname` — confirm Save button disables with an inline squiggle before the\nrequest is sent. Then save `snake_name` and confirm it works.\n- [ ] Manual: open the field-library flyout for a new definition, enter\n`name: risk-score` — confirm charset error shown inline.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: Michael Olorunnisola <michael.olorunnisola@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"014d21819ed495802c6865ab4ea2003f7e68f513"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/285423","number":285423,"mergeCommit":{"message":"[Cases] Harden templates-v2 extended-field key names with split read/write validation (#285423)\n\n## Summary\n\nHardens the cases templates v2 extended-field `name` so every derived\n`<name>_as_<type>` storage key is safe for ES `flattened` mapping,\ndata-view runtime fields, and Painless interpolation.\n\n### Why this matters\n\nA template field `name` was unconstrained (`z.string()`). The derived\nstorage key `<name>_as_<type>` ends up in two dangerous places:\n\n- **Painless string literal** — an apostrophe in the name corrupts the\nPainless source at search time.\n- **`splitSnakeKey` charset guard** — anything outside `[A-Za-z0-9_-]`\ncauses the key to be silently dropped, so the field never appears in\nDiscover or Lens with no error anywhere.\n\n### Two-guard split\n\n| | Constant | Charset | Used by |\n|---|---|---|---|\n| **Lenient (read)** | `SAFE_SNAKE_KEY` | `[A-Za-z0-9_-]` |\n`splitSnakeKey`, analytics runtime fields, Painless literal guard |\n| **Strict (write)** | `AUTHORABLE_SNAKE_KEY` | `[A-Za-z0-9_]` | All\ntemplate and field-definition write paths |\n\nContainment is structural: one base charset string\n(`AUTHORABLE_KEY_CHARS`) plus an explicit tolerated-extras string\n(`READ_TOLERATED_KEY_CHARS = '-'`). A unit test pins the delta to\nexactly `['-']` so the two guards can never drift silently.\n\nThe lenient read guard keeps already-stored data and v1→v2 migration\noutput (UUID names with hyphens) working, including making them\nanalytics-visible for the first time. The strict write guard stops new\ninvalid names at the point of authoring with a message that names the\noffending field.\n\n### Changes\n\n**Server**\n\n- `TemplatesService` — new private `assertFieldNamesAreAuthorable`\nmethod (same pattern as `assertFieldCountWithinLimit`). Runs\n`StrictFieldsArraySchema.safeParse` and throws `Boom.badRequest` naming\nthe offending field. Called from `createTemplate`, `updateTemplate`, and\n`validateWriteInput` so every write path is gated regardless of which\nroute the client uses.\n- `patch_template_route.ts` — replaced duplicated inline YAML validation\nwith the shared `validateTemplateDefinition` helper, bringing PATCH in\nline with POST and PUT.\n- `extended_field_search_utils.ts` — added `isSafeExtendedFieldKey`\nguard before interpolating a key into the Painless literal, closing the\ninjection vector.\n\n**Client**\n\n- `validate_template_definition.ts` — after the structural parse, runs\n`StrictFieldsArraySchema` and returns the first issue message so the\nSave button disables and the footer names the offending field before the\nrequest is sent.\n- `field_definition_yaml_editor.tsx` — uses `StrictInlineFieldSchema`\nand surfaces the specific issue message instead of the generic \"invalid\nfield definition YAML\".\n- `field_definition_flyout.tsx` — `isDefinitionValid` uses\n`StrictInlineFieldSchema` on create (lenient on edit, since name is\nimmutable and the server also uses the lenient schema for updates).\n- `use_field_name_validation.ts` — new `createInvalidNameMarkers` places\nan inline Monaco squiggle on the offending name in the template YAML\neditor, alongside the existing duplicate-name markers.\n\n### What stays lenient (intentional)\n\n- Read and preview paths (`use_resolved_fields.ts`,\n`template_preview.tsx`, `field_definition_preview.tsx`) — stored data\nmust always render regardless of when it was authored.\n- `updateFieldDefinition` (field library) — name is immutable once\ncreated (409 `FIELD_IDENTITY_IMMUTABLE`), so applying the strict rule on\nupdate would permanently strand pre-existing definitions.\n- v1→v2 migration — writes via `repo.create`, bypassing service\nvalidation. UUID names (hex + hyphens) now produce runtime fields for\nthe first time thanks to the lenient read guard and the\n`RUNTIME_FIELDS_BUILD_VERSION` bump.\n\n### Out of scope\n\n- `$ref` target string (library definition names — UUID-shaped by\nmigration, intentionally not validated here).\n- `extended_fields` key-allowlist gap for no-template cases\n(`server/client/cases/validators.ts:297`).\n\n## Test plan\n\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/common/constants\nx-pack/platform/plugins/shared/cases/common/types/domain/template` —\ndrift guards and round-trip invariant\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/server/services/templates` —\ncreate/update reject invalid names; dry-run and real write agree\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/server/routes/api/templates/template_routes.test.ts`\n— PATCH with an invalid field name returns 400\n- [ ] `node scripts/jest\nx-pack/platform/plugins/shared/cases/public/components/templates_v2\nx-pack/platform/plugins/shared/cases/public/components/field_library`\n- [ ] Manual: edit an existing template, change a field name to `bad\nname` — confirm Save button disables with an inline squiggle before the\nrequest is sent. Then save `snake_name` and confirm it works.\n- [ ] Manual: open the field-library flyout for a new definition, enter\n`name: risk-score` — confirm charset error shown inline.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: Michael Olorunnisola <michael.olorunnisola@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"014d21819ed495802c6865ab4ea2003f7e68f513"}},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->