### PR TITLE
Make HMR indicator position relative to dev toolbar

### DIFF
--- a/packages/kbn-rspack-optimizer/src/hmr/hmr_client.js
+++ b/packages/kbn-rspack-optimizer/src/hmr/hmr_client.js
@@ -66,6 +66,10 @@ function injectIndicatorStyles() {
     '#' + INDICATOR_ID + ' {',
     '  width: 14px;',
     '  padding: 0 2px;',
+    '  bottom: 16px;',
+    '}',
+    'body:has(#developerToolbar) #' + INDICATOR_ID + ' {',
+    '  bottom: 40px;', // 32px toolbar + 8px gap
     '}',
     '#' + INDICATOR_ID + ':hover {',
     '  width: 150px;',
@@ -95,7 +99,6 @@ function createIndicator() {
     'style',
     [
       'position:fixed',
-      'bottom:16px',
       'right:16px',
       'height:28px',
       'border-radius:14px',

--- a/packages/kbn-rspack-optimizer/src/hmr/hmr_client.test.js
+++ b/packages/kbn-rspack-optimizer/src/hmr/hmr_client.test.js
@@ -227,4 +227,18 @@ describe('hmr_client', () => {
     expect(EventSource).not.toHaveBeenCalled();
     expect(document.getElementById('__kbn_hmr_indicator__')).toBeNull();
   });
+
+  it('offsets the indicator above #developerToolbar via stylesheet, not inline bottom', () => {
+    loadHmrClient();
+
+    const indicator = document.getElementById('__kbn_hmr_indicator__');
+    expect(indicator).not.toBeNull();
+    expect(indicator.getAttribute('style')).not.toMatch(/(?:^|;)\s*bottom\s*:/);
+
+    const styles = document.getElementById('__kbn_hmr_indicator_styles__');
+    expect(styles).not.toBeNull();
+    expect(styles.textContent).toContain('body:has(#developerToolbar) #__kbn_hmr_indicator__');
+    expect(styles.textContent).toContain('bottom: 40px');
+    expect(styles.textContent).toMatch(/#__kbn_hmr_indicator__\s*\{[^}]*bottom:\s*16px/);
+  });
 });


### PR DESCRIPTION
## Summary

This PR fixes the HMR indicator overlapping with developer toolbar by keeping the position relative to developer toolbar.

### Visuals 

| Before | After (with toolbar) | After (without toolbar) |
|---|---|---|
| <img width="500" height="246" alt="hmr_before" src="https://github.com/user-attachments/assets/67942058-6437-4e85-99e5-ffbb2643f14a" /> | <img width="410" height="192" alt="Screenshot 2026-08-20 at 15 08 13" src="https://github.com/user-attachments/assets/e50cbb33-25c9-4ec6-a396-6a89ce69e476" /> | <img width="328" height="174" alt="Screenshot 2026-08-20 at 15 08 20" src="https://github.com/user-attachments/assets/efaab7d2-2335-46ce-b10c-d49bbee3b2b8" /> |
