### PR TITLE
[9.4] [ResponseOps][Alerting][Actions] add meta labels to alerting and action logs (#282523)

### DIFF
--- a/x-pack/platform/plugins/shared/actions/README.md
+++ b/x-pack/platform/plugins/shared/actions/README.md
@@ -33,6 +33,7 @@ Table of Contents
     - [actionsClient.execute(options)](#actionsclientexecuteoptions)
       - [Example](#example-2)
 - [Command Line Utility](#command-line-utility)
+- [Logging](#Logging)
 
 ## Terminology
 
@@ -296,3 +297,7 @@ $ kbn-action create .slack "post to slack" '{"webhookUrl": "https://hooks.slack.
     "version": "WzMsMV0="
 }
 ```
+
+# Logging
+
+For logging and editorial guidance see the [logging guidelines](../../../../../docs/extend/contributing/codebase/logging.md).

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
@@ -360,7 +360,14 @@ describe('Action Executor', () => {
         signal: undefined,
       });
 
-      expect(loggerMock.debug).toBeCalledWith('executing action test:1: 1');
+      expect(loggerMock.debug).toBeCalledWith('executing action test:1: 1', {
+        labels: {
+          actionId: '1',
+          actionLabel: 'test:1: 1',
+          actionTypeId: 'test',
+          spaceId: 'some-namespace',
+        },
+      });
       expect(eventLogger.logEvent).toHaveBeenCalledTimes(2);
 
       const execStartDoc = getBaseExecuteStartEventLogDoc(executeUnsecure);
@@ -509,7 +516,14 @@ describe('Action Executor', () => {
           profileUid: executeUnsecure ? undefined : mockUser?.profile_uid,
         });
 
-        expect(loggerMock.debug).toBeCalledWith('executing action test:1: 1');
+        expect(loggerMock.debug).toBeCalledWith('executing action test:1: 1', {
+          labels: {
+            actionId: '1',
+            actionLabel: 'test:1: 1',
+            actionTypeId: 'test',
+            spaceId: 'some-namespace',
+          },
+        });
         expect(eventLogger.logEvent).toHaveBeenCalledTimes(2);
 
         const execStartDoc = getBaseExecuteStartEventLogDoc(executeUnsecure);
@@ -599,7 +613,17 @@ describe('Action Executor', () => {
         ...(executeUnsecure ? {} : { source: SOURCE }),
       });
 
-      expect(loggerMock.debug).toBeCalledWith('executing action test:preconfigured: Preconfigured');
+      expect(loggerMock.debug).toBeCalledWith(
+        'executing action test:preconfigured: Preconfigured',
+        {
+          labels: {
+            actionId: 'preconfigured',
+            actionLabel: 'test:preconfigured: Preconfigured',
+            actionTypeId: 'test',
+            spaceId: 'some-namespace',
+          },
+        }
+      );
       expect(eventLogger.logEvent).toHaveBeenCalledTimes(2);
 
       const execStartDoc = getBaseExecuteStartEventLogDoc(executeUnsecure);
@@ -696,7 +720,15 @@ describe('Action Executor', () => {
         }
       );
       expect(loggerMock.debug).toBeCalledWith(
-        'executing action .cases:system-connector-.cases: System action: .cases'
+        'executing action .cases:system-connector-.cases: System action: .cases',
+        {
+          labels: {
+            actionId: 'system-connector-.cases',
+            actionLabel: '.cases:system-connector-.cases: System action: .cases',
+            actionTypeId: '.cases',
+            spaceId: 'some-namespace',
+          },
+        }
       );
       expect(eventLogger.logEvent).toHaveBeenCalledTimes(2);
 
@@ -807,7 +839,14 @@ describe('Action Executor', () => {
         ...(executeUnsecure ? {} : { source: SOURCE }),
       });
 
-      expect(loggerMock.debug).toBeCalledWith('executing action test.sub-feature-action:1: 1');
+      expect(loggerMock.debug).toBeCalledWith('executing action test.sub-feature-action:1: 1', {
+        labels: {
+          actionId: '1',
+          actionLabel: 'test.sub-feature-action:1: 1',
+          actionTypeId: 'test.sub-feature-action',
+          spaceId: 'some-namespace',
+        },
+      });
       expect(eventLogger.logEvent).toHaveBeenCalledTimes(2);
 
       const execStartDoc = getBaseExecuteStartEventLogDoc(executeUnsecure);
@@ -1248,7 +1287,17 @@ describe('Action Executor', () => {
         ...(executeUnsecure ? {} : { source: SOURCE }),
       });
 
-      expect(loggerMock.debug).toBeCalledWith('executing action test:preconfigured: Preconfigured');
+      expect(loggerMock.debug).toBeCalledWith(
+        'executing action test:preconfigured: Preconfigured',
+        {
+          labels: {
+            actionId: 'preconfigured',
+            actionLabel: 'test:preconfigured: Preconfigured',
+            actionTypeId: 'test',
+            spaceId: 'some-namespace',
+          },
+        }
+      );
       expect(eventLogger.logEvent).toHaveBeenCalledTimes(2);
 
       const execStartDoc = getBaseExecuteStartEventLogDoc(executeUnsecure);
@@ -1347,7 +1396,15 @@ describe('Action Executor', () => {
       });
 
       expect(loggerMock.debug).toBeCalledWith(
-        'executing action .cases:system-connector-.cases: System action: .cases'
+        'executing action .cases:system-connector-.cases: System action: .cases',
+        {
+          labels: {
+            actionId: 'system-connector-.cases',
+            actionLabel: '.cases:system-connector-.cases: System action: .cases',
+            actionTypeId: '.cases',
+            spaceId: 'some-namespace',
+          },
+        }
       );
       expect(eventLogger.logEvent).toHaveBeenCalledTimes(2);
 
@@ -1451,7 +1508,19 @@ describe('Action Executor', () => {
         await actionExecutor.execute(executeParams);
       }
       expect(loggerMock.warn).toBeCalledWith(
-        'action execution failure: test:1: 1: message for action execution error: serviceMessage for action execution error'
+        'action execution failure: test:1: 1: message for action execution error: serviceMessage for action execution error',
+        {
+          labels: {
+            actionId: '1',
+            actionLabel: 'test:1: 1',
+            actionTypeId: 'test',
+            alertExecutionId: undefined,
+            alertId: undefined,
+            name: '1',
+            ruleId: undefined,
+            spaceId: 'some-namespace',
+          },
+        }
       );
     });
 
@@ -1475,11 +1544,34 @@ describe('Action Executor', () => {
 
       expect(executorResult?.errorSource).toBe(TaskErrorSource.FRAMEWORK);
       expect(loggerMock.warn).toBeCalledWith(
-        'action execution failure: test:1: 1: an error occurred while running the action: this action execution is intended to fail; retry: true'
+        'action execution failure: test:1: 1: an error occurred while running the action: this action execution is intended to fail; retry: true',
+        {
+          labels: {
+            actionId: '1',
+            actionLabel: 'test:1: 1',
+            actionTypeId: 'test',
+            alertExecutionId: undefined,
+            alertId: undefined,
+            name: '1',
+            ruleId: undefined,
+            spaceId: 'some-namespace',
+          },
+        }
       );
       expect(loggerMock.error).toBeCalledWith(err, {
         error: { stack_trace: 'foo error\n  stack 1\n  stack 2\n  stack 3' },
-        tags: ['test', '1', 'action-run-failed', 'framework-error'],
+        labels: {
+          actionId: '1',
+          actionLabel: 'test:1: 1',
+          actionTypeId: 'test',
+          alertExecutionId: undefined,
+          alertId: undefined,
+          name: '1',
+          ruleId: undefined,
+          ruleName: undefined,
+          spaceId: 'some-namespace',
+        },
+        tags: ['action-run-failed', 'framework-error'],
       });
     });
 
@@ -1506,11 +1598,33 @@ describe('Action Executor', () => {
 
       expect(executorResult?.errorSource).toBe(TaskErrorSource.USER);
       expect(loggerMock.warn).toBeCalledWith(
-        'action execution failure: test:1: 1: an error occurred while running the action: this action execution is intended to fail; retry: true'
+        'action execution failure: test:1: 1: an error occurred while running the action: this action execution is intended to fail; retry: true',
+        {
+          labels: {
+            actionId: '1',
+            actionLabel: 'test:1: 1',
+            actionTypeId: 'test',
+            alertExecutionId: undefined,
+            alertId: undefined,
+            name: '1',
+            ruleId: undefined,
+            spaceId: 'some-namespace',
+          },
+        }
       );
       expect(loggerMock.error).toBeCalledWith(err, {
         error: { stack_trace: 'foo error\n  stack 1\n  stack 2\n  stack 3' },
-        tags: ['test', '1', 'action-run-failed', 'user-error'],
+        labels: {
+          actionId: '1',
+          actionLabel: 'test:1: 1',
+          actionTypeId: 'test',
+          alertExecutionId: undefined,
+          alertId: undefined,
+          name: '1',
+          ruleId: undefined,
+          spaceId: 'some-namespace',
+        },
+        tags: ['action-run-failed', 'user-error'],
       });
     });
 
@@ -1535,7 +1649,19 @@ describe('Action Executor', () => {
         await actionExecutor.execute(executeParams);
       }
       expect(loggerMock.warn).toBeCalledWith(
-        'action execution failure: test:1: 1: returned unexpected result "invalid-status"'
+        'action execution failure: test:1: 1: returned unexpected result "invalid-status"',
+        {
+          labels: {
+            actionId: '1',
+            actionLabel: 'test:1: 1',
+            actionTypeId: 'test',
+            alertExecutionId: undefined,
+            alertId: undefined,
+            name: '1',
+            ruleId: undefined,
+            spaceId: 'some-namespace',
+          },
+        }
       );
     });
 
@@ -1623,11 +1749,33 @@ describe('Action Executor', () => {
 
       expect(executorResult?.errorSource).toBe(TaskErrorSource.USER);
       expect(loggerMock.warn).toBeCalledWith(
-        'action execution failure: test:1: 1: an error occurred while running the action: Client network socket disconnected before secure TLS connection was established; retry: true'
+        'action execution failure: test:1: 1: an error occurred while running the action: Client network socket disconnected before secure TLS connection was established; retry: true',
+        {
+          labels: {
+            actionId: '1',
+            actionLabel: 'test:1: 1',
+            actionTypeId: 'test',
+            alertExecutionId: undefined,
+            alertId: undefined,
+            name: '1',
+            ruleId: undefined,
+            spaceId: 'some-namespace',
+          },
+        }
       );
       expect(loggerMock.error).toBeCalledWith(err, {
         error: { stack_trace: 'foo error\n  stack 1\n  stack 2\n  stack 3' },
-        tags: ['test', '1', 'action-run-failed', 'user-error'],
+        labels: {
+          actionId: '1',
+          actionLabel: 'test:1: 1',
+          actionTypeId: 'test',
+          alertExecutionId: undefined,
+          alertId: undefined,
+          name: '1',
+          ruleId: undefined,
+          spaceId: 'some-namespace',
+        },
+        tags: ['action-run-failed', 'user-error'],
       });
     });
   }

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
@@ -481,7 +481,14 @@ export class ActionExecutor {
         }
 
         const actionLabel = `${actionTypeId}:${actionId}: ${name}`;
-        logger.debug(`executing action ${actionLabel}`);
+        logger.debug(`executing action ${actionLabel}`, {
+          labels: {
+            actionLabel,
+            actionTypeId,
+            actionId,
+            spaceId,
+          },
+        });
 
         const task = taskInfo
           ? {
@@ -553,7 +560,15 @@ export class ActionExecutor {
           event.event!.outcome = 'failure';
           event.message = `action execution failure: ${actionLabel}`;
           event.error = { message: err.message };
-          logger.warn(`action execution failure: ${actionLabel}: ${err.message}`);
+          logger.warn(`action execution failure: ${actionLabel}: ${err.message}`, {
+            labels: {
+              actionTypeId,
+              actionLabel,
+              actionId,
+              spaceId,
+              name,
+            },
+          });
           eventLogger.logEvent(event);
           return err.result;
         }
@@ -646,11 +661,32 @@ export class ActionExecutor {
             event.error.message = actionErrorToMessage(result);
             if (result.error) {
               logger.error(result.error, {
-                tags: [actionTypeId, actionId, 'action-run-failed', `${result.errorSource}-error`],
+                labels: {
+                  actionLabel,
+                  actionTypeId,
+                  actionId,
+                  spaceId,
+                  name,
+                  alertId: validatedParams.alertId,
+                  alertExecutionId: validatedParams.alertExecutionId,
+                  ruleId: validatedParams.ruleId,
+                },
+                tags: ['action-run-failed', `${result.errorSource}-error`],
                 error: { stack_trace: result.error.stack },
               });
             }
-            logger.warn(`action execution failure: ${actionLabel}: ${event.error.message}`);
+            logger.warn(`action execution failure: ${actionLabel}: ${event.error.message}`, {
+              labels: {
+                actionLabel,
+                actionTypeId,
+                actionId,
+                spaceId,
+                name,
+                alertId: validatedParams.alertId,
+                alertExecutionId: validatedParams.alertExecutionId,
+                ruleId: validatedParams.ruleId,
+              },
+            });
           } else {
             span?.setOutcome('failure');
             event.event!.outcome = 'failure';
@@ -658,7 +694,19 @@ export class ActionExecutor {
             event.error = event.error || {};
             event.error.message = 'action execution returned unexpected result';
             logger.warn(
-              `action execution failure: ${actionLabel}: returned unexpected result "${result.status}"`
+              `action execution failure: ${actionLabel}: returned unexpected result "${result.status}"`,
+              {
+                labels: {
+                  actionLabel,
+                  actionTypeId,
+                  actionId,
+                  spaceId,
+                  name,
+                  alertId: validatedParams.alertId,
+                  alertExecutionId: validatedParams.alertExecutionId,
+                  ruleId: validatedParams.ruleId,
+                },
+              }
             );
           }
 
@@ -699,8 +747,29 @@ export class ActionExecutor {
               }
             })
             .catch((err) => {
-              logger.error('Failed to calculate tokens from streaming response');
-              logger.error(err);
+              logger.error('Failed to calculate tokens from streaming response', {
+                labels: {
+                  actionLabel,
+                  actionTypeId,
+                  actionId,
+                  spaceId,
+                  name,
+                  alertId: validatedParams.alertId,
+                  alertExecutionId: validatedParams.alertExecutionId,
+                },
+              });
+              logger.error(err, {
+                labels: {
+                  actionLabel,
+                  actionTypeId,
+                  actionId,
+                  spaceId,
+                  name,
+                  alertId: validatedParams.alertId,
+                  alertExecutionId: validatedParams.alertExecutionId,
+                  ruleId: validatedParams.ruleId,
+                },
+              });
             })
             .finally(() => {
               completeEventLogging();

--- a/x-pack/platform/plugins/shared/actions/server/lib/task_runner_factory.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/task_runner_factory.test.ts
@@ -35,6 +35,8 @@ import {
 import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { ConnectorRateLimiter } from './connector_rate_limiter';
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const executeParamsFields = [
   'actionId',
   'params',
@@ -517,7 +519,15 @@ describe('Task Runner Factory', () => {
     expect(mockedActionExecutor.logCancellation.mock.calls.length).toBe(1);
 
     expect(taskRunnerFactoryInitializerParams.logger.debug).toHaveBeenCalledWith(
-      `Cancelling action task for action with id 2 - execution error due to timeout.`
+      `Cancelling action task for action with id 2 - execution error due to timeout.`,
+      {
+        labels: {
+          actionExecutionId: expect.stringMatching(UUID_REGEX),
+          actionId: '2',
+          executionId: '123abc',
+          spaceId: 'test',
+        },
+      }
     );
   });
 
@@ -539,7 +549,8 @@ describe('Task Runner Factory', () => {
       { refresh: false }
     );
     expect(taskRunnerFactoryInitializerParams.logger.error).toHaveBeenCalledWith(
-      'Failed to cleanup action_task_params object [id="3"]: Fail'
+      'Failed to cleanup action_task_params object [id="3"]: Fail',
+      { labels: { actionExecutionId: expect.stringMatching(UUID_REGEX) } }
     );
   });
 
@@ -934,7 +945,15 @@ describe('Task Runner Factory', () => {
     expect(isRetryableError(err)).toEqual(false);
     expect(taskRunnerFactoryInitializerParams.logger.error as jest.Mock).toHaveBeenCalledWith(
       `Action '2' failed: Error message`,
-      { tags: ['connector-run-failed', 'framework-error'] }
+      {
+        labels: {
+          actionExecutionId: expect.stringMatching(UUID_REGEX),
+          actionId: '2',
+          executionId: '123abc',
+          spaceId: 'test',
+        },
+        tags: ['connector-run-failed', 'framework-error'],
+      }
     );
     expect(getErrorSource(err)).toBe(TaskErrorSource.FRAMEWORK);
   });
@@ -985,7 +1004,15 @@ describe('Task Runner Factory', () => {
     expect(err).toBeDefined();
     expect(taskRunnerFactoryInitializerParams.logger.error as jest.Mock).toHaveBeenCalledWith(
       `Action '2' failed: Error message: Service message`,
-      { tags: ['connector-run-failed', 'framework-error'] }
+      {
+        labels: {
+          actionExecutionId: expect.stringMatching(UUID_REGEX),
+          actionId: '2',
+          executionId: '123abc',
+          spaceId: 'test',
+        },
+        tags: ['connector-run-failed', 'framework-error'],
+      }
     );
   });
 
@@ -1088,7 +1115,15 @@ describe('Task Runner Factory', () => {
     expect(err).toBeDefined();
     expect(taskRunnerFactoryInitializerParams.logger.error as jest.Mock).toHaveBeenCalledWith(
       `Action '2' failed: Fail`,
-      { tags: ['connector-run-failed', 'framework-error'] }
+      {
+        labels: {
+          actionExecutionId: expect.stringMatching(UUID_REGEX),
+          actionId: '2',
+          executionId: '123abc',
+          spaceId: 'test',
+        },
+        tags: ['connector-run-failed', 'framework-error'],
+      }
     );
     expect(thrownError).toEqual(err);
     expect(getErrorSource(err)).toBe(TaskErrorSource.FRAMEWORK);
@@ -1207,7 +1242,12 @@ describe('Task Runner Factory', () => {
 
       expect(taskRunnerFactoryInitializerParams.logger.error).toHaveBeenCalledWith(
         `Failed to load action task params ${mockedTaskInstance.params.actionTaskParamsId}: test`,
-        { tags: ['connector-run-failed', 'framework-error'] }
+        {
+          labels: {
+            spaceId: 'test',
+          },
+          tags: ['connector-run-failed', 'framework-error'],
+        }
       );
     }
   });

--- a/x-pack/platform/plugins/shared/actions/server/lib/task_runner_factory.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/task_runner_factory.ts
@@ -141,6 +141,12 @@ export class TaskRunnerFactory {
               ? TaskErrorSource.USER
               : getErrorSource(e) || TaskErrorSource.FRAMEWORK;
           logger.error(`Action '${actionId}' failed: ${e.message}`, {
+            labels: {
+              actionId,
+              actionExecutionId,
+              executionId,
+              spaceId,
+            },
             tags: ['connector-run-failed', `${errorSource}-error`],
           });
           if (e instanceof ActionTypeDisabledError) {
@@ -159,6 +165,12 @@ export class TaskRunnerFactory {
             message = `${message}: ${executorResult.serviceMessage}`;
           }
           logger.error(`Action '${actionId}' failed: ${message}`, {
+            labels: {
+              actionId,
+              actionExecutionId,
+              executionId,
+              spaceId,
+            },
             tags: ['connector-run-failed', `${executorResult.errorSource}-error`],
           });
 
@@ -201,7 +213,15 @@ export class TaskRunnerFactory {
         inMemoryMetrics.increment(IN_MEMORY_METRICS.ACTION_TIMEOUTS);
 
         logger.debug(
-          `Cancelling action task for action with id ${actionId} - execution error due to timeout.`
+          `Cancelling action task for action with id ${actionId} - execution error due to timeout.`,
+          {
+            labels: {
+              actionId,
+              actionExecutionId,
+              executionId,
+              spaceId,
+            },
+          }
         );
         return { state: {} };
       },
@@ -216,7 +236,12 @@ export class TaskRunnerFactory {
         } catch (e) {
           // Log error only, we shouldn't fail the task because of an error here (if ever there's retry logic)
           logger.error(
-            `Failed to cleanup ${ACTION_TASK_PARAMS_SAVED_OBJECT_TYPE} object [id="${actionTaskExecutorParams.actionTaskParamsId}"]: ${e.message}`
+            `Failed to cleanup ${ACTION_TASK_PARAMS_SAVED_OBJECT_TYPE} object [id="${actionTaskExecutorParams.actionTaskParamsId}"]: ${e.message}`,
+            {
+              labels: {
+                actionExecutionId,
+              },
+            }
           );
         }
       },
@@ -277,7 +302,12 @@ async function getActionTaskParams(
       : TaskErrorSource.FRAMEWORK;
     logger.error(
       `Failed to load action task params ${executorParams.actionTaskParamsId}: ${e.message}`,
-      { tags: ['connector-run-failed', `${errorSource}-error`] }
+      {
+        labels: {
+          spaceId,
+        },
+        tags: ['connector-run-failed', `${errorSource}-error`],
+      }
     );
     if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
       throw createRetryableError(createTaskRunError(e, errorSource), true);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/action_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/action_scheduler.test.ts
@@ -462,7 +462,15 @@ describe('Action Scheduler', () => {
     });
 
     expect(defaultSchedulerContext.logger.error).toHaveBeenCalledWith(
-      'Invalid action group "invalid-group" for rule "test".'
+      'Invalid action group "invalid-group" for rule "test".',
+      {
+        labels: {
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'test1',
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+        },
+      }
     );
 
     expect(ruleRunMetricsStore.getNumberOfTriggeredActions()).toBe(0);
@@ -843,7 +851,15 @@ describe('Action Scheduler', () => {
     expect(actionsClient.bulkEnqueueExecution).toHaveBeenCalledTimes(0);
     expect(defaultSchedulerContext.logger.debug).nthCalledWith(
       1,
-      `skipping scheduling of actions for '1' in rule ${defaultSchedulerContext.ruleLabel}: rule is muted`
+      `skipping scheduling of actions for '1' in rule ${defaultSchedulerContext.ruleLabel}: rule is muted`,
+      {
+        labels: {
+          alertId: '1',
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+          ruleId: '1',
+          spaceId: 'test1',
+        },
+      }
     );
   });
 
@@ -868,7 +884,17 @@ describe('Action Scheduler', () => {
     expect(actionsClient.bulkEnqueueExecution).toHaveBeenCalledTimes(0);
     expect(defaultSchedulerContext.logger.debug).nthCalledWith(
       1,
-      `skipping scheduling of actions for '1' in rule ${defaultSchedulerContext.ruleLabel}: rule is throttled`
+      `skipping scheduling of actions for '1' in rule ${defaultSchedulerContext.ruleLabel}: rule is throttled`,
+      {
+        labels: {
+          actionId: '1',
+          alertId: '1',
+          actionTypeId: 'test',
+          ruleId: '1',
+          spaceId: 'test1',
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+        },
+      }
     );
   });
 
@@ -904,7 +930,17 @@ describe('Action Scheduler', () => {
     expect(actionsClient.bulkEnqueueExecution).toHaveBeenCalledTimes(0);
     expect(defaultSchedulerContext.logger.debug).nthCalledWith(
       1,
-      `skipping scheduling of actions for '1' in rule ${defaultSchedulerContext.ruleLabel}: rule is throttled`
+      `skipping scheduling of actions for '1' in rule ${defaultSchedulerContext.ruleLabel}: rule is throttled`,
+      {
+        labels: {
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+          ruleId: '1',
+          actionId: '1',
+          actionTypeId: 'test',
+          alertId: '1',
+          spaceId: 'test1',
+        },
+      }
     );
   });
 
@@ -956,7 +992,15 @@ describe('Action Scheduler', () => {
     expect(actionsClient.bulkEnqueueExecution).toHaveBeenCalledTimes(0);
     expect(defaultSchedulerContext.logger.debug).nthCalledWith(
       1,
-      `skipping scheduling of actions for '1' in rule ${defaultSchedulerContext.ruleLabel}: rule is muted`
+      `skipping scheduling of actions for '1' in rule ${defaultSchedulerContext.ruleLabel}: rule is muted`,
+      {
+        labels: {
+          alertId: '1',
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+          ruleId: '1',
+          spaceId: 'test1',
+        },
+      }
     );
   });
 
@@ -1357,7 +1401,15 @@ describe('Action Scheduler', () => {
     });
 
     expect(defaultSchedulerContext.logger.error).toHaveBeenCalledWith(
-      'Skipping action "1" for rule "1" because the rule type "Test" does not support alert-as-data.'
+      'Skipping action "1" for rule "1" because the rule type "Test" does not support alert-as-data.',
+      {
+        labels: {
+          actionId: '1',
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'test1',
+        },
+      }
     );
 
     expect(ruleRunMetricsStore.getNumberOfTriggeredActions()).toBe(0);
@@ -1565,7 +1617,8 @@ describe('Action Scheduler', () => {
     expect(alertingEventLogger.logAction).not.toHaveBeenCalled();
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledTimes(1);
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledWith(
-      '(2) alerts have been filtered out for: testActionTypeId:111'
+      '(2) alerts have been filtered out for: testActionTypeId:111',
+      { labels: { actionId: '1', actionTypeId: 'testActionTypeId' } }
     );
   });
 
@@ -1735,7 +1788,16 @@ describe('Action Scheduler', () => {
     });
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledTimes(1);
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledWith(
-      '(2) alerts have been filtered out for: testActionTypeId:111-111'
+      '(2) alerts have been filtered out for: testActionTypeId:111-111',
+      {
+        labels: {
+          actionId: '1',
+          actionTypeId: 'testActionTypeId',
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+          ruleId: '1',
+          spaceId: 'test1',
+        },
+      }
     );
   });
 
@@ -1818,7 +1880,8 @@ describe('Action Scheduler', () => {
 
     expect(defaultSchedulerContext.logger.debug).toHaveBeenNthCalledWith(
       1,
-      '(3) alerts have been filtered out for: testActionTypeId:1'
+      '(3) alerts have been filtered out for: testActionTypeId:1',
+      { labels: { actionId: '1', actionTypeId: 'testActionTypeId' } }
     );
   });
 
@@ -1870,7 +1933,8 @@ describe('Action Scheduler', () => {
 
     expect(defaultSchedulerContext.logger.debug).toHaveBeenNthCalledWith(
       1,
-      '(3) alerts have been filtered out for: testActionTypeId:1'
+      '(3) alerts have been filtered out for: testActionTypeId:1',
+      { labels: { actionId: '1', actionTypeId: 'testActionTypeId' } }
     );
   });
 
@@ -1890,13 +1954,43 @@ describe('Action Scheduler', () => {
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledTimes(3);
 
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledWith(
-      'no scheduling of actions "1" for alert "1" from rule "1": has active maintenance windows test-id-1.'
+      'no scheduling of actions "1" for alert "1" from rule "1": has active maintenance windows test-id-1.',
+      {
+        labels: {
+          actionId: '1',
+          actionTypeId: 'test',
+          alertId: '1',
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+          ruleId: '1',
+          spaceId: 'test1',
+        },
+      }
     );
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledWith(
-      'no scheduling of actions "1" for alert "2" from rule "1": has active maintenance windows test-id-2.'
+      'no scheduling of actions "1" for alert "2" from rule "1": has active maintenance windows test-id-2.',
+      {
+        labels: {
+          actionId: '1',
+          alertId: '2',
+          actionTypeId: 'test',
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+          ruleId: '1',
+          spaceId: 'test1',
+        },
+      }
     );
     expect(defaultSchedulerContext.logger.debug).toHaveBeenCalledWith(
-      'no scheduling of actions "1" for alert "3" from rule "1": has active maintenance windows test-id-3.'
+      'no scheduling of actions "1" for alert "3" from rule "1": has active maintenance windows test-id-3.',
+      {
+        labels: {
+          actionId: '1',
+          alertId: '3',
+          actionTypeId: 'test',
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+          ruleId: '1',
+          spaceId: 'test1',
+        },
+      }
     );
   });
 
@@ -2793,7 +2887,17 @@ describe('Action Scheduler', () => {
       expect(actionsClient.bulkEnqueueExecution).not.toHaveBeenCalled();
       expect(alertingEventLogger.logAction).not.toHaveBeenCalled();
       expect(executorParams.logger.warn).toHaveBeenCalledWith(
-        'Rule "1" skipped scheduling system action "action-id" because no connector adapter is configured'
+        'Rule "1" skipped scheduling system action "action-id" because no connector adapter is configured',
+        {
+          labels: {
+            actionId: 'action-id',
+            actionTypeId: '.connector-adapter-not-exists',
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            ruleId: '1',
+            ruleType: 'test',
+            spaceId: 'test1',
+          },
+        }
       );
     });
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/action_scheduler.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/action_scheduler.ts
@@ -21,7 +21,7 @@ import type {
   RuleAlertData,
 } from '../../../common';
 import { getSummaryActionsFromTaskState } from './lib';
-import { withAlertingSpan } from '../lib';
+import { createTaskRunnerLogger, withAlertingSpan } from '../lib';
 import * as schedulers from './schedulers';
 
 const BULK_SCHEDULE_CHUNK_SIZE = 1000;
@@ -117,6 +117,17 @@ export class ActionScheduler<
     }
 
     const actionsToNotLog: string[] = [];
+    const logger = createTaskRunnerLogger({
+      logger: this.context.logger,
+      labels: {
+        ruleId: this.context.rule.id,
+        ruleType: this.context.rule.alertTypeId,
+        spaceId: this.context.taskInstance.params.spaceId,
+        executionId: this.context.executionId,
+        taskInstanceId: this.context.taskInstance.id,
+      },
+    });
+
     if (bulkScheduleResponse.length) {
       for (const r of bulkScheduleResponse) {
         if (r.response === ExecutionResponseType.QUEUED_ACTIONS_LIMIT_ERROR) {
@@ -130,7 +141,7 @@ export class ActionScheduler<
             status: ActionsCompletion.PARTIAL,
           });
 
-          this.context.logger.debug(
+          logger.debug(
             `Rule "${this.context.rule.id}" skipped scheduling action "${r.id}" because the maximum number of queued actions has been reached.`
           );
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/build_rule_url.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/build_rule_url.test.ts
@@ -135,7 +135,8 @@ describe('buildRuleUrl', () => {
     ).toBeUndefined();
 
     expect(logger.debug).toHaveBeenCalledWith(
-      `Rule "1" encountered an error while constructing the rule.url variable: Invalid URL: foo-url`
+      `Rule "1" encountered an error while constructing the rule.url variable: Invalid URL: foo-url`,
+      { labels: { ruleId: '1' } }
     );
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/build_rule_url.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/build_rule_url.ts
@@ -59,7 +59,13 @@ export const buildRuleUrl = <Params extends RuleTypeParams>(
     };
   } catch (error) {
     opts.logger.debug(
-      `Rule "${opts.rule.id}" encountered an error while constructing the rule.url variable: ${error.message}`
+      `Rule "${opts.rule.id}" encountered an error while constructing the rule.url variable: ${error.message}`,
+      {
+        labels: {
+          ruleType: opts.rule.alertTypeId,
+          ruleId: opts.rule.id,
+        },
+      }
     );
     return;
   }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/rule_action_helper.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/rule_action_helper.test.ts
@@ -358,7 +358,8 @@ describe('rule_action_helper', () => {
         action: mockSummaryAction,
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        '(5) alerts have been filtered out for: slack:111-111'
+        '(5) alerts have been filtered out for: slack:111-111',
+        { labels: { actionId: '1', actionTypeId: 'slack' } }
       );
     });
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/rule_action_helper.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/rule_action_helper.ts
@@ -138,7 +138,13 @@ export const logNumberOfFilteredAlerts = ({
     logger.debug(
       `(${count}) alert${count > 1 ? 's' : ''} ${
         count > 1 ? 'have' : 'has'
-      } been filtered out for: ${action.actionTypeId}:${action.uuid}`
+      } been filtered out for: ${action.actionTypeId}:${action.uuid}`,
+      {
+        labels: {
+          actionId: action.id,
+          actionTypeId: action.actionTypeId,
+        },
+      }
     );
   }
 };

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/should_schedule_action.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/should_schedule_action.test.ts
@@ -51,7 +51,8 @@ describe('shouldScheduleAction', () => {
       status: ActionsCompletion.PARTIAL,
     });
     expect(logger.debug).toHaveBeenCalledWith(
-      `Rule "1" skipped scheduling action "1" because the maximum number of allowed actions has been reached.`
+      `Rule "1" skipped scheduling action "1" because the maximum number of allowed actions has been reached.`,
+      { labels: { actionId: '1', actionTypeId: 'test-action-type-id', ruleId: '1' } }
     );
   });
 
