### PR TITLE
[9.4] Revert "Revert "[Fleet] Improve validation for dynamic Kafka topics"" (#285581)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_topics.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_topics.tsx
@@ -38,7 +38,7 @@ export const OutputFormKafkaTopics: React.FunctionComponent<{ inputs: OutputForm
   const dynamicOptions: Array<EuiComboBoxOptionOption<string>> = useMemo(() => {
     const options = KAFKA_DYNAMIC_FIELDS.map((option) => ({
       label: option,
-      value: option,
+      value: `%{[${option}]}`,
     }));
     return options;
   }, []);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.test.tsx
@@ -16,6 +16,10 @@ import {
   validateKafkaHosts,
   validateKibanaURL,
   validateKibanaAPIKey,
+  validateSSLCertificate,
+  validateSSLKey,
+  validateSslPathInput,
+  validateDynamicKafkaTopics,
 } from './output_form_validators';
 
 const validateYamlConfig = createValidateYamlConfig(parse);
@@ -338,6 +342,99 @@ describe('Output form validation', () => {
           message: 'Missing value for key "test3"',
         },
       ]);
+    });
+  });
+
+  describe('SSL certificate validators', () => {
+    describe('validateSSLCertificate', () => {
+      it('should return an error when value is empty', () => {
+        expect(validateSSLCertificate('')).toEqual(['SSL certificate is required']);
+      });
+
+      it('should return an error for a path containing whitespace', () => {
+        expect(validateSSLCertificate('/path/with spaces/cert.pem')).toBeDefined();
+      });
+
+      it('should return undefined for a valid file path', () => {
+        expect(validateSSLCertificate('/etc/ssl/cert.pem')).toBeUndefined();
+      });
+
+      it('should return undefined for inline PEM certificate content', () => {
+        expect(
+          validateSSLCertificate(
+            '-----BEGIN CERTIFICATE-----\nMIIBIjANBg==\n-----END CERTIFICATE-----'
+          )
+        ).toBeUndefined();
+      });
+    });
+
+    describe('validateSSLKey', () => {
+      it('should return an error when value is empty', () => {
+        expect(validateSSLKey('')).toEqual(['SSL key is required']);
+      });
+
+      it('should return an error for a path containing whitespace', () => {
+        expect(validateSSLKey('/path/with spaces/key.pem')).toBeDefined();
+      });
+
+      it('should return undefined for a valid file path', () => {
+        expect(validateSSLKey('/etc/ssl/key.pem')).toBeUndefined();
+      });
+
+      it('should return undefined for inline PEM key content', () => {
+        expect(
+          validateSSLKey(
+            '-----BEGIN RSA PRIVATE KEY-----\nMIIBIjANBg==\n-----END RSA PRIVATE KEY-----'
+          )
+        ).toBeUndefined();
+      });
+    });
+
+    describe('validateSslPathInput', () => {
+      it('should return undefined for an empty string — the field is optional', () => {
+        expect(validateSslPathInput('')).toBeUndefined();
+      });
+
+      it('should return undefined for a valid file path', () => {
+        expect(validateSslPathInput('/etc/ssl/ca.pem')).toBeUndefined();
+      });
+
+      it('should return undefined for inline PEM content', () => {
+        expect(
+          validateSslPathInput(
+            '-----BEGIN CERTIFICATE-----\nMIIBIjANBg==\n-----END CERTIFICATE-----'
+          )
+        ).toBeUndefined();
+      });
+
+      it('should return an error for a path containing whitespace', () => {
+        expect(validateSslPathInput('/path/with spaces/cert.pem')).toBeDefined();
+      });
+    });
+  });
+
+  describe('validateDynamicKafkaTopics', () => {
+    const validTopics = [
+      { label: 'field1', value: '%{[field]}' },
+      { label: 'field2', value: 'field2' },
+      { label: 'field3', value: '%{[field2]}-%{[field3]}' },
+      { label: 'field4', value: '%{[data_stream.type]}-%{[service.common_name]:agent-monitoring}' },
+    ];
+    const invalidBracketTopic = [{ label: '%{[field}', value: '%{[field}' }];
+    const invalidPercentTopic = [{ label: '{[field]}', value: '{[field]}' }];
+    it('should work with valid topics', () => {
+      const res = validateDynamicKafkaTopics(validTopics);
+      expect(res).toBeUndefined();
+    });
+    it("should return error with missing brackets in topic's name", () => {
+      const res = validateDynamicKafkaTopics(invalidBracketTopic);
+      expect(res).toEqual([
+        'The topic should have a matching number of opening and closing brackets',
+      ]);
+    });
+    it("should return error with missing percent sign before opening brackets in topic's name", () => {
+      const res = validateDynamicKafkaTopics(invalidPercentTopic);
+      expect(res).toEqual(['Opening brackets should be preceded by a percent sign']);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
@@ -21,6 +21,16 @@ const toSecretValidator =
     return validator(value ?? '');
   };
 
+const getAllIndices = (str: string, substring: string): number[] => {
+  const indices = [];
+  let index = str.indexOf(substring);
+  while (index !== -1) {
+    indices.push(index);
+    index = str.indexOf(substring, index + 1);
+  }
+  return indices;
+};
+
 export function validateKafkaHosts(value: string[]) {
   const res: Array<{ message: string; index?: number }> = [];
   const urlIndexes: { [key: string]: number[] } = {};
@@ -368,12 +378,33 @@ export function validateKafkaStaticTopic(value: string) {
 export function validateDynamicKafkaTopics(value: Array<EuiComboBoxOptionOption<string>>) {
   const res = [];
   value.forEach((val, idx) => {
-    if (!val) {
+    if (!val || !val.value) {
       res.push(
         i18n.translate('xpack.fleet.settings.outputForm.kafkaTopicFieldRequiredMessage', {
           defaultMessage: 'Topic is required',
         })
       );
+    } else {
+      const topic = val.value;
+      const openingBrackets = getAllIndices(topic, '{[');
+      const closingBracketCount =
+        getAllIndices(topic, ']}').length + getAllIndices(topic, ']:').length;
+      if (openingBrackets.length !== closingBracketCount) {
+        res.push(
+          i18n.translate('xpack.fleet.settings.outputForm.kafkaTopicBracketsError', {
+            defaultMessage:
+              'The topic should have a matching number of opening and closing brackets',
+          })
+        );
+      }
+      // check for preceding percent sign
+      if (!openingBrackets.every((item) => topic[item - 1] === '%')) {
+        res.push(
+          i18n.translate('xpack.fleet.settings.outputForm.kafkaTopicPercentError', {
+            defaultMessage: 'Opening brackets should be preceded by a percent sign',
+          })
+        );
+      }
     }
   });
 
@@ -384,6 +415,7 @@ export function validateDynamicKafkaTopics(value: Array<EuiComboBoxOptionOption<
       })
     );
   }
+
   if (res.length) {
     return res;
   }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.test.tsx
@@ -46,8 +46,8 @@ describe('use_output_form', () => {
 
       expect(res).toEqual([
         {
-          label: 'default.dataset',
-          value: 'default.dataset',
+          label: '%{[default.dataset]}',
+          value: '%{[default.dataset]}',
         },
       ]);
     });
@@ -63,8 +63,8 @@ describe('use_output_form', () => {
 
       expect(res).toEqual([
         {
-          label: '@timestamp',
-          value: '@timestamp',
+          label: '%{[@timestamp]}',
+          value: '%{[@timestamp]}',
         },
       ]);
     });
@@ -80,8 +80,8 @@ describe('use_output_form', () => {
 
       expect(res).toEqual([
         {
-          label: 'something',
-          value: 'something',
+          label: '%{[something]}',
+          value: '%{[something]}',
         },
       ]);
     });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -189,13 +189,10 @@ export function extractDefaultDynamicKafkaTopics(
   if (!o?.topic || (o?.topic && !o.topic?.includes('%{['))) {
     return [];
   }
-  const matched = o.topic.match(/(%\{\[)(\S*)(\]\})/);
-  const parsed = matched?.length ? matched[2] : '';
-
   return [
     {
-      label: parsed,
-      value: parsed,
+      label: o.topic,
+      value: o.topic,
     },
   ];
 }
@@ -1002,7 +999,7 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOutp
                   }
                 : kafkaTopicsInput.value === kafkaTopicsType.Dynamic && kafkaDynamicTopicInput.value
                 ? {
-                    topic: `%{[${kafkaDynamicTopicInput.value}]}`,
+                    topic: kafkaDynamicTopicInput.value,
                   }
                 : {}),
               headers: kafkaHeadersInput.value,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Revert "Revert "[Fleet] Improve validation for dynamic Kafka topics"" (#285581)](https://github.com/elastic/kibana/pull/285581)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jill Guyonnet","email":"jill.guyonnet@elastic.co"},"sourceCommit":{"committedDate":"2026-08-20T08:07:50Z","message":"Revert \"Revert \"[Fleet] Improve validation for dynamic Kafka topics\"\" (#285581)\n\n## Summary\n\nReverts https://github.com/elastic/kibana/pull/219415\n\nThe original fix in https://github.com/elastic/kibana/pull/212422:\n* Removed the hardcoded wrapping of free-text topic entries\n* Added validation for malformed `%{[...]}` bracket pairs\n* Kept auto-wrapping only for items selected from the dropdown (not free\ntext)\n\nThis allows users to enter multi-format-string patterns like\n`%{[data_stream.type]}-%{[service.common_name]:agent-monitoring}`\ndirectly in the Dynamic Topic field.\n\nIt was reverted in https://github.com/elastic/kibana/pull/219415 because\nexposing Beats `%{[]}` syntax harms OTel migration. This concern is now\n[moot](https://github.com/elastic/kibana/issues/206194#issuecomment-5062392746).\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow. The [original fix](https://github.com/elastic/kibana/pull/212422)\nwas already merged and running in production for ~8 weeks before being\nreverted. The change is confined to the Kafka output flyout: it removes\nthe unconditional `%{[…]} `wrapping of free-text topic entries and\nreplaces it with bracket-pair validation, while preserving auto-wrapping\nfor preset dropdown selections. All existing tests pass and no other\noutput types are touched. The only behavioral change users will notice\nis that a topic string entered as free text is no longer silently\nmangled: malformed entries are now rejected with a clear validation\nerror instead.\n\n## Release note\n\nFixes a bug in Fleet where entering a multi-field format string (e.g.\n`%{[data_stream.type]}-%{[data_stream.namespace]}`) in the Kafka output\nDynamic Topic field would produce a double-wrapped, invalid topic\nexpression; the field now accepts the full format string directly and\nvalidates bracket syntax.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c34fbb804e6745e43500001b33be98c753da0247","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.6.0","Team:streams-ui","v9.4.6","v9.5.2"],"title":"Revert \"Revert \"[Fleet] Improve validation for dynamic Kafka topics\"\"","number":285581,"url":"https://github.com/elastic/kibana/pull/285581","mergeCommit":{"message":"Revert \"Revert \"[Fleet] Improve validation for dynamic Kafka topics\"\" (#285581)\n\n## Summary\n\nReverts https://github.com/elastic/kibana/pull/219415\n\nThe original fix in https://github.com/elastic/kibana/pull/212422:\n* Removed the hardcoded wrapping of free-text topic entries\n* Added validation for malformed `%{[...]}` bracket pairs\n* Kept auto-wrapping only for items selected from the dropdown (not free\ntext)\n\nThis allows users to enter multi-format-string patterns like\n`%{[data_stream.type]}-%{[service.common_name]:agent-monitoring}`\ndirectly in the Dynamic Topic field.\n\nIt was reverted in https://github.com/elastic/kibana/pull/219415 because\nexposing Beats `%{[]}` syntax harms OTel migration. This concern is now\n[moot](https://github.com/elastic/kibana/issues/206194#issuecomment-5062392746).\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow. The [original fix](https://github.com/elastic/kibana/pull/212422)\nwas already merged and running in production for ~8 weeks before being\nreverted. The change is confined to the Kafka output flyout: it removes\nthe unconditional `%{[…]} `wrapping of free-text topic entries and\nreplaces it with bracket-pair validation, while preserving auto-wrapping\nfor preset dropdown selections. All existing tests pass and no other\noutput types are touched. The only behavioral change users will notice\nis that a topic string entered as free text is no longer silently\nmangled: malformed entries are now rejected with a clear validation\nerror instead.\n\n## Release note\n\nFixes a bug in Fleet where entering a multi-field format string (e.g.\n`%{[data_stream.type]}-%{[data_stream.namespace]}`) in the Kafka output\nDynamic Topic field would produce a double-wrapped, invalid topic\nexpression; the field now accepts the full format string directly and\nvalidates bracket syntax.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c34fbb804e6745e43500001b33be98c753da0247"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/285581","number":285581,"mergeCommit":{"message":"Revert \"Revert \"[Fleet] Improve validation for dynamic Kafka topics\"\" (#285581)\n\n## Summary\n\nReverts https://github.com/elastic/kibana/pull/219415\n\nThe original fix in https://github.com/elastic/kibana/pull/212422:\n* Removed the hardcoded wrapping of free-text topic entries\n* Added validation for malformed `%{[...]}` bracket pairs\n* Kept auto-wrapping only for items selected from the dropdown (not free\ntext)\n\nThis allows users to enter multi-format-string patterns like\n`%{[data_stream.type]}-%{[service.common_name]:agent-monitoring}`\ndirectly in the Dynamic Topic field.\n\nIt was reverted in https://github.com/elastic/kibana/pull/219415 because\nexposing Beats `%{[]}` syntax harms OTel migration. This concern is now\n[moot](https://github.com/elastic/kibana/issues/206194#issuecomment-5062392746).\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow. The [original fix](https://github.com/elastic/kibana/pull/212422)\nwas already merged and running in production for ~8 weeks before being\nreverted. The change is confined to the Kafka output flyout: it removes\nthe unconditional `%{[…]} `wrapping of free-text topic entries and\nreplaces it with bracket-pair validation, while preserving auto-wrapping\nfor preset dropdown selections. All existing tests pass and no other\noutput types are touched. The only behavioral change users will notice\nis that a topic string entered as free text is no longer silently\nmangled: malformed entries are now rejected with a clear validation\nerror instead.\n\n## Release note\n\nFixes a bug in Fleet where entering a multi-field format string (e.g.\n`%{[data_stream.type]}-%{[data_stream.namespace]}`) in the Kafka output\nDynamic Topic field would produce a double-wrapped, invalid topic\nexpression; the field now accepts the full format string directly and\nvalidates bracket syntax.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c34fbb804e6745e43500001b33be98c753da0247"}},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/286238","number":286238,"state":"MERGED","mergeCommit":{"sha":"344cc26c1b2a3f23323a98bef547acbddf06304e","message":"[9.5] Revert \"Revert \"[Fleet] Improve validation for dynamic Kafka topics\"\" (#285581) (#286238)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [Revert \"Revert \"[Fleet] Improve validation for dynamic Kafka topics\"\"\n(#285581)](https://github.com/elastic/kibana/pull/285581)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jill Guyonnet <jill.guyonnet@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->