### PR TITLE
[CI] Pass the git changed-file list to Moon affected-module detection

### DIFF
--- a/.buildkite/pipeline-utils/affected-packages/README.md
+++ b/.buildkite/pipeline-utils/affected-packages/README.md
@@ -125,10 +125,16 @@ const filteredFiles = filterFilesByPackages(
 **Performance**: ~500ms (first call, includes module discovery); subsequent calls use cache
 
 ### Moon Strategy
-1. Query Moon with `--affected [--downstream deep]`
-2. Return affected project IDs
+1. Collect changed files exactly as the git strategy does (steps 1–2 above)
+2. Pipe that list to `moon query projects --affected [--downstream deep]` on stdin
+3. Return affected project IDs
 
 **Performance**: ~5-7 seconds
+
+Moon does not derive its own touched files: `--affected` also picks up local working-tree
+state, so files written by earlier CI steps would count as changes. Sharing the git list
+keeps both strategies on identical input. `--ignore` / `AFFECTED_IGNORE` still applies to
+the git strategy only.
 
 ## PR Jest selective testing
 

--- a/.buildkite/pipeline-utils/affected-packages/strategy_moon.test.ts
+++ b/.buildkite/pipeline-utils/affected-packages/strategy_moon.test.ts
@@ -10,15 +10,24 @@
 jest.mock('child_process');
 jest.mock('fs');
 jest.mock('../utils', () => ({ getKibanaDir: () => '/repo' }));
+jest.mock('./strategy_git', () => ({ listChangedFiles: jest.fn(() => ['from/git/strategy.ts']) }));
 
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
+import { listChangedFiles } from './strategy_git';
 import { getAffectedProjectsMoon } from './strategy_moon';
 
 const mockExecSync = execSync as jest.Mock;
 const mockExistsSync = existsSync as jest.Mock;
+const mockListChangedFiles = listChangedFiles as jest.Mock;
 
 const moonResponse = JSON.stringify({ projects: [{ id: '@kbn/foo' }] });
+
+beforeEach(() => {
+  mockExistsSync.mockReturnValue(true);
+  mockExecSync.mockReturnValue(moonResponse);
+  mockListChangedFiles.mockReturnValue(['from/git/strategy.ts']);
+});
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -26,52 +35,73 @@ afterEach(() => {
 
 describe('getAffectedProjectsMoon', () => {
   it('invokes the moon binary directly from node_modules/.bin (not via PATH)', () => {
-    mockExistsSync.mockReturnValue(true);
-    mockExecSync
-      .mockReturnValueOnce('resolved-sha\n') // git merge-base
-      .mockReturnValueOnce(moonResponse); // moon query
-
-    const result = getAffectedProjectsMoon('main', false);
+    const result = getAffectedProjectsMoon('main', false, ['some/file.ts']);
 
     expect(result).toEqual(new Set(['@kbn/foo']));
     expect(mockExecSync).toHaveBeenCalledWith(
       expect.stringContaining('/repo/node_modules/.bin/moon'),
-      expect.objectContaining({ env: expect.objectContaining({ MOON_BASE: 'resolved-sha' }) })
-    );
-  });
-
-  it('recomputes the merge base locally instead of trusting the raw ref, mirroring the git strategy', () => {
-    mockExistsSync.mockReturnValue(true);
-    mockExecSync.mockReturnValueOnce('resolved-sha\n').mockReturnValueOnce(moonResponse);
-
-    getAffectedProjectsMoon('some-possibly-stale-ref', false);
-
-    expect(mockExecSync).toHaveBeenNthCalledWith(
-      1,
-      'git merge-base some-possibly-stale-ref HEAD',
       expect.anything()
-    );
-    expect(mockExecSync).toHaveBeenNthCalledWith(
-      2,
-      expect.anything(),
-      expect.objectContaining({ env: expect.objectContaining({ MOON_BASE: 'resolved-sha' }) })
     );
   });
 
   it('falls back to `yarn which moon` when node_modules/.bin/moon is missing', () => {
     mockExistsSync.mockReturnValue(false);
-    mockExecSync
-      .mockReturnValueOnce('resolved-sha\n') // git merge-base
-      .mockReturnValueOnce('/resolved/moon\n') // yarn which moon
-      .mockReturnValueOnce(moonResponse); // moon query
+    mockExecSync.mockReturnValueOnce('/resolved/moon\n').mockReturnValueOnce(moonResponse);
 
-    getAffectedProjectsMoon('main', false);
+    getAffectedProjectsMoon('main', false, ['some/file.ts']);
 
-    expect(mockExecSync).toHaveBeenNthCalledWith(2, 'yarn --silent which moon', expect.anything());
+    expect(mockExecSync).toHaveBeenNthCalledWith(1, 'yarn --silent which moon', expect.anything());
     expect(mockExecSync).toHaveBeenNthCalledWith(
-      3,
+      2,
       expect.stringContaining('/resolved/moon'),
       expect.anything()
     );
+  });
+
+  it('requests deep dependents only when downstream traversal is asked for', () => {
+    getAffectedProjectsMoon('main', true, ['some/file.ts']);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('--downstream deep'),
+      expect.anything()
+    );
+
+    mockExecSync.mockClear();
+
+    getAffectedProjectsMoon('main', false, ['some/file.ts']);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.not.stringContaining('--downstream'),
+      expect.anything()
+    );
+  });
+
+  it('pipes the given changed files on stdin and never falls back to MOON_BASE', () => {
+    getAffectedProjectsMoon('main', true, ['a/one.ts', 'b/two.ts']);
+
+    const [, options] = mockExecSync.mock.calls[0];
+    expect(options.input).toEqual(JSON.stringify({ files: ['a/one.ts', 'b/two.ts'] }));
+    expect(options.env?.MOON_BASE).toBeUndefined();
+    expect(mockExecSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('git merge-base'),
+      expect.anything()
+    );
+  });
+
+  it('sends an empty file list rather than letting moon scan local state', () => {
+    const result = getAffectedProjectsMoon('main', true, []);
+
+    const [, options] = mockExecSync.mock.calls[0];
+    expect(options.input).toEqual(JSON.stringify({ files: [] }));
+    expect(result).toEqual(new Set(['@kbn/foo']));
+  });
+
+  it('defaults to the git strategy changed-file list when none is given', () => {
+    getAffectedProjectsMoon('some-possibly-stale-ref', true);
+
+    expect(mockListChangedFiles).toHaveBeenCalledWith({
+      mergeBase: 'some-possibly-stale-ref',
+      commit: 'HEAD',
+    });
+    const [, options] = mockExecSync.mock.calls[0];
+    expect(options.input).toEqual(JSON.stringify({ files: ['from/git/strategy.ts'] }));
   });
 });

--- a/.buildkite/pipeline-utils/affected-packages/strategy_moon.ts
+++ b/.buildkite/pipeline-utils/affected-packages/strategy_moon.ts
@@ -11,6 +11,7 @@ import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 import path from 'path';
 import { getKibanaDir } from '../utils';
+import { listChangedFiles } from './strategy_git';
 
 const REPO_ROOT = getKibanaDir();
 
@@ -24,29 +25,28 @@ function getMoonBinPath(): string {
   return execSync('yarn --silent which moon', { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
 }
 
+/**
+ * Affected Moon project IDs for the changes between `mergeBase` and `HEAD`.
+ *
+ * `changedFiles` goes to Moon on stdin rather than letting `--affected` derive it:
+ * Moon unions the base diff with the local working tree, so files written by earlier
+ * CI steps would count as changes and fan out through `--downstream deep`. Sharing the
+ * git strategy's list keeps any remaining difference a real dependency-graph difference.
+ */
 export function getAffectedProjectsMoon(
   mergeBase: string,
-  includeDownstream: boolean
+  includeDownstream: boolean,
+  changedFiles: readonly string[] = listChangedFiles({ mergeBase, commit: 'HEAD' })
 ): Set<string> {
-  const execOptions = {
-    cwd: REPO_ROOT,
-    encoding: 'utf8' as const,
-    maxBuffer: 30 * 1024 * 1024, // 30MB buffer
-  };
-
-  // Mirror the git strategy: recompute the actual merge base instead of trusting `mergeBase` as-is.
-  const actualBase = execSync(`git merge-base ${mergeBase} HEAD`, execOptions).trim();
-
   const downstreamFlag = includeDownstream ? '--downstream deep' : '';
   const command = `"${getMoonBinPath()}" query projects --affected ${downstreamFlag}`;
 
   const output = execSync(command, {
-    ...execOptions,
+    cwd: REPO_ROOT,
+    encoding: 'utf8' as const,
+    maxBuffer: 30 * 1024 * 1024, // 30MB buffer
     timeout: 30000, // 30 seconds
-    env: {
-      ...process.env,
-      MOON_BASE: actualBase,
-    },
+    input: JSON.stringify({ files: [...changedFiles] }),
   });
 
   const result = JSON.parse(output);

--- a/.buildkite/scripts/steps/test/scout/moon_shadow.test.ts
+++ b/.buildkite/scripts/steps/test/scout/moon_shadow.test.ts
@@ -75,6 +75,20 @@ describe('computeMoonShadow', () => {
     expect(log.warning).toHaveBeenCalled();
   });
 
+  it('queries moon with the same changed-file list git used', () => {
+    mockGetAffectedProjectsMoon.mockReturnValue(new Set(['@kbn/foo']));
+    const gitChangedFiles = ['x-pack/solutions/observability/plugins/slo/server/index.ts'];
+
+    computeMoonShadow({
+      mergeBase: 'main',
+      gitChangedFiles,
+      gitAffectedModules: new Set(['@kbn/foo']),
+      log: createMockLog(),
+    });
+
+    expect(mockGetAffectedProjectsMoon).toHaveBeenCalledWith('main', true, gitChangedFiles);
+  });
+
   it('overlays implicit consumers from the changed-files list', () => {
     mockGetAffectedProjectsMoon.mockReturnValue(new Set(['@kbn/ml-plugin']));
 

--- a/.buildkite/scripts/steps/test/scout/moon_shadow.ts
+++ b/.buildkite/scripts/steps/test/scout/moon_shadow.ts
@@ -40,7 +40,7 @@ export function computeMoonShadow({
 }): MoonShadowResult | null {
   try {
     const moonAffectedModules = expandWithImplicitConsumers(
-      getAffectedProjectsMoon(mergeBase, true),
+      getAffectedProjectsMoon(mergeBase, true, gitChangedFiles),
       gitChangedFiles,
       log
     );

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -20,8 +20,8 @@ echo '--- Verify Playwright CLI is functional'
 node scripts/scout run-playwright-test-check
 
 echo '--- Update Scout Test Config Manifests'
-# Updates **/test/scout/.meta (manifest) files. Those paths are excluded from affected-packages
-# so they do not cause extra modules to be considered "changed" in the next step.
+# Updates **/test/scout/.meta (manifest) files, dirtying the working tree. Affected-module
+# detection below must therefore look at the committed diff only.
 node scripts/scout.js update-test-config-manifests --concurrencyLimit 3
 
 # Resolve Scout's selective-testing scope once, before either distribution


### PR DESCRIPTION
## Summary

Moon's affected-module detection was again _over-reporting on PR builds_. [#286060](https://github.com/elastic/kibana/pull/286060) with a one-line change to a single Scout spec:

- the git strategy reported **6** affected modules
- the Moon strategy reported **170** affected modules

#### Root cause: 

`moon query projects --affected` unions the `MOON_BASE` diff with the **local working tree**, while the `git` strategy uses a commit-only diff in CI. `test_run_builder.sh` refreshes the `**/test/scout/.meta` manifests immediately before selective-testing resolution, which dirties the tree. On that build the manifest refresh touched `x-pack/platform/plugins/shared/lens`, so Moon treated `@kbn/lens-plugin` as changed and `--downstream deep` fanned it out — the reported set is exactly the deep-dependent closure of Lens.

#### Fix: 

`getAffectedProjectsMoon` now takes the changed-file list and pipes it to Moon on stdin instead of setting `MOON_BASE`. The parameter defaults to the git strategy's `listChangedFiles`, so every caller (shadow mode, `getAffectedPackages`, the `list_affected` CLI) shares one input and the two strategies can't drift apart again.

No behavior change for test selection: git is still authoritative and Moon runs in shadow mode only. This makes the shadow diff measure dependency-graph differences rather than CI side effects.

Also corrects a comment in `test_run_builder.sh` that claimed the `.meta` paths were excluded from affected-packages ( no such exclusion exists ).

## Verification

- Reproduced the failure: a single dirty Lens file yields Moon's 170-module list byte-for-byte.
- After the fix, same scenario reports 0 affected modules, matching git.
- On a real diff, both strategies independently produce the same 276 modules, with nothing in `onlyInGit` or `onlyInMoon`.
- Jest, `yarn typecheck` (`.buildkite`), and ESLint pass.