### PR TITLE
[Observability Onboarding] Remove logoIcon tooltip from Add Data tile icons

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/shared/logo_icon.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/shared/logo_icon.tsx
@@ -127,7 +127,7 @@ export function LogoIcon({
       <EuiAvatar
         color={color}
         iconType={resolvedIconType}
-        name="logoIcon"
+        name=""
         size={size}
         type={avatarType}
         className={className}


### PR DESCRIPTION
## Summary

Hovering a tile icon on Add Data V2 shows a tooltip that says `logoIcon`. Curated tiles, mini tiles, and Browse all render those icons through `LogoIcon` as an `EuiAvatar`, and the avatar `name` was hardcoded to `"logoIcon"`.

`EuiAvatar` wraps a truthy `name` in `EuiToolTip`. Empty `name` skips the wrapper. The tile title is already on the card. Same pattern as the onboarding flow header.

Before: 
<img width="876" height="342" alt="image" src="https://github.com/user-attachments/assets/fb0ba6c2-8b89-47df-ad11-a6df15adb849" />

After:
<img width="539" height="230" alt="image" src="https://github.com/user-attachments/assets/90773e66-531b-4611-9cc7-5294796fa6da" />

(you have to belive me that my cursor is on the icon 😄 )
