### PR TITLE
[Chrome Next] Fix overflow popover positioning in classic

### DIFF
--- a/src/platform/kbn-ui/app-menu/src/components/app_menu_overflow_button.tsx
+++ b/src/platform/kbn-ui/app-menu/src/components/app_menu_overflow_button.tsx
@@ -94,6 +94,7 @@ export const AppMenuOverflowButton = ({
       onClose={onPopoverClose}
       onCloseOverflowButton={onPopoverClose}
       anchorPosition="downRight"
+      repositionToCrossAxis={false}
     />
   );
 };


### PR DESCRIPTION
## Summary

This PR fixes a bug where in classic, the overflow popover menu would render to the left of the `⋯` button instead of hanging from it. The overflow popover now sets `repositionToCrossAxis={false}`, matching the other AppMenu popovers, so EUI keeps `downRight` when the control sits on the viewport edge.

### Visuals
| Before | After |
|---|---|
| <img width="1622" height="296" alt="Screenshot 2026-08-20 at 14 38 08" src="https://github.com/user-attachments/assets/3c2a09b5-d6ef-457b-bb04-d850ed2dfe2d" /> | <img width="1629" height="274" alt="Screenshot 2026-08-20 at 14 37 37" src="https://github.com/user-attachments/assets/a3bba55a-af8e-44ea-9258-e8d6cc46cd6c" /> |



