### PR TITLE
[Chrome Next] Migrate snapshot and restore to AppHeader

### DIFF
--- a/x-pack/platform/plugins/private/snapshot_restore/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/__jest__/client_integration/helpers/setup_environment.tsx
@@ -14,6 +14,7 @@ import type { LocationDescriptorObject } from 'history';
 import { I18nProvider } from '@kbn/i18n-react';
 
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import type { HttpSetup } from '@kbn/core/public';
 import { coreMock, scopedHistoryMock } from '@kbn/core/public/mocks';
 import { setUiMetricService, httpService } from '../../../public/application/services/http';
@@ -115,18 +116,20 @@ export const WithAppDependencies =
     ) as unknown as AppDependencies;
 
     return (
-      <I18nProvider>
-        <AuthorizationContext.Provider
-          value={createAuthorizationContextValue(privileges as Privileges)}
-        >
-          <KibanaContextProvider services={kibanaContextDependencies}>
-            <AppContextProvider value={appContextValue}>
-              <GlobalFlyoutProvider>
-                <Comp {...props} />
-              </GlobalFlyoutProvider>
-            </AppContextProvider>
-          </KibanaContextProvider>
-        </AuthorizationContext.Provider>
-      </I18nProvider>
+      <KibanaRenderContextProvider {...core}>
+        <I18nProvider>
+          <AuthorizationContext.Provider
+            value={createAuthorizationContextValue(privileges as Privileges)}
+          >
+            <KibanaContextProvider services={kibanaContextDependencies}>
+              <AppContextProvider value={appContextValue}>
+                <GlobalFlyoutProvider>
+                  <Comp {...props} />
+                </GlobalFlyoutProvider>
+              </AppContextProvider>
+            </KibanaContextProvider>
+          </AuthorizationContext.Provider>
+        </I18nProvider>
+      </KibanaRenderContextProvider>
     );
   };

--- a/x-pack/platform/plugins/private/snapshot_restore/__jest__/client_integration/home.test.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/__jest__/client_integration/home.test.ts
@@ -7,6 +7,8 @@
 
 import './helpers/mocks';
 
+import { APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
+import { openAppMenuOverflow } from '@kbn/app-header/test_helpers';
 import { getRandomString } from '@kbn/test-jest-helpers';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -84,7 +86,7 @@ describe('<SnapshotRestoreHome />', () => {
 
       renderHomePage();
 
-      const appTitle = await screen.findByTestId('appTitle');
+      const appTitle = await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.title);
       expect(appTitle).toHaveTextContent('Snapshot and Restore');
     });
 
