### PR TITLE
[CPS] Fix projectRoutingStrategy in flyout project picker

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/project_picker_flyout.test.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/project_picker_flyout.test.tsx
@@ -150,6 +150,34 @@ describe('ProjectPickerFlyoutContent', () => {
     expect(onApplyChanges).toHaveBeenCalledWith('_id:* AND NOT _id:linked1');
   });
 
+  it('applies selected projects as explicit ids in snapshot mode', async () => {
+    const user = userEvent.setup();
+    const { onApplyChanges } = renderFlyout({
+      projectRoutingStrategy: 'snapshot',
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(getProjectPickerListItemSwitchTestSubj(linkedProjectOne._id))
+      ).toHaveAttribute('aria-checked', 'true');
+    });
+
+    await user.click(
+      screen.getByTestId(getProjectPickerListItemSwitchTestSubj(linkedProjectOne._id))
+    );
+    await user.click(
+      screen.getByTestId(getProjectPickerListItemSwitchTestSubj(linkedProjectTwo._id))
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('projectPickerFlyoutApplyButton')).toBeEnabled();
+    });
+
+    await user.click(screen.getByTestId('projectPickerFlyoutApplyButton'));
+
+    expect(onApplyChanges).toHaveBeenCalledWith('_id:origin');
+  });
+
   it('disables Discard and Apply after round-tripping back to the baseline selection', async () => {
     const user = userEvent.setup();
     renderFlyout();

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/project_picker_flyout.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/project_picker_flyout.tsx
@@ -82,6 +82,7 @@ export function ProjectPickerFlyoutContent({
   fetchProjectsByRouting,
   originProjectId,
   projectRouting,
+  projectRoutingStrategy,
   titleId: titleIdProp,
   title = defaultTitle,
 }: ProjectPickerFlyoutProps) {
@@ -136,6 +137,7 @@ export function ProjectPickerFlyoutContent({
       originProjectId={originProjectId}
       onProjectRoutingChange={setStagedProjectRouting}
       fetchProjectsByRouting={fetchProjectsByRouting}
+      projectRoutingStrategy={projectRoutingStrategy}
     >
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>


### PR DESCRIPTION
## Summary

Fixes the Project Picker flyout so it correctly forwards `projectRoutingStrategy` to `ProjectPickerStateProvider`.

Without this, consumers using the flyout in `snapshot` mode could still get dynamic-style routing expressions, e.g. `_id:* AND NOT _id:<linked_project_id>`, when selecting only the local project. With this fix, snapshot mode preserves explicit project IDs such as `_id:<local_project_id>`.

For Transforms, this fixes the Edit transform project scope flow: selecting only the local project in the Project scope flyout now saves the expected explicit local project routing instead of an exclusion-based routing expression.

## Testing

- Added a regression test for `ProjectPickerFlyoutContent` to verify snapshot mode applies selected projects as explicit `_id` routing.
- Ran:

```bash
node scripts/jest src/platform/packages/shared/kbn-cps-utils/components/project_picker_update/project_picker_flyout.test.tsx
```



