### PR TITLE
[CI] Register Moon projects that live in hidden directories

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -2,8 +2,9 @@
 $schema: https://moonrepo.dev/schemas/v2/workspace.json
 
 projects:
-  # Glob-based discovery skips dotfile directories, so `.buildkite` is registered
-  # explicitly via `sources` below.
+  # Glob-based discovery skips dotfile directories, so projects living under one are
+  # registered explicitly via `sources` below. `regenerate_moon_projects --check`
+  # fails when a generated project is missing here.
   globs:
     - src/**/moon.yml
     - x-pack/**/moon.yml
@@ -11,6 +12,7 @@ projects:
     - packages/**/moon.yml
   sources:
     kibana-buildkite: .buildkite
+    '@kbn/esql-resource-browser-storybook-config': src/platform/packages/shared/kbn-esql-resource-browser/.storybook
 vcs:
   defaultBranch: main
   client: git

--- a/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
+++ b/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
@@ -22,7 +22,12 @@ import type { ToolingLog } from '@kbn/tooling-log';
 
 import { createFailError } from '@kbn/dev-cli-errors';
 
-import { KIBANA_JSONC_FILENAME, MOON_CONFIG_KEY_ORDER, MOON_CONST } from '../const';
+import {
+  KIBANA_JSONC_FILENAME,
+  MOON_CONFIG_KEY_ORDER,
+  MOON_CONST,
+  MOON_WORKSPACE_CONFIG_PATH,
+} from '../const';
 import type { MoonProjectConfig } from './moon_project_type';
 import {
   compactFilePathsToGlobs,
@@ -131,6 +136,8 @@ export function regenerateMoonProjects() {
       ].join('\n')
     );
 
+    assertHiddenDirProjectsAreRegistered(allPackages);
+
     if (check) {
       const outOfDate = [...projectResults.create, ...projectResults.update];
       if (outOfDate.length > 0) {
@@ -142,6 +149,31 @@ export function regenerateMoonProjects() {
       }
     }
   }, cliOptions);
+}
+
+/**
+ * Moon discovers projects with the `src/**\/moon.yml` style globs in
+ * `.moon/workspace.yml`, and glob matching skips hidden directories. A project under
+ * one (`.storybook`, `.buildkite`, ...) gets a `moon.yml` that Moon never loads, so it
+ * silently drops out of the project graph and of affected-module detection. Such
+ * projects must be listed under `projects.sources` instead.
+ */
+function assertHiddenDirProjectsAreRegistered(allPackages: readonly Package[]) {
+  const workspace = parse(readFile(path.resolve(REPO_ROOT, MOON_WORKSPACE_CONFIG_PATH)));
+  const registered = new Set<string>(Object.values(workspace?.projects?.sources ?? {}));
+
+  const unregistered = allPackages
+    .map((pkg) => pkg.normalizedRepoRelativeDir)
+    .filter((dir) => dir.split('/').some((segment) => segment.startsWith('.')))
+    .filter((dir) => !registered.has(dir));
+
+  if (unregistered.length > 0) {
+    throw createFailError(
+      `${unregistered.length} Moon project(s) live in a hidden directory but are not listed under ` +
+        `'projects.sources' in ${MOON_WORKSPACE_CONFIG_PATH}, so Moon cannot discover them:\n` +
+        unregistered.map((dir) => `  ${dir}`).join('\n')
+    );
+  }
 }
 
 const getGeneratedPreambleForProject = (projectId: string) =>

--- a/packages/kbn-moon/src/const.ts
+++ b/packages/kbn-moon/src/const.ts
@@ -20,6 +20,7 @@ export const MOON_CONFIG_KEY_ORDER = [
 ];
 
 export const KIBANA_JSONC_FILENAME = 'kibana.jsonc';
+export const MOON_WORKSPACE_CONFIG_PATH = '.moon/workspace.yml';
 export const MOON_CONST = {
   MOON_CONFIG_FILE_NAME: 'moon.yml',
   TEMPLATE_FILE_NAME: 'moon.template.yml',


### PR DESCRIPTION
## Summary

Moon discovers projects with globs (`src/**/moon.yml`, `x-pack/**/moon.yml`, ...) and glob matching skips hidden directories. A module whose directory sits under one — today only `@kbn/esql-resource-browser-storybook-config` at `src/platform/packages/shared/kbn-esql-resource-browser/.storybook` — gets a generated `moon.yml` that Moon never loads, so the project silently disappears from the project graph and from Moon's affected-module detection. `.buildkite` already had this treatment via `projects.sources`; this one was missed.

This surfaced while comparing the git and Moon affected-module strategies: the module is present in git's `kibana.jsonc`-derived registry but absent from Moon's, which is a source of shadow-mode divergence.

- Register the project under `projects.sources` in `.moon/workspace.yml` (Moon goes from 1453 to 1454 projects).
- Fail `regenerate_moon_projects --check` when a generated project lives in a hidden directory and is not listed under `projects.sources`, so the same gap cannot silently reappear. This check already runs as part of `node scripts/check.js`.

No behavior change for the affected-module strategies beyond the newly visible project.

## Test plan

- [x] `node scripts/regenerate_moon_projects.js --check` no longer reports the hidden-directory project (the 5 pre-existing out-of-date configs it reports are unrelated to this change and also present on `main`).
- [x] Removing the new `sources` entry makes the check fail with a message naming the unregistered directory.
- [x] `moon query projects` resolves `@kbn/esql-resource-browser-storybook-config` to its `.storybook` source.
- [x] Feeding a `.storybook` file to `moon query projects --affected` now attributes it to the storybook project instead of dropping it.
- [x] Lint and type check pass for `packages/kbn-moon`.

Made with [Cursor](https://cursor.com)