@@ -129,7 +130,14 @@ describe('shouldScheduleAction', () => {
       status: ActionsCompletion.PARTIAL,
     });
     expect(logger.debug).toHaveBeenCalledWith(
-      `Rule "1" skipped scheduling action "1" because the maximum number of allowed actions for connector type test-action-type-id has been reached.`
+      `Rule "1" skipped scheduling action "1" because the maximum number of allowed actions for connector type test-action-type-id has been reached.`,
+      {
+        labels: {
+          actionId: '1',
+          actionTypeId: 'test-action-type-id',
+          ruleId: '1',
+        },
+      }
     );
   });
 
@@ -161,7 +169,13 @@ describe('shouldScheduleAction', () => {
     ).toEqual(false);
 
     expect(logger.warn).toHaveBeenCalledWith(
-      `Rule "1" skipped scheduling action "1" because it is disabled`
+      `Rule "1" skipped scheduling action "1" because it is disabled`,
+      {
+        labels: {
+          actionId: '1',
+          ruleId: '1',
+        },
+      }
     );
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/should_schedule_action.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/lib/should_schedule_action.ts
@@ -36,7 +36,14 @@ export const shouldScheduleAction = (opts: ShouldScheduleActionOpts): boolean =>
       status: ActionsCompletion.PARTIAL,
     });
     logger.debug(
-      `Rule "${opts.ruleId}" skipped scheduling action "${action.id}" because the maximum number of allowed actions has been reached.`
+      `Rule "${opts.ruleId}" skipped scheduling action "${action.id}" because the maximum number of allowed actions has been reached.`,
+      {
+        labels: {
+          actionId: action.id,
+          ruleId: opts.ruleId,
+          actionTypeId: action.actionTypeId,
+        },
+      }
     );
     return false;
   }
