### PR TITLE
[Visual refresh] Gap between list items in Navigation

### DIFF
--- a/src/core/packages/chrome/browser-components/src/classic/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/core/packages/chrome/browser-components/src/classic/__snapshots__/collapsible_nav.test.tsx.snap
@@ -33,7 +33,7 @@ Array [
             class="euiThemeProvider emotion-euiColorMode-dark"
           >
             <ul
-              class="euiListGroup emotion-euiListGroup"
+              class="euiListGroup emotion-euiListGroup-navListGroupCss"
               style="max-inline-size: none;"
             >
               <li
@@ -80,7 +80,7 @@ Array [
         >
           <ul
             aria-label="Pinned links"
-            class="euiListGroup emotion-euiListGroup"
+            class="euiListGroup emotion-euiListGroup-navListGroupCss"
             style="max-inline-size: none;"
           >
             <li
@@ -183,7 +183,7 @@ Array [
           >
             <ul
               aria-label="Recently viewed links"
-              class="euiListGroup emotion-euiListGroup-navRecentsListGroupCss"
+              class="euiListGroup emotion-euiListGroup-navListGroupCss-navRecentsListGroupCss-CollapsibleNav"
               style="max-inline-size: none;"
             >
               <li
@@ -317,7 +317,7 @@ Array [
             >
               <ul
                 aria-label="Primary navigation links, Analytics"
-                class="euiListGroup emotion-euiListGroup"
+                class="euiListGroup emotion-euiListGroup-navListGroupCss"
                 style="max-inline-size: none;"
               >
                 <li
@@ -463,7 +463,7 @@ Array [
             >
               <ul
                 aria-label="Primary navigation links, Observability"
-                class="euiListGroup emotion-euiListGroup"
+                class="euiListGroup emotion-euiListGroup-navListGroupCss"
                 style="max-inline-size: none;"
               >
                 <li
@@ -587,7 +587,7 @@ Array [
             >
               <ul
                 aria-label="Primary navigation links, Security"
-                class="euiListGroup emotion-euiListGroup"
+                class="euiListGroup emotion-euiListGroup-navListGroupCss"
                 style="max-inline-size: none;"
               >
                 <li
@@ -689,7 +689,7 @@ Array [
             >
               <ul
                 aria-label="Primary navigation links, Management"
-                class="euiListGroup emotion-euiListGroup"
+                class="euiListGroup emotion-euiListGroup-navListGroupCss"
                 style="max-inline-size: none;"
               >
                 <li
@@ -728,7 +728,7 @@ Array [
           class="euiCollapsibleNavGroup__children emotion-euiCollapsibleNavGroup__children"
         >
           <ul
-            class="euiListGroup emotion-euiListGroup-maxWidthDefault"
+            class="euiListGroup emotion-euiListGroup-maxWidthDefault-navListGroupCss"
           >
             <li
               class="euiListItemLayout__wrapper emotion-euiListItemLayout__wrapper-isInteractive"

--- a/src/core/packages/chrome/browser-components/src/classic/collapsible_nav.tsx
+++ b/src/core/packages/chrome/browser-components/src/classic/collapsible_nav.tsx
@@ -54,6 +54,9 @@ const getCollapsibleNavStyles = (euiThemeContext: UseEuiTheme) => {
         overflowY: 'auto',
       },
     }),
+    navListGroupCss: css({
+      gap: euiTheme.size.xs,
+    }),
     navRecentsListGroupCss: [
       css({ maxHeight: `calc(${euiTheme.size.base} * 10)`, marginRight: `-${euiTheme.size.s}` }),
       _euiYScroll,
@@ -214,6 +217,7 @@ export function CollapsibleNav({
                     }),
                   ]}
                   maxWidth="none"
+                  css={styles.navListGroupCss}
                 />
               </EuiThemeProvider>
             </EuiCollapsibleNavGroup>
@@ -254,6 +258,7 @@ export function CollapsibleNav({
             ]}
             maxWidth="none"
             color="text"
+            css={styles.navListGroupCss}
           />
         </EuiCollapsibleNavGroup>
       </EuiFlexItem>
@@ -298,7 +303,7 @@ export function CollapsibleNav({
             })}
             maxWidth="none"
             color="subdued"
-            css={styles.navRecentsListGroupCss}
+            css={[styles.navListGroupCss, styles.navRecentsListGroupCss]}
           />
         </EuiCollapsibleNavGroup>
       )}
@@ -348,6 +353,7 @@ export function CollapsibleNav({
                 listItems={allCategorizedLinks[categoryName].map((link) => readyForEUI(link))}
                 maxWidth="none"
                 color="subdued"
+                css={styles.navListGroupCss}
               />
             </EuiCollapsibleNavGroup>
           );
@@ -356,7 +362,7 @@ export function CollapsibleNav({
         {/* Things with no category (largely for custom plugins) */}
         {unknowns.map((link, i) => (
           <EuiCollapsibleNavGroup data-test-subj={`collapsibleNavGroup-noCategory`} key={i}>
-            <EuiListGroup>
+            <EuiListGroup css={styles.navListGroupCss}>
               <EuiListGroupItem color="text" {...readyForEUI(link, true)} />
             </EuiListGroup>
           </EuiCollapsibleNavGroup>

--- a/src/platform/kbn-ui/side-navigation/src/components/secondary_menu/section.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/secondary_menu/section.tsx
@@ -63,6 +63,7 @@ export const SecondaryMenuSectionComponent = ({
   const listStyles = css`
     display: flex;
     flex-direction: column;
+    gap: ${euiTheme.size.xs};
     width: 100%;
   `;
 


### PR DESCRIPTION
## Summary

This is a simple visual gutter PR to add 4px space between list items in our navigation. 

<img width="9030" height="2402" alt="image" src="https://github.com/user-attachments/assets/f7b8e2bd-62bf-43f5-afec-15ac0eaf73f4" />
