### PR TITLE
[Security Solution][CPS] Disable Respond functionality when the host is on a linked project

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/translations.ts
@@ -25,3 +25,9 @@ export const METADATA_API_ERROR_TOOLTIP = i18n.translate(
   'xpack.securitySolution.endpoint.detections.takeAction.responseActionConsole.generalMetadataErrorTooltip',
   { defaultMessage: 'Failed to retrieve Endpoint metadata' }
 );
+export const HOST_ON_LINKED_PROJECT_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.endpoint.detections.takeAction.responseActionConsole.hostOnLinkedProjectTooltip',
+  {
+    defaultMessage: 'Response actions are not available for a host enrolled in a linked project.',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.test.ts
@@ -17,6 +17,7 @@ import {
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import {
   HOST_ENDPOINT_UNENROLLED_TOOLTIP,
+  HOST_ON_LINKED_PROJECT_TOOLTIP,
   LOADING_ENDPOINT_DATA_TOOLTIP,
   METADATA_API_ERROR_TOOLTIP,
   NOT_FROM_ENDPOINT_HOST_TOOLTIP,
@@ -171,6 +172,61 @@ describe('use responder action data hooks', () => {
       });
 
       it('should show action enabled if host metadata was retrieved and host is enrolled', async () => {
+        const { result } = renderHook();
+        await waitFor(() => expect(result.current.isDisabled).toBe(false));
+
+        expect(result.current).toEqual(getExpectedResponderActionData());
+      });
+
+      it('should show action disabled when the alert host is from a linked project (CPS), even if metadata was retrieved', () => {
+        alertDetailItemData = endpointAlertDataMock.generateEndpointAlertDetailsItemData({
+          'kibana.alert.ancestors.index': {
+            category: 'kibana',
+            field: 'kibana.alert.ancestors.index',
+            values: ['linked_local_project:.ds-logs-endpoint.events-default'],
+            originalValue: ['linked_local_project:.ds-logs-endpoint.events-default'],
+            isObjectArray: false,
+          },
+        });
+
+        expect(renderHook().result.current).toEqual(
+          getExpectedResponderActionData({
+            isDisabled: true,
+            tooltip: HOST_ON_LINKED_PROJECT_TOOLTIP,
+          })
+        );
+      });
+
+      it('should NOT open the response console for a host from a linked project', () => {
+        alertDetailItemData = endpointAlertDataMock.generateEndpointAlertDetailsItemData({
+          'kibana.alert.ancestors.index': {
+            category: 'kibana',
+            field: 'kibana.alert.ancestors.index',
+            values: ['linked_local_project:.ds-logs-endpoint.events-default'],
+            originalValue: ['linked_local_project:.ds-logs-endpoint.events-default'],
+            isObjectArray: false,
+          },
+        });
+
+        const { result } = renderHook();
+        act(() => {
+          result.current.handleResponseActionsClick();
+        });
+
+        expect(onClickMock).not.toHaveBeenCalled();
+      });
+
+      it('should keep the action enabled when the ancestor index is local', async () => {
+        alertDetailItemData = endpointAlertDataMock.generateEndpointAlertDetailsItemData({
+          'kibana.alert.ancestors.index': {
+            category: 'kibana',
+            field: 'kibana.alert.ancestors.index',
+            values: ['.ds-logs-endpoint.events-default'],
+            originalValue: ['.ds-logs-endpoint.events-default'],
+            isObjectArray: false,
+          },
+        });
+
         const { result } = renderHook();
         await waitFor(() => expect(result.current.isDisabled).toBe(false));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.test.ts
@@ -15,6 +15,7 @@ import {
   useWithResponderActionDataFromAlert,
 } from './use_responder_action_data';
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+import type { ICPSManager } from '@kbn/cps-utils';
 import {
   HOST_ENDPOINT_UNENROLLED_TOOLTIP,
   HOST_ON_LINKED_PROJECT_TOOLTIP,
@@ -49,6 +50,15 @@ describe('use responder action data hooks', () => {
       tooltip: undefined,
       handleResponseActionsClick: expect.any(Function),
       ...overrides,
+    };
+  };
+
+  // The linked-project guard only runs on CPS-enabled deployments, which the client detects via the
+  // presence of `cps.cpsManager`. Tests exercising that path must enable it explicitly.
+  const enableCps = () => {
+    appContextMock.startServices.cps = {
+      cpsManager: { whenReady: jest.fn().mockResolvedValue(undefined) } as unknown as ICPSManager,
+      isTierEligible: true,
     };
   };
 
@@ -179,6 +189,7 @@ describe('use responder action data hooks', () => {
       });
 
       it('should show action disabled when the alert host is from a linked project (CPS), even if metadata was retrieved', () => {
+        enableCps();
         alertDetailItemData = endpointAlertDataMock.generateEndpointAlertDetailsItemData({
           'kibana.alert.ancestors.index': {
             category: 'kibana',
@@ -198,6 +209,7 @@ describe('use responder action data hooks', () => {
       });
 
       it('should NOT open the response console for a host from a linked project', () => {
+        enableCps();
         alertDetailItemData = endpointAlertDataMock.generateEndpointAlertDetailsItemData({
           'kibana.alert.ancestors.index': {
             category: 'kibana',
@@ -214,6 +226,23 @@ describe('use responder action data hooks', () => {
         });
 
         expect(onClickMock).not.toHaveBeenCalled();
+      });
+
+      it('should keep the action enabled for a non-local ancestor index when CPS is disabled', async () => {
+        alertDetailItemData = endpointAlertDataMock.generateEndpointAlertDetailsItemData({
+          'kibana.alert.ancestors.index': {
+            category: 'kibana',
+            field: 'kibana.alert.ancestors.index',
+            values: ['linked_local_project:.ds-logs-endpoint.events-default'],
+            originalValue: ['linked_local_project:.ds-logs-endpoint.events-default'],
+            isObjectArray: false,
+          },
+        });
+
+        const { result } = renderHook();
+        await waitFor(() => expect(result.current.isDisabled).toBe(false));
+
+        expect(result.current).toEqual(getExpectedResponderActionData());
       });
 
       it('should keep the action enabled when the ancestor index is local', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.ts
@@ -8,6 +8,7 @@ import type { ReactNode } from 'react';
 import { useCallback, useMemo } from 'react';
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import { isNonLocalIndexName } from '@kbn/es-query';
+import { useKibana } from '../../../../lib/kibana';
 import { useAlertResponseActionsSupport } from '../../../../hooks/endpoint/use_alert_response_actions_support';
 import type {
   EndpointCapabilities,
@@ -58,6 +59,11 @@ export const useWithResponderActionDataFromAlert = ({
 
   const isEndpointHost = agentType === 'endpoint';
 
+  // Only meaningful when CPS is on: `cpsManager` is present solely on CPS-enabled deployments. Off
+  // CPS (including CCS deployments), an ancestor index can legitimately carry a remote-cluster prefix
+  // that `isNonLocalIndexName` would flag, so the check must be gated to avoid a false positive.
+  const isCpsEnabled = Boolean(useKibana().services.cps?.cpsManager);
+
   // In a Cross-Project Search deployment an alert can be generated off a document that lives in a
   // linked project even though the alert itself is stored locally. Response actions run origin-only
   // and reject such a host, so every command opened from the console would fail. Elasticsearch
@@ -65,11 +71,12 @@ export const useWithResponderActionDataFromAlert = ({
   // that the host belongs to a linked project.
   const isHostFromLinkedProject = useMemo<boolean>(
     () =>
+      isCpsEnabled &&
       getEventDetailsFieldValues(
         { category: 'kibana', field: 'kibana.alert.ancestors.index' },
         eventData
       ).some(isNonLocalIndexName),
-    [eventData]
+    [isCpsEnabled, eventData]
   );
 
   const endpointHostData = useResponderDataForEndpointHost(

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/responder/from_alerts/use_responder_action_data.ts
@@ -7,6 +7,7 @@
 import type { ReactNode } from 'react';
 import { useCallback, useMemo } from 'react';
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import { useAlertResponseActionsSupport } from '../../../../hooks/endpoint/use_alert_response_actions_support';
 import type {
   EndpointCapabilities,
@@ -14,8 +15,10 @@ import type {
 } from '../../../../../../common/endpoint/service/response_actions/constants';
 import { useGetEndpointDetails, useWithShowResponder } from '../../../../../management/hooks';
 import { HostStatus } from '../../../../../../common/endpoint/types';
+import { getEventDetailsFieldValues } from '../../../../lib/endpoint/utils/get_event_details_field_values';
 import {
   HOST_ENDPOINT_UNENROLLED_TOOLTIP,
+  HOST_ON_LINKED_PROJECT_TOOLTIP,
   LOADING_ENDPOINT_DATA_TOOLTIP,
   METADATA_API_ERROR_TOOLTIP,
   NOT_FROM_ENDPOINT_HOST_TOOLTIP,
@@ -55,6 +58,20 @@ export const useWithResponderActionDataFromAlert = ({
 
   const isEndpointHost = agentType === 'endpoint';
 
+  // In a Cross-Project Search deployment an alert can be generated off a document that lives in a
+  // linked project even though the alert itself is stored locally. Response actions run origin-only
+  // and reject such a host, so every command opened from the console would fail. Elasticsearch
+  // prefixes the source `_index` with the project alias, so a non-local ancestor index is the signal
+  // that the host belongs to a linked project.
+  const isHostFromLinkedProject = useMemo<boolean>(
+    () =>
+      getEventDetailsFieldValues(
+        { category: 'kibana', field: 'kibana.alert.ancestors.index' },
+        eventData
+      ).some(isNonLocalIndexName),
+    [eventData]
+  );
+
   const endpointHostData = useResponderDataForEndpointHost(
     agentId,
     hostSupportsResponseActions && isEndpointHost
@@ -62,6 +79,12 @@ export const useWithResponderActionDataFromAlert = ({
   const showResponseActionsConsole = useWithShowResponder();
 
   const [isDisabled, tooltip]: [disabled: boolean, tooltip: ReactNode] = useMemo(() => {
+    // Checked first so its reason wins: the metadata lookup that gates the endpoint path can fan out
+    // under CPS and report the linked host as enrolled, which would otherwise leave this enabled.
+    if (isHostFromLinkedProject) {
+      return [true, HOST_ON_LINKED_PROJECT_TOOLTIP];
+    }
+
     if (!hostSupportsResponseActions) {
       return [
         true,
@@ -75,6 +98,7 @@ export const useWithResponderActionDataFromAlert = ({
 
     return [false, undefined];
   }, [
+    isHostFromLinkedProject,
     hostSupportsResponseActions,
     isEndpointHost,
     agentType,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/endpoint/utils/get_event_details_field_values.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/endpoint/utils/get_event_details_field_values.ts
@@ -15,7 +15,7 @@ import { find } from 'lodash/fp';
  * @param field
  * @param data
  */
-const getEventDetailsFieldValues = (
+export const getEventDetailsFieldValues = (
   {
     category,
     field,


### PR DESCRIPTION
## Summary

This PR makes a small change to the respond logic that disables it in the Take action dropdown menu in the flyout.

#### On `main`

https://github.com/user-attachments/assets/b92567f8-5886-4d2f-8686-99e9ec3d7a26

#### On this branch

https://github.com/user-attachments/assets/b06ec0e5-2489-4416-840b-108ab02137d6

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/286208