@@ -49,7 +56,14 @@ export const shouldScheduleAction = (opts: ShouldScheduleActionOpts): boolean =>
   ) {
     if (!ruleRunMetricsStore.hasConnectorTypeReachedTheLimit(action.actionTypeId)) {
       logger.debug(
-        `Rule "${opts.ruleId}" skipped scheduling action "${action.id}" because the maximum number of allowed actions for connector type ${action.actionTypeId} has been reached.`
+        `Rule "${opts.ruleId}" skipped scheduling action "${action.id}" because the maximum number of allowed actions for connector type ${action.actionTypeId} has been reached.`,
+        {
+          labels: {
+            actionId: action.id,
+            ruleId: opts.ruleId,
+            actionTypeId: action.actionTypeId,
+          },
+        }
       );
     }
     ruleRunMetricsStore.setTriggeredActionsStatusByConnectorType({
@@ -61,7 +75,13 @@ export const shouldScheduleAction = (opts: ShouldScheduleActionOpts): boolean =>
 
   if (!opts.isActionExecutable(action.id, action.actionTypeId, { notifyUsage: true })) {
     logger.warn(
-      `Rule "${opts.ruleId}" skipped scheduling action "${action.id}" because it is disabled`
+      `Rule "${opts.ruleId}" skipped scheduling action "${action.id}" because it is disabled`,
+      {
+        labels: {
+          actionId: action.id,
+          ruleId: opts.ruleId,
+        },
+      }
     );
     return false;
   }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/per_alert_action_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/per_alert_action_scheduler.test.ts
@@ -197,7 +197,16 @@ describe('Per-Alert Action Scheduler', () => {
     expect(scheduler.actions).toEqual([actions[0]]);
     expect(logger.error).toHaveBeenCalledTimes(1);
     expect(logger.error).toHaveBeenCalledWith(
-      `Skipping action \"2\" for rule \"rule-id-1\" because the rule type \"Test\" does not support alert-as-data.`
+      `Skipping action \"2\" for rule \"rule-id-1\" because the rule type \"Test\" does not support alert-as-data.`,
+      {
+        labels: {
+          actionId: '2',
+          actionTypeId: 'test',
+          executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+          ruleId: 'rule-id-1',
+          spaceId: 'test1',
+        },
+      }
     );
   });
 
@@ -332,11 +341,31 @@ describe('Per-Alert Action Scheduler', () => {
       expect(logger.debug).toHaveBeenCalledTimes(2);
       expect(logger.debug).toHaveBeenNthCalledWith(
         1,
-        `no scheduling of actions \"action-1\" for alert \"1\" from rule \"rule-id-1\": has active maintenance windows mw-1.`
+        `no scheduling of actions \"action-1\" for alert \"1\" from rule \"rule-id-1\": has active maintenance windows mw-1.`,
+        {
+          labels: {
+            actionId: 'action-1',
+            actionTypeId: 'test',
+            alertId: '1',
+            ruleId: 'rule-id-1',
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            spaceId: 'test1',
+          },
+        }
       );
       expect(logger.debug).toHaveBeenNthCalledWith(
         2,
-        `no scheduling of actions \"action-2\" for alert \"1\" from rule \"rule-id-1\": has active maintenance windows mw-1.`
+        `no scheduling of actions \"action-2\" for alert \"1\" from rule \"rule-id-1\": has active maintenance windows mw-1.`,
+        {
+          labels: {
+            actionId: 'action-2',
+            actionTypeId: 'test',
+            alertId: '1',
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            ruleId: 'rule-id-1',
+            spaceId: 'test1',
+          },
+        }
       );
 
       expect(ruleRunMetricsStore.getNumberOfGeneratedActions()).toEqual(2);
@@ -371,11 +400,27 @@ describe('Per-Alert Action Scheduler', () => {
       expect(logger.error).toHaveBeenCalledTimes(2);
       expect(logger.error).toHaveBeenNthCalledWith(
         1,
-        `Invalid action group \"invalid\" for rule \"test\".`
+        `Invalid action group \"invalid\" for rule \"test\".`,
+        {
+          labels: {
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            ruleId: 'rule-id-1',
+            ruleType: 'test',
+            spaceId: 'test1',
+          },
+        }
       );
       expect(logger.error).toHaveBeenNthCalledWith(
         2,
-        `Invalid action group \"invalid\" for rule \"test\".`
+        `Invalid action group \"invalid\" for rule \"test\".`,
+        {
+          labels: {
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            ruleId: 'rule-id-1',
+            ruleType: 'test',
+            spaceId: 'test1',
+          },
+        }
       );
 
       expect(ruleRunMetricsStore.getNumberOfGeneratedActions()).toEqual(2);
@@ -514,7 +559,15 @@ describe('Per-Alert Action Scheduler', () => {
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug).toHaveBeenNthCalledWith(
         1,
-        `skipping scheduling of actions for '2' in rule rule-label: rule is muted`
+        `skipping scheduling of actions for '2' in rule rule-label: rule is muted`,
+        {
+          labels: {
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            ruleId: 'rule-id-1',
+            spaceId: 'test1',
+            alertId: '2',
+          },
+        }
       );
 
       expect(ruleRunMetricsStore.getNumberOfGeneratedActions()).toEqual(2);
@@ -575,7 +628,17 @@ describe('Per-Alert Action Scheduler', () => {
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug).toHaveBeenNthCalledWith(
         1,
-        `skipping scheduling of actions for '2' in rule rule-label: alert is active but action group has not changed`
+        `skipping scheduling of actions for '2' in rule rule-label: alert is active but action group has not changed`,
+        {
+          labels: {
+            actionId: 'action-4',
+            actionTypeId: 'test',
+            alertId: '2',
+            spaceId: 'test1',
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            ruleId: 'rule-id-1',
+          },
+        }
       );
 
       expect(ruleRunMetricsStore.getNumberOfGeneratedActions()).toEqual(3);
@@ -632,7 +695,17 @@ describe('Per-Alert Action Scheduler', () => {
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug).toHaveBeenNthCalledWith(
         1,
-        `skipping scheduling of actions for '2' in rule rule-label: rule is throttled`
+        `skipping scheduling of actions for '2' in rule rule-label: rule is throttled`,
+        {
+          labels: {
+            actionId: 'action-5',
+            actionTypeId: 'test',
+            alertId: '2',
+            spaceId: 'test1',
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            ruleId: 'rule-id-1',
+          },
+        }
       );
 
       expect(ruleRunMetricsStore.getNumberOfGeneratedActions()).toEqual(3);
@@ -1107,7 +1180,16 @@ describe('Per-Alert Action Scheduler', () => {
       });
 
       expect(logger.debug).toHaveBeenCalledWith(
-        `Rule "rule-id-1" skipped scheduling action "action-2" because the maximum number of allowed actions has been reached.`
+        `Rule "rule-id-1" skipped scheduling action "action-2" because the maximum number of allowed actions has been reached.`,
+        {
+          labels: {
+            actionId: 'action-2',
+            actionTypeId: 'test',
+            ruleId: 'rule-id-1',
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            spaceId: 'test1',
+          },
+        }
       );
 
       expect(results).toHaveLength(3);
@@ -1145,7 +1227,16 @@ describe('Per-Alert Action Scheduler', () => {
       });
 
       expect(logger.debug).toHaveBeenCalledWith(
-        `Rule "rule-id-1" skipped scheduling action "action-1" because the maximum number of allowed actions for connector type test has been reached.`
+        `Rule "rule-id-1" skipped scheduling action "action-1" because the maximum number of allowed actions for connector type test has been reached.`,
+        {
+          labels: {
+            actionId: 'action-1',
+            actionTypeId: 'test',
+            ruleId: 'rule-id-1',
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            spaceId: 'test1',
+          },
+        }
       );
 
       expect(results).toHaveLength(1);
@@ -1286,7 +1377,16 @@ describe('Per-Alert Action Scheduler', () => {
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug).toHaveBeenNthCalledWith(
         1,
-        `skipping scheduling of actions for '2' in rule rule-label: alert is delayed`
+        `skipping scheduling of actions for '2' in rule rule-label: alert is delayed`,
+        {
+          labels: {
+            alertId: '2',
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            ruleType: 'test',
+            ruleId: 'rule-id-1',
+            spaceId: 'test1',
+          },
+        }
       );
 
       expect(ruleRunMetricsStore.getNumberOfGeneratedActions()).toEqual(2);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/per_alert_action_scheduler.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/per_alert_action_scheduler.ts
@@ -9,6 +9,7 @@ import type { AlertInstanceState, AlertInstanceContext } from '@kbn/alerting-sta
 import type { RuleAction, RuleTypeParams } from '@kbn/alerting-types';
 import { RuleNotifyWhen } from '@kbn/alerting-types';
 import { compact } from 'lodash';
+import { createTaskRunnerLogger } from '../../lib';
 import type { RuleTypeState, RuleAlertData } from '../../../../common';
 import { parseDuration } from '../../../../common';
 import type { GetSummarizedAlertsParams } from '../../../alerts_client/types';
@@ -95,7 +96,18 @@ export class PerAlertActionScheduler<
         .map((action) => {
           if (!canGetSummarizedAlerts && action.alertsFilter) {
             this.context.logger.error(
-              `Skipping action "${action.id}" for rule "${this.context.rule.id}" because the rule type "${this.context.ruleType.name}" does not support alert-as-data.`
+              `Skipping action "${action.id}" for rule "${this.context.rule.id}" because the rule type "${this.context.ruleType.name}" does not support alert-as-data.`,
+              {
+                labels: {
+                  ruleId: this.context.rule.id,
+                  ruleType: this.context.rule.alertTypeId,
+                  spaceId: this.context.taskInstance.params.spaceId,
+                  executionId: this.context.executionId,
+                  taskInstanceId: this.context.taskInstance.id,
+                  actionId: action.id,
+                  actionTypeId: action.actionTypeId,
+                },
+              }
             );
             return null;
           }
@@ -121,6 +133,16 @@ export class PerAlertActionScheduler<
     }> = [];
     const results: ActionsToSchedule[] = [];
 
+    const logger = createTaskRunnerLogger({
+      logger: this.context.logger,
+      labels: {
+        executionId: this.context.executionId,
+        spaceId: this.context.taskInstance.params.spaceId,
+        taskInstanceId: this.context.taskInstance.id,
+        ruleType: this.context.rule.alertTypeId,
+        ruleId: this.context.rule.id,
+      },
+    });
     const activeAlertsArray = Object.values(activeAlerts || {});
     const recoveredAlertsArray = Object.values(recoveredAlerts || {});
 
@@ -149,7 +171,7 @@ export class PerAlertActionScheduler<
         });
 
         logNumberOfFilteredAlerts({
-          logger: this.context.logger,
+          logger,
           numberOfAlerts: activeAlertsArray.length + recoveredAlertsArray.length,
           numberOfSummarizedAlerts: summarizedAlerts.all.count,
           action,
@@ -185,7 +207,7 @@ export class PerAlertActionScheduler<
     const ruleUrl = buildRuleUrl({
       getViewInAppRelativeUrl: this.context.ruleType.getViewInAppRelativeUrl,
       kibanaBaseUrl: this.context.taskRunnerContext.kibanaBaseUrl,
-      logger: this.context.logger,
+      logger,
       rule: this.context.rule,
       spaceId: this.context.taskInstance.params.spaceId,
     });
@@ -202,7 +224,7 @@ export class PerAlertActionScheduler<
           action,
           actionsConfigMap: this.context.taskRunnerContext.actionsConfigMap,
           isActionExecutable: this.context.taskRunnerContext.actionsPlugin.isActionExecutable,
-          logger: this.context.logger,
+          logger,
           ruleId: this.context.rule.id,
           ruleRunMetricsStore: this.context.ruleRunMetricsStore,
         })
@@ -323,8 +345,21 @@ export class PerAlertActionScheduler<
 
     const alertId = alert.getId();
     const {
-      context: { rule, logger, ruleLabel },
+      context: { rule, ruleLabel },
     } = this;
+    const logger = createTaskRunnerLogger({
+      logger: this.context.logger,
+      labels: {
+        alertId,
+        ruleId: rule.id,
+        ruleType: rule.alertTypeId,
+        actionId: action.id,
+        actionTypeId: action.actionTypeId,
+        executionId: this.context.executionId,
+        taskInstanceId: this.context.taskInstance.id,
+        spaceId: this.context.taskInstance.params.spaceId,
+      },
+    });
     const notifyWhen = action.frequency?.notifyWhen || rule.notifyWhen;
 
     if (notifyWhen === 'onActionGroupChange' && !alert.scheduledActionGroupHasChanged()) {
@@ -356,7 +391,17 @@ export class PerAlertActionScheduler<
           (this.skippedAlerts[alertId] && this.skippedAlerts[alertId].reason !== Reasons.THROTTLED)
         ) {
           logger.debug(
-            `skipping scheduling of actions for '${alertId}' in rule ${ruleLabel}: rule is throttled`
+            `skipping scheduling of actions for '${alertId}' in rule ${ruleLabel}: rule is throttled`,
+            {
+              labels: {
+                alertId,
+                ruleId: this.context.rule.id,
+                ruleType: this.context.rule.alertTypeId,
+                spaceId: this.context.taskInstance.params.spaceId,
+                executionId: this.context.executionId,
+                taskInstanceId: this.context.taskInstance.id,
+              },
+            }
           );
         }
         this.skippedAlerts[alertId] = { reason: Reasons.THROTTLED };
@@ -382,7 +427,17 @@ export class PerAlertActionScheduler<
         (this.skippedAlerts[alertId] && this.skippedAlerts[alertId].reason !== Reasons.MUTED)
       ) {
         this.context.logger.debug(
-          `skipping scheduling of actions for '${alertId}' in rule ${this.context.ruleLabel}: rule is muted`
+          `skipping scheduling of actions for '${alertId}' in rule ${this.context.ruleLabel}: rule is muted`,
+          {
+            labels: {
+              alertId,
+              ruleId: this.context.rule.id,
+              ruleType: this.context.rule.alertTypeId,
+              spaceId: this.context.taskInstance.params.spaceId,
+              executionId: this.context.executionId,
+              taskInstanceId: this.context.taskInstance.id,
+            },
+          }
         );
       }
       this.skippedAlerts[alertId] = { reason: Reasons.MUTED };
@@ -401,7 +456,17 @@ export class PerAlertActionScheduler<
         (this.skippedAlerts[alertId] && this.skippedAlerts[alertId].reason !== Reasons.DELAYED)
       ) {
         this.context.logger.debug(
-          `skipping scheduling of actions for '${alertId}' in rule ${this.context.ruleLabel}: alert is delayed`
+          `skipping scheduling of actions for '${alertId}' in rule ${this.context.ruleLabel}: alert is delayed`,
+          {
+            labels: {
+              alertId,
+              ruleId: this.context.rule.id,
+              ruleType: this.context.ruleType.id,
+              spaceId: this.context.taskInstance.params.spaceId,
+              executionId: this.context.executionId,
+              taskInstanceId: this.context.taskInstance.id,
+            },
+          }
         );
       }
       this.skippedAlerts[alertId] = { reason: Reasons.DELAYED };
@@ -413,7 +478,16 @@ export class PerAlertActionScheduler<
   private isValidActionGroup(actionGroup: ActionGroupIds | RecoveryActionGroupId) {
     if (!this.ruleTypeActionGroups!.has(actionGroup)) {
       this.context.logger.error(
-        `Invalid action group "${actionGroup}" for rule "${this.context.ruleType.id}".`
+        `Invalid action group "${actionGroup}" for rule "${this.context.ruleType.id}".`,
+        {
+          labels: {
+            ruleId: this.context.rule.id,
+            ruleType: this.context.ruleType.id,
+            spaceId: this.context.taskInstance.params.spaceId,
+            executionId: this.context.executionId,
+            taskInstanceId: this.context.taskInstance.id,
+          },
+        }
       );
       return false;
     }
@@ -426,10 +500,23 @@ export class PerAlertActionScheduler<
   }: HelperOpts<ActionGroupIds, RecoveryActionGroupId>) {
     const alertMaintenanceWindowIds = alert.getMaintenanceWindowIds();
     if (alertMaintenanceWindowIds.length !== 0) {
+      const alertId = alert.getId();
       this.context.logger.debug(
-        `no scheduling of actions "${action.id}" for alert "${alert.getId()}" from rule "${
+        `no scheduling of actions "${action.id}" for alert "${alertId}" from rule "${
           this.context.rule.id
-        }": has active maintenance windows ${alertMaintenanceWindowIds.join(', ')}.`
+        }": has active maintenance windows ${alertMaintenanceWindowIds.join(', ')}.`,
+        {
+          labels: {
+            alertId,
+            actionId: action.id,
+            actionTypeId: action.actionTypeId,
+            ruleId: this.context.rule.id,
+            ruleType: this.context.rule.alertTypeId,
+            spaceId: this.context.taskInstance.params.spaceId,
+            executionId: this.context.executionId,
+            taskInstanceId: this.context.taskInstance.id,
+          },
+        }
       );
       return true;
     }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/summary_action_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/summary_action_scheduler.test.ts
@@ -169,11 +169,27 @@ describe('Summary Action Scheduler', () => {
     expect(logger.error).toHaveBeenCalledTimes(2);
     expect(logger.error).toHaveBeenNthCalledWith(
       1,
-      `Skipping action \"action-2\" for rule \"rule-id-1\" because the rule type \"Test\" does not support alert-as-data.`
+      `Skipping action \"action-2\" for rule \"rule-id-1\" because the rule type \"Test\" does not support alert-as-data.`,
+      {
+        labels: {
+          actionId: 'action-2',
+          ruleId: 'rule-id-1',
+          ruleType: 'test',
+          spaceId: 'test1',
+        },
+      }
     );
     expect(logger.error).toHaveBeenNthCalledWith(
       2,
-      `Skipping action \"action-3\" for rule \"rule-id-1\" because the rule type \"Test\" does not support alert-as-data.`
+      `Skipping action \"action-3\" for rule \"rule-id-1\" because the rule type \"Test\" does not support alert-as-data.`,
+      {
+        labels: {
+          actionId: 'action-3',
+          ruleId: 'rule-id-1',
+          ruleType: 'test',
+          spaceId: 'test1',
+        },
+      }
     );
   });
 
@@ -526,11 +542,13 @@ describe('Summary Action Scheduler', () => {
       expect(logger.debug).toHaveBeenCalledTimes(2);
       expect(logger.debug).toHaveBeenNthCalledWith(
         1,
-        `(1) alert has been filtered out for: test:222-222`
+        `(1) alert has been filtered out for: test:222-222`,
+        { labels: { actionId: 'action-2', actionTypeId: 'test' } }
       );
       expect(logger.debug).toHaveBeenNthCalledWith(
         2,
-        `(1) alert has been filtered out for: test:333-333`
+        `(1) alert has been filtered out for: test:333-333`,
+        { labels: { actionId: 'action-3', actionTypeId: 'test' } }
       );
 
       expect(ruleRunMetricsStore.getNumberOfGeneratedActions()).toEqual(2);
@@ -586,7 +604,8 @@ describe('Summary Action Scheduler', () => {
       });
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug).toHaveBeenCalledWith(
-        `(2) alerts have been filtered out for: test:333-333`
+        `(2) alerts have been filtered out for: test:333-333`,
+        { labels: { actionId: 'action-3', actionTypeId: 'test' } }
       );
 
       expect(ruleRunMetricsStore.getNumberOfGeneratedActions()).toEqual(1);
@@ -704,7 +723,8 @@ describe('Summary Action Scheduler', () => {
       });
 
       expect(logger.debug).toHaveBeenCalledWith(
-        `Rule "rule-id-1" skipped scheduling action "action-3" because the maximum number of allowed actions has been reached.`
+        `Rule "rule-id-1" skipped scheduling action "action-3" because the maximum number of allowed actions has been reached.`,
+        { labels: { actionId: 'action-3', ruleId: 'rule-id-1', actionTypeId: 'test' } }
       );
 
       expect(results).toHaveLength(1);
@@ -761,7 +781,8 @@ describe('Summary Action Scheduler', () => {
       });
 
       expect(logger.debug).toHaveBeenCalledWith(
-        `Rule "rule-id-1" skipped scheduling action "action-3" because the maximum number of allowed actions for connector type test has been reached.`
+        `Rule "rule-id-1" skipped scheduling action "action-3" because the maximum number of allowed actions for connector type test has been reached.`,
+        { labels: { actionId: 'action-3', actionTypeId: 'test', ruleId: 'rule-id-1' } }
       );
 
       expect(results).toHaveLength(1);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/summary_action_scheduler.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/summary_action_scheduler.ts
@@ -67,7 +67,15 @@ export class SummaryActionScheduler<
         .map((action) => {
           if (!canGetSummarizedAlerts) {
             this.context.logger.error(
-              `Skipping action "${action.id}" for rule "${this.context.rule.id}" because the rule type "${this.context.ruleType.name}" does not support alert-as-data.`
+              `Skipping action "${action.id}" for rule "${this.context.rule.id}" because the rule type "${this.context.ruleType.name}" does not support alert-as-data.`,
+              {
+                labels: {
+                  actionId: action.id,
+                  ruleId: this.context.rule.id,
+                  ruleType: this.context.ruleType.id,
+                  spaceId: this.context.taskInstance.params.spaceId,
+                },
+              }
             );
             return null;
           }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/system_action_scheduler.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/system_action_scheduler.test.ts
@@ -406,7 +406,16 @@ describe('System Action Scheduler', () => {
       });
 
       expect(logger.debug).toHaveBeenCalledWith(
-        `Rule "rule-id-1" skipped scheduling action "system-action-1" because the maximum number of allowed actions has been reached.`
+        `Rule "rule-id-1" skipped scheduling action "system-action-1" because the maximum number of allowed actions has been reached.`,
+        {
+          labels: {
+            actionId: 'system-action-1',
+            actionTypeId: '.test-system-action',
+            ruleId: 'rule-id-1',
+            ruleType: 'test',
+            spaceId: 'test1',
+          },
+        }
       );
 
       expect(results).toHaveLength(1);
@@ -468,7 +477,16 @@ describe('System Action Scheduler', () => {
       });
 
       expect(logger.debug).toHaveBeenCalledWith(
-        `Rule "rule-id-1" skipped scheduling action "system-action-1" because the maximum number of allowed actions for connector type .test-system-action has been reached.`
+        `Rule "rule-id-1" skipped scheduling action "system-action-1" because the maximum number of allowed actions for connector type .test-system-action has been reached.`,
+        {
+          labels: {
+            actionId: 'system-action-1',
+            actionTypeId: '.test-system-action',
+            ruleId: 'rule-id-1',
+            ruleType: 'test',
+            spaceId: 'test1',
+          },
+        }
       );
 
       expect(results).toHaveLength(1);
@@ -512,7 +530,17 @@ describe('System Action Scheduler', () => {
       expect(ruleRunMetricsStore.getNumberOfTriggeredActions()).toEqual(0);
 
       expect(logger.warn).toHaveBeenCalledWith(
-        `Rule "rule-id-1" skipped scheduling system action "different-action-1" because no connector adapter is configured`
+        `Rule "rule-id-1" skipped scheduling system action "different-action-1" because no connector adapter is configured`,
+        {
+          labels: {
+            actionTypeId: '.test-bad-system-action',
+            executionId: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
+            actionId: 'different-action-1',
+            ruleId: 'rule-id-1',
+            ruleType: 'test',
+            spaceId: 'test1',
+          },
+        }
       );
 
       expect(results).toHaveLength(0);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/system_action_scheduler.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/action_scheduler/schedulers/system_action_scheduler.ts
@@ -7,6 +7,7 @@
 
 import type { AlertInstanceState, AlertInstanceContext } from '@kbn/alerting-state-types';
 import type { RuleSystemAction, RuleTypeParams } from '@kbn/alerting-types';
+import { createTaskRunnerLogger } from '../../lib';
 import type { CombinedSummarizedAlerts } from '../../../types';
 import type { RuleTypeState, RuleAlertData } from '../../../../common';
 import type { GetSummarizedAlertsParams } from '../../../alerts_client/types';
@@ -67,6 +68,14 @@ export class SystemActionScheduler<
       summarizedAlerts: CombinedSummarizedAlerts;
     }> = [];
     const results: ActionsToSchedule[] = [];
+    const logger = createTaskRunnerLogger({
+      logger: this.context.logger,
+      labels: {
+        ruleId: this.context.rule.id,
+        ruleType: this.context.ruleType.id,
+        spaceId: this.context.taskInstance.params.spaceId,
+      },
+    });
 
     for (const action of this.actions) {
       const options: GetSummarizedAlertsParams = {
@@ -93,7 +102,7 @@ export class SystemActionScheduler<
     const ruleUrl = buildRuleUrl({
       getViewInAppRelativeUrl: this.context.ruleType.getViewInAppRelativeUrl,
       kibanaBaseUrl: this.context.taskRunnerContext.kibanaBaseUrl,
-      logger: this.context.logger,
+      logger,
       rule: this.context.rule,
       spaceId: this.context.taskInstance.params.spaceId,
     });
@@ -106,7 +115,7 @@ export class SystemActionScheduler<
           action,
           actionsConfigMap: this.context.taskRunnerContext.actionsConfigMap,
           isActionExecutable: this.context.taskRunnerContext.actionsPlugin.isActionExecutable,
-          logger: this.context.logger,
+          logger,
           ruleId: this.context.rule.id,
           ruleRunMetricsStore: this.context.ruleRunMetricsStore,
         })
@@ -120,8 +129,16 @@ export class SystemActionScheduler<
 
       // System actions without an adapter cannot be executed
       if (!hasConnectorAdapter) {
-        this.context.logger.warn(
-          `Rule "${this.context.rule.id}" skipped scheduling system action "${action.id}" because no connector adapter is configured`
+        logger.warn(
+          `Rule "${this.context.rule.id}" skipped scheduling system action "${action.id}" because no connector adapter is configured`,
+          {
+            labels: {
+              actionId: action.id,
+              actionTypeId: action.actionTypeId,
+              ruleId: this.context.rule.id,
+              executionId: this.context.executionId,
+            },
+          }
         );
 
         continue;

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
@@ -584,7 +584,16 @@ describe('Ad Hoc Task Runner', () => {
     expect(logger.debug).toHaveBeenCalledTimes(2);
     expect(logger.debug).nthCalledWith(
       1,
-      `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`
+      `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`,
+      {
+        labels: {
+          spaceId: 'default',
+          executionId: UUID,
+          ruleId: RULE_ID,
+          ruleType: 'test',
+          taskInstanceId: '',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       2,
@@ -858,7 +867,16 @@ describe('Ad Hoc Task Runner', () => {
     expect(logger.debug).toHaveBeenCalledTimes(2);
     expect(logger.debug).nthCalledWith(
       1,
-      `Executing ad hoc run for rule test:rule-id for runAt ${schedule4.runAt}`
+      `Executing ad hoc run for rule test:rule-id for runAt ${schedule4.runAt}`,
+      {
+        labels: {
+          spaceId: 'default',
+          executionId: UUID,
+          ruleId: RULE_ID,
+          ruleType: 'test',
+          taskInstanceId: '',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       2,
@@ -997,7 +1015,16 @@ describe('Ad Hoc Task Runner', () => {
     expect(logger.debug).toHaveBeenCalledTimes(2);
     expect(logger.debug).nthCalledWith(
       1,
-      `Executing ad hoc run for rule test:rule-id for runAt ${schedule5.runAt}`
+      `Executing ad hoc run for rule test:rule-id for runAt ${schedule5.runAt}`,
+      {
+        labels: {
+          spaceId: 'default',
+          executionId: UUID,
+          ruleId: RULE_ID,
+          ruleType: 'test',
+          taskInstanceId: '',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       2,
@@ -1189,7 +1216,14 @@ describe('Ad Hoc Task Runner', () => {
       expect(loggerCallPrefix[0].trim()).toMatchInlineSnapshot(
         `"Executing ad hoc run with id \\"abc\\" has resulted in Error: rule type not enabled"`
       );
-      expect(loggerMeta?.tags).toEqual(['abc', 'rule-ad-hoc-run-failed', 'test', 'rule-id']);
+      expect(loggerMeta?.tags).toEqual(['abc', 'rule-ad-hoc-run-failed']);
+      expect(loggerMeta?.labels).toEqual({
+        executionId: UUID,
+        spaceId: 'default',
+        ruleId: RULE_ID,
+        ruleType: 'test',
+        taskInstanceId: '',
+      });
       expect(loggerMeta?.error?.stack_trace).toBeDefined();
     });
 
@@ -1253,7 +1287,14 @@ describe('Ad Hoc Task Runner', () => {
       expect(loggerCallPrefix[0].trim()).toMatchInlineSnapshot(
         `"Executing ad hoc run with id \\"abc\\" has resulted in Error: params not valid"`
       );
-      expect(loggerMeta?.tags).toEqual(['abc', 'rule-ad-hoc-run-failed', 'test', 'rule-id']);
+      expect(loggerMeta?.tags).toEqual(['abc', 'rule-ad-hoc-run-failed']);
+      expect(loggerMeta?.labels).toEqual({
+        executionId: UUID,
+        spaceId: 'default',
+        ruleId: RULE_ID,
+        ruleType: 'test',
+        taskInstanceId: '',
+      });
       expect(loggerMeta?.error?.stack_trace).toBeDefined();
     });
 
@@ -1319,7 +1360,16 @@ describe('Ad Hoc Task Runner', () => {
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug).nthCalledWith(
         1,
-        `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`
+        `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`,
+        {
+          labels: {
+            spaceId: 'default',
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.error).toHaveBeenCalledTimes(1);
 
@@ -1329,7 +1379,14 @@ describe('Ad Hoc Task Runner', () => {
       expect(loggerCallPrefix[0].trim()).toMatchInlineSnapshot(
         `"Executing ad hoc run with id \\"abc\\" has resulted in Error: executor failed"`
       );
-      expect(loggerMeta?.tags).toEqual(['abc', 'rule-ad-hoc-run-failed', 'test', 'rule-id']);
+      expect(loggerMeta?.tags).toEqual(['abc', 'rule-ad-hoc-run-failed']);
+      expect(loggerMeta?.labels).toEqual({
+        executionId: UUID,
+        spaceId: 'default',
+        ruleId: RULE_ID,
+        ruleType: 'test',
+        taskInstanceId: '',
+      });
       expect(loggerMeta?.error?.stack_trace).toBeDefined();
     });
 
@@ -1403,12 +1460,22 @@ describe('Ad Hoc Task Runner', () => {
       expect(logger.debug).toHaveBeenCalledTimes(1);
       expect(logger.debug).nthCalledWith(
         1,
-        `Executing ad hoc run for rule test:rule-id for runAt ${schedule5.runAt}`
+        `Executing ad hoc run for rule test:rule-id for runAt ${schedule5.runAt}`,
+        {
+          labels: {
+            spaceId: 'default',
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.error).toHaveBeenCalledTimes(1);
       expect(logger.error).nthCalledWith(
         1,
-        `Failed to cleanup ad_hoc_run_params object [id="abc"]: trouble deleting this`
+        `Failed to cleanup ad_hoc_run_params object [id="abc"]: trouble deleting this`,
+        { labels: { executionId: UUID, ruleId: RULE_ID, ruleType: 'test', taskInstanceId: '' } }
       );
     });
   });
@@ -1471,27 +1538,62 @@ describe('Ad Hoc Task Runner', () => {
       expect(logger.debug).toHaveBeenCalledTimes(6);
       expect(logger.debug).nthCalledWith(
         1,
-        `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`
+        `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`,
+        {
+          labels: {
+            spaceId: 'default',
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         2,
-        `Cancelling execution for ad hoc run with id abc for rule type test with id rule-id - execution exceeded rule type timeout of 3m`
+        `Cancelling execution for ad hoc run with id abc for rule type test with id rule-id - execution exceeded rule type timeout of 3m`,
+        { labels: { executionId: UUID, ruleId: RULE_ID, ruleType: 'test', taskInstanceId: '' } }
       );
       expect(logger.debug).nthCalledWith(
         3,
-        `Aborting any in-progress ES searches for rule type test with id rule-id`
+        `Aborting any in-progress ES searches for rule type test with id rule-id`,
+        { labels: { executionId: UUID, ruleId: RULE_ID, ruleType: 'test', taskInstanceId: '' } }
       );
       expect(logger.debug).nthCalledWith(
         4,
-        `skipping persisting alerts for rule test:rule-id: 'test': rule execution has been cancelled.`
+        `skipping persisting alerts for rule test:rule-id: 'test': rule execution has been cancelled.`,
+        {
+          labels: {
+            ruleId: RULE_ID,
+            ruleType: 'siem.queryRule',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         5,
-        `no scheduling of actions for rule test:rule-id: 'test': rule execution has been cancelled.`
+        `no scheduling of actions for rule test:rule-id: 'test': rule execution has been cancelled.`,
+        {
+          labels: {
+            spaceId: 'default',
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         6,
-        `skipping updating alerts for rule test:rule-id: 'test': rule execution has been cancelled.`
+        `skipping updating alerts for rule test:rule-id: 'test': rule execution has been cancelled.`,
+        {
+          labels: {
+            spaceId: 'default',
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.error).not.toHaveBeenCalled();
     });
@@ -1561,27 +1663,76 @@ describe('Ad Hoc Task Runner', () => {
       expect(logger.debug).toHaveBeenCalledTimes(6);
       expect(logger.debug).nthCalledWith(
         1,
-        `Executing ad hoc run for rule test:rule-id for runAt ${schedule2.runAt}`
+        `Executing ad hoc run for rule test:rule-id for runAt ${schedule2.runAt}`,
+        {
+          labels: {
+            spaceId: 'default',
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         2,
-        `Cancelling execution for ad hoc run with id abc for rule type test with id rule-id - execution exceeded rule type timeout of 3m`
+        `Cancelling execution for ad hoc run with id abc for rule type test with id rule-id - execution exceeded rule type timeout of 3m`,
+        {
+          labels: {
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         3,
-        `Aborting any in-progress ES searches for rule type test with id rule-id`
+        `Aborting any in-progress ES searches for rule type test with id rule-id`,
+        {
+          labels: {
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         4,
-        `skipping persisting alerts for rule test:rule-id: 'test': rule execution has been cancelled.`
+        `skipping persisting alerts for rule test:rule-id: 'test': rule execution has been cancelled.`,
+        {
+          labels: {
+            ruleId: RULE_ID,
+            ruleType: 'siem.queryRule',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         5,
-        `no scheduling of actions for rule test:rule-id: 'test': rule execution has been cancelled.`
+        `no scheduling of actions for rule test:rule-id: 'test': rule execution has been cancelled.`,
+        {
+          labels: {
+            spaceId: 'default',
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         6,
-        `skipping updating alerts for rule test:rule-id: 'test': rule execution has been cancelled.`
+        `skipping updating alerts for rule test:rule-id: 'test': rule execution has been cancelled.`,
+        {
+          labels: {
+            spaceId: 'default',
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.error).not.toHaveBeenCalled();
     });
@@ -1650,15 +1801,40 @@ describe('Ad Hoc Task Runner', () => {
       expect(logger.debug).toHaveBeenCalledTimes(3);
       expect(logger.debug).nthCalledWith(
         1,
-        `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`
+        `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`,
+        {
+          labels: {
+            spaceId: 'default',
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         2,
-        `Cancelling execution for ad hoc run with id abc for rule type test with id rule-id - execution exceeded rule type timeout of 3m`
+        `Cancelling execution for ad hoc run with id abc for rule type test with id rule-id - execution exceeded rule type timeout of 3m`,
+        {
+          labels: {
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.debug).nthCalledWith(
         3,
-        `Aborting any in-progress ES searches for rule type test with id rule-id`
+        `Aborting any in-progress ES searches for rule type test with id rule-id`,
+        {
+          labels: {
+            executionId: UUID,
+            ruleId: RULE_ID,
+            ruleType: 'test',
+            taskInstanceId: '',
+          },
+        }
       );
       expect(logger.error).toHaveBeenCalledTimes(1);
 
@@ -1668,7 +1844,14 @@ describe('Ad Hoc Task Runner', () => {
       expect(loggerCallPrefix[0].trim()).toMatchInlineSnapshot(
         `"Executing ad hoc run with id \\"abc\\" has resulted in Error: Search has been aborted due to cancelled execution"`
       );
-      expect(loggerMeta?.tags).toEqual(['abc', 'rule-ad-hoc-run-failed', 'test', 'rule-id']);
+      expect(loggerMeta?.tags).toEqual(['abc', 'rule-ad-hoc-run-failed']);
+      expect(loggerMeta?.labels).toEqual({
+        executionId: UUID,
+        spaceId: 'default',
+        ruleId: RULE_ID,
+        ruleType: 'test',
+        taskInstanceId: '',
+      });
       expect(loggerMeta?.error?.stack_trace).toBeDefined();
     });
   });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
@@ -161,7 +161,15 @@ export class AdHocTaskRunner implements CancellableTask {
         }
       );
     } catch (err) {
-      this.logger.error(`error updating ad hoc run ${adHocRunParamsId} ${err.message}`);
+      this.logger.error(`error updating ad hoc run ${adHocRunParamsId} ${err.message}`, {
+        labels: {
+          spaceId: this.taskInstance.params.spaceId,
+          executionId: this.executionId,
+          ruleId: this.ruleId,
+          ruleType: this.ruleTypeId,
+          taskInstanceId: this.taskInstance.id,
+        },
+      });
     }
   }
 
@@ -302,7 +310,16 @@ export class AdHocTaskRunner implements CancellableTask {
       });
     } else {
       this.logger.debug(
-        `no scheduling of actions for rule ${ruleLabel}: rule execution has been cancelled.`
+        `no scheduling of actions for rule ${ruleLabel}: rule execution has been cancelled.`,
+        {
+          labels: {
+            spaceId: this.taskInstance.params.spaceId,
+            executionId: this.executionId,
+            ruleId: rule.id,
+            ruleType: this.ruleTypeId,
+            taskInstanceId: this.taskInstance.id,
+          },
+        }
       );
     }
 
@@ -313,7 +330,16 @@ export class AdHocTaskRunner implements CancellableTask {
       });
     } else {
       this.logger.debug(
-        `skipping updating alerts for rule ${ruleTypeRunnerContext.ruleLogPrefix}: rule execution has been cancelled.`
+        `skipping updating alerts for rule ${ruleTypeRunnerContext.ruleLogPrefix}: rule execution has been cancelled.`,
+        {
+          labels: {
+            spaceId: this.taskInstance.params.spaceId,
+            executionId: this.executionId,
+            ruleId: rule.id,
+            ruleType: this.ruleTypeId,
+            taskInstanceId: this.taskInstance.id,
+          },
+        }
       );
     }
 
@@ -460,7 +486,16 @@ export class AdHocTaskRunner implements CancellableTask {
         this.logger.debug(
           `Executing ad hoc run for rule ${ruleType.id}:${rule.id} for runAt ${
             this.adHocRunSchedule[this.scheduleToRunIndex].runAt
-          }`
+          }`,
+          {
+            labels: {
+              spaceId,
+              executionId: this.executionId,
+              ruleId: rule.id,
+              ruleType: ruleType.id,
+              taskInstanceId: this.taskInstance.id,
+            },
+          }
         );
         this.adHocRunSchedule[this.scheduleToRunIndex].status = adHocRunStatus.RUNNING;
         this.taskRunning.start(
@@ -505,14 +540,18 @@ export class AdHocTaskRunner implements CancellableTask {
         const message = `Executing ad hoc run with id "${adHocRunParamsId}" has resulted in Error: ${getEsErrorMessage(
           error
         )} - ${stack ?? ''}`;
-        const tags = [adHocRunParamsId, 'rule-ad-hoc-run-failed'];
-        if (this.ruleTypeId.length > 0) {
-          tags.push(this.ruleTypeId);
-        }
-        if (this.ruleId.length > 0) {
-          tags.push(this.ruleId);
-        }
-        this.logger.error(message, { tags, error: { stack_trace: stack } });
+
+        this.logger.error(message, {
+          labels: {
+            spaceId,
+            executionId: this.executionId,
+            ...(this.ruleId.length > 0 && { ruleId: this.ruleId }),
+            ...(this.ruleTypeId.length > 0 && { ruleType: this.ruleTypeId }),
+            taskInstanceId: this.taskInstance.id,
+          },
+          tags: [adHocRunParamsId, 'rule-ad-hoc-run-failed'],
+          error: { stack_trace: stack },
+        });
       }
 
       if (apm.currentTransaction) {
@@ -646,10 +685,26 @@ export class AdHocTaskRunner implements CancellableTask {
     } = this.taskInstance;
 
     this.logger.debug(
-      `Cancelling execution for ad hoc run with id ${adHocRunParamsId} for rule type ${this.ruleTypeId} with id ${this.ruleId} - execution exceeded rule type timeout of ${timeoutOverride}`
+      `Cancelling execution for ad hoc run with id ${adHocRunParamsId} for rule type ${this.ruleTypeId} with id ${this.ruleId} - execution exceeded rule type timeout of ${timeoutOverride}`,
+      {
+        labels: {
+          executionId: this.executionId,
+          ruleId: this.ruleId,
+          ruleType: this.ruleTypeId,
+          taskInstanceId: this.taskInstance.id,
+        },
+      }
     );
     this.logger.debug(
-      `Aborting any in-progress ES searches for rule type ${this.ruleTypeId} with id ${this.ruleId}`
+      `Aborting any in-progress ES searches for rule type ${this.ruleTypeId} with id ${this.ruleId}`,
+      {
+        labels: {
+          executionId: this.executionId,
+          ruleId: this.ruleId,
+          ruleType: this.ruleTypeId,
+          taskInstanceId: this.taskInstance.id,
+        },
+      }
     );
     this.alertingEventLogger.logTimeout({
       backfill: {
@@ -687,7 +742,15 @@ export class AdHocTaskRunner implements CancellableTask {
     } catch (e) {
       // Log error only, we shouldn't fail the task because of an error here (if ever there's retry logic)
       this.logger.error(
-        `Failed to cleanup ${AD_HOC_RUN_SAVED_OBJECT_TYPE} object [id="${this.taskInstance.params.adHocRunParamsId}"]: ${e.message}`
+        `Failed to cleanup ${AD_HOC_RUN_SAVED_OBJECT_TYPE} object [id="${this.taskInstance.params.adHocRunParamsId}"]: ${e.message}`,
+        {
+          labels: {
+            executionId: this.executionId,
+            ruleId: this.ruleId,
+            ruleType: this.ruleTypeId,
+            taskInstanceId: this.taskInstance.id,
+          },
+        }
       );
     }
   }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/get_state.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/get_state.ts
@@ -47,7 +47,7 @@ export function getState({
           err
         )}`;
         logger.debug(message, {
-          tags: [ruleTypeId, ruleId, 'rule-run-failed', errorSourceTag],
+          tags: ['rule-run-failed', errorSourceTag],
         });
       } else {
         const error = stackTraceLog ? stackTraceLog.message : err;
@@ -56,7 +56,7 @@ export function getState({
           error
         )} - ${stack ?? ''}`;
         logger.error(message, {
-          tags: [ruleTypeId, ruleId, 'rule-run-failed', errorSourceTag],
+          tags: ['rule-run-failed', errorSourceTag],
           error: { stack_trace: stack },
         });
       }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/get_task_run_error.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/get_task_run_error.ts
@@ -43,7 +43,7 @@ export function getTaskRunError({
       .join(',');
     const errorMessage = `Executing Rule ${ruleTypeId}:${ruleId} has resulted in the following error(s): ${lasRunErrorMessages}`;
     logger.error(errorMessage, {
-      tags: [ruleTypeId, ruleId, 'rule-run-failed', `${errorSource}-error`],
+      tags: ['rule-run-failed', `${errorSource}-error`],
     });
     return {
       taskRunError: createTaskRunError(new Error(errorMessage), errorSource),

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/task_runner_logger.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/task_runner_logger.test.ts
@@ -75,6 +75,78 @@ describe('createTaskRunnerLogger', () => {
     expect(logger.fatal).toHaveBeenCalledWith('test fatal message', { tags: ['tag-1', 'tag-2'] });
   });
 
+  test('should inject baseline labels into log messages', () => {
+    const logger: ReturnType<typeof loggingSystemMock.createLogger> =
+      loggingSystemMock.createLogger();
+    const taskRunnerLogger = createTaskRunnerLogger({
+      logger,
+      tags: ['tag-1', 'tag-2'],
+      labels: { ruleId: 'rule-1', ruleType: 'my-rule' },
+    });
+
+    taskRunnerLogger.trace('test trace message');
+    taskRunnerLogger.debug('test debug message');
+    taskRunnerLogger.info('test info message');
+    taskRunnerLogger.warn('test warn message');
+    taskRunnerLogger.error('test error message');
+    taskRunnerLogger.fatal('test fatal message');
+
+    const expectedLabels = { ruleId: 'rule-1', ruleType: 'my-rule' };
+    expect(logger.trace).toHaveBeenCalledWith('test trace message', {
+      tags: ['tag-1', 'tag-2'],
+      labels: expectedLabels,
+    });
+    expect(logger.debug).toHaveBeenCalledWith('test debug message', {
+      tags: ['tag-1', 'tag-2'],
+      labels: expectedLabels,
+    });
+    expect(logger.info).toHaveBeenCalledWith('test info message', {
+      tags: ['tag-1', 'tag-2'],
+      labels: expectedLabels,
+    });
+    expect(logger.warn).toHaveBeenCalledWith('test warn message', {
+      tags: ['tag-1', 'tag-2'],
+      labels: expectedLabels,
+    });
+    expect(logger.error).toHaveBeenCalledWith('test error message', {
+      tags: ['tag-1', 'tag-2'],
+      labels: expectedLabels,
+    });
+    expect(logger.fatal).toHaveBeenCalledWith('test fatal message', {
+      tags: ['tag-1', 'tag-2'],
+      labels: expectedLabels,
+    });
+  });
+
+  test('should merge baseline labels with per-call labels', () => {
+    const logger: ReturnType<typeof loggingSystemMock.createLogger> =
+      loggingSystemMock.createLogger();
+    const taskRunnerLogger = createTaskRunnerLogger({
+      logger,
+      tags: ['rule-id', 'rule-type'],
+      labels: { ruleId: 'rule-1', alertId: 'alert-1', spaceId: 'default' },
+    });
+
+    taskRunnerLogger.debug('first logger call', {
+      labels: { taskInstanceId: 'task-1' },
+    });
+    taskRunnerLogger.debug('second logger call', { labels: { alertId: 'another-alert' } });
+
+    expect(logger.debug).toHaveBeenNthCalledWith(1, 'first logger call', {
+      tags: ['rule-id', 'rule-type'],
+      labels: {
+        ruleId: 'rule-1',
+        alertId: 'alert-1',
+        spaceId: 'default',
+        taskInstanceId: 'task-1',
+      },
+    });
+    expect(logger.debug).toHaveBeenNthCalledWith(2, 'second logger call', {
+      tags: ['rule-id', 'rule-type'],
+      labels: { ruleId: 'rule-1', alertId: 'another-alert', spaceId: 'default' },
+    });
+  });
+
   test('should pass through other functions', () => {
     const logger: ReturnType<typeof loggingSystemMock.createLogger> =
       loggingSystemMock.createLogger();

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/task_runner_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/task_runner_logger.ts
@@ -10,7 +10,8 @@ import type { LogLevelId, LogMessageSource, LogRecord } from '@kbn/logging';
 
 interface TaskRunnerLoggerOpts {
   logger: Logger;
-  tags: string[];
+  tags?: string[];
+  labels?: Record<string, unknown>;
 }
 
 export function createTaskRunnerLogger(opts: TaskRunnerLoggerOpts): Logger {
@@ -18,34 +19,66 @@ export function createTaskRunnerLogger(opts: TaskRunnerLoggerOpts): Logger {
 }
 
 class TaskRunnerLogger implements Logger {
-  private loggerMetaTags: string[] = [];
+  private loggerMetaTags: string[] | undefined;
+  private loggerMetaLabels: Record<string, unknown> | undefined;
 
   constructor(private readonly opts: TaskRunnerLoggerOpts) {
     this.loggerMetaTags = opts.tags;
+    this.loggerMetaLabels = opts.labels;
   }
 
   trace<Meta extends LogMeta = LogMeta>(message: LogMessageSource, meta?: Meta) {
-    this.opts.logger.trace(message, { ...meta, tags: this.combineTags(meta?.tags) });
+    const labels = this.combineLabels(meta?.labels);
+    this.opts.logger.trace(message, {
+      ...meta,
+      tags: this.combineTags(meta?.tags),
+      ...(labels && { labels }),
+    });
   }
 
   debug<Meta extends LogMeta = LogMeta>(message: LogMessageSource, meta?: Meta) {
-    this.opts.logger.debug(message, { ...meta, tags: this.combineTags(meta?.tags) });
+    const labels = this.combineLabels(meta?.labels);
+    this.opts.logger.debug(message, {
+      ...meta,
+      tags: this.combineTags(meta?.tags),
+      ...(labels && { labels }),
+    });
   }
 
   info<Meta extends LogMeta = LogMeta>(message: LogMessageSource, meta?: Meta) {
-    this.opts.logger.info(message, { ...meta, tags: this.combineTags(meta?.tags) });
+    const labels = this.combineLabels(meta?.labels);
+    this.opts.logger.info(message, {
+      ...meta,
+      tags: this.combineTags(meta?.tags),
+      ...(labels && { labels }),
+    });
   }
 
   warn<Meta extends LogMeta = LogMeta>(errorOrMessage: LogMessageSource | Error, meta?: Meta) {
-    this.opts.logger.warn(errorOrMessage, { ...meta, tags: this.combineTags(meta?.tags) });
+    const labels = this.combineLabels(meta?.labels);
+    this.opts.logger.warn(errorOrMessage, {
+      ...meta,
+      tags: this.combineTags(meta?.tags),
+      ...(labels && { labels }),
+    });
   }
 
   error<Meta extends LogMeta = LogMeta>(errorOrMessage: LogMessageSource | Error, meta?: Meta) {
-    this.opts.logger.error(errorOrMessage, { ...meta, tags: this.combineTags(meta?.tags) });
+    const labels = this.combineLabels(meta?.labels);
+    this.opts.logger.error(errorOrMessage, {
+      ...meta,
+      tags: this.combineTags(meta?.tags),
+      ...(labels && { labels }),
+    });
   }
 
   fatal<Meta extends LogMeta = LogMeta>(errorOrMessage: LogMessageSource | Error, meta?: Meta) {
-    this.opts.logger.fatal(errorOrMessage, { ...meta, tags: this.combineTags(meta?.tags) });
+    const labels = this.combineLabels(meta?.labels);
+    this.opts.logger.fatal(errorOrMessage, {
+      ...meta,
+      tags: this.combineTags(meta?.tags),
+      ...(labels && { labels }),
+    });
   }
 
   log(record: LogRecord) {
@@ -60,15 +93,22 @@ class TaskRunnerLogger implements Logger {
     return this.opts.logger.get(...childContextPaths);
   }
 
-  private combineTags(tags?: string[] | string): string[] {
+  private combineTags(tags?: string[] | string): string[] | undefined {
     if (!tags) {
       return this.loggerMetaTags;
     }
 
     if (typeof tags === 'string') {
-      return [...new Set([...this.loggerMetaTags, tags])];
+      return [...new Set([...(this.loggerMetaTags || []), tags])];
     }
 
-    return [...new Set([...this.loggerMetaTags, ...tags])];
+    return [...new Set([...(this.loggerMetaTags || []), ...tags])];
+  }
+
+  private combineLabels(labels?: Record<string, unknown>): Record<string, unknown> | undefined {
+    if (!this.loggerMetaLabels) {
+      return labels;
+    }
+    return { ...this.loggerMetaLabels, ...labels };
   }
 }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_loader.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_loader.ts
@@ -167,6 +167,7 @@ export function getFakeKibanaRequest(
       context.logger.warn(
         'UIAM API key is not provided to create a fake request, falling back to regular API key.',
         {
+          labels: { spaceId },
           tags: UIAM_LOGS_USAGE_TAGS,
         }
       );

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_running_handler.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_running_handler.ts
@@ -64,7 +64,8 @@ export class RuleRunningHandler {
         this.runningPromise = undefined;
         this.isUpdating = false;
         this.logger.error(
-          `error updating running attribute rule for ${this.ruleTypeId}:${ruleId} ${err.message}`
+          `error updating running attribute rule for ${this.ruleTypeId}:${ruleId} ${err.message}`,
+          { labels: { ruleId, ruleType: this.ruleTypeId } }
         );
       });
   }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.test.ts
@@ -758,7 +758,13 @@ describe('RuleTypeRunner', () => {
       });
 
       expect(logger.warn).toHaveBeenCalledWith(
-        `rule execution generated greater than 100 alerts: test:1: 'rule-name'`
+        `rule execution generated greater than 100 alerts: test:1: 'rule-name'`,
+        {
+          labels: {
+            ruleId: '1',
+            ruleType: 'test',
+          },
+        }
       );
       expect(ruleRunMetricsStore.setHasReachedAlertLimit).toHaveBeenCalledWith(true);
       expect(state).toEqual({ foo: 'bar' });
@@ -880,7 +886,13 @@ describe('RuleTypeRunner', () => {
       });
 
       expect(logger.warn).toHaveBeenCalledWith(
-        `rule execution generated greater than 100 alerts: test:1: 'rule-name'`
+        `rule execution generated greater than 100 alerts: test:1: 'rule-name'`,
+        {
+          labels: {
+            ruleId: '1',
+            ruleType: 'test',
+          },
+        }
       );
       expect(ruleRunMetricsStore.setHasReachedAlertLimit).toHaveBeenCalledWith(true);
       expect(state).toBeUndefined();

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.ts
@@ -204,7 +204,10 @@ export class RuleTypeRunner<
           const maxAlerts = alertsClient.getMaxAlertLimit();
           if (reachedLimit) {
             context.logger.warn(
-              `rule execution generated greater than ${maxAlerts} alerts: ${context.ruleLogPrefix}`
+              `rule execution generated greater than ${maxAlerts} alerts: ${context.ruleLogPrefix}`,
+              {
+                labels: { ruleId: context.ruleId, ruleType: ruleTypeId },
+              }
             );
             context.ruleRunMetricsStore.setHasReachedAlertLimit(true);
           }
@@ -406,7 +409,10 @@ export class RuleTypeRunner<
           await alertsClient.persistAlerts();
         } else {
           context.logger.debug(
-            `skipping persisting alerts for rule ${context.ruleLogPrefix}: rule execution has been cancelled.`
+            `skipping persisting alerts for rule ${context.ruleLogPrefix}: rule execution has been cancelled.`,
+            {
+              labels: { ruleId: context.ruleId, ruleType: ruleTypeId },
+            }
           );
         }
       })

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -108,6 +108,7 @@ import {
 import { ErrorWithType } from '../lib/error_with_type';
 import { eventLogClientMock } from '@kbn/event-log-plugin/server/mocks';
 
+const RULE_EXECUTION_UUID = '5f6aa57d-3e22-484e-bae8-cbed868f4d28';
 jest.mock('uuid', () => ({
   v4: () => '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
 }));
@@ -319,22 +320,52 @@ describe('Task Runner', () => {
 
     expect(logger.debug).toHaveBeenCalledTimes(5);
     expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-      tags: ['1', 'test'],
+      labels: {
+        executionId: RULE_EXECUTION_UUID,
+        ruleId: '1',
+        ruleType: 'test',
+        spaceId: 'default',
+        taskInstanceId: '1',
+      },
     });
     expect(logger.debug).nthCalledWith(
       2,
       'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"ok"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       3,
       'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":0,"new":0,"recovered":0,"ignored":0}}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       4,
       'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":0,"numberOfGeneratedActions":0,"numberOfActiveAlerts":0,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":0,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     testAlertingEventLogCalls({ status: 'ok' });
@@ -573,27 +604,65 @@ describe('Task Runner', () => {
 
     expect(logger.debug).toHaveBeenCalledTimes(6);
     expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-      tags: ['1', 'test'],
+      labels: {
+        executionId: RULE_EXECUTION_UUID,
+        ruleId: '1',
+        ruleType: 'test',
+        spaceId: 'default',
+        taskInstanceId: '1',
+      },
     });
     expect(logger.debug).nthCalledWith(
       2,
       `rule test:1: '${RULE_NAME}' has 1 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"}]`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       3,
       'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       4,
       'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":1,"new":1,"recovered":0,"ignored":0}}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       5,
       'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":1,"numberOfGeneratedActions":1,"numberOfActiveAlerts":1,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":1,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     testAlertingEventLogCalls({
@@ -662,32 +731,78 @@ describe('Task Runner', () => {
 
     expect(logger.debug).toHaveBeenCalledTimes(7);
     expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-      tags: ['1', 'test'],
+      labels: {
+        executionId: RULE_EXECUTION_UUID,
+        ruleId: '1',
+        ruleType: 'test',
+        spaceId: 'default',
+        taskInstanceId: '1',
+      },
     });
     expect(logger.debug).nthCalledWith(
       2,
       `rule test:1: '${RULE_NAME}' has 1 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"}]`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       3,
       `no scheduling of actions for rule test:1: '${RULE_NAME}': rule is snoozed.`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       4,
       'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       5,
       'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":1,"new":1,"recovered":0,"ignored":0}}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       6,
       'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":0,"numberOfGeneratedActions":0,"numberOfActiveAlerts":1,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":1,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     testAlertingEventLogCalls({
@@ -802,7 +917,15 @@ describe('Task Runner', () => {
       if (expectedExecutions) {
         expect(logger.debug).not.toHaveBeenCalledWith(expectedMessage);
       } else {
-        expect(logger.debug).toHaveBeenCalledWith(expectedMessage, { tags: ['1', 'test'] });
+        expect(logger.debug).toHaveBeenCalledWith(expectedMessage, {
+          labels: {
+            executionId: RULE_EXECUTION_UUID,
+            ruleId: '1',
+            ruleType: 'test',
+            spaceId: 'default',
+            taskInstanceId: '1',
+          },
+        });
       }
     }
   );
@@ -1055,32 +1178,80 @@ describe('Task Runner', () => {
 
     expect(logger.debug).toHaveBeenCalledTimes(7);
     expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-      tags: ['1', 'test'],
+      labels: {
+        executionId: RULE_EXECUTION_UUID,
+        ruleId: '1',
+        ruleType: 'test',
+        spaceId: 'default',
+        taskInstanceId: '1',
+      },
     });
     expect(logger.debug).nthCalledWith(
       2,
       `rule test:1: '${RULE_NAME}' has 2 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"},{\"instanceId\":\"2\",\"actionGroup\":\"default\"}]`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       3,
       `skipping scheduling of actions for '2' in rule test:1: '${RULE_NAME}': rule is muted`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          alertId: '2',
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       4,
       'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       5,
       'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":2,"new":2,"recovered":0,"ignored":0}}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       6,
       'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":1,"numberOfGeneratedActions":1,"numberOfActiveAlerts":2,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":2,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
   });
@@ -1145,7 +1316,18 @@ describe('Task Runner', () => {
     expect(logger.debug).nthCalledWith(
       3,
       `skipping scheduling of actions for '2' in rule test:1: '${RULE_NAME}': rule is throttled`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          actionId: '1',
+          alertId: '2',
+          actionTypeId: 'action',
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
   });
 
@@ -1188,7 +1370,16 @@ describe('Task Runner', () => {
     expect(logger.debug).nthCalledWith(
       3,
       `skipping scheduling of actions for '2' in rule test:1: '${RULE_NAME}': rule is muted`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          alertId: '2',
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
   });
 
@@ -1479,32 +1670,78 @@ describe('Task Runner', () => {
 
     expect(logger.debug).toHaveBeenCalledTimes(7);
     expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-      tags: ['1', 'test'],
+      labels: {
+        executionId: RULE_EXECUTION_UUID,
+        ruleId: '1',
+        ruleType: 'test',
+        spaceId: 'default',
+        taskInstanceId: '1',
+      },
     });
     expect(logger.debug).nthCalledWith(
       2,
       `rule test:1: '${RULE_NAME}' has 1 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"}]`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       3,
       `rule test:1: '${RULE_NAME}' has 1 recovered alerts: [\"2\"]`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       4,
       'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       5,
       'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":1,"new":0,"recovered":1,"ignored":0}}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       6,
       'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":2,"numberOfGeneratedActions":2,"numberOfActiveAlerts":1,"numberOfRecoveredAlerts":1,"numberOfNewAlerts":0,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     testAlertingEventLogCalls({
@@ -1609,28 +1846,68 @@ describe('Task Runner', () => {
 
     expect(logger.debug).toHaveBeenCalledWith(
       `rule test:1: '${RULE_NAME}' has 1 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"}]`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     expect(logger.debug).nthCalledWith(
       3,
       `rule test:1: '${RULE_NAME}' has 1 recovered alerts: [\"2\"]`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       4,
       `deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       5,
       'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":1,"new":0,"recovered":1,"ignored":0}}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       6,
       `ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":2,"numberOfGeneratedActions":2,"numberOfActiveAlerts":1,"numberOfRecoveredAlerts":1,"numberOfNewAlerts":0,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     testAlertingEventLogCalls({
@@ -2002,7 +2279,7 @@ describe('Task Runner', () => {
     expect(loggerCallPrefix[0].trim()).toMatchInlineSnapshot(
       `"Executing Rule default:test:1 has resulted in Error: Response Error"`
     );
-    expect(loggerMeta?.tags).toEqual(['1', 'test', 'rule-run-failed', 'user-error']);
+    expect(loggerMeta?.tags).toEqual(['rule-run-failed', 'user-error']);
   });
 
   test('should set unexpected errors as framework-error', async () => {
@@ -2031,7 +2308,7 @@ describe('Task Runner', () => {
     expect(loggerCallPrefix[0].trim()).toMatchInlineSnapshot(
       `"Executing Rule default:test:1 has resulted in Error: test"`
     );
-    expect(loggerMeta?.tags).toEqual(['1', 'test', 'rule-run-failed', 'framework-error']);
+    expect(loggerMeta?.tags).toEqual(['rule-run-failed', 'framework-error']);
   });
 
   test('recovers gracefully when the RuleType executor throws an exception', async () => {
@@ -2082,7 +2359,7 @@ describe('Task Runner', () => {
     expect(loggerCallPrefix[0].trim()).toMatchInlineSnapshot(
       `"Executing Rule default:test:1 has resulted in Error: GENERIC ERROR MESSAGE"`
     );
-    expect(loggerMeta?.tags).toEqual(['1', 'test', 'rule-run-failed', 'framework-error']);
+    expect(loggerMeta?.tags).toEqual(['rule-run-failed', 'framework-error']);
     expect(loggerMeta?.error?.stack_trace).toBeDefined();
     expect(logger.error).toBeCalledTimes(1);
     expect(getErrorSource(runnerResult.taskRunError as Error)).toBe(TaskErrorSource.FRAMEWORK);
@@ -2222,7 +2499,7 @@ describe('Task Runner', () => {
       expect(logger.warn).nthCalledWith(
         1,
         `Unable to execute rule "1" in the "foo" space because Saved object [alert/1] not found - this rule will not be rescheduled. To restart rule execution, try disabling and re-enabling this rule.`,
-        { tags: ['1', 'test'] }
+        { labels: { ruleId: '1', ruleType: 'test', spaceId: 'foo' } }
       );
       expect(isUnrecoverableError(ex)).toBeTruthy();
       expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
@@ -2307,8 +2584,8 @@ describe('Task Runner', () => {
       expect(logger.warn).toHaveBeenCalledTimes(1);
       expect(logger.warn).nthCalledWith(
         1,
-        `Unable to execute rule "1" in the "test space" space because Saved object [alert/1] not found - this rule will not be rescheduled. To restart rule execution, try disabling and re-enabling this rule.`,
-        { tags: ['1', 'test'] }
+        `Unable to execute rule "1" in the "test-space" space because Saved object [alert/1] not found - this rule will not be rescheduled. To restart rule execution, try disabling and re-enabling this rule.`,
+        { labels: { ruleId: '1', ruleType: 'test', spaceId: 'test-space' } }
       );
       expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
     });
@@ -3030,7 +3307,17 @@ describe('Task Runner', () => {
     expect(logger.debug).nthCalledWith(
       3,
       'Rule "1" skipped scheduling action "4" because the maximum number of allowed actions has been reached.',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          actionId: '4',
+          actionTypeId: 'action',
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     testAlertingEventLogCalls({
@@ -3225,7 +3512,17 @@ describe('Task Runner', () => {
     expect(logger.debug).nthCalledWith(
       3,
       'Rule "1" skipped scheduling action "1" because the maximum number of allowed actions for connector type .server-log has been reached.',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          actionId: '1',
+          actionTypeId: '.server-log',
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     testAlertingEventLogCalls({
@@ -3392,7 +3689,16 @@ describe('Task Runner', () => {
     );
     expect(logger.error).toHaveBeenCalledWith(
       'Executing Rule test:1 has resulted in the following error(s): an error occurred,second error occurred',
-      { tags: ['1', 'test', 'rule-run-failed', 'framework-error'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+        tags: ['rule-run-failed', 'framework-error'],
+      }
     );
   });
 
@@ -3525,7 +3831,14 @@ describe('Task Runner', () => {
     expect(logger.debug).toHaveBeenCalledWith(
       'Executing Rule default:test:1 has resulted in Error: Index is blocked',
       {
-        tags: ['1', 'test', 'rule-run-failed', 'framework-error'],
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+        tags: ['rule-run-failed', 'framework-error'],
       }
     );
   });
@@ -3554,7 +3867,13 @@ describe('Task Runner', () => {
     expect(logger.debug).toHaveBeenCalledWith(
       'ruleRunStatus for test:1: {"outcome":"failed","outcomeOrder":20,"warning":"unknown","outcomeMsg":["GENERIC ERROR MESSAGE"],"alertsCount":{}}',
       {
-        tags: ['1', 'test'],
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
       }
     );
   });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -736,7 +736,16 @@ export class TaskRunner<
       schedule: taskSchedule,
     } = this.taskInstance;
 
-    this.logger = createTaskRunnerLogger({ logger: this.logger, tags: [ruleId, this.ruleType.id] });
+    this.logger = createTaskRunnerLogger({
+      logger: this.logger,
+      labels: {
+        ruleId,
+        ruleType: this.ruleType.id,
+        spaceId,
+        executionId: this.executionId,
+        taskInstanceId: this.taskInstance.id,
+      },
+    });
 
     let runRuleResult: Result<RunRuleResult, Error>;
     let schedule: Result<IntervalSchedule, Error>;

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_alerts_client.test.ts
@@ -116,6 +116,7 @@ import {
 import { rulesSettingsServiceMock } from '../rules_settings/rules_settings_service.mock';
 import { eventLogClientMock } from '@kbn/event-log-plugin/server/mocks';
 
+const RULE_EXECUTION_UUID = '5f6aa57d-3e22-484e-bae8-cbed868f4d28';
 jest.mock('uuid', () => ({
   v4: () => '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
 }));
@@ -130,7 +131,16 @@ jest.mock('../rules_client/lib/get_alert_from_raw');
 const mockGetAlertFromRaw = getAlertFromRaw as jest.MockedFunction<typeof getAlertFromRaw>;
 
 const logger: ReturnType<typeof loggingSystemMock.createLogger> = loggingSystemMock.createLogger();
-const taskRunnerLogger = createTaskRunnerLogger({ logger, tags: ['1', 'test'] });
+const taskRunnerLogger = createTaskRunnerLogger({
+  logger,
+  labels: {
+    ruleId: '1',
+    ruleType: 'test',
+    spaceId: 'default',
+    executionId: RULE_EXECUTION_UUID,
+    taskInstanceId: '1',
+  },
+});
 
 const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
 const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
@@ -380,22 +390,52 @@ describe('Task Runner', () => {
         expect(ruleType.executor).toHaveBeenCalledTimes(1);
         expect(logger.debug).toHaveBeenCalledTimes(5);
         expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-          tags: ['1', 'test'],
+          labels: {
+            executionId: RULE_EXECUTION_UUID,
+            ruleId: '1',
+            ruleType: 'test',
+            spaceId: 'default',
+            taskInstanceId: '1',
+          },
         });
         expect(logger.debug).nthCalledWith(
           2,
           'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"ok"}',
-          { tags: ['1', 'test'] }
+          {
+            labels: {
+              executionId: RULE_EXECUTION_UUID,
+              ruleId: '1',
+              ruleType: 'test',
+              spaceId: 'default',
+              taskInstanceId: '1',
+            },
+          }
         );
         expect(logger.debug).nthCalledWith(
           3,
           'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":0,"new":0,"recovered":0,"ignored":0}}',
-          { tags: ['1', 'test'] }
+          {
+            labels: {
+              executionId: RULE_EXECUTION_UUID,
+              ruleId: '1',
+              ruleType: 'test',
+              spaceId: 'default',
+              taskInstanceId: '1',
+            },
+          }
         );
         expect(logger.debug).nthCalledWith(
           4,
           'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":0,"numberOfGeneratedActions":0,"numberOfActiveAlerts":0,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":0,"hasReachedAlertLimit":false,"triggeredActionsStatus":"complete"}',
-          { tags: ['1', 'test'] }
+          {
+            labels: {
+              executionId: RULE_EXECUTION_UUID,
+              ruleId: '1',
+              ruleType: 'test',
+              spaceId: 'default',
+              taskInstanceId: '1',
+            },
+          }
         );
 
         expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
@@ -500,7 +540,15 @@ describe('Task Runner', () => {
         expect(logger.debug).nthCalledWith(
           debugCall++,
           'executing rule test:1 at 1970-01-01T00:00:00.000Z',
-          { tags: ['1', 'test'] }
+          {
+            labels: {
+              executionId: RULE_EXECUTION_UUID,
+              ruleId: '1',
+              ruleType: 'test',
+              spaceId: 'default',
+              taskInstanceId: '1',
+            },
+          }
         );
         expect(logger.debug).nthCalledWith(debugCall++, `Initializing resources for AlertsService`);
 
@@ -525,17 +573,41 @@ describe('Task Runner', () => {
         expect(logger.debug).nthCalledWith(
           debugCall++,
           'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"ok"}',
-          { tags: ['1', 'test'] }
+          {
+            labels: {
+              executionId: RULE_EXECUTION_UUID,
+              ruleId: '1',
+              ruleType: 'test',
+              spaceId: 'default',
+              taskInstanceId: '1',
+            },
+          }
         );
         expect(logger.debug).nthCalledWith(
           debugCall++,
           'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":0,"new":0,"recovered":0,"ignored":0}}',
-          { tags: ['1', 'test'] }
+          {
+            labels: {
+              executionId: RULE_EXECUTION_UUID,
+              ruleId: '1',
+              ruleType: 'test',
+              spaceId: 'default',
+              taskInstanceId: '1',
+            },
+          }
         );
         expect(logger.debug).nthCalledWith(
           debugCall++,
           'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":0,"numberOfGeneratedActions":0,"numberOfActiveAlerts":0,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":0,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
-          { tags: ['1', 'test'] }
+          {
+            labels: {
+              executionId: RULE_EXECUTION_UUID,
+              ruleId: '1',
+              ruleType: 'test',
+              spaceId: 'default',
+              taskInstanceId: '1',
+            },
+          }
         );
         expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
           ...generateRuleUpdateParams({
@@ -720,7 +792,15 @@ describe('Task Runner', () => {
         expect(mockAlertsService.createAlertsClient).toHaveBeenCalled();
         expect(logger.error).toHaveBeenCalledWith(
           `Error initializing AlertsClient for context test. Using legacy alerts client instead. - Could not initialize!`,
-          { tags: ['1', 'test'] }
+          {
+            labels: {
+              taskInstanceId: '1',
+              executionId: RULE_EXECUTION_UUID,
+              ruleId: '1',
+              ruleType: 'test',
+              spaceId: 'default',
+            },
+          }
         );
         expect(LegacyAlertsClientModule.LegacyAlertsClient).toHaveBeenCalledWith({
           alertingEventLogger,
@@ -740,7 +820,13 @@ describe('Task Runner', () => {
 
         expect(logger.debug).toHaveBeenCalledTimes(5);
         expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-          tags: ['1', 'test'],
+          labels: {
+            taskInstanceId: '1',
+            executionId: RULE_EXECUTION_UUID,
+            ruleId: '1',
+            ruleType: 'test',
+            spaceId: 'default',
+          },
         });
 
         expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
@@ -835,7 +921,13 @@ describe('Task Runner', () => {
 
         expect(logger.debug).toHaveBeenCalledTimes(5);
         expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-          tags: ['1', 'test'],
+          labels: {
+            taskInstanceId: '1',
+            executionId: RULE_EXECUTION_UUID,
+            ruleId: '1',
+            ruleType: 'test',
+            spaceId: 'default',
+          },
         });
 
         expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
@@ -66,6 +66,7 @@ import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-serve
 import { maintenanceWindowsServiceMock } from './maintenance_windows/maintenance_windows_service.mock';
 import { eventLogClientMock } from '@kbn/event-log-plugin/server/mocks';
 
+const RULE_EXECUTION_UUID = '5f6aa57d-3e22-484e-bae8-cbed868f4d28';
 jest.mock('uuid', () => ({
   v4: () => '5f6aa57d-3e22-484e-bae8-cbed868f4d28',
 }));
@@ -222,23 +223,55 @@ describe('Task Runner Cancel', () => {
     expect(logger.debug).toHaveBeenNthCalledWith(
       3,
       `Aborting any in-progress ES searches for rule type test with id 1`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     expect(logger.debug).toHaveBeenNthCalledWith(
       5,
       `skipping persisting alerts for rule test:1: 'rule-name': rule execution has been cancelled.`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).toHaveBeenNthCalledWith(
       6,
       `no scheduling of actions for rule test:1: 'rule-name': rule execution has been cancelled.`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).toHaveBeenNthCalledWith(
       7,
       `skipping updating alerts for rule test:1: 'rule-name': rule execution has been cancelled.`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
 
     testAlertingEventLogCalls({ status: 'ok' });
@@ -482,37 +515,91 @@ describe('Task Runner Cancel', () => {
   function testLogger() {
     expect(logger.debug).toHaveBeenCalledTimes(8);
     expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-      tags: ['1', 'test'],
+      labels: {
+        executionId: RULE_EXECUTION_UUID,
+        ruleId: '1',
+        ruleType: 'test',
+        spaceId: 'default',
+        taskInstanceId: '1',
+      },
     });
     expect(logger.debug).nthCalledWith(
       2,
       `Cancelling rule type test with id 1 - execution exceeded rule type timeout of 5m`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       3,
       'Aborting any in-progress ES searches for rule type test with id 1',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       4,
       `Updating rule task for test rule with id 1 - execution error due to timeout`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       5,
       `rule test:1: 'rule-name' has 1 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"}]`,
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       6,
       'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
     expect(logger.debug).nthCalledWith(
       8,
       'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":1,"numberOfGeneratedActions":1,"numberOfActiveAlerts":1,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":1,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
-      { tags: ['1', 'test'] }
+      {
+        labels: {
+          executionId: RULE_EXECUTION_UUID,
+          ruleId: '1',
+          ruleType: 'test',
+          spaceId: 'default',
+          taskInstanceId: '1',
+        },
+      }
     );
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ResponseOps][Alerting][Actions] add meta labels to alerting and action logs (#282523)](https://github.com/elastic/kibana/pull/282523)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"lu(cia)","email":"lucia.petracca@elastic.co"},"sourceCommit":{"committedDate":"2026-08-17T09:28:39Z","message":"[ResponseOps][Alerting][Actions] add meta labels to alerting and action logs (#282523)\n\nResolves https://github.com/elastic/kibana/issues/271706\n\nChanges to TaskRunnerLogger class:\n- Adds optional `labels` param to to define them at context level\nwithout repeating on every `logger.*` call.\n- Changes the existing `tags` param to optional (was required)\n\nAdd structured meta labels (`labels: { ... }`) to `logger.debug` and\n`logger.error` calls under\n- `actions/server/lib/action_executor.ts`\n- `actions/server/lib/task_runner_factory.ts`\n- `x-pack/platform/plugins/shared/alerting/server/task_runner/**`\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"79ee51784300bb00563abea5f32ebe8f1550410e","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Feature:Actions","Team:ResponseOps","backport missing","backport:all-open","ci:cloud-deploy","v9.6.0"],"title":"[ResponseOps][Alerting][Actions] add meta labels to alerting and action logs","number":282523,"url":"https://github.com/elastic/kibana/pull/282523","mergeCommit":{"message":"[ResponseOps][Alerting][Actions] add meta labels to alerting and action logs (#282523)\n\nResolves https://github.com/elastic/kibana/issues/271706\n\nChanges to TaskRunnerLogger class:\n- Adds optional `labels` param to to define them at context level\nwithout repeating on every `logger.*` call.\n- Changes the existing `tags` param to optional (was required)\n\nAdd structured meta labels (`labels: { ... }`) to `logger.debug` and\n`logger.error` calls under\n- `actions/server/lib/action_executor.ts`\n- `actions/server/lib/task_runner_factory.ts`\n- `x-pack/platform/plugins/shared/alerting/server/task_runner/**`\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"79ee51784300bb00563abea5f32ebe8f1550410e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/282523","number":282523,"mergeCommit":{"message":"[ResponseOps][Alerting][Actions] add meta labels to alerting and action logs (#282523)\n\nResolves https://github.com/elastic/kibana/issues/271706\n\nChanges to TaskRunnerLogger class:\n- Adds optional `labels` param to to define them at context level\nwithout repeating on every `logger.*` call.\n- Changes the existing `tags` param to optional (was required)\n\nAdd structured meta labels (`labels: { ... }`) to `logger.debug` and\n`logger.error` calls under\n- `actions/server/lib/action_executor.ts`\n- `actions/server/lib/task_runner_factory.ts`\n- `x-pack/platform/plugins/shared/alerting/server/task_runner/**`\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"79ee51784300bb00563abea5f32ebe8f1550410e"}}]}] BACKPORT-->