### PR TITLE
[Entity Analytics] Fix serverless security role index privilege gaps

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles/security/roles.yml
+++ b/src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles/security/roles.yml
@@ -45,6 +45,7 @@ viewer:
         - '.entities.v2.latest.*'
         - '.entities.v2.metadata.*'
         - 'entities-latest-*'
+        - 'entities-metadata-*'
         - '.ml-anomalies-*'
         - '.entity_analytics.entity-leads*'
         - '.entity_analytics.watchlists.*'
@@ -133,6 +134,9 @@ editor:
         - '.entities.v2.latest.*'
         - '.entities.v2.metadata.*'
         - 'entities-latest-*'
+        - 'entities-metadata-*'
+        - '.entity_analytics.watchlists.*'
+        - '.entity_analytics.entity-leads*'
       privileges:
         - 'read'
         - 'view_index_metadata'
@@ -231,14 +235,21 @@ t1_analyst:
         - .entities.v1.updates.security_*
         - '.entities.v1.latest.security_*'
         - '.entities.v1.history.*.security_*'
-        - '.entities.v2.latest.*'
-        - '.entities.v2.metadata.*'
         - 'entities-latest-*'
+        - 'entities-metadata-*'
         - '.ml-anomalies-*'
         - security_solution-*.misconfiguration_latest*
         - .entity_analytics.monitoring*
+        - '.entity_analytics.watchlists.*'
+        - '.entity_analytics.entity-leads*'
       privileges:
         - read
+    - names:
+        - '.entities.v2.latest.*'
+        - '.entities.v2.metadata.*'
+      privileges:
+        - read
+        - view_index_metadata
   applications:
     - application: 'kibana-.kibana'
       privileges:
@@ -307,6 +318,7 @@ t2_analyst:
         - .entities.v1.updates.security_*
         - '.entities.v1.history.*.security_*'
         - 'entities-latest-*'
+        - 'entities-metadata-*'
         - '.ml-anomalies-*'
         - security_solution-*.misconfiguration_latest*
         - .entity_analytics.monitoring*
@@ -316,6 +328,8 @@ t2_analyst:
         - .asset-criticality.asset-criticality-*
         - '.entities.v2.latest.*'
         - '.entities.v2.metadata.*'
+        - '.entity_analytics.watchlists.*'
+        - '.entity_analytics.entity-leads*'
       privileges:
         - read
         - view_index_metadata
@@ -366,6 +380,8 @@ t3_analyst:
         - .asset-criticality.asset-criticality-*
         - '.entities.v2.latest.*'
         - '.entities.v2.metadata.*'
+        - '.entity_analytics.watchlists.*'
+        - '.entity_analytics.entity-leads*'
         - security_solution-*.misconfiguration_latest*
       privileges:
         - read
@@ -402,6 +418,7 @@ t3_analyst:
         - .entities.v1.updates.security_*
         - '.entities.v1.history.*.security_*'
         - 'entities-latest-*'
+        - 'entities-metadata-*'
         - '.ml-anomalies-*'
         - .entity_analytics.monitoring*
       privileges:
@@ -651,6 +668,9 @@ soc_manager:
         - '.entities.v2.latest.*'
         - '.entities.v2.metadata.*'
         - 'entities-latest-*'
+        - 'entities-metadata-*'
+        - '.entity_analytics.watchlists.*'
+        - '.entity_analytics.entity-leads*'
         - security_solution-*.misconfiguration_latest*
       privileges:
         - read
@@ -675,10 +695,14 @@ soc_manager:
         - write
         - view_index_metadata
     - names:
+        - risk-score.risk-score-*
+      privileges:
+        - read
+        - write
+    - names:
         - metrics-endpoint.metadata_current_*
         - .fleet-agents*
         - .fleet-actions*
-        - risk-score.risk-score-*
         - '.ml-anomalies-*'
         - .entity_analytics.monitoring*
       privileges:
@@ -844,6 +868,9 @@ platform_engineer:
         - '.entities.v2.latest.*'
         - '.entities.v2.metadata.*'
         - 'entities-latest-*'
+        - 'entities-metadata-*'
+        - '.entity_analytics.watchlists.*'
+        - '.entity_analytics.entity-leads*'
       privileges:
         - read
         - view_index_metadata

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/routes/sync.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/routes/sync.ts
@@ -7,7 +7,8 @@
 
 import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
-import type { IKibanaResponse, Logger } from '@kbn/core/server';
+import type { IKibanaResponse, KibanaRequest, Logger } from '@kbn/core/server';
+import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { API_VERSIONS } from '@kbn/elastic-assistant-common';
 import { APP_ID } from '@kbn/security-solution-features/constants';
 
@@ -17,6 +18,16 @@ import type { EntityAnalyticsRoutesDeps } from '../../../types';
 import { withMinimumLicense } from '../../../utils/with_minimum_license';
 import { createEntitySourcesService } from '../../entity_sources/entity_sources_service';
 import { getWatchlistSavedObjectClient } from '../../shared/utils';
