### PR TITLE
[8.19] [Fleet] Add allow list for cluster privileges declared in package manifests (#286084)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -7,7 +7,11 @@
 
 jest.mock('../epm/packages');
 
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+
 import type { PackagePolicy, RegistryDataStream } from '../../types';
+
+import { appContextService } from '../app_context';
 
 import type { DataStreamMeta } from './package_policies_to_agent_permissions';
 import {
@@ -467,6 +471,113 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
         cluster: ['monitor'],
       },
     });
+  });
+
+  it('Filters out disallowed cluster privileges and logs a warning', async () => {
+    const mockLogger = loggingSystemMock.createLogger();
+    jest.spyOn(appContextService, 'getLogger').mockReturnValue(mockLogger);
+
+    const packagePolicies: PackagePolicy[] = [
+      {
+        id: 'package-policy-uuid-test-123',
+        name: 'test-policy',
+        namespace: 'test',
+        enabled: true,
+        package: { name: 'test_package', version: '0.0.0', title: 'Test Package' },
+        elasticsearch: {
+          privileges: {
+            cluster: ['monitor', 'all'],
+          },
+        },
+        inputs: [
+          {
+            type: 'test-logs',
+            enabled: true,
+            streams: [
+              {
+                id: 'test-logs',
+                enabled: true,
+                data_stream: { type: 'logs', dataset: 'some-logs' },
+                compiled_stream: { data_stream: { dataset: 'compiled' } },
+              },
+            ],
+          },
+        ],
+        created_at: '',
+        updated_at: '',
+        created_by: '',
+        updated_by: '',
+        revision: 1,
+        policy_id: '',
+        policy_ids: [''],
+      },
+    ];
+
+    const permissions = await storedPackagePoliciesToAgentPermissions(
+      packageInfoCache,
+      'test',
+      packagePolicies
+    );
+    expect(permissions).toMatchObject({
+      'package-policy-uuid-test-123': {
+        cluster: ['monitor'],
+      },
+    });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('package-policy-uuid-test-123')
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('all'));
+  });
+
+  it('Omits cluster descriptor when all declared cluster privileges are disallowed', async () => {
+    const mockLogger = loggingSystemMock.createLogger();
+    jest.spyOn(appContextService, 'getLogger').mockReturnValue(mockLogger);
+
+    const packagePolicies: PackagePolicy[] = [
+      {
+        id: 'package-policy-uuid-test-123',
+        name: 'test-policy',
+        namespace: 'test',
+        enabled: true,
+        package: { name: 'test_package', version: '0.0.0', title: 'Test Package' },
+        elasticsearch: {
+          privileges: {
+            cluster: ['all', 'manage_security'],
+          },
+        },
+        inputs: [
+          {
+            type: 'test-logs',
+            enabled: true,
+            streams: [
+              {
+                id: 'test-logs',
+                enabled: true,
+                data_stream: { type: 'logs', dataset: 'some-logs' },
+                compiled_stream: { data_stream: { dataset: 'compiled' } },
+              },
+            ],
+          },
+        ],
+        created_at: '',
+        updated_at: '',
+        created_by: '',
+        updated_by: '',
+        revision: 1,
+        policy_id: '',
+        policy_ids: [''],
+      },
+    ];
+
+    const permissions = await storedPackagePoliciesToAgentPermissions(
+      packageInfoCache,
+      'test',
+      packagePolicies
+    );
+    expect(permissions?.['package-policy-uuid-test-123']).not.toHaveProperty('cluster');
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('package-policy-uuid-test-123')
+    );
   });
 
   it('Returns the dataset for osquery_manager package', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -31,6 +31,8 @@ import { pkgToPkgKey } from '../epm/registry';
 
 export const DEFAULT_CLUSTER_PERMISSIONS = ['monitor'];
 
+export const PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES = new Set(['monitor']);
+
 export const UNIVERSAL_PROFILING_PERMISSIONS = [
   'auto_configure',
   'read',
@@ -161,9 +163,18 @@ export function storedPackagePoliciesToAgentPermissions(
 
     let clusterRoleDescriptor = {};
     const cluster = packagePolicy?.elasticsearch?.privileges?.cluster ?? [];
-    if (cluster.length > 0) {
+    const validCluster = cluster.filter((p) => PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES.has(p));
+    const invalidCluster = cluster.filter((p) => !PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES.has(p));
+    if (invalidCluster.length) {
+      appContextService
+        .getLogger()
+        .warn(
+          `Ignoring invalid or forbidden cluster privilege(s) in package policy "${packagePolicy.id}": ${invalidCluster}`
+        );
+    }
+    if (validCluster.length > 0) {
       clusterRoleDescriptor = {
-        cluster,
+        cluster: validCluster,
       };
     }
     // namespace is either the package policy's or the agent policy one

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -16,6 +16,8 @@ import {
   FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE,
 } from '../../../common/constants';
 
+import { appContextService } from '../app_context';
+
 import { getNormalizedDataStreams } from '../../../common/services';
 
 import type {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Fleet] Add allow list for cluster privileges declared in package manifests (#286084)](https://github.com/elastic/kibana/pull/286084)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jill Guyonnet","email":"jill.guyonnet@elastic.co"},"sourceCommit":{"committedDate":"2026-08-20T08:07:33Z","message":"[Fleet] Add allow list for cluster privileges declared in package manifests (#286084)\n\n## Summary\n\nThis PR adds a `PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES` allow-list\n(`{ monitor })` to `package_policies_to_agent_permissions.ts` and\nfilters `elasticsearch.privileges.cluster` from the package manifest\nagainst it before writing the agent API-key role descriptor, mirroring\nthe existing `DATA_STREAM_ALLOWED_INDEX_PRIVILEGES` filter that already\nprotects index privileges. Anything outside the allow-list is dropped\nwith a warning log; if nothing survives, no `cluster` field is written\nat all. The allow-list is intentionally narrow (`monitor` only) since\nthat covers every legitimate use case in published packages; hardcoded\npaths for APM and connectors are unaffected as they bypass this code\nentirely.\n\n### Testing\n\nPrerequisites:\n* Create a role with Fleet privileges only (no Elasticsearch privileges)\nand assign it to a test user\n* Create a minimal working test package: leave everything to default but\nadd this to the root `manifest.yml`:\n   ```yml\n   elasticsearch:\n     privileges:\n       cluster:\n         - all\n   ```\n\n#### Package with `all` cluster privilege: disallowed privilege is\nstripped\n\n1. As the test user, upload the test package with `POST\n/api/fleet/epm/packages`: it should show up in Kibana UI\n2. Create an agent policy, add the package, then (still as the test\nuser) call `GET /api/fleet/agent_policies/<id>/full`\n3. Expected:` output_permissions.<package-policy-id>` has no `cluster`\nkey\n4. Expected: Kibana server logs contain a WARN line referencing the\npackage policy ID and `all`, e.g.\n   ```\n[WARN ][plugins.fleet] Ignoring invalid or forbidden cluster\nprivilege(s) in package policy \"e8dc6e53-d256-43fc-8db1-581f9e0ecee6\":\nall\n   ```\n\n### Package with `monitor` cluster privilege: no change\n\n1. Create a new test package with `cluster: [monitor]` privilege (or\nedit and rebuild the previous one)\n2. Repeat upload + fetch policy steps\n3. Expected: in the compiled agent policy,\n`output_permissions.<package-policy-id>.cluster` is `[\"monitor\"]`\n4. Expected: no WARN log\n\n### Package with mixed privileges: only `monitor` survives\n\n1. Create a new test package with `cluster: [monitor, manage_security]`\nprivileges (or edit and rebuild the previous one)\n2. Repeat upload + fetch policy steps\n3. Expected: `output_permissions.<package-policy-id>.cluster` is\n`[\"monitor\"]` only\n4. Expected: warning log references `manage_security` but not `monitor`\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow. The allow-list (`monitor`) covers every legitimate cluster\nprivilege used by published packages via the manifest path; APM and\nconnectors bypass this code entirely through their own hardcoded paths\nand are unaffected. The only observable behavior change is that a\n`cluster` key declaring anything other than monitor is silently dropped\nwith a warning rather than passed through, which is the intended\nsecurity improvement.\n\n## Release note\n\nAdds an allow-list for cluster privileges declared in package manifests,\nmirroring the existing filter already applied to index privileges.","sha":"5c1ae1fbc1b24ecb12f304a41dffbfc7c01ce257","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","v9.6.0","Team:streams-ui"],"title":"[Fleet] Add allow list for cluster privileges declared in package manifests","number":286084,"url":"https://github.com/elastic/kibana/pull/286084","mergeCommit":{"message":"[Fleet] Add allow list for cluster privileges declared in package manifests (#286084)\n\n## Summary\n\nThis PR adds a `PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES` allow-list\n(`{ monitor })` to `package_policies_to_agent_permissions.ts` and\nfilters `elasticsearch.privileges.cluster` from the package manifest\nagainst it before writing the agent API-key role descriptor, mirroring\nthe existing `DATA_STREAM_ALLOWED_INDEX_PRIVILEGES` filter that already\nprotects index privileges. Anything outside the allow-list is dropped\nwith a warning log; if nothing survives, no `cluster` field is written\nat all. The allow-list is intentionally narrow (`monitor` only) since\nthat covers every legitimate use case in published packages; hardcoded\npaths for APM and connectors are unaffected as they bypass this code\nentirely.\n\n### Testing\n\nPrerequisites:\n* Create a role with Fleet privileges only (no Elasticsearch privileges)\nand assign it to a test user\n* Create a minimal working test package: leave everything to default but\nadd this to the root `manifest.yml`:\n   ```yml\n   elasticsearch:\n     privileges:\n       cluster:\n         - all\n   ```\n\n#### Package with `all` cluster privilege: disallowed privilege is\nstripped\n\n1. As the test user, upload the test package with `POST\n/api/fleet/epm/packages`: it should show up in Kibana UI\n2. Create an agent policy, add the package, then (still as the test\nuser) call `GET /api/fleet/agent_policies/<id>/full`\n3. Expected:` output_permissions.<package-policy-id>` has no `cluster`\nkey\n4. Expected: Kibana server logs contain a WARN line referencing the\npackage policy ID and `all`, e.g.\n   ```\n[WARN ][plugins.fleet] Ignoring invalid or forbidden cluster\nprivilege(s) in package policy \"e8dc6e53-d256-43fc-8db1-581f9e0ecee6\":\nall\n   ```\n\n### Package with `monitor` cluster privilege: no change\n\n1. Create a new test package with `cluster: [monitor]` privilege (or\nedit and rebuild the previous one)\n2. Repeat upload + fetch policy steps\n3. Expected: in the compiled agent policy,\n`output_permissions.<package-policy-id>.cluster` is `[\"monitor\"]`\n4. Expected: no WARN log\n\n### Package with mixed privileges: only `monitor` survives\n\n1. Create a new test package with `cluster: [monitor, manage_security]`\nprivileges (or edit and rebuild the previous one)\n2. Repeat upload + fetch policy steps\n3. Expected: `output_permissions.<package-policy-id>.cluster` is\n`[\"monitor\"]` only\n4. Expected: warning log references `manage_security` but not `monitor`\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow. The allow-list (`monitor`) covers every legitimate cluster\nprivilege used by published packages via the manifest path; APM and\nconnectors bypass this code entirely through their own hardcoded paths\nand are unaffected. The only observable behavior change is that a\n`cluster` key declaring anything other than monitor is silently dropped\nwith a warning rather than passed through, which is the intended\nsecurity improvement.\n\n## Release note\n\nAdds an allow-list for cluster privileges declared in package manifests,\nmirroring the existing filter already applied to index privileges.","sha":"5c1ae1fbc1b24ecb12f304a41dffbfc7c01ce257"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/286084","number":286084,"mergeCommit":{"message":"[Fleet] Add allow list for cluster privileges declared in package manifests (#286084)\n\n## Summary\n\nThis PR adds a `PACKAGE_POLICY_ALLOWED_CLUSTER_PRIVILEGES` allow-list\n(`{ monitor })` to `package_policies_to_agent_permissions.ts` and\nfilters `elasticsearch.privileges.cluster` from the package manifest\nagainst it before writing the agent API-key role descriptor, mirroring\nthe existing `DATA_STREAM_ALLOWED_INDEX_PRIVILEGES` filter that already\nprotects index privileges. Anything outside the allow-list is dropped\nwith a warning log; if nothing survives, no `cluster` field is written\nat all. The allow-list is intentionally narrow (`monitor` only) since\nthat covers every legitimate use case in published packages; hardcoded\npaths for APM and connectors are unaffected as they bypass this code\nentirely.\n\n### Testing\n\nPrerequisites:\n* Create a role with Fleet privileges only (no Elasticsearch privileges)\nand assign it to a test user\n* Create a minimal working test package: leave everything to default but\nadd this to the root `manifest.yml`:\n   ```yml\n   elasticsearch:\n     privileges:\n       cluster:\n         - all\n   ```\n\n#### Package with `all` cluster privilege: disallowed privilege is\nstripped\n\n1. As the test user, upload the test package with `POST\n/api/fleet/epm/packages`: it should show up in Kibana UI\n2. Create an agent policy, add the package, then (still as the test\nuser) call `GET /api/fleet/agent_policies/<id>/full`\n3. Expected:` output_permissions.<package-policy-id>` has no `cluster`\nkey\n4. Expected: Kibana server logs contain a WARN line referencing the\npackage policy ID and `all`, e.g.\n   ```\n[WARN ][plugins.fleet] Ignoring invalid or forbidden cluster\nprivilege(s) in package policy \"e8dc6e53-d256-43fc-8db1-581f9e0ecee6\":\nall\n   ```\n\n### Package with `monitor` cluster privilege: no change\n\n1. Create a new test package with `cluster: [monitor]` privilege (or\nedit and rebuild the previous one)\n2. Repeat upload + fetch policy steps\n3. Expected: in the compiled agent policy,\n`output_permissions.<package-policy-id>.cluster` is `[\"monitor\"]`\n4. Expected: no WARN log\n\n### Package with mixed privileges: only `monitor` survives\n\n1. Create a new test package with `cluster: [monitor, manage_security]`\nprivileges (or edit and rebuild the previous one)\n2. Repeat upload + fetch policy steps\n3. Expected: `output_permissions.<package-policy-id>.cluster` is\n`[\"monitor\"]` only\n4. Expected: warning log references `manage_security` but not `monitor`\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow. The allow-list (`monitor`) covers every legitimate cluster\nprivilege used by published packages via the manifest path; APM and\nconnectors bypass this code entirely through their own hardcoded paths\nand are unaffected. The only observable behavior change is that a\n`cluster` key declaring anything other than monitor is silently dropped\nwith a warning rather than passed through, which is the intended\nsecurity improvement.\n\n## Release note\n\nAdds an allow-list for cluster privileges declared in package manifests,\nmirroring the existing filter already applied to index privileges.","sha":"5c1ae1fbc1b24ecb12f304a41dffbfc7c01ce257"}},{"url":"https://github.com/elastic/kibana/pull/286219","number":286219,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/286220","number":286220,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->