### PR TITLE
[Agent Builder] remove fast model loading call

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/model_provider.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/runner/model_provider.ts
@@ -124,8 +124,6 @@ export const createModelProvider = ({
     return connectorId;
   });
 
-  getFastModelConnectorId().catch(() => undefined);
-
   const selectModelId = async (opts: ModelSelectionPreferences): Promise<string> => {
     const { effortLevel = EffortLevels.medium } = opts;
     if (effortLevel === EffortLevels.low) {


### PR DESCRIPTION
## Summary

Used it for testing (to show the logs) and then forgot about it. Impact is low, but it's still unecessary so let's remove it.