### PR TITLE
[Entity Store] Report legacy Security-scoped asset names in engine status

### DIFF
--- a/x-pack/platform/plugins/shared/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
+++ b/x-pack/platform/plugins/shared/entity_store/server/domain/asset_manager/asset_manager_client.test.ts
@@ -10,6 +10,7 @@ import type {
   KibanaRequest,
   SavedObjectsClientContract,
 } from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { loggerMock } from '@kbn/logging-mocks';
 import type { SecurityPluginStart } from '@kbn/security-plugin/server';
@@ -676,5 +677,241 @@ describe('AssetManagerClient.reinstallSharedAssetsIfMissing', () => {
     });
     expect(mockInstallSharedElasticsearchAssets).not.toHaveBeenCalled();
     expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('AssetManagerClient.getStatus component name resolution', () => {
+  /**
+   * Tests for the legacy-aware template and component-template collectors introduced to fix
+   * https://github.com/elastic/kibana/issues/286283 — status page reports neutral names as
+   * missing after an FF-off upgrade that leaves legacy Security-scoped assets in place.
+   *
+   * getIndexComponents is already legacy-aware; this suite covers getIndexTemplateComponents
+   * and getComponentTemplateComponents which were not.
+   */
+
+  const namespace = 'default';
+
+  const buildClient = ({
+    latestTemplateExists,
+    legacyLatestTemplateExists,
+    updatesTemplateExists,
+    legacyUpdatesTemplateExists,
+    latestComponentTemplateExists,
+    legacyLatestComponentTemplateExists,
+    updatesComponentTemplateExists,
+    legacyUpdatesComponentTemplateExists,
+  }: {
+    latestTemplateExists: boolean;
+    legacyLatestTemplateExists: boolean;
+    updatesTemplateExists: boolean;
+    legacyUpdatesTemplateExists: boolean;
+    latestComponentTemplateExists: boolean;
+    legacyLatestComponentTemplateExists: boolean;
+    updatesComponentTemplateExists: boolean;
+    legacyUpdatesComponentTemplateExists: boolean;
+  }) => {
+    const getIndexTemplate = jest.fn().mockImplementation(async ({ name }: { name: string }) => {
+      const exists =
+        (name.includes('security_') && name.includes('latest') && legacyLatestTemplateExists) ||
+        (!name.includes('security_') && name.includes('latest') && latestTemplateExists) ||
+        (name.includes('security_') && name.includes('updates') && legacyUpdatesTemplateExists) ||
+        (!name.includes('security_') && name.includes('updates') && updatesTemplateExists);
+      if (!exists) throw new Error('index_template not found [404]');
+      return {};
+    });
+
+    const getComponentTemplate = jest
+      .fn()
+      .mockImplementation(async ({ name }: { name: string }) => {
+        const exists =
+          (name.includes('security_') &&
+            name.includes('latest') &&
+            legacyLatestComponentTemplateExists) ||
+          (!name.includes('security_') &&
+            name.includes('latest') &&
+            latestComponentTemplateExists) ||
+          (name.includes('security_') &&
+            name.includes('updates') &&
+            legacyUpdatesComponentTemplateExists) ||
+          (!name.includes('security_') &&
+            name.includes('updates') &&
+            updatesComponentTemplateExists);
+        if (!exists) throw new Error('component_template not found [404]');
+        return {};
+      });
+
+    // Stub the minimum ES surface getStatus/getComponentsForEngine needs.
+    // index and dataStream probes are not under test here — return "found" for all of them
+    // so the index rows don't interfere with the assertions.
+    const esClient = {
+      indices: {
+        exists: jest.fn().mockResolvedValue(true),
+        getIndexTemplate,
+        getDataStream: jest.fn().mockResolvedValue({ data_streams: [{}] }),
+      },
+      cluster: { getComponentTemplate },
+    } as unknown as jest.Mocked<ElasticsearchClient>;
+
+    const taskManager = {
+      get: jest
+        .fn()
+        .mockRejectedValue(
+          SavedObjectsErrorHelpers.createGenericNotFoundError('task', 'entity_store')
+        ),
+    } as unknown as jest.Mocked<TaskManagerStartContract>;
+
+    const engineDescriptorClient = {
+      getAll: jest.fn().mockResolvedValue([{ type: 'user', status: 'started' }]),
+      init: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const globalStateClient = {
+      findOrThrow: jest.fn().mockResolvedValue({ historySnapshot: {}, logsExtraction: {} }),
+      init: jest.fn(),
+      find: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    return new AssetManagerClient({
+      logger: loggerMock.create(),
+      esClient,
+      internalEsClient: esClient,
+      taskManager,
+      engineDescriptorClient:
+        engineDescriptorClient as unknown as import('../saved_objects').EngineDescriptorClient,
+      globalStateClient:
+        globalStateClient as unknown as import('../saved_objects').EntityStoreGlobalStateClient,
+      remoteLogExtractionStateClient: {
+        delete: jest.fn(),
+      } as unknown as import('../saved_objects/remote_log_extraction_state').RemoteLogExtractionStateClient,
+      namespace,
+      isServerless: true,
+      logsExtractionClient: {} as unknown as import('../logs_extraction').LogsExtractionClient,
+      security: {} as import('@kbn/security-plugin/server').SecurityPluginStart,
+      analytics: {
+        reportEvent: jest.fn(),
+      } as unknown as import('../../telemetry/events').TelemetryReporter,
+      savedObjectsClient: {} as SavedObjectsClientContract,
+    });
+  };
+
+  const getComponentsByResource = async (client: AssetManagerClient, resource: string) => {
+    const { engines } = await client.getStatus(true);
+    const components =
+      (engines[0] as { components?: Array<{ resource: string; id: string; installed: boolean }> })
+        .components ?? [];
+    return components.filter((c) => c.resource === resource);
+  };
+
+  describe('legacy-only assets (FF-off post-upgrade scenario)', () => {
+    it('reports legacy index template names as installed', async () => {
+      const client = buildClient({
+        latestTemplateExists: false,
+        legacyLatestTemplateExists: true,
+        updatesTemplateExists: false,
+        legacyUpdatesTemplateExists: true,
+        latestComponentTemplateExists: false,
+        legacyLatestComponentTemplateExists: true,
+        updatesComponentTemplateExists: false,
+        legacyUpdatesComponentTemplateExists: true,
+      });
+
+      const templates = await getComponentsByResource(client, 'index_template');
+
+      expect(templates).toHaveLength(2);
+      expect(templates[0].id).toContain('security_');
+      expect(templates[0].installed).toBe(true);
+      expect(templates[1].id).toContain('security_');
+      expect(templates[1].installed).toBe(true);
+    });
+
+    it('reports legacy component template names as installed', async () => {
+      const client = buildClient({
+        latestTemplateExists: false,
+        legacyLatestTemplateExists: true,
+        updatesTemplateExists: false,
+        legacyUpdatesTemplateExists: true,
+        latestComponentTemplateExists: false,
+        legacyLatestComponentTemplateExists: true,
+        updatesComponentTemplateExists: false,
+        legacyUpdatesComponentTemplateExists: true,
+      });
+
+      const componentTemplates = await getComponentsByResource(client, 'component_template');
+
+      expect(componentTemplates).toHaveLength(2);
+      expect(componentTemplates[0].id).toContain('security_');
+      expect(componentTemplates[0].installed).toBe(true);
+      expect(componentTemplates[1].id).toContain('security_');
+      expect(componentTemplates[1].installed).toBe(true);
+    });
+  });
+
+  describe('neutral-only assets (greenfield install)', () => {
+    it('reports neutral index template names as installed', async () => {
+      const client = buildClient({
+        latestTemplateExists: true,
+        legacyLatestTemplateExists: false,
+        updatesTemplateExists: true,
+        legacyUpdatesTemplateExists: false,
+        latestComponentTemplateExists: true,
+        legacyLatestComponentTemplateExists: false,
+        updatesComponentTemplateExists: true,
+        legacyUpdatesComponentTemplateExists: false,
+      });
+
+      const templates = await getComponentsByResource(client, 'index_template');
+
+      expect(templates).toHaveLength(2);
+      expect(templates[0].id).not.toContain('security_');
+      expect(templates[0].installed).toBe(true);
+      expect(templates[1].id).not.toContain('security_');
+      expect(templates[1].installed).toBe(true);
+    });
+
+    it('reports neutral component template names as installed', async () => {
+      const client = buildClient({
+        latestTemplateExists: true,
+        legacyLatestTemplateExists: false,
+        updatesTemplateExists: true,
+        legacyUpdatesTemplateExists: false,
+        latestComponentTemplateExists: true,
+        legacyLatestComponentTemplateExists: false,
+        updatesComponentTemplateExists: true,
+        legacyUpdatesComponentTemplateExists: false,
+      });
+
+      const componentTemplates = await getComponentsByResource(client, 'component_template');
+
+      expect(componentTemplates).toHaveLength(2);
+      expect(componentTemplates[0].id).not.toContain('security_');
+      expect(componentTemplates[0].installed).toBe(true);
+      expect(componentTemplates[1].id).not.toContain('security_');
+      expect(componentTemplates[1].installed).toBe(true);
+    });
+  });
+
+  describe('no assets present (not installed)', () => {
+    it('reports legacy names with installed: false when neither naming scheme exists', async () => {
+      const client = buildClient({
+        latestTemplateExists: false,
+        legacyLatestTemplateExists: false,
+        updatesTemplateExists: false,
+        legacyUpdatesTemplateExists: false,
+        latestComponentTemplateExists: false,
+        legacyLatestComponentTemplateExists: false,
+        updatesComponentTemplateExists: false,
+        legacyUpdatesComponentTemplateExists: false,
+      });
+
+      const templates = await getComponentsByResource(client, 'index_template');
+      const componentTemplates = await getComponentsByResource(client, 'component_template');
+
+      expect(templates.every((t) => !t.installed)).toBe(true);
+      expect(componentTemplates.every((t) => !t.installed)).toBe(true);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/platform/plugins/shared/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -60,9 +60,20 @@ import {
   getLegacySecurityLatestEntitiesIndexName,
   getLegacySecurityLatestEntityIndexPattern,
 } from '../../../common/domain/entity_index';
-import { getLatestIndexTemplateId } from './latest_index_template';
-import { getUpdatesIndexTemplateId } from './updates_index_template';
-import { getComponentTemplateName, getUpdatesComponentTemplateName } from './component_templates';
+import {
+  getLatestIndexTemplateId,
+  getLegacySecurityLatestIndexTemplateId,
+} from './latest_index_template';
+import {
+  getUpdatesIndexTemplateId,
+  getLegacySecurityUpdatesIndexTemplateId,
+} from './updates_index_template';
+import {
+  getComponentTemplateName,
+  getLegacySecurityComponentTemplateName,
+  getUpdatesComponentTemplateName,
+  getLegacySecurityUpdatesComponentTemplateName,
+} from './component_templates';
 import {
   getUpdatesEntitiesDataStreamName,
   getLegacySecurityUpdatesEntitiesDataStreamName,
@@ -556,18 +567,46 @@ export class AssetManagerClient {
     };
   }
 
+  /**
+   * Resolves a component's installed status by checking the neutral name first, then falling
+   * back to the legacy Security-scoped name. Mirrors the dual-probe pattern used by
+   * {@link getIndexComponents} for concrete indices and data streams.
+   *
+   * Preference: neutral wins when both exist (e.g. after a re-install post-upgrade).
+   * If only legacy exists, the legacy id is reported as installed.
+   * If neither exists, the legacy id is reported as not installed.
+   */
+  private async resolveComponentStatus(
+    resource: EngineComponentResource,
+    neutralId: string,
+    legacyId: string,
+    exists: (id: string) => Promise<boolean>
+  ): Promise<EngineComponentStatus> {
+    const [neutralExists, legacyExists] = await Promise.all([exists(neutralId), exists(legacyId)]);
+    if (neutralExists) {
+      return { id: neutralId, installed: true, resource };
+    } else {
+      return { id: legacyId, installed: legacyExists, resource };
+    }
+  }
+
   private async getIndexTemplateComponents(): Promise<EngineComponentStatus[]> {
-    const resource = 'index_template';
-    const latestId = getLatestIndexTemplateId(this.namespace);
-    const updatesId = getUpdatesIndexTemplateId(this.namespace);
-    const [latestExists, updatesExists] = await Promise.all([
-      this.tryAsBoolean(this.esClient.indices.getIndexTemplate({ name: latestId })),
-      this.tryAsBoolean(this.esClient.indices.getIndexTemplate({ name: updatesId })),
+    const probe = (id: string) =>
+      this.tryAsBoolean(this.esClient.indices.getIndexTemplate({ name: id }));
+    return Promise.all([
+      this.resolveComponentStatus(
+        'index_template',
+        getLatestIndexTemplateId(this.namespace),
+        getLegacySecurityLatestIndexTemplateId(this.namespace),
+        probe
+      ),
+      this.resolveComponentStatus(
+        'index_template',
+        getUpdatesIndexTemplateId(this.namespace),
+        getLegacySecurityUpdatesIndexTemplateId(this.namespace),
+        probe
+      ),
     ]);
-    return [
-      { id: latestId, installed: latestExists, resource },
-      { id: updatesId, installed: updatesExists, resource },
-    ];
   }
 
   private async getIndexComponents(): Promise<EngineComponentStatus[]> {
@@ -608,17 +647,22 @@ export class AssetManagerClient {
   private async getComponentTemplateComponents(
     definition: ManagedEntityDefinition
   ): Promise<EngineComponentStatus[]> {
-    const resource: EngineComponentResource = 'component_template';
-    const latestName = getComponentTemplateName(definition.type, this.namespace);
-    const updatesName = getUpdatesComponentTemplateName(definition.type, this.namespace);
-    const [latestExists, updatesExists] = await Promise.all([
-      this.tryAsBoolean(this.esClient.cluster.getComponentTemplate({ name: latestName })),
-      this.tryAsBoolean(this.esClient.cluster.getComponentTemplate({ name: updatesName })),
+    const probe = (name: string) =>
+      this.tryAsBoolean(this.esClient.cluster.getComponentTemplate({ name }));
+    return Promise.all([
+      this.resolveComponentStatus(
+        'component_template',
+        getComponentTemplateName(definition.type, this.namespace),
+        getLegacySecurityComponentTemplateName(definition.type, this.namespace),
+        probe
+      ),
+      this.resolveComponentStatus(
+        'component_template',
+        getUpdatesComponentTemplateName(definition.type, this.namespace),
+        getLegacySecurityUpdatesComponentTemplateName(definition.type, this.namespace),
+        probe
+      ),
     ]);
-    return [
-      { id: latestName, installed: latestExists, resource },
-      { id: updatesName, installed: updatesExists, resource },
-    ];
   }
 
   private async getIlmPolicyComponents(): Promise<EngineComponentStatus[]> {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/286283

After upgrading a serverless project with legacy Security-scoped Entity Store assets to a build containing #282130 + #285777, with `entityStore.migrateLegacySecurityAssets` **off**, the status page incorrectly shows index templates and component templates as not installed — even though the store is healthy, extracting, and all the assets it actually uses are present.

**This is a reporting defect, not an asset defect.** Verified live on a QA serverless project.

### Root cause

`getComponentsForEngine` fans out to six collectors. Only the index collector (`getIndexComponents`) was legacy-aware: it checks both neutral and legacy-named concrete indices/data streams. The two failing collectors — `getIndexTemplateComponents` and `getComponentTemplateComponents` — probed only neutral names (`entities_v2_latest_default_index_template`, `entities-v2-user_default-latest@platform`, etc.) while the actually-installed assets have legacy names (`entities_v2_latest_security_default_index_template`, `entities-v2-security_user_default-latest@platform`, etc.).

All the legacy name builders already existed (added by #282130/#285777 for the migration task) — they were just never used in the status path.

### Fix

Adds a private `resolveComponentStatus` helper that mirrors the dual-probe pattern already used by `getIndexComponents`: checks neutral first, falls back to legacy. Preference order:

- **Neutral exists** → report neutral id as installed
- **Only legacy exists** → report legacy id as installed
- **Neither exists** → report legacy id as not installed (consistent with the id that would appear once installed on a legacy deployment)

Updates both `getIndexTemplateComponents` and `getComponentTemplateComponents` to use it.

**Before (FF-off post-upgrade, user engine):**
```
MISS index_template      entities_v2_latest_default_index_template
MISS index_template      .entities_v2_updates_default_index_template
OK   index               .entities.v2.latest.security_default-00001
OK   index               .entities.v2.updates.security_default
MISS component_template  entities-v2-user_default-latest@platform
MISS component_template  entities-v2-user_default-updates@platform
```

**After:**
```
OK   index_template      entities_v2_latest_security_default_index_template
OK   index_template      .entities_v2_updates_security_default_index_template
OK   index               .entities.v2.latest.security_default-00001
OK   index               .entities.v2.updates.security_default
OK   component_template  entities-v2-security_user_default-latest@platform
OK   component_template  entities-v2-security_user_default-updates@platform
```

Greenfield (neutral) deployments are unaffected — the neutral names are checked first and win when both exist.

### Test coverage

Added a new `describe('AssetManagerClient.getStatus component name resolution')` block in `asset_manager_client.test.ts` covering:
- Legacy-only assets (the regression scenario)
- Neutral-only assets (greenfield, no regression)
- Neither exists: `installed: false`, legacy id reported