### PR TITLE
[Security Solution][CPS] Disable isolate host functionality when the host is on a linked project

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/translations.ts
@@ -35,3 +35,10 @@ export const RETURN_TO_ALERT_DETAILS = i18n.translate(
   'xpack.securitySolution.endpoint.hostIsolation.returnToAlertDetails',
   { defaultMessage: 'Return to alert details' }
 );
+
+export const HOST_ON_LINKED_PROJECT_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.endpoint.hostIsolation.hostOnLinkedProject',
+  {
+    defaultMessage: 'Host isolation is not available for a host enrolled in a linked project.',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action.test.tsx
@@ -15,7 +15,8 @@ import { useUserPrivileges as _useUserPrivileges } from '../../../user_privilege
 import type { AlertTableContextMenuItem } from '../../../../../detections/components/alerts_table/types';
 import type { ResponseActionsApiCommandNames } from '../../../../../../common/endpoint/service/response_actions/constants';
 import { agentStatusMocks } from '../../../../../../common/endpoint/service/response_actions/mocks/agent_status.mocks';
-import { ISOLATE_HOST, UNISOLATE_HOST } from './translations';
+import type { ICPSManager } from '@kbn/cps-utils';
+import { HOST_ON_LINKED_PROJECT_TOOLTIP, ISOLATE_HOST, UNISOLATE_HOST } from './translations';
 import {
   HOST_ENDPOINT_UNENROLLED_TOOLTIP,
   LOADING_ENDPOINT_DATA_TOOLTIP,
@@ -48,6 +49,15 @@ describe('useHostIsolationAction', () => {
 
   const render = () => {
     return appContextMock.renderHook(() => useHostIsolationAction(hookProps));
+  };
+
+  // The linked-project guard only runs on CPS-enabled deployments, which the client detects via the
+  // presence of `cps.cpsManager`. Tests exercising that path must enable it explicitly.
+  const enableCps = () => {
+    appContextMock.startServices.cps = {
+      cpsManager: { whenReady: jest.fn().mockResolvedValue(undefined) } as unknown as ICPSManager,
+      isTierEligible: true,
+    };
   };
 
   beforeEach(() => {
@@ -169,6 +179,63 @@ describe('useHostIsolationAction', () => {
       );
     }
   );
+
+  it('should return disabled menu item when the host is from a linked project (CPS)', async () => {
+    enableCps();
+    hookProps.detailsData = endpointAlertDataMock.generateEndpointAlertDetailsItemData({
+      'kibana.alert.ancestors.index': {
+        category: 'kibana',
+        field: 'kibana.alert.ancestors.index',
+        values: ['linked_local_project:.ds-logs-endpoint.events-default'],
+        originalValue: ['linked_local_project:.ds-logs-endpoint.events-default'],
+        isObjectArray: false,
+      },
+    });
+    const { result } = render();
+
+    await appContextMock.waitFor(() =>
+      expect(result.current).toEqual([
+        buildExpectedMenuItemResult({
+          disabled: true,
+          toolTipContent: HOST_ON_LINKED_PROJECT_TOOLTIP,
+        }),
+      ])
+    );
+  });
+
+  it('should return enabled menu item for a non-local ancestor index when CPS is disabled', async () => {
+    hookProps.detailsData = endpointAlertDataMock.generateEndpointAlertDetailsItemData({
+      'kibana.alert.ancestors.index': {
+        category: 'kibana',
+        field: 'kibana.alert.ancestors.index',
+        values: ['linked_local_project:.ds-logs-endpoint.events-default'],
+        originalValue: ['linked_local_project:.ds-logs-endpoint.events-default'],
+        isObjectArray: false,
+      },
+    });
+    const { result } = render();
+
+    await appContextMock.waitFor(() =>
+      expect(result.current).toEqual([buildExpectedMenuItemResult()])
+    );
+  });
+
+  it('should return enabled menu item when the ancestor index is local', async () => {
+    hookProps.detailsData = endpointAlertDataMock.generateEndpointAlertDetailsItemData({
+      'kibana.alert.ancestors.index': {
+        category: 'kibana',
+        field: 'kibana.alert.ancestors.index',
+        values: ['.ds-logs-endpoint.events-default'],
+        originalValue: ['.ds-logs-endpoint.events-default'],
+        isObjectArray: false,
+      },
+    });
+    const { result } = render();
+
+    await appContextMock.waitFor(() =>
+      expect(result.current).toEqual([buildExpectedMenuItemResult()])
+    );
+  });
 
   it('should call isolate API when agent is currently NOT isolated', async () => {
     const { result } = render();

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/host_isolation/from_alerts/use_host_isolation_action.tsx
@@ -6,6 +6,7 @@
  */
 import { useCallback, useMemo } from 'react';
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import {
   HOST_ENDPOINT_UNENROLLED_TOOLTIP,
   LOADING_ENDPOINT_DATA_TOOLTIP,
@@ -13,7 +14,9 @@ import {
 } from '../../responder';
 import { useAlertResponseActionsSupport } from '../../../../hooks/endpoint/use_alert_response_actions_support';
 import { HostStatus } from '../../../../../../common/endpoint/types';
-import { ISOLATE_HOST, UNISOLATE_HOST } from './translations';
+import { getEventDetailsFieldValues } from '../../../../lib/endpoint/utils/get_event_details_field_values';
+import { useKibana } from '../../../../lib/kibana';
+import { HOST_ON_LINKED_PROJECT_TOOLTIP, ISOLATE_HOST, UNISOLATE_HOST } from './translations';
 import { useUserPrivileges } from '../../../user_privileges';
 import type { AlertTableContextMenuItem } from '../../../../../detections/components/alerts_table/types';
 import { useGetAgentStatus } from '../../../../../management/hooks/agents/use_get_agent_status';
@@ -76,6 +79,26 @@ export const useHostIsolationAction = ({
     );
   }, [hostSupportsResponseActions, agentStatus]);
 
+  // Only meaningful when CPS is on: `cpsManager` is present solely on CPS-enabled deployments. Off
+  // CPS (including CCS deployments), an ancestor index can legitimately carry a remote-cluster prefix
+  // that `isNonLocalIndexName` would flag, so the check must be gated to avoid a false positive.
+  const isCpsEnabled = Boolean(useKibana().services.cps?.cpsManager);
+
+  // In a Cross-Project Search deployment an alert can be generated off a document that lives in a
+  // linked project even though the alert itself is stored locally. The host is then only visible to
+  // the origin via a fanned-out (project-routed) search, while response actions run origin-only and
+  // reject the host as not enrolled. Elasticsearch prefixes the source `_index` with the project
+  // alias, so a non-local ancestor index is the signal that the host belongs to a linked project.
+  const isHostFromLinkedProject = useMemo<boolean>(
+    () =>
+      isCpsEnabled &&
+      getEventDetailsFieldValues(
+        { category: 'kibana', field: 'kibana.alert.ancestors.index' },
+        detailsData
+      ).some(isNonLocalIndexName),
+    [isCpsEnabled, detailsData]
+  );
+
   return useMemo<AlertTableContextMenuItem[]>(() => {
     // If user has no Authz, then don't show the menu item at all
     if ((isHostIsolated && !canUnIsolateHost) || !canIsolateHost) {
@@ -91,7 +114,12 @@ export const useHostIsolationAction = ({
     };
 
     // Determine if menu item should be disabled
-    if (!doesHostSupportIsolation) {
+    if (isHostFromLinkedProject) {
+      // Checked first so its reason wins: agent status fans out and reports the linked host as
+      // enrolled, so the other branches below would otherwise show a misleading tooltip.
+      menuItem.disabled = true;
+      menuItem.toolTipContent = HOST_ON_LINKED_PROJECT_TOOLTIP;
+    } else if (!doesHostSupportIsolation) {
       menuItem.disabled = true;
       // If we were able to calculate the agentType and we have a reason why the host is does not
       // support response actions, then show that as the tooltip. Else, just show the normal "enroll" message
@@ -115,6 +143,7 @@ export const useHostIsolationAction = ({
     canIsolateHost,
     isHostAgentUnEnrolled,
     isolateHostHandler,
+    isHostFromLinkedProject,
     doesHostSupportIsolation,
     isLoading,
     isFetched,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/endpoint/utils/get_event_details_field_values.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/endpoint/utils/get_event_details_field_values.ts
@@ -15,7 +15,7 @@ import { find } from 'lodash/fp';
  * @param field
  * @param data
  */
-const getEventDetailsFieldValues = (
+export const getEventDetailsFieldValues = (
   {
     category,
     field,


### PR DESCRIPTION
> [!NOTE]
> This is a very similar change to the Respond [fix](https://github.com/elastic/kibana/pull/286209) we just merged.

## Summary

This PR makes a small change to the isolate host logic that disables it in the `Take action` dropdown menu in the flyout.

#### On `main`

https://github.com/user-attachments/assets/94c4bab8-5287-4fa2-984e-1b67a05fc710

#### On this branch

https://github.com/user-attachments/assets/b5b1fba8-802d-4117-a143-a6c2efc19dc0

## How to test

- spin up a local CPS environment (see [this guide](https://docs.google.com/document/d/16c6H8EVyyAUwp7QDm-77__RHz_hSJ2_wE40_as7WIqE/edit?tab=t.0))
- generate local alert from linked documents
- open the document details flyout for one of those alert, open the `Take action` button and see that `Isolate host` is disabled with the proper tooltip

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/286206