### PR TITLE
[Accessibility] Fix panel loading indicators ignoring accessibility:disableAnimations

### DIFF
--- a/src/core/packages/integrations/browser-internal/src/styles/disable_animations.css
+++ b/src/core/packages/integrations/browser-internal/src/styles/disable_animations.css
@@ -13,9 +13,40 @@
   -webkit-animation-duration: 0s !important;
   animation-duration: 0s !important;
 
+  /**
+   * Zero animation-delay so staggered animations do not produce a visible
+   * delay-window where elements appear in a pre-animation state. Without
+   * this, elements with animation-delay > 0 sit in their default (unanimated)
+   * position for the duration of the delay even though duration is 0s.
+   */
+  -webkit-animation-delay: 0s !important;
+  animation-delay: 0s !important;
+
   -webkit-transition-duration: 0s !important;
   transition-duration: 0s !important;
 
   -webkit-transition-delay: 0s !important;
   transition-delay: 0s !important;
+}
+
+/**
+ * EUI loading spinners (EuiLoadingChart, EuiLoadingElastic, EuiLoadingSpinner,
+ * etc.) gate their keyframe animation behind @media (prefers-reduced-motion:
+ * no-preference), which is an OS-level preference and is not controlled by the
+ * Kibana accessibility:disableAnimations setting.  The duration-zeroing rules
+ * above stop the animation from advancing, but the animation is still
+ * "running" (play-state: running) which can produce non-deterministic
+ * screenshots and visible flicker on some browser/OS combinations.
+ *
+ * Pure-visual loading indicators do not rely on animationend/animationiteration
+ * callbacks, so it is safe to pause them outright.  We identify them via the
+ * `.kbnLoadingIndicator` marker class added by kbn-panel-loader and
+ * kbn-screenshot-mode.
+ *
+ * https://github.com/elastic/kibana/issues/283806
+ */
+.kbnLoadingIndicator,
+.kbnLoadingIndicator * {
+  -webkit-animation-play-state: paused !important;
+  animation-play-state: paused !important;
 }

--- a/src/core/packages/integrations/browser-internal/src/styles/disable_animations.css
+++ b/src/core/packages/integrations/browser-internal/src/styles/disable_animations.css
@@ -22,6 +22,16 @@
   -webkit-animation-delay: 0s !important;
   animation-delay: 0s !important;
 
+  /**
+   * Detach scroll-driven animations (introduced in EUI v116 for overflow
+   * scroll shadows in EuiSelectable, EuiComboBox, EuiContextMenu).
+   * scroll-driven animations use scroll position as their timeline, so
+   * animation-duration: 0s has no effect on them. Setting animation-timeline
+   * to the default `auto` (time-based) makes the duration-zeroing rule above
+   * apply to them as well.
+   */
+  animation-timeline: auto !important;
+
   -webkit-transition-duration: 0s !important;
   transition-duration: 0s !important;
 

--- a/src/platform/packages/private/kbn-panel-loader/index.tsx
+++ b/src/platform/packages/private/kbn-panel-loader/index.tsx
@@ -35,7 +35,7 @@ export const PanelLoader = (props: {
       hasBorder={props.showBorder}
       data-test-subj={props.dataTestSubj}
     >
-      <EuiLoadingChart size="l" />
+      <EuiLoadingChart size="l" className="kbnLoadingIndicator" />
     </EuiPanel>
   );
 };

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
@@ -177,9 +177,9 @@ export function DashboardRenderer({
   });
 
   const loadingSpinner = showPlainSpinner ? (
-    <EuiLoadingSpinner size="xxl" />
+    <EuiLoadingSpinner size="xxl" className="kbnLoadingIndicator" />
   ) : (
-    <EuiLoadingElastic size="xxl" />
+    <EuiLoadingElastic size="xxl" className="kbnLoadingIndicator" />
   );
 
   const renderDashboardContents = () => {


### PR DESCRIPTION
## Summary

Closes #283806

### Root cause

EUI loading components (`EuiLoadingChart`, `EuiLoadingElastic`, `EuiLoadingSpinner`) gate their keyframe animations behind `@media (prefers-reduced-motion: no-preference)` — an OS-level media query that Kibana's `accessibility:disableAnimations` UI setting does not control.

Kibana's `StylesService` injects `disable_animations.css` when the setting is on, which zeroes `animation-duration` via `!important`. This prevents the animation from advancing in time, but the animation remains in `play-state: running`. On some browser/OS combinations (first observed in EUI v116 / Kibana 9.5, while not present in EUI v115 / Kibana 9.4), this produces:
- Visible spinning/bouncing on the panel loading indicator
- Non-deterministic panel states in functional test screenshots

### Changes

| File | Change |
|---|---|
| `disable_animations.css` | Add `animation-delay: 0s !important` — staggered delays (e.g. `EuiLoadingChart` uses `0.0s / 0.1s / 0.2s / 0.3s`) are not currently zeroed, leaving bars in their pre-animation position for up to 300ms |
| `disable_animations.css` | Add `.kbnLoadingIndicator` rule that sets `animation-play-state: paused !important` — unlike global duration-zeroing, pausing is safe for _pure-visual_ loading indicators because they do not rely on `animationend` / `animationiteration` callbacks |
| `kbn-panel-loader/index.tsx` | Apply `className="kbnLoadingIndicator"` to `EuiLoadingChart` |
| `dashboard_renderer.tsx` | Apply `className="kbnLoadingIndicator"` to `EuiLoadingElastic` / `EuiLoadingSpinner` |

The `.kbnLoadingIndicator` class has no visual effect on its own — the CSS rule is only injected when `disableAnimations` is `true`.
