### PR TITLE
[inference] Scope the chatComplete reasoning `effort: none` default to gpt-5 models

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/create_openai_request.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/create_openai_request.ts
@@ -12,6 +12,7 @@ import type { CreateOpenAIRequestOptions } from './types';
 import { applyProviderTransforms } from './providers';
 import { getTemperatureIfValid } from '../../utils/get_temperature';
 import { resolveChatCompletionReasoning } from '../../utils/resolve_chat_completion_reasoning';
+import { getModelId } from './utils';
 
 export const createRequest = (options: CreateOpenAIRequestOptions): OpenAIRequest => {
   const {
@@ -25,6 +26,9 @@ export const createRequest = (options: CreateOpenAIRequestOptions): OpenAIReques
     reasoning,
   } = applyProviderTransforms(options);
 
+  // Preconfigured EIS connectors carry no model_id, so fall back to the inference endpoint id.
+  const model = modelName ?? getModelId(options.connector) ?? options.connector.config?.inferenceId;
+
   let request: OpenAIRequest;
   if (simulatedFunctionCalling) {
     const wrapped = wrapWithSimulatedFunctionCalling({
@@ -36,6 +40,7 @@ export const createRequest = (options: CreateOpenAIRequestOptions): OpenAIReques
     const resolvedReasoning = resolveChatCompletionReasoning({
       reasoning,
       hasNativeTools: false,
+      model,
     });
     request = {
       ...getTemperatureIfValid(temperature, { connector: options.connector, modelName }),
@@ -49,6 +54,7 @@ export const createRequest = (options: CreateOpenAIRequestOptions): OpenAIReques
     const resolvedReasoning = resolveChatCompletionReasoning({
       reasoning,
       hasNativeTools: hasTools,
+      model,
     });
 
     request = {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/inference_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference/inference_adapter.test.ts
@@ -255,7 +255,45 @@ describe('inferenceAdapter', () => {
       });
     });
 
-    it('defaults reasoning effort to none when native tools are present', () => {
+    it('defaults reasoning effort to none when native tools are present and the model requires it', () => {
+      inferenceAdapter
+        .chatComplete({
+          logger,
+          executor: executorMock,
+          messages: [{ role: MessageRole.User, content: 'question' }],
+          modelName: 'gpt-5.4',
+          tools: {
+            foo: { description: 'my tool' },
+          },
+          toolChoice: ToolChoiceType.auto,
+        })
+        .subscribe(noop);
+
+      expect(executorMock.invoke).toHaveBeenCalledTimes(1);
+      expect(executorMock.invoke).toHaveBeenCalledWith({
+        subAction: 'unified_completion_stream',
+        subActionParams: expect.objectContaining({
+          body: expect.objectContaining({
+            tools: expect.any(Array),
+            reasoning: { effort: 'none' },
+          }),
+        }),
+      });
+    });
+
+    it('resolves the model from the connector inference endpoint id for the reasoning default', () => {
+      executorMock.getConnector.mockImplementation(() => {
+        return {
+          type: InferenceConnectorType.Inference,
+          name: 'inference connector',
+          connectorId: '.id',
+          config: { provider: 'elastic', inferenceId: '.openai-gpt-5.4-chat_completion' },
+          capabilities: {},
+          isInferenceEndpoint: false,
+          isPreconfigured: false,
+        };
+      });
+
       inferenceAdapter
         .chatComplete({
           logger,
@@ -275,6 +313,66 @@ describe('inferenceAdapter', () => {
           body: expect.objectContaining({
             tools: expect.any(Array),
             reasoning: { effort: 'none' },
+          }),
+        }),
+      });
+    });
+
+    it('omits the reasoning default when the model does not tolerate disabled reasoning', () => {
+      executorMock.getConnector.mockImplementation(() => {
+        return {
+          type: InferenceConnectorType.Inference,
+          name: 'inference connector',
+          connectorId: '.id',
+          config: { provider: 'elastic', inferenceId: '.google-gemini-2.5-pro-chat_completion' },
+          capabilities: {},
+          isInferenceEndpoint: false,
+          isPreconfigured: false,
+        };
+      });
+
+      inferenceAdapter
+        .chatComplete({
+          logger,
+          executor: executorMock,
+          messages: [{ role: MessageRole.User, content: 'question' }],
+          tools: {
+            foo: { description: 'my tool' },
+          },
+          toolChoice: ToolChoiceType.auto,
+        })
+        .subscribe(noop);
+
+      expect(executorMock.invoke).toHaveBeenCalledTimes(1);
+      expect(executorMock.invoke).toHaveBeenCalledWith({
+        subAction: 'unified_completion_stream',
+        subActionParams: expect.objectContaining({
+          body: expect.not.objectContaining({
+            reasoning: expect.anything(),
+          }),
+        }),
+      });
+    });
+
+    it('omits the reasoning default when the model is unknown', () => {
+      inferenceAdapter
+        .chatComplete({
+          logger,
+          executor: executorMock,
+          messages: [{ role: MessageRole.User, content: 'question' }],
+          tools: {
+            foo: { description: 'my tool' },
+          },
+          toolChoice: ToolChoiceType.auto,
+        })
+        .subscribe(noop);
+
+      expect(executorMock.invoke).toHaveBeenCalledTimes(1);
+      expect(executorMock.invoke).toHaveBeenCalledWith({
+        subAction: 'unified_completion_stream',
+        subActionParams: expect.objectContaining({
+          body: expect.not.objectContaining({
+            reasoning: expect.anything(),
           }),
         }),
       });

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.test.ts
@@ -345,7 +345,60 @@ describe('inferenceEndpointAdapter', () => {
       );
     });
 
-    it('defaults reasoning effort to none when native tools are present', () => {
+    it('defaults reasoning effort to none when native tools are present and the model requires it', () => {
+      executorMock.invoke.mockResolvedValue(
+        observableIntoEventSourceStream(of({ choices: [], usage: null }), logger)
+      );
+
+      inferenceEndpointAdapter
+        .chatComplete({
+          ...defaultArgs,
+          messages: [{ role: MessageRole.User, content: 'question' }],
+          endpointModelId: 'openai-gpt-5.4',
+          tools: {
+            foo: { description: 'my tool' },
+          },
+          toolChoice: ToolChoiceType.auto,
+        })
+        .subscribe(noop);
+
+      expect(executorMock.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            tools: expect.any(Array),
+            reasoning: { effort: 'none' },
+          }),
+        })
+      );
+    });
+
+    it('omits the reasoning default when the model does not tolerate disabled reasoning', () => {
+      executorMock.invoke.mockResolvedValue(
+        observableIntoEventSourceStream(of({ choices: [], usage: null }), logger)
+      );
+
+      inferenceEndpointAdapter
+        .chatComplete({
+          ...defaultArgs,
+          messages: [{ role: MessageRole.User, content: 'question' }],
+          endpointModelId: 'google-gemini-2.5-pro',
+          tools: {
+            foo: { description: 'my tool' },
+          },
+          toolChoice: ToolChoiceType.auto,
+        })
+        .subscribe(noop);
+
+      expect(executorMock.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.not.objectContaining({
+            reasoning: expect.anything(),
+          }),
+        })
+      );
+    });
+
+    it('omits the reasoning default when the model is unknown', () => {
       executorMock.invoke.mockResolvedValue(
         observableIntoEventSourceStream(of({ choices: [], usage: null }), logger)
       );
@@ -363,9 +416,8 @@ describe('inferenceEndpointAdapter', () => {
 
       expect(executorMock.invoke).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
-            tools: expect.any(Array),
-            reasoning: { effort: 'none' },
+          body: expect.not.objectContaining({
+            reasoning: expect.anything(),
           }),
         })
       );

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/inference_endpoint/inference_endpoint_adapter.ts
@@ -177,6 +177,7 @@ const createEndpointRequest = ({
     const resolvedReasoning = resolveChatCompletionReasoning({
       reasoning,
       hasNativeTools: false,
+      model: endpointModelId ?? modelName,
     });
     return {
       ...temperatureOptions,
@@ -193,6 +194,7 @@ const createEndpointRequest = ({
   const resolvedReasoning = resolveChatCompletionReasoning({
     reasoning,
     hasNativeTools: hasTools,
+    model: endpointModelId ?? modelName,
   });
 
   return {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/resolve_chat_completion_reasoning.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/resolve_chat_completion_reasoning.test.ts
@@ -13,22 +13,62 @@ describe('resolveChatCompletionReasoning', () => {
       resolveChatCompletionReasoning({
         reasoning: { effort: 'high', summary: 'detailed' },
         hasNativeTools: true,
+        model: 'gpt-5.4',
       })
     ).toEqual({ effort: 'high', summary: 'detailed' });
   });
 
-  it('defaults to effort none when native tools are present and reasoning is omitted', () => {
+  it('defaults to effort none when native tools are present and the model rejects tools with reasoning', () => {
+    const models = [
+      'gpt-5',
+      'gpt-5.4',
+      'openai/gpt-5',
+      'openai-gpt-5.2',
+      '.openai-gpt-5.4-chat_completion',
+    ];
+    for (const model of models) {
+      expect(
+        resolveChatCompletionReasoning({
+          hasNativeTools: true,
+          model,
+        })
+      ).toEqual({ effort: 'none' });
+    }
+  });
+
+  it('returns undefined when tools are present but the model tolerates or requires reasoning', () => {
+    const models = [
+      'google-gemini-2.5-pro',
+      '.google-gemini-3.5-flash-chat_completion',
+      'openai-gpt-oss-120b',
+      'anthropic-claude-5-sonnet',
+      'gpt-4.1',
+      'o3-mini',
+      'gpt-52',
+    ];
+    for (const model of models) {
+      expect(
+        resolveChatCompletionReasoning({
+          hasNativeTools: true,
+          model,
+        })
+      ).toBeUndefined();
+    }
+  });
+
+  it('returns undefined when tools are present and the model is unknown', () => {
     expect(
       resolveChatCompletionReasoning({
         hasNativeTools: true,
       })
-    ).toEqual({ effort: 'none' });
+    ).toBeUndefined();
   });
 
   it('returns undefined when tools are absent and reasoning is omitted', () => {
     expect(
       resolveChatCompletionReasoning({
         hasNativeTools: false,
+        model: 'gpt-5.4',
       })
     ).toBeUndefined();
   });
@@ -38,6 +78,7 @@ describe('resolveChatCompletionReasoning', () => {
       resolveChatCompletionReasoning({
         reasoning: { effort: 'none' },
         hasNativeTools: true,
+        model: 'google-gemini-2.5-pro',
       })
     ).toEqual({ effort: 'none' });
   });

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/resolve_chat_completion_reasoning.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/resolve_chat_completion_reasoning.ts
@@ -7,26 +7,44 @@
 
 import type { ChatCompletionReasoning } from '@kbn/inference-common';
 
+// OpenAI Chat Completions rejects function tools on these reasoning models unless
+// reasoning effort is explicitly `none`. Keep the default scoped to them: models with
+// mandatory reasoning (e.g. Gemini Pro, gpt-oss via EIS) reject `effort: none` with a 400.
+// Remove once Elasticsearch exposes parameter capabilities for inference endpoints.
+const MODELS_REJECTING_TOOLS_WITHOUT_NONE_REASONING = ['gpt-5'];
+
+const modelRejectsToolsWithoutNoneReasoning = (model: string): boolean => {
+  // Normalize ids like `openai/gpt-5`, `openai-gpt-5.4` or `.openai-gpt-5.4-chat_completion`.
+  const normalized = model.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  return MODELS_REJECTING_TOOLS_WITHOUT_NONE_REASONING.some((candidate) =>
+    new RegExp(`(?:^|-)${candidate}(?:-|$)`).test(normalized)
+  );
+};
+
 /**
  * Resolve the reasoning payload for a unified chat completion request.
  *
  * OpenAI Chat Completions rejects function tools when reasoning effort defaults
- * to anything other than `none` on newer reasoning models. When native tools are
- * present and the caller did not set reasoning, default to `{ effort: 'none' }`.
- * Explicit caller values always win.
+ * to anything other than `none` on newer reasoning models (gpt-5 family). When
+ * native tools are present, the caller did not set reasoning, and the model is
+ * known to require it, default to `{ effort: 'none' }`. Explicit caller values
+ * always win. For every other model the field is omitted, since models with
+ * mandatory reasoning reject `effort: none` outright.
  */
 export const resolveChatCompletionReasoning = ({
   reasoning,
   hasNativeTools,
+  model,
 }: {
   reasoning?: ChatCompletionReasoning;
   hasNativeTools: boolean;
+  model?: string;
 }): ChatCompletionReasoning | undefined => {
   if (reasoning) {
     return reasoning;
   }
 
-  if (hasNativeTools) {
+  if (hasNativeTools && model && modelRejectsToolsWithoutNoneReasoning(model)) {
     return { effort: 'none' };
   }
 


### PR DESCRIPTION
Cherry-pick of #286109 onto `deploy-fix@1787155978`.

## Summary

#284554 made the unified chat-completion adapters default to `reasoning: { effort: 'none' }` whenever native function tools are present, to unblock tool calling on newer OpenAI reasoning models. Applied unconditionally, that default breaks every model whose reasoning **cannot be disabled**: the EIS gateway rejects the request with `400 — "Reasoning is mandatory for this endpoint and cannot be disabled."`.

Because Agent Builder always binds tools to its agents, every `/api/agent_builder/converse` call against those models started failing with a 400. This is what broke the daily Agent Builder LLM smoke tests for `google-gemini-2.5-pro`, `google-gemini-3.1-pro`, `google-gemini-3.5-flash`, `google-gemini-3.6-flash`, and `openai-gpt-oss-120b`.

### Fix

- `resolveChatCompletionReasoning` now only defaults to `{ effort: 'none' }` when the model is in the **gpt-5 family**. For every other model the field is omitted, restoring pre-#284554 behavior. Explicit caller-provided `reasoning` still always wins.
- Model identity is resolved from the request `modelName`, falling back to the connector's `providerConfig.model_id`, then to the connector's `inferenceId`.
- Both unified-completion call sites are covered: the `.inference` connector adapter (`create_openai_request.ts`) and the inference-endpoint adapter (`inference_endpoint_adapter.ts`).

Addresses #284554