### PR TITLE
[Prototype] Integrations add-flow vision — reference implementation (components built to graduate)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/index.tsx
@@ -22,6 +22,7 @@ import { Policy } from './screens/policy';
 import { CreateIntegration } from './screens/create';
 import { CustomLanguagesOverview } from './screens/detail/custom_languages_overview';
 import { CollectionDetailPage } from './screens/collection';
+import { IntegrationsVisionPage } from './screens/integrations_vision';
 
 export const EPMApp: React.FunctionComponent = () => {
   const { automaticImport } = useStartServices();
@@ -31,6 +32,9 @@ export const EPMApp: React.FunctionComponent = () => {
 
   return (
     <Routes>
+      <Route path={INTEGRATIONS_ROUTING_PATHS.integrations_vision}>
+        <IntegrationsVisionPage />
+      </Route>
       <Route path={INTEGRATIONS_ROUTING_PATHS.add_integration_to_policy}>
         <CreatePackagePolicyPage />
       </Route>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/add_integration_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/add_integration_modal.tsx
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiCard,
+  EuiEmptyPrompt,
+  EuiFieldSearch,
+  EuiFlexGrid,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiListGroup,
+  EuiListGroupItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiNotificationBadge,
+  EuiSpacer,
+  EuiTabs,
+  EuiTab,
+  EuiText,
+} from '@elastic/eui';
+
+import {
+  VISION_CATEGORIES,
+  VISION_INTEGRATIONS,
+  getInstalledIntegrations,
+  type VisionIntegration,
+} from './integrations_data';
+
+type View = 'browse' | 'installed';
+
+// The single, reusable "browse & add integrations" experience — designed to
+// be opened from any entry point (the global "Add data" action, the
+// integrations catalog page, etc.) so the experience itself stays portable
+// and consistent no matter where it's launched from. This is a first,
+// intentionally small skeleton: just enough structure (search, category
+// browsing, installed view) to validate the shape of the idea before going
+// further. Built with EUI components/patterns only.
+export const AddIntegrationModal: React.FunctionComponent<{ onClose: () => void }> = ({
+  onClose,
+}) => {
+  const [view, setView] = useState<View>('browse');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeCategoryId, setActiveCategoryId] = useState<string>('all');
+
+  const installedIntegrations = useMemo(() => getInstalledIntegrations(), []);
+
+  const visibleIntegrations = useMemo(() => {
+    const source = view === 'installed' ? installedIntegrations : VISION_INTEGRATIONS;
+    return source.filter((integration) => {
+      const matchesCategory =
+        view === 'installed' ||
+        activeCategoryId === 'all' ||
+        integration.categoryIds.includes(activeCategoryId);
+      const matchesQuery =
+        searchQuery.trim().length === 0 ||
+        integration.name.toLowerCase().includes(searchQuery.trim().toLowerCase());
+      return matchesCategory && matchesQuery;
+    });
+  }, [view, activeCategoryId, searchQuery, installedIntegrations]);
+
+  return (
+    <EuiModal
+      onClose={onClose}
+      aria-label="Add integrations"
+      data-test-subj="addIntegrationVisionModal"
+      style={{ width: 900, maxWidth: '90vw' }}
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>Add integrations</EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiFieldSearch
+          fullWidth
+          placeholder="Search integrations"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          isClearable
+          aria-label="Search integrations"
+          data-test-subj="addIntegrationVisionSearch"
+        />
+        <EuiSpacer size="m" />
+
+        <EuiFlexGroup gutterSize="l" alignItems="flexStart">
+          <EuiFlexItem grow={false} style={{ width: 200 }}>
+            <EuiListGroup>
+              <EuiListGroupItem
+                label="Browse catalog"
+                isActive={view === 'browse'}
+                onClick={() => setView('browse')}
+                data-test-subj="addIntegrationVisionNavBrowse"
+              />
+              <EuiListGroupItem
+                label={
+                  <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                    <EuiFlexItem grow={false}>Installed</EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiNotificationBadge color="subdued">
+                        {installedIntegrations.length}
+                      </EuiNotificationBadge>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                }
+                isActive={view === 'installed'}
+                onClick={() => setView('installed')}
+                data-test-subj="addIntegrationVisionNavInstalled"
+              />
+            </EuiListGroup>
+          </EuiFlexItem>
+
+          <EuiFlexItem style={{ minWidth: 0 }}>
+            {view === 'browse' && (
+              <>
+                <EuiTabs size="s">
+                  <EuiTab
+                    isSelected={activeCategoryId === 'all'}
+                    onClick={() => setActiveCategoryId('all')}
+                  >
+                    All
+                  </EuiTab>
+                  {VISION_CATEGORIES.map((category) => (
+                    <EuiTab
+                      key={category.id}
+                      isSelected={activeCategoryId === category.id}
+                      onClick={() => setActiveCategoryId(category.id)}
+                    >
+                      {category.label}
+                    </EuiTab>
+                  ))}
+                </EuiTabs>
+                <EuiSpacer size="m" />
+              </>
+            )}
+
+            {visibleIntegrations.length === 0 ? (
+              <EuiEmptyPrompt
+                iconType="magnify"
+                title={<h3>No integrations found</h3>}
+                body={<p>Try a different search term{view === 'browse' ? ' or category' : ''}.</p>}
+              />
+            ) : (
+              <EuiFlexGrid columns={3} gutterSize="m">
+                {visibleIntegrations.map((integration) => (
+                  <EuiFlexItem key={integration.id}>
+                    <IntegrationCard integration={integration} />
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGrid>
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalBody>
+    </EuiModal>
+  );
+};
+
+const IntegrationCard: React.FunctionComponent<{ integration: VisionIntegration }> = ({
+  integration,
+}) => {
+  return (
+    <EuiCard
+      layout="vertical"
+      textAlign="left"
+      icon={<EuiIcon type={integration.iconType} size="xl" aria-hidden="true" />}
+      title={integration.name}
+      description={integration.description}
+      titleSize="xs"
+      data-test-subj={`addIntegrationVisionCard-${integration.id}`}
+      footer={
+        integration.isInstalled ? (
+          <EuiBadge color="success" iconType="check">
+            Installed
+          </EuiBadge>
+        ) : (
+          <EuiButton size="s" iconType="plus" data-test-subj="addIntegrationVisionAddButton">
+            Add
+          </EuiButton>
+        )
+      }
+    />
+  );
+};
+
+// Standalone summary shown next to each demo entry point on the skeleton
+// page below, so it's obvious both triggers open the exact same component.
+export const AddIntegrationModalPortabilityNote: React.FunctionComponent = () => (
+  <EuiText size="s" color="subdued">
+    <p>
+      Both entry points below open this exact same modal component — the browsing experience itself
+      is portable and doesn&apos;t belong to either page.
+    </p>
+  </EuiText>
+);
+
+export const HorizontalRuleSpacer: React.FunctionComponent = () => (
+  <>
+    <EuiSpacer size="l" />
+    <EuiHorizontalRule margin="none" />
+    <EuiSpacer size="l" />
+  </>
+);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/add_integration_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/add_integration_modal.tsx
@@ -30,7 +30,6 @@ import {
   EuiTab,
   EuiTabs,
   EuiText,
-  EuiTitle,
   EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
@@ -47,7 +46,7 @@ const MAX_SIDEBAR_CATEGORIES = 9;
 type SidebarView = 'browse' | 'installed' | 'for_you';
 type ContentTab = 'all' | 'integration' | 'content' | 'connectors' | 'policies';
 
-const CARD_HEIGHT = 92;
+const CARD_HEIGHT = 112;
 
 const ComingSoon: React.FunctionComponent<{ title: string }> = ({ title }) => (
   <EuiEmptyPrompt
@@ -101,11 +100,18 @@ const IntegrationCard: React.FunctionComponent<{ item: PackageListItem }> = ({ i
           </div>
         </EuiFlexItem>
         <EuiFlexItem style={{ minWidth: 0, height: '100%' }}>
-          <EuiFlexGroup direction="column" gutterSize="xs" style={{ height: '100%' }}>
+          <EuiFlexGroup direction="column" gutterSize="s" style={{ height: '100%' }}>
             <EuiFlexItem grow={false} style={{ minWidth: 0 }}>
-              <EuiTitle size="xxs">
-                <h3 className="eui-textTruncate">{item.title}</h3>
-              </EuiTitle>
+              <EuiText
+                size="s"
+                className="eui-textTruncate"
+                style={{ fontWeight: euiTheme.font.weight.semiBold }}
+              >
+                {item.title}
+              </EuiText>
+              <EuiText size="xs" color="subdued" className="eui-textTruncate">
+                Description
+              </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={true} style={{ minWidth: 0, justifyContent: 'flex-end' }}>
               <EuiFlexGroup gutterSize="xs" wrap responsive={false} style={{ overflow: 'hidden' }}>
@@ -139,12 +145,15 @@ const IntegrationCard: React.FunctionComponent<{ item: PackageListItem }> = ({ i
 // vision doc) — search, a left rail (Browse all / Installed / For you +
 // live categories), a secondary content-type tab row, and a scrollable
 // card grid backed by the real EPR catalog (useGetPackagesQuery) and real
-// package icons (CardIcon). Descriptions are intentionally omitted for now
-// per design feedback; only "Browse all" / "All" are wired up — the other
-// nav items are present but inert until a later pass.
+// package icons (CardIcon). Real descriptions aren't wired up yet, so
+// cards show a subdued "Description" placeholder for now. Only
+// "Browse all/Installed" + "All/Integrations/Content packages" are
+// functionally wired — "For you", "Connectors", and "Policies" are
+// present but inert until a later pass.
 export const AddIntegrationModal: React.FunctionComponent<{ onClose: () => void }> = ({
   onClose,
 }) => {
+  const { euiTheme } = useEuiTheme();
   const [sidebarView, setSidebarView] = useState<SidebarView>('browse');
   const [contentTab, setContentTab] = useState<ContentTab>('all');
   const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
@@ -194,8 +203,8 @@ export const AddIntegrationModal: React.FunctionComponent<{ onClose: () => void 
       onClose={onClose}
       aria-label="Sources"
       data-test-subj="addIntegrationVisionModal"
-      maxWidth={1200}
-      style={{ width: 1200, height: 720 }}
+      maxWidth={1400}
+      style={{ width: 'min(1400px, 92vw)', height: '75vh' }}
     >
       <EuiModalHeader>
         <EuiFlexGroup direction="column" gutterSize="xs">
@@ -205,7 +214,11 @@ export const AddIntegrationModal: React.FunctionComponent<{ onClose: () => void 
                 <EuiModalHeaderTitle>Sources</EuiModalHeaderTitle>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiBadge color="hollow" iconType="pencil" iconSide="right">
+                <EuiBadge
+                  color={euiTheme.colors.backgroundLightPrimary}
+                  iconType="pencil"
+                  iconSide="right"
+                >
                   OTel-Native
                 </EuiBadge>
               </EuiFlexItem>
@@ -316,51 +329,45 @@ export const AddIntegrationModal: React.FunctionComponent<{ onClose: () => void 
               />
             </EuiListGroup>
 
-            {sidebarView === 'browse' && (
-              <>
-                <EuiSpacer size="m" />
-                <EuiHorizontalRule margin="none" />
-                <EuiSpacer size="m" />
-                <EuiText size="xs" color="subdued">
-                  <strong>CATEGORIES</strong>
-                </EuiText>
-                <EuiSpacer size="s" />
-                <EuiListGroup data-test-subj="addIntegrationVisionCategories">
-                  {sidebarCategories.map((category) => (
-                    <EuiListGroupItem
-                      key={category.id}
-                      label={
-                        <EuiFlexGroup
-                          gutterSize="s"
-                          alignItems="center"
-                          justifyContent="spaceBetween"
-                          responsive={false}
-                        >
-                          <EuiFlexItem grow={false} className="eui-textTruncate">
-                            {category.title}
-                          </EuiFlexItem>
-                          <EuiFlexItem grow={false}>
-                            <EuiNotificationBadge color="subdued">
-                              {category.count}
-                            </EuiNotificationBadge>
-                          </EuiFlexItem>
-                        </EuiFlexGroup>
-                      }
-                      isActive={activeCategoryId === category.id}
-                      onClick={() =>
-                        setActiveCategoryId((current) =>
-                          current === category.id ? null : category.id
-                        )
-                      }
-                    />
-                  ))}
-                </EuiListGroup>
-              </>
-            )}
+            <EuiSpacer size="m" />
+            <EuiHorizontalRule margin="none" />
+            <EuiSpacer size="m" />
+            <EuiText size="xs" color="subdued">
+              <strong>CATEGORIES</strong>
+            </EuiText>
+            <EuiSpacer size="s" />
+            <EuiListGroup data-test-subj="addIntegrationVisionCategories">
+              {sidebarCategories.map((category) => (
+                <EuiListGroupItem
+                  key={category.id}
+                  label={
+                    <EuiFlexGroup
+                      gutterSize="s"
+                      alignItems="center"
+                      justifyContent="spaceBetween"
+                      responsive={false}
+                    >
+                      <EuiFlexItem grow={false} className="eui-textTruncate">
+                        {category.title}
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiNotificationBadge color="subdued">
+                          {category.count}
+                        </EuiNotificationBadge>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  isActive={activeCategoryId === category.id}
+                  onClick={() =>
+                    setActiveCategoryId((current) => (current === category.id ? null : category.id))
+                  }
+                />
+              ))}
+            </EuiListGroup>
           </EuiFlexItem>
 
           <EuiFlexItem style={{ minWidth: 0, display: 'flex', flexDirection: 'column' }}>
-            <EuiTabs size="s" data-test-subj="addIntegrationVisionTabs">
+            <EuiTabs data-test-subj="addIntegrationVisionTabs">
               <EuiTab isSelected={contentTab === 'all'} onClick={() => setContentTab('all')}>
                 All
               </EuiTab>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/add_integration_modal.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/add_integration_modal.tsx
@@ -8,8 +8,8 @@
 import React, { useMemo, useState } from 'react';
 import {
   EuiBadge,
-  EuiButton,
-  EuiCard,
+  EuiButtonEmpty,
+  EuiButtonIcon,
   EuiEmptyPrompt,
   EuiFieldSearch,
   EuiFlexGrid,
@@ -17,195 +17,418 @@ import {
   EuiFlexItem,
   EuiHorizontalRule,
   EuiIcon,
+  EuiIconTip,
   EuiListGroup,
   EuiListGroupItem,
+  EuiLoadingSpinner,
   EuiModal,
   EuiModalBody,
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiNotificationBadge,
   EuiSpacer,
-  EuiTabs,
   EuiTab,
+  EuiTabs,
   EuiText,
+  EuiTitle,
+  EuiToolTip,
+  useEuiTheme,
 } from '@elastic/eui';
 
-import {
-  VISION_CATEGORIES,
-  VISION_INTEGRATIONS,
-  getInstalledIntegrations,
-  type VisionIntegration,
-} from './integrations_data';
+import { CardIcon } from '../../../../../../components/package_icon';
+import { useGetCategoriesQuery, useGetPackagesQuery } from '../../../../hooks';
+import type { PackageListItem } from '../../../../../../types';
 
-type View = 'browse' | 'installed';
+// Real EPR category ids don't map 1:1 onto the reference design's sidebar
+// (which lists a handful of illustrative groupings), so the sidebar shows
+// whatever categories the live catalog actually returns, sorted by size.
+const MAX_SIDEBAR_CATEGORIES = 9;
 
-// The single, reusable "browse & add integrations" experience — designed to
-// be opened from any entry point (the global "Add data" action, the
-// integrations catalog page, etc.) so the experience itself stays portable
-// and consistent no matter where it's launched from. This is a first,
-// intentionally small skeleton: just enough structure (search, category
-// browsing, installed view) to validate the shape of the idea before going
-// further. Built with EUI components/patterns only.
+type SidebarView = 'browse' | 'installed' | 'for_you';
+type ContentTab = 'all' | 'integration' | 'content' | 'connectors' | 'policies';
+
+const CARD_HEIGHT = 92;
+
+const ComingSoon: React.FunctionComponent<{ title: string }> = ({ title }) => (
+  <EuiEmptyPrompt
+    iconType="clock"
+    titleSize="s"
+    title={<h3>{title}</h3>}
+    body={<p>Not built yet — coming in a later pass of this prototype.</p>}
+  />
+);
+
+const IntegrationCard: React.FunctionComponent<{ item: PackageListItem }> = ({ item }) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <div
+      style={{
+        height: CARD_HEIGHT,
+        padding: euiTheme.size.m,
+        border: euiTheme.border.thin,
+        borderRadius: euiTheme.border.radius.medium,
+        background: euiTheme.colors.emptyShade,
+      }}
+      data-test-subj={`addIntegrationVisionCard-${item.id}`}
+    >
+      <EuiFlexGroup
+        gutterSize="s"
+        alignItems="flexStart"
+        responsive={false}
+        style={{ height: '100%' }}
+      >
+        <EuiFlexItem grow={false}>
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+              background: euiTheme.colors.backgroundBaseSubdued,
+              border: euiTheme.border.thin,
+              borderRadius: euiTheme.border.radius.medium,
+            }}
+          >
+            <CardIcon
+              icons={item.icons}
+              packageName={item.name}
+              integrationName={item.integration}
+              version={item.version}
+              size="l"
+            />
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem style={{ minWidth: 0, height: '100%' }}>
+          <EuiFlexGroup direction="column" gutterSize="xs" style={{ height: '100%' }}>
+            <EuiFlexItem grow={false} style={{ minWidth: 0 }}>
+              <EuiTitle size="xxs">
+                <h3 className="eui-textTruncate">{item.title}</h3>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={true} style={{ minWidth: 0, justifyContent: 'flex-end' }}>
+              <EuiFlexGroup gutterSize="xs" wrap responsive={false} style={{ overflow: 'hidden' }}>
+                {(item.categories ?? []).slice(0, 2).map((category) => (
+                  <EuiFlexItem grow={false} key={category}>
+                    <EuiBadge color="hollow">{category}</EuiBadge>
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiToolTip content={`Add ${item.title}`} disableScreenReaderOutput>
+            <EuiButtonIcon
+              display="base"
+              color="text"
+              iconType="plus"
+              size="m"
+              aria-label={`Add ${item.title}`}
+              data-test-subj="addIntegrationVisionAddButton"
+            />
+          </EuiToolTip>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  );
+};
+
+// The redesigned, pixel-matched "Add integrations" modal (per the Figma
+// vision doc) — search, a left rail (Browse all / Installed / For you +
+// live categories), a secondary content-type tab row, and a scrollable
+// card grid backed by the real EPR catalog (useGetPackagesQuery) and real
+// package icons (CardIcon). Descriptions are intentionally omitted for now
+// per design feedback; only "Browse all" / "All" are wired up — the other
+// nav items are present but inert until a later pass.
 export const AddIntegrationModal: React.FunctionComponent<{ onClose: () => void }> = ({
   onClose,
 }) => {
-  const [view, setView] = useState<View>('browse');
+  const [sidebarView, setSidebarView] = useState<SidebarView>('browse');
+  const [contentTab, setContentTab] = useState<ContentTab>('all');
+  const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [activeCategoryId, setActiveCategoryId] = useState<string>('all');
 
-  const installedIntegrations = useMemo(() => getInstalledIntegrations(), []);
+  const { data: packagesData, isLoading: isLoadingPackages } = useGetPackagesQuery({
+    prerelease: false,
+  });
+  const { data: categoriesData } = useGetCategoriesQuery({});
 
-  const visibleIntegrations = useMemo(() => {
-    const source = view === 'installed' ? installedIntegrations : VISION_INTEGRATIONS;
-    return source.filter((integration) => {
+  const allPackages = useMemo(() => packagesData?.items ?? [], [packagesData]);
+  const installedPackages = useMemo(
+    () => allPackages.filter((pkg) => pkg.status === 'installed'),
+    [allPackages]
+  );
+
+  const sidebarCategories = useMemo(
+    () =>
+      (categoriesData?.items ?? [])
+        .filter((category) => !category.parent_id)
+        .sort((a, b) => b.count - a.count)
+        .slice(0, MAX_SIDEBAR_CATEGORIES),
+    [categoriesData]
+  );
+
+  const visiblePackages = useMemo(() => {
+    const source = sidebarView === 'installed' ? installedPackages : allPackages;
+    return source.filter((pkg) => {
+      const matchesTab =
+        contentTab === 'all' ||
+        (contentTab === 'integration' && pkg.type === 'integration') ||
+        (contentTab === 'content' && pkg.type === 'content');
       const matchesCategory =
-        view === 'installed' ||
-        activeCategoryId === 'all' ||
-        integration.categoryIds.includes(activeCategoryId);
+        !activeCategoryId || ((pkg.categories ?? []) as string[]).includes(activeCategoryId);
       const matchesQuery =
         searchQuery.trim().length === 0 ||
-        integration.name.toLowerCase().includes(searchQuery.trim().toLowerCase());
-      return matchesCategory && matchesQuery;
+        pkg.title.toLowerCase().includes(searchQuery.trim().toLowerCase());
+      return matchesTab && matchesCategory && matchesQuery;
     });
-  }, [view, activeCategoryId, searchQuery, installedIntegrations]);
+  }, [sidebarView, allPackages, installedPackages, contentTab, activeCategoryId, searchQuery]);
+
+  const isPlaceholderTab = contentTab === 'connectors' || contentTab === 'policies';
+  const isPlaceholderSidebarView = sidebarView === 'for_you';
 
   return (
     <EuiModal
       onClose={onClose}
-      aria-label="Add integrations"
+      aria-label="Sources"
       data-test-subj="addIntegrationVisionModal"
-      style={{ width: 900, maxWidth: '90vw' }}
+      maxWidth={1200}
+      style={{ width: 1200, height: 720 }}
     >
       <EuiModalHeader>
-        <EuiModalHeaderTitle>Add integrations</EuiModalHeaderTitle>
+        <EuiFlexGroup direction="column" gutterSize="xs">
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiModalHeaderTitle>Sources</EuiModalHeaderTitle>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="hollow" iconType="pencil" iconSide="right">
+                  OTel-Native
+                </EuiBadge>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s" color="subdued">
+              <p>Connect your systems and get full visibility into logs, metrics, and traces.</p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiModalHeader>
-      <EuiModalBody>
+
+      <EuiModalBody style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
         <EuiFieldSearch
           fullWidth
-          placeholder="Search integrations"
+          placeholder="Search integrations, content packages, etc."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           isClearable
-          aria-label="Search integrations"
+          aria-label="Search integrations, content packages, etc."
           data-test-subj="addIntegrationVisionSearch"
         />
+        <EuiSpacer size="s" />
+
+        {/* Sort/filter controls are visual-only for now — wiring them up is
+            deferred to a later pass, per design feedback. */}
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty size="xs" iconType="chevronSingleDown" iconSide="right" color="text">
+              Sort fields
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              {['Filter', 'Filter', 'Filter'].map((label, i) => (
+                <EuiFlexItem grow={false} key={i}>
+                  <EuiButtonEmpty
+                    size="xs"
+                    iconType="chevronSingleDown"
+                    iconSide="right"
+                    color="text"
+                  >
+                    {label}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              ))}
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
         <EuiSpacer size="m" />
 
-        <EuiFlexGroup gutterSize="l" alignItems="flexStart">
-          <EuiFlexItem grow={false} style={{ width: 200 }}>
-            <EuiListGroup>
-              <EuiListGroupItem
-                label="Browse catalog"
-                isActive={view === 'browse'}
-                onClick={() => setView('browse')}
-                data-test-subj="addIntegrationVisionNavBrowse"
-              />
+        <EuiFlexGroup gutterSize="l" style={{ flex: 1, minHeight: 0 }}>
+          <EuiFlexItem grow={false} style={{ width: 220 }}>
+            <EuiListGroup data-test-subj="addIntegrationVisionSidebarNav">
               <EuiListGroupItem
                 label={
-                  <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-                    <EuiFlexItem grow={false}>Installed</EuiFlexItem>
+                  <EuiFlexGroup
+                    gutterSize="s"
+                    alignItems="center"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <EuiFlexItem grow={false}>Browse all</EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiNotificationBadge color="subdued">
-                        {installedIntegrations.length}
+                        {allPackages.length}
                       </EuiNotificationBadge>
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 }
-                isActive={view === 'installed'}
-                onClick={() => setView('installed')}
+                isActive={sidebarView === 'browse'}
+                onClick={() => setSidebarView('browse')}
+                data-test-subj="addIntegrationVisionNavBrowse"
+              />
+              <EuiListGroupItem
+                label={
+                  <EuiFlexGroup
+                    gutterSize="s"
+                    alignItems="center"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <EuiFlexItem grow={false}>Installed</EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiNotificationBadge color="subdued">
+                        {installedPackages.length}
+                      </EuiNotificationBadge>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                }
+                isActive={sidebarView === 'installed'}
+                onClick={() => setSidebarView('installed')}
                 data-test-subj="addIntegrationVisionNavInstalled"
               />
+              <EuiListGroupItem
+                label={
+                  <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                    <EuiFlexItem grow={false}>For you</EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon type="sparkles" size="s" color="accent" aria-hidden="true" />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                }
+                isActive={sidebarView === 'for_you'}
+                onClick={() => setSidebarView('for_you')}
+                data-test-subj="addIntegrationVisionNavForYou"
+              />
             </EuiListGroup>
-          </EuiFlexItem>
 
-          <EuiFlexItem style={{ minWidth: 0 }}>
-            {view === 'browse' && (
+            {sidebarView === 'browse' && (
               <>
-                <EuiTabs size="s">
-                  <EuiTab
-                    isSelected={activeCategoryId === 'all'}
-                    onClick={() => setActiveCategoryId('all')}
-                  >
-                    All
-                  </EuiTab>
-                  {VISION_CATEGORIES.map((category) => (
-                    <EuiTab
-                      key={category.id}
-                      isSelected={activeCategoryId === category.id}
-                      onClick={() => setActiveCategoryId(category.id)}
-                    >
-                      {category.label}
-                    </EuiTab>
-                  ))}
-                </EuiTabs>
                 <EuiSpacer size="m" />
+                <EuiHorizontalRule margin="none" />
+                <EuiSpacer size="m" />
+                <EuiText size="xs" color="subdued">
+                  <strong>CATEGORIES</strong>
+                </EuiText>
+                <EuiSpacer size="s" />
+                <EuiListGroup data-test-subj="addIntegrationVisionCategories">
+                  {sidebarCategories.map((category) => (
+                    <EuiListGroupItem
+                      key={category.id}
+                      label={
+                        <EuiFlexGroup
+                          gutterSize="s"
+                          alignItems="center"
+                          justifyContent="spaceBetween"
+                          responsive={false}
+                        >
+                          <EuiFlexItem grow={false} className="eui-textTruncate">
+                            {category.title}
+                          </EuiFlexItem>
+                          <EuiFlexItem grow={false}>
+                            <EuiNotificationBadge color="subdued">
+                              {category.count}
+                            </EuiNotificationBadge>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      }
+                      isActive={activeCategoryId === category.id}
+                      onClick={() =>
+                        setActiveCategoryId((current) =>
+                          current === category.id ? null : category.id
+                        )
+                      }
+                    />
+                  ))}
+                </EuiListGroup>
               </>
             )}
+          </EuiFlexItem>
 
-            {visibleIntegrations.length === 0 ? (
-              <EuiEmptyPrompt
-                iconType="magnify"
-                title={<h3>No integrations found</h3>}
-                body={<p>Try a different search term{view === 'browse' ? ' or category' : ''}.</p>}
-              />
-            ) : (
-              <EuiFlexGrid columns={3} gutterSize="m">
-                {visibleIntegrations.map((integration) => (
-                  <EuiFlexItem key={integration.id}>
-                    <IntegrationCard integration={integration} />
+          <EuiFlexItem style={{ minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+            <EuiTabs size="s" data-test-subj="addIntegrationVisionTabs">
+              <EuiTab isSelected={contentTab === 'all'} onClick={() => setContentTab('all')}>
+                All
+              </EuiTab>
+              <EuiTab
+                isSelected={contentTab === 'integration'}
+                onClick={() => setContentTab('integration')}
+              >
+                Integrations
+              </EuiTab>
+              <EuiTab
+                isSelected={contentTab === 'content'}
+                onClick={() => setContentTab('content')}
+              >
+                Content packages
+              </EuiTab>
+              <EuiTab
+                isSelected={contentTab === 'connectors'}
+                onClick={() => setContentTab('connectors')}
+              >
+                Connectors
+              </EuiTab>
+              <EuiTab
+                isSelected={contentTab === 'policies'}
+                onClick={() => setContentTab('policies')}
+              >
+                <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                  <EuiFlexItem grow={false}>Policies</EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiIconTip content="Existing agent and package policies." position="right" />
                   </EuiFlexItem>
-                ))}
-              </EuiFlexGrid>
-            )}
+                </EuiFlexGroup>
+              </EuiTab>
+            </EuiTabs>
+            <EuiSpacer size="m" />
+
+            <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+              {isPlaceholderSidebarView ? (
+                <ComingSoon title="For you" />
+              ) : isPlaceholderTab ? (
+                <ComingSoon title={contentTab === 'connectors' ? 'Connectors' : 'Policies'} />
+              ) : isLoadingPackages ? (
+                <EuiFlexGroup
+                  justifyContent="center"
+                  alignItems="center"
+                  style={{ height: '100%' }}
+                >
+                  <EuiLoadingSpinner size="xl" />
+                </EuiFlexGroup>
+              ) : visiblePackages.length === 0 ? (
+                <EuiEmptyPrompt
+                  iconType="magnify"
+                  titleSize="s"
+                  title={<h3>No integrations found</h3>}
+                  body={<p>Try a different search term or category.</p>}
+                />
+              ) : (
+                <EuiFlexGrid columns={2} gutterSize="s" data-test-subj="addIntegrationVisionGrid">
+                  {visiblePackages.map((pkg) => (
+                    <EuiFlexItem key={pkg.id}>
+                      <IntegrationCard item={pkg} />
+                    </EuiFlexItem>
+                  ))}
+                </EuiFlexGrid>
+              )}
+            </div>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiModalBody>
     </EuiModal>
   );
 };
-
-const IntegrationCard: React.FunctionComponent<{ integration: VisionIntegration }> = ({
-  integration,
-}) => {
-  return (
-    <EuiCard
-      layout="vertical"
-      textAlign="left"
-      icon={<EuiIcon type={integration.iconType} size="xl" aria-hidden="true" />}
-      title={integration.name}
-      description={integration.description}
-      titleSize="xs"
-      data-test-subj={`addIntegrationVisionCard-${integration.id}`}
-      footer={
-        integration.isInstalled ? (
-          <EuiBadge color="success" iconType="check">
-            Installed
-          </EuiBadge>
-        ) : (
-          <EuiButton size="s" iconType="plus" data-test-subj="addIntegrationVisionAddButton">
-            Add
-          </EuiButton>
-        )
-      }
-    />
-  );
-};
-
-// Standalone summary shown next to each demo entry point on the skeleton
-// page below, so it's obvious both triggers open the exact same component.
-export const AddIntegrationModalPortabilityNote: React.FunctionComponent = () => (
-  <EuiText size="s" color="subdued">
-    <p>
-      Both entry points below open this exact same modal component — the browsing experience itself
-      is portable and doesn&apos;t belong to either page.
-    </p>
-  </EuiText>
-);
-
-export const HorizontalRuleSpacer: React.FunctionComponent = () => (
-  <>
-    <EuiSpacer size="l" />
-    <EuiHorizontalRule margin="none" />
-    <EuiSpacer size="l" />
-  </>
-);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/index.tsx
@@ -6,113 +6,36 @@
  */
 
 import React, { useState } from 'react';
-import {
-  EuiButton,
-  EuiButtonIcon,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiIcon,
-  EuiPanel,
-  EuiSpacer,
-  EuiText,
-  EuiTitle,
-  EuiToolTip,
-} from '@elastic/eui';
-import { KbnInfoCallout } from '@kbn/ui-callout';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 
-import { AddIntegrationModal, AddIntegrationModalPortabilityNote } from './add_integration_modal';
+import { AddIntegrationModal } from './add_integration_modal';
 
-// Design-prototype-only page. Completely separate from the AWS onboarding
-// wizard prototype — this one is exploring a different, longer-term
-// question: instead of a full page per entry point, can "adding an
-// integration" be a single portable modal opened from wherever the user
-// already is? Two entry points are mocked up below (the global "Add data"
-// nav action, and the integrations catalog page), both opening the exact
-// same modal component to prove the experience is entry-point-agnostic.
+// Design-prototype-only page, separate from the AWS onboarding wizard
+// prototype. Just enough scaffolding to open the real deliverable — the
+// "Add data" button below opens the pixel-matched Sources modal.
 export const IntegrationsVisionPage: React.FunctionComponent = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
-    <div style={{ maxWidth: 960, margin: '0 auto', padding: 24 }}>
-      <KbnInfoCallout
-        title="Design prototype — not a real feature"
-        text={
-          <p>
-            This page mocks up two places a user might start adding an integration from. Both
-            buttons below open the same modal — the point of this skeleton is to test whether a
-            single, portable browsing experience can replace separate pages per entry point.
-          </p>
-        }
-        data-test-subj="integrationsVisionDisclaimer"
-      />
+    <div style={{ maxWidth: 1200, margin: '0 auto', padding: 24 }}>
+      <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="l">
+            <h1>Integrations</h1>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            fill
+            iconType="plusCircle"
+            onClick={() => setIsModalOpen(true)}
+            data-test-subj="addDataButton"
+          >
+            Add data
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
       <EuiSpacer size="l" />
-
-      <EuiTitle size="l">
-        <h1>Integrations — long-term add flow (vision)</h1>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <AddIntegrationModalPortabilityNote />
-      <EuiSpacer size="xl" />
-
-      {/* Entry point 1 — mocked global nav "Add data" action */}
-      <EuiTitle size="xs">
-        <h2>Entry point 1: global nav</h2>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiPanel hasBorder paddingSize="s" style={{ maxWidth: 480 }}>
-        <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <EuiIcon type="logoElastic" size="l" aria-hidden="true" />
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size="s" color="subdued">
-              Project navigation (mocked)
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiToolTip content="Add data" disableScreenReaderOutput>
-              <EuiButtonIcon
-                display="fill"
-                iconType="plusCircle"
-                size="m"
-                aria-label="Add data"
-                onClick={() => setIsModalOpen(true)}
-                data-test-subj="addDataNavButton"
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
-
-      <EuiSpacer size="xl" />
-      <EuiHorizontalRule margin="none" />
-      <EuiSpacer size="xl" />
-
-      {/* Entry point 2 — mocked integrations catalog page header */}
-      <EuiTitle size="xs">
-        <h2>Entry point 2: integrations catalog page</h2>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiPanel hasBorder paddingSize="m" style={{ maxWidth: 480 }}>
-        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
-              <h3>Integrations</h3>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              fill
-              iconType="plusCircle"
-              onClick={() => setIsModalOpen(true)}
-              data-test-subj="browseCatalogButton"
-            >
-              Browse integrations
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
 
       {isModalOpen && <AddIntegrationModal onClose={() => setIsModalOpen(false)} />}
     </div>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/index.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  EuiToolTip,
+} from '@elastic/eui';
+import { KbnInfoCallout } from '@kbn/ui-callout';
+
+import { AddIntegrationModal, AddIntegrationModalPortabilityNote } from './add_integration_modal';
+
+// Design-prototype-only page. Completely separate from the AWS onboarding
+// wizard prototype — this one is exploring a different, longer-term
+// question: instead of a full page per entry point, can "adding an
+// integration" be a single portable modal opened from wherever the user
+// already is? Two entry points are mocked up below (the global "Add data"
+// nav action, and the integrations catalog page), both opening the exact
+// same modal component to prove the experience is entry-point-agnostic.
+export const IntegrationsVisionPage: React.FunctionComponent = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <div style={{ maxWidth: 960, margin: '0 auto', padding: 24 }}>
+      <KbnInfoCallout
+        title="Design prototype — not a real feature"
+        text={
+          <p>
+            This page mocks up two places a user might start adding an integration from. Both
+            buttons below open the same modal — the point of this skeleton is to test whether a
+            single, portable browsing experience can replace separate pages per entry point.
+          </p>
+        }
+        data-test-subj="integrationsVisionDisclaimer"
+      />
+      <EuiSpacer size="l" />
+
+      <EuiTitle size="l">
+        <h1>Integrations — long-term add flow (vision)</h1>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <AddIntegrationModalPortabilityNote />
+      <EuiSpacer size="xl" />
+
+      {/* Entry point 1 — mocked global nav "Add data" action */}
+      <EuiTitle size="xs">
+        <h2>Entry point 1: global nav</h2>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiPanel hasBorder paddingSize="s" style={{ maxWidth: 480 }}>
+        <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="logoElastic" size="l" aria-hidden="true" />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s" color="subdued">
+              Project navigation (mocked)
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content="Add data" disableScreenReaderOutput>
+              <EuiButtonIcon
+                display="fill"
+                iconType="plusCircle"
+                size="m"
+                aria-label="Add data"
+                onClick={() => setIsModalOpen(true)}
+                data-test-subj="addDataNavButton"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+
+      <EuiSpacer size="xl" />
+      <EuiHorizontalRule margin="none" />
+      <EuiSpacer size="xl" />
+
+      {/* Entry point 2 — mocked integrations catalog page header */}
+      <EuiTitle size="xs">
+        <h2>Entry point 2: integrations catalog page</h2>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiPanel hasBorder paddingSize="m" style={{ maxWidth: 480 }}>
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h3>Integrations</h3>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill
+              iconType="plusCircle"
+              onClick={() => setIsModalOpen(true)}
+              data-test-subj="browseCatalogButton"
+            >
+              Browse integrations
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+
+      {isModalOpen && <AddIntegrationModal onClose={() => setIsModalOpen(false)} />}
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/integrations_data.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/integrations_vision/integrations_data.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Design-prototype-only mock data — a small, representative slice of the
+// real integrations catalog, just enough to demonstrate the browsing
+// experience (categorization, search, install state) without wiring up
+// the actual package registry.
+
+export interface VisionIntegration {
+  id: string;
+  name: string;
+  description: string;
+  iconType: string;
+  categoryIds: string[];
+  isInstalled?: boolean;
+}
+
+export interface VisionCategory {
+  id: string;
+  label: string;
+}
+
+export const VISION_CATEGORIES: VisionCategory[] = [
+  { id: 'cloud', label: 'Cloud' },
+  { id: 'infrastructure', label: 'Infrastructure' },
+  { id: 'observability', label: 'Observability' },
+  { id: 'security', label: 'Security' },
+  { id: 'application', label: 'Application' },
+  { id: 'custom', label: 'Custom' },
+];
+
+export const VISION_INTEGRATIONS: VisionIntegration[] = [
+  {
+    id: 'aws',
+    name: 'AWS',
+    description: 'Collect logs and metrics from Amazon Web Services.',
+    iconType: 'logoAWS',
+    categoryIds: ['cloud', 'infrastructure'],
+    isInstalled: true,
+  },
+  {
+    id: 'gcp',
+    name: 'Google Cloud Platform',
+    description: 'Collect logs and metrics from GCP services.',
+    iconType: 'logoGCP',
+    categoryIds: ['cloud', 'infrastructure'],
+  },
+  {
+    id: 'azure',
+    name: 'Microsoft Azure',
+    description: 'Collect logs and metrics from Azure services.',
+    iconType: 'logoAzure',
+    categoryIds: ['cloud', 'infrastructure'],
+  },
+  {
+    id: 'kubernetes',
+    name: 'Kubernetes',
+    description: 'Monitor Kubernetes clusters, pods, and workloads.',
+    iconType: 'logoKubernetes',
+    categoryIds: ['infrastructure', 'observability'],
+    isInstalled: true,
+  },
+  {
+    id: 'docker',
+    name: 'Docker',
+    description: 'Collect container logs and performance metrics.',
+    iconType: 'logoDocker',
+    categoryIds: ['infrastructure'],
+  },
+  {
+    id: 'nginx',
+    name: 'Nginx',
+    description: 'Collect access, error, and status logs from Nginx.',
+    iconType: 'logoNginx',
+    categoryIds: ['application', 'infrastructure'],
+  },
+  {
+    id: 'apache',
+    name: 'Apache',
+    description: 'Collect access and error logs from Apache HTTP Server.',
+    iconType: 'logoApache',
+    categoryIds: ['application', 'infrastructure'],
+  },
+  {
+    id: 'mysql',
+    name: 'MySQL',
+    description: 'Collect error, slow, and general logs from MySQL.',
+    iconType: 'logoMySQL',
+    categoryIds: ['application'],
+  },
+  {
+    id: 'postgresql',
+    name: 'PostgreSQL',
+    description: 'Collect logs and query performance metrics from PostgreSQL.',
+    iconType: 'logoPostgres',
+    categoryIds: ['application'],
+  },
+  {
+    id: 'redis',
+    name: 'Redis',
+    description: 'Collect logs and metrics from Redis instances.',
+    iconType: 'logoRedis',
+    categoryIds: ['application'],
+  },
+  {
+    id: 'apm',
+    name: 'Elastic APM',
+    description: 'Collect distributed traces from your applications.',
+    iconType: 'apmApp',
+    categoryIds: ['observability', 'application'],
+    isInstalled: true,
+  },
+  {
+    id: 'synthetics',
+    name: 'Elastic Synthetics',
+    description: 'Monitor uptime and user journeys from the outside in.',
+    iconType: 'uptimeApp',
+    categoryIds: ['observability'],
+  },
+  {
+    id: 'okta',
+    name: 'Okta',
+    description: 'Collect authentication and audit logs from Okta.',
+    iconType: 'lock',
+    categoryIds: ['security'],
+  },
+  {
+    id: 'crowdstrike',
+    name: 'CrowdStrike',
+    description: 'Ingest endpoint detection and response data.',
+    iconType: 'securityApp',
+    categoryIds: ['security'],
+  },
+  {
+    id: 'custom_logs',
+    name: 'Custom Logs',
+    description: 'Collect logs from any file on your filesystem.',
+    iconType: 'documents',
+    categoryIds: ['custom'],
+  },
+  {
+    id: 'httpjson',
+    name: 'Custom API (HTTP JSON)',
+    description: 'Collect data from any custom HTTP JSON endpoint.',
+    iconType: 'logstashInput',
+    categoryIds: ['custom'],
+  },
+];
+
+export const getInstalledIntegrations = () => VISION_INTEGRATIONS.filter((i) => i.isInstalled);

--- a/x-pack/platform/plugins/shared/fleet/public/constants/page_paths.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/constants/page_paths.ts
@@ -125,6 +125,7 @@ export const INTEGRATIONS_ROUTING_PATHS = {
   integration_policy_upgrade: '/edit-integration/:packagePolicyId',
   add_integration_to_policy: '/detail/:pkgkey/add-integration/:integration?',
   integration_collection: '/collection/:groupId',
+  integrations_vision: '/vision',
 };
 
 export const pagePathGetters: {


### PR DESCRIPTION
## What this is

A **reference implementation** of the integrations add-flow vision: a portable, entry-point-agnostic "Add data" modal.

This PR is not meant to merge as a whole — it stays a draft as the living reference for the design north star ([elastic/ingest-dev#9020](https://github.com/elastic/ingest-dev/issues/9020)). It is, however, built to graduate: everything composes EUI (Borealis) components with Emotion, follows Kibana conventions, and documents its deviations — so individual components (cards, badges, categories, the wizard step library) can be ported into the product incrementally as each roadmap track is picked up by engineering, with i18n, tests, and real Fleet/EPR wiring added at that point.

## Where the work is tracked

- Design north star + roadmap: [elastic/ingest-dev#9020](https://github.com/elastic/ingest-dev/issues/9020)
- Figma: [Onboarding template](https://www.figma.com/design/3gsJ6Jz0QtuoZUj1gFdMnX/Onboarding-template?node-id=3108-54253&t=kh5dr7fTBbQNEv8E-1)
- Interactive live preview (Elastic SSO): https://scaling-chainsaw-nyj68ke.pages.github.io/
