### PR TITLE
Skip serverless Streams attachments test suite for MKI runs

### DIFF
--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/attachments/attachments.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/attachments/attachments.ts
@@ -51,6 +51,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const SECOND_RULE_ID = '312638da-43d1-4d6e-8fb8-9cae201cdd3a';
 
   describe('Attachments API', function () {
+    // failsOnMKI see https://github.com/elastic/kibana/issues/286262
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
       await enableStreams(apiClient);


### PR DESCRIPTION
## Summary

This PR skips the serverless Streams attachments test suite for MKI runs.
Details on the failure in #286262
