### PR TITLE
[ES|QL]  Rejects deep queries nesting

### DIFF
--- a/src/platform/plugins/shared/esql/server/routes/get_timefield.test.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_timefield.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { IRouter, PluginInitializerContext } from '@kbn/core/server';
+import { registerGetTimeFieldRoute } from './get_timefield';
+import { TIMEFIELD_ROUTE } from '@kbn/esql-types';
+
+jest.mock('@kbn/esql-server-utils', () => ({
+  EsqlService: jest.fn().mockImplementation(() => ({
+    getViews: jest.fn().mockResolvedValue({ views: [] }),
+    getDatasets: jest.fn().mockResolvedValue({ datasets: [] }),
+  })),
+}));
+
+const { parseTimeFieldFromESQLQuery } = jest.requireMock('@kbn/esql-utils');
+const { Parser } = jest.requireMock('@elastic/esql');
+
+function buildMocks() {
+  const handler = jest.fn();
+  const router = {
+    post: jest.fn((_, h) => {
+      handler.mockImplementation(h);
+    }),
+  };
+
+  const featureFlags = { getBooleanValue: jest.fn().mockResolvedValue(false) };
+  const esClient = {
+    asCurrentUser: {
+      fieldCaps: jest.fn().mockResolvedValue({ fields: { '@timestamp': {} } }),
+      transport: { request: jest.fn().mockResolvedValue({ columns: [] }) },
+    },
+  };
+  const core = {
+    elasticsearch: { client: esClient },
+    featureFlags,
+  };
+  const requestHandlerContext = { core: Promise.resolve(core) };
+  const response = {
+    ok: jest.fn((r) => ({ status: 200, ...r })),
+    badRequest: jest.fn((r) => ({ status: 400, ...r })),
+    customError: jest.fn((r) => ({ status: r?.statusCode ?? 500, ...r })),
+  };
+  const context = { logger: { get: () => ({ error: jest.fn() }) } };
+
+  return {
+    router: router as unknown as IRouter,
+    handler,
+    requestHandlerContext,
+    response,
+    context: context as unknown as PluginInitializerContext,
+  };
+}
+
+describe('registerGetTimeFieldRoute', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('registers a POST handler at the correct path', () => {
+    const { router, context } = buildMocks();
+    registerGetTimeFieldRoute(router, context);
+    expect(router.post).toHaveBeenCalledWith(
+      expect.objectContaining({ path: TIMEFIELD_ROUTE }),
+      expect.any(Function)
+    );
+  });
+
+  describe('nesting-depth guard', () => {
+    it('returns 400 for a query whose parenthesis nesting depth exceeds the limit', async () => {
+      const { router, handler, requestHandlerContext, response, context } = buildMocks();
+      registerGetTimeFieldRoute(router, context);
+
+      const depth = 51;
+      const query = 'FROM a | WHERE ' + '('.repeat(depth) + '1' + ')'.repeat(depth);
+      await handler(requestHandlerContext, { body: { query } }, response);
+
+      expect(response.badRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ body: expect.stringContaining('nesting depth') })
+      );
+      expect(parseTimeFieldFromESQLQuery).not.toHaveBeenCalled();
+      expect(Parser.parse).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a deeply nested bracket query (square brackets)', async () => {
+      const { router, handler, requestHandlerContext, response, context } = buildMocks();
+      registerGetTimeFieldRoute(router, context);
+
+      const depth = 60;
+      const query = 'FROM a | WHERE x IN ' + '['.repeat(depth) + '1' + ']'.repeat(depth);
+      await handler(requestHandlerContext, { body: { query } }, response);
+
+      expect(response.badRequest).toHaveBeenCalled();
+      expect(parseTimeFieldFromESQLQuery).not.toHaveBeenCalled();
+    });
+
+    it('allows a query exactly at the nesting limit (depth 50)', async () => {
+      const { router, handler, requestHandlerContext, response, context } = buildMocks();
+      registerGetTimeFieldRoute(router, context);
+
+      const depth = 50;
+      const query = 'FROM a | WHERE ' + '('.repeat(depth) + '1' + ')'.repeat(depth);
+      await handler(requestHandlerContext, { body: { query } }, response);
+
+      expect(response.badRequest).not.toHaveBeenCalled();
+    });
+
+    it('allows a normal flat query', async () => {
+      const { router, handler, requestHandlerContext, response, context } = buildMocks();
+      registerGetTimeFieldRoute(router, context);
+
+      const query = 'FROM logs-* | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend';
+      await handler(requestHandlerContext, { body: { query } }, response);
+
+      expect(response.badRequest).not.toHaveBeenCalled();
+    });
+
+    it('blocks the PoC payload from the vulnerability report (depth 120)', async () => {
+      const { router, handler, requestHandlerContext, response, context } = buildMocks();
+      registerGetTimeFieldRoute(router, context);
+
+      const depth = 120;
+      const query = 'FROM a | WHERE ' + '('.repeat(depth) + '1' + ')'.repeat(depth);
+      await handler(requestHandlerContext, { body: { query } }, response);
+
+      expect(response.badRequest).toHaveBeenCalled();
+      expect(parseTimeFieldFromESQLQuery).not.toHaveBeenCalled();
+      expect(Parser.parse).not.toHaveBeenCalled();
+    });
+
+    it('blocks the permanent-hang PoC payload (depth 1500)', async () => {
+      const { router, handler, requestHandlerContext, response, context } = buildMocks();
+      registerGetTimeFieldRoute(router, context);
+
+      const depth = 1500;
+      const query = 'FROM a | WHERE ' + '('.repeat(depth) + '1' + ')'.repeat(depth);
+      await handler(requestHandlerContext, { body: { query } }, response);
+
+      expect(response.badRequest).toHaveBeenCalled();
+      expect(parseTimeFieldFromESQLQuery).not.toHaveBeenCalled();
+      expect(Parser.parse).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/platform/plugins/shared/esql/server/routes/get_timefield.test.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_timefield.test.ts
@@ -11,6 +11,16 @@ import type { IRouter, PluginInitializerContext } from '@kbn/core/server';
 import { registerGetTimeFieldRoute } from './get_timefield';
 import { TIMEFIELD_ROUTE } from '@kbn/esql-types';
 
+jest.mock('@kbn/esql-utils', () => ({
+  getIndexPatternFromESQLQuery: jest.fn().mockReturnValue('logs-*'),
+  parseTimeFieldFromESQLQuery: jest.fn().mockReturnValue(undefined),
+}));
+
+jest.mock('@elastic/esql', () => ({
+  Parser: { parse: jest.fn().mockReturnValue({ root: { commands: [] } }) },
+  isSubQuery: jest.fn().mockReturnValue(false),
+}));
+
 jest.mock('@kbn/esql-server-utils', () => ({
   EsqlService: jest.fn().mockImplementation(() => ({
     getViews: jest.fn().mockResolvedValue({ views: [] }),
@@ -116,19 +126,6 @@ describe('registerGetTimeFieldRoute', () => {
       await handler(requestHandlerContext, { body: { query } }, response);
 
       expect(response.badRequest).not.toHaveBeenCalled();
-    });
-
-    it('blocks the PoC payload from the vulnerability report (depth 120)', async () => {
-      const { router, handler, requestHandlerContext, response, context } = buildMocks();
-      registerGetTimeFieldRoute(router, context);
-
-      const depth = 120;
-      const query = 'FROM a | WHERE ' + '('.repeat(depth) + '1' + ')'.repeat(depth);
-      await handler(requestHandlerContext, { body: { query } }, response);
-
-      expect(response.badRequest).toHaveBeenCalled();
-      expect(parseTimeFieldFromESQLQuery).not.toHaveBeenCalled();
-      expect(Parser.parse).not.toHaveBeenCalled();
     });
 
     it('blocks the permanent-hang PoC payload (depth 1500)', async () => {

--- a/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_timefield.ts
@@ -21,6 +21,25 @@ const ES_TIMESTAMP_FIELD_NAME = '@timestamp';
 // Temporary: remove once dataset filtering is enabled by default in ES
 const DATASET_FILTERING_FEATURE_FLAG_KEY = 'esql.datasetFilteringEnabled';
 
+// ANTLR ALL(*) adaptive-prediction cost grows super-linearly with parenthesis nesting depth.
+// Reject deep queries before touching the parser to prevent event-loop stalls (DoS via a single
+// small request from a low-privileged account).
+const MAX_NESTING_DEPTH = 50;
+
+const getMaxNestingDepth = (query: string): number => {
+  let max = 0;
+  let depth = 0;
+  for (const ch of query) {
+    if (ch === '(' || ch === '[') {
+      depth++;
+      if (depth > max) max = depth;
+    } else if (ch === ')' || ch === ']') {
+      depth--;
+    }
+  }
+  return max;
+};
+
 const hasTimestampInFieldCapsResponse = (result: FieldCapsResponse) =>
   Boolean(result.fields && result.fields['@timestamp']);
 
@@ -211,6 +230,13 @@ export const registerGetTimeFieldRoute = (
     },
     async (requestHandlerContext, request, response) => {
       const { query } = request.body;
+
+      if (getMaxNestingDepth(query) > MAX_NESTING_DEPTH) {
+        return response.badRequest({
+          body: 'Query nesting depth exceeds the maximum allowed limit',
+        });
+      }
+
       const core = await requestHandlerContext.core;
       const client = core.elasticsearch.client.asCurrentUser;
       // Temporary: remove once dataset filtering is enabled by default in ES


### PR DESCRIPTION
## Summary

This PR is adding a nesting guard to fix a deep nesting of ES|QL queries.

Note: The other routes do not have this problem

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->