@@ -115,8 +117,10 @@ describe('<SnapshotRestoreHome />', () => {
 
       renderHomePage();
 
-      const docLink = await screen.findByTestId('documentationLink');
-      expect(docLink).toHaveTextContent('Snapshot and Restore docs');
+      await openAppMenuOverflow();
+      const docLink = await screen.findByTestId(APP_HEADER_TEST_SUBJECTS.menuDocumentation);
+      expect(docLink).toHaveAttribute('href');
+      expect(docLink).toHaveAttribute('target', '_blank');
     });
 
     describe('tabs', () => {

--- a/x-pack/platform/plugins/private/snapshot_restore/moon.yml
+++ b/x-pack/platform/plugins/private/snapshot_restore/moon.yml
@@ -17,6 +17,7 @@ project:
   owner: '@elastic/kibana-management'
   sourceRoot: x-pack/platform/plugins/private/snapshot_restore
 dependsOn:
+  - '@kbn/app-header'
   - '@kbn/core'
   - '@kbn/licensing-plugin'
   - '@kbn/features-plugin'

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/home.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/home.tsx
@@ -6,11 +6,12 @@
  */
 
 import React, { useEffect, useRef } from 'react';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import type { RouteComponentProps } from 'react-router-dom';
 import { Routes, Route } from '@kbn/shared-ux-router';
 
-import { EuiButtonEmpty, EuiPageHeader, EuiSpacer } from '@elastic/eui';
+import { EuiSpacer } from '@elastic/eui';
+import { AppHeader, type AppHeaderTab } from '@kbn/app-header';
 
 import type { Section } from '../../constants';
 import { BASE_PATH, UIM_REPOSITORY_SET_DEFAULT_PRIVILEGE_MISSING } from '../../constants';
@@ -39,54 +40,51 @@ export const SnapshotRestoreHome: React.FunctionComponent<RouteComponentProps<Ma
   const canSetDefaultRepository = useCanSetDefaultRepository();
   const hasReportedMissingSetDefaultPrivilege = useRef(false);
 
-  const tabs: Array<{
-    id: Section;
-    name: React.ReactNode;
-  }> = [
+  const onSectionChange = (newSection: Section) => {
+    history.push(encodeURI(`${BASE_PATH}/${encodeURIComponent(newSection)}`));
+  };
+
+  const tabs: AppHeaderTab[] = [
     {
       id: 'snapshots',
-      name: (
-        <FormattedMessage
-          id="xpack.snapshotRestore.home.snapshotsTabTitle"
-          defaultMessage="Snapshots"
-        />
-      ),
+      label: i18n.translate('xpack.snapshotRestore.home.snapshotsTabTitle', {
+        defaultMessage: 'Snapshots',
+      }),
+      isSelected: section === 'snapshots',
+      onClick: () => onSectionChange('snapshots'),
+      'data-test-subj': 'snapshots_tab',
     },
     {
       id: 'repositories',
-      name: (
-        <FormattedMessage
-          id="xpack.snapshotRestore.home.repositoriesTabTitle"
-          defaultMessage="Repositories"
-        />
-      ),
+      label: i18n.translate('xpack.snapshotRestore.home.repositoriesTabTitle', {
+        defaultMessage: 'Repositories',
+      }),
+      isSelected: section === 'repositories',
+      onClick: () => onSectionChange('repositories'),
+      'data-test-subj': 'repositories_tab',
     },
     {
       id: 'restore_status',
-      name: (
-        <FormattedMessage
-          id="xpack.snapshotRestore.home.restoreTabTitle"
-          defaultMessage="Restore Status"
-        />
-      ),
+      label: i18n.translate('xpack.snapshotRestore.home.restoreTabTitle', {
+        defaultMessage: 'Restore Status',
+      }),
+      isSelected: section === 'restore_status',
+      onClick: () => onSectionChange('restore_status'),
+      'data-test-subj': 'restore_status_tab',
     },
   ];
 
   if (slmUi.enabled) {
     tabs.splice(2, 0, {
       id: 'policies',
-      name: (
-        <FormattedMessage
-          id="xpack.snapshotRestore.home.policiesTabTitle"
-          defaultMessage="Policies"
-        />
-      ),
+      label: i18n.translate('xpack.snapshotRestore.home.policiesTabTitle', {
+        defaultMessage: 'Policies',
+      }),
+      isSelected: section === 'policies',
+      onClick: () => onSectionChange('policies'),
+      'data-test-subj': 'policies_tab',
     });
   }
-
-  const onSectionChange = (newSection: Section) => {
-    history.push(encodeURI(`${BASE_PATH}/${encodeURIComponent(newSection)}`));
-  };
 
   // Set breadcrumb and page title
   useEffect(() => {
@@ -104,42 +102,17 @@ export const SnapshotRestoreHome: React.FunctionComponent<RouteComponentProps<Ma
 
   return (
     <>
-      <EuiPageHeader
-        bottomBorder
-        pageTitle={
-          <span data-test-subj="appTitle">
-            <FormattedMessage
-              id="xpack.snapshotRestore.home.snapshotRestoreTitle"
-              defaultMessage="Snapshot and Restore"
-            />
-          </span>
-        }
-        rightSideItems={[
-          <EuiButtonEmpty
-            href={docLinks.links.snapshotRestore.guide}
-            target="_blank"
-            iconType="question"
-            data-test-subj="documentationLink"
-          >
-            <FormattedMessage
-              id="xpack.snapshotRestore.home.snapshotRestoreDocsLinkText"
-              defaultMessage="Snapshot and Restore docs"
-            />
-          </EuiButtonEmpty>,
-        ]}
-        description={
-          <FormattedMessage
-            id="xpack.snapshotRestore.home.snapshotRestoreDescription"
-            defaultMessage="Use repositories to store and recover backups of your Elasticsearch indices and clusters."
-          />
-        }
-        tabs={tabs.map((tab) => ({
-          onClick: () => onSectionChange(tab.id),
-          isSelected: tab.id === section,
-          key: tab.id,
-          'data-test-subj': tab.id.toLowerCase() + '_tab',
-          label: tab.name,
-        }))}
+      <AppHeader
+        title={i18n.translate('xpack.snapshotRestore.home.snapshotRestoreTitle', {
+          defaultMessage: 'Snapshot and Restore',
+        })}
+        description={i18n.translate('xpack.snapshotRestore.home.snapshotRestoreDescription', {
+          defaultMessage:
+            'Use repositories to store and recover backups of your Elasticsearch indices and clusters.',
+        })}
+        tabs={tabs}
+        docLink={docLinks.links.snapshotRestore.guide}
+        spacing="bleed"
       />
 
       <EuiSpacer size="l" />

--- a/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/fixtures/page_objects/snapshot_restore_page.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/test/scout/ui/fixtures/page_objects/snapshot_restore_page.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { APP_HEADER_TEST_SUBJECTS } from '@kbn/app-header';
 import type { ScoutPage } from '@kbn/scout';
 
 export class SnapshotRestorePage {
@@ -32,7 +33,7 @@ export class SnapshotRestorePage {
   }
 
   async appTitleText(): Promise<string> {
-    return this.page.testSubj.locator('appTitle').innerText();
+    return this.page.testSubj.locator(APP_HEADER_TEST_SUBJECTS.title).innerText();
   }
 
   async navToRepositories() {

--- a/x-pack/platform/plugins/private/snapshot_restore/tsconfig.json
+++ b/x-pack/platform/plugins/private/snapshot_restore/tsconfig.json
@@ -12,6 +12,7 @@
     "../../../../../typings/**/*",
   ],
   "kbn_references": [
+    "@kbn/app-header",
     "@kbn/core",
     "@kbn/licensing-plugin",
     "@kbn/features-plugin",

--- a/x-pack/platform/plugins/private/translations/translations/de-DE.json
+++ b/x-pack/platform/plugins/private/translations/translations/de-DE.json
@@ -52146,7 +52146,6 @@
     "xpack.snapshotRestore.home.repositoriesTabTitle": "Repositories",
     "xpack.snapshotRestore.home.restoreTabTitle": "Status wiederherstellen",
     "xpack.snapshotRestore.home.snapshotRestoreDescription": "Verwenden Sie Repositories, um Backups Ihrer Elasticsearch-Indizes und -Cluster zu speichern und wiederherzustellen.",
-    "xpack.snapshotRestore.home.snapshotRestoreDocsLinkText": "Snapshot- und Wiederherstellungsdokumentation",
     "xpack.snapshotRestore.home.snapshotRestoreTitle": "Snapshot und Wiederherstellung",
     "xpack.snapshotRestore.home.snapshotsTabTitle": "Snapshots",
     "xpack.snapshotRestore.indicesList.allIndicesValue": "Alle Indizes",

--- a/x-pack/platform/plugins/private/translations/translations/fr-FR.json
+++ b/x-pack/platform/plugins/private/translations/translations/fr-FR.json
@@ -51914,7 +51914,6 @@
     "xpack.snapshotRestore.home.repositoriesTabTitle": "Référentiels",
     "xpack.snapshotRestore.home.restoreTabTitle": "Statut de restauration",
     "xpack.snapshotRestore.home.snapshotRestoreDescription": "Utilisez les référentiels pour stocker et récupérer les sauvegardes de vos index et clusters Elasticsearch.",
-    "xpack.snapshotRestore.home.snapshotRestoreDocsLinkText": "Documents de snapshot et restauration",
     "xpack.snapshotRestore.home.snapshotRestoreTitle": "Snapshot et restauration",
     "xpack.snapshotRestore.home.snapshotsTabTitle": "Snapshots",
     "xpack.snapshotRestore.indicesList.allIndicesValue": "Tous les index",

--- a/x-pack/platform/plugins/private/translations/translations/ja-JP.json
+++ b/x-pack/platform/plugins/private/translations/translations/ja-JP.json
@@ -52319,7 +52319,6 @@
     "xpack.snapshotRestore.home.repositoriesTabTitle": "レポジトリ",
     "xpack.snapshotRestore.home.restoreTabTitle": "ステータスの復元",
     "xpack.snapshotRestore.home.snapshotRestoreDescription": "レポジトリを使用して Elasticsearch のインデックスとクラスターのバックアップを保管します。",
-    "xpack.snapshotRestore.home.snapshotRestoreDocsLinkText": "スナップショットと復元ドキュメント",
     "xpack.snapshotRestore.home.snapshotRestoreTitle": "スナップショットリポジドリ",
     "xpack.snapshotRestore.home.snapshotsTabTitle": "スナップショット",
     "xpack.snapshotRestore.indicesList.allIndicesValue": "すべてのインデックス",

--- a/x-pack/platform/plugins/private/translations/translations/zh-CN.json
+++ b/x-pack/platform/plugins/private/translations/translations/zh-CN.json
@@ -52323,7 +52323,6 @@
     "xpack.snapshotRestore.home.repositoriesTabTitle": "存储库",
     "xpack.snapshotRestore.home.restoreTabTitle": "还原状态",
     "xpack.snapshotRestore.home.snapshotRestoreDescription": "使用存储库存储 Elasticsearch 索引和集群的备份。",
-    "xpack.snapshotRestore.home.snapshotRestoreDocsLinkText": "快照和还原文档",
     "xpack.snapshotRestore.home.snapshotRestoreTitle": "拍取快照并还原",
     "xpack.snapshotRestore.home.snapshotsTabTitle": "快照",
     "xpack.snapshotRestore.indicesList.allIndicesValue": "所有索引",


### PR DESCRIPTION
## Summary

This PR migrates `Snapshot and restore` page to the new `AppHeader`.

> [!NOTE]  
> The position of the overflow menu dropdown in classic is a bug and it will get resolved on component level independently of this PR in https://github.com/elastic/kibana/pull/286295.

Part of: https://github.com/elastic/kibana-team/issues/3945

### Visuals
| Before (classic) | After (classic) |
|---|---|
| <img width="1630" height="302" alt="classic_before" src="https://github.com/user-attachments/assets/184c755c-764b-47f1-ba6f-4d7865559ffb" /> | <img width="1624" height="304" alt="classic_after" src="https://github.com/user-attachments/assets/61ff365a-0aea-461e-b262-50991942c4d5" /> |

| Before (solution) | After (solution) |
|---|---|
| <img width="1730" height="271" alt="solution_before" src="https://github.com/user-attachments/assets/3cab9661-e6d3-444a-83c0-af4440ebfd6e" /> | <img width="1621" height="273" alt="solution_after" src="https://github.com/user-attachments/assets/50cd01af-77e0-44a2-b411-eaaa16a3ffdb" /> |