+import { getUserWatchlistPrivileges } from '../get_user_watchlist_privileges';
+
+const hasWatchlistWritePrivileges = async (
+  request: KibanaRequest,
+  security: SecurityPluginStart,
+  namespace: string
+): Promise<boolean> => {
+  const { has_write_permissions } = await getUserWatchlistPrivileges(request, security, namespace);
+  return has_write_permissions ?? false;
+};
 
 export const syncWatchlistRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -49,12 +60,22 @@ export const syncWatchlistRoute = (
         try {
           const secSol = await context.securitySolution;
           const core = await context.core;
+          const namespace = secSol.getSpaceId();
+
+          const [, { security }] = await getStartServices();
+
+          if (!(await hasWatchlistWritePrivileges(request, security, namespace))) {
+            return siemResponse.error({
+              statusCode: 403,
+              body: 'User is not authorized to sync watchlists. Write privileges are required.',
+            });
+          }
 
           const entitySourcesService = createEntitySourcesService({
             esClient: core.elasticsearch.client.asCurrentUser,
             soClient: getWatchlistSavedObjectClient(core),
             logger,
-            namespace: secSol.getSpaceId(),
+            namespace,
             getStartServices,
             hasEncryptionKey,
           });


### PR DESCRIPTION
## Summary

Addresses the index privilege gaps identified in #281192 during the serverless role validation pass.

Four gaps are fixed:

**1. `.entity_analytics.watchlists.*` and `.entity_analytics.entity-leads*` - only `viewer` had access (inverted)**

All roles except `viewer` had no index-level access to these patterns. This is inverted from the expected privilege hierarchy. Added appropriate read or `read, view_index_metadata, write` access to each role, following the same model as `.asset-criticality.asset-criticality-*`.

**2. `entities-metadata-*` - absent from every role**

The `entities-metadata-*` pattern did not appear in any role definition despite being a companion pattern to `entities-latest-*`. Added it to all roles mirroring the `entities-latest-*` privilege levels.

**3. `t1_analyst` on `.entities.v2.*` - missing `view_index_metadata`**

Split `.entities.v2.latest.*` and `.entities.v2.metadata.*` into their own index block for `t1_analyst` and added `view_index_metadata` for consistency with `t2_analyst`/`t3_analyst`. Write is intentionally not granted - `t1_analyst` is a read-only role for EA indices.

**4. `soc_manager` on `risk-score.risk-score-*` - read-only despite write on all other EA patterns**

Upgraded `soc_manager` from `read` to `read, write` on `risk-score.risk-score-*`, consistent with their write access on `.entities.v2.*`, `entities-latest-*`, and `.asset-criticality.*`.

## Updated privilege matrix

| Index pattern | viewer | editor | t1_analyst | t2_analyst | t3_analyst | soc_manager | platform_engineer |
|---|---|---|---|---|---|---|---|
| `.entities.v2.latest.*` | read | read, vim, write | read, vim | read, vim, write | read, vim, write | read, write | read, vim, write |
| `.entities.v2.metadata.*` | read | read, vim, write | read, vim | read, vim, write | read, vim, write | read, write | read, vim, write |
| `entities-latest-*` | read | read, vim, write | read | read | read | read, write | read, vim, write |
| `entities-metadata-*` | **read** | **read, vim, write** | **read** | **read** | **read** | **read, write** | **read, vim, write** |
| `risk-score.risk-score-*` | read | read, vim, write, maintenance | read | read | read | **read, write** | all |
| `.asset-criticality.*` | read | read, vim, write | read | read, vim, write | read, vim, write | read, write | read, vim, write |
| `.entity_analytics.watchlists.*` | read | **read, vim, write** | **read** | **read, vim, write** | **read, vim, write** | **read, write** | **read, vim, write** |
| `.entity_analytics.entity-leads*` | read | **read, vim, write** | **read** | **read, vim, write** | **read, vim, write** | **read, write** | **read, vim, write** |
| `.ml-anomalies-*` | read | read | read | read | read | read | read |

_vim = view_index_metadata; bold = new in this PR_

## Watchlist sync route - explicit write privilege check

While verifying the role changes, a related gap was found in the watchlist sync route (`POST /api/entity_analytics/watchlists/{id}/_sync`): it had no explicit write privilege check. Access control relied incidentally on an ES auth failure from an entity-count read query inside `WatchlistConfigClient.get()` - once `t1_analyst` correctly received `read` on `.entity_analytics.watchlists.*`, that implicit gate disappeared and the route returned 200 for a read-only user.

The fix adds an explicit `hasWatchlistWritePrivileges` check at the top of the handler (reusing the existing `getUserWatchlistPrivileges` helper) and returns 403 before any work is done if the user lacks write access. This restores the intended behaviour and makes the enforcement explicit rather than accidental.

## Notes

- This file (`src/platform/packages/shared/kbn-es/src/serverless_resources/project_roles/security/roles.yml`) is a copy of the source-of-truth in `elastic/elasticsearch-controller` at `internal/config/roles/security.yaml`. The same changes must be applied there to take effect in production serverless. A separate ticket/PR for elasticsearch-controller will be needed.
- These index privileges only govern direct ES access (curl, SDK, API keys). Kibana UI flows are unaffected since they use the Kibana service account. See #281192 for the full analysis.

Addresses #281192

## Test plan

- [ ] Start local serverless env (`yarn es serverless --projectType=security` + `yarn serverless-security`)
- [ ] Verify each role's effective privilege on the fixed patterns via direct ES API calls with the pre-configured test users (`t1_analyst:changeme`, `t2_analyst:changeme`, etc.)
- [ ] Confirm no regressions in existing FTR tests that reference these roles
- [ ] Verify `t1_analyst` receives 403 on `POST /api/entity_analytics/watchlists/{id}/_sync`
- [ ] Verify `t2_analyst` and above can sync successfully

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->