### PR TITLE
[kbn-rspack-optimizer] Ignore .scout output dirs in watch mode

### DIFF
--- a/packages/kbn-rspack-optimizer/src/run_build.test.ts
+++ b/packages/kbn-rspack-optimizer/src/run_build.test.ts
@@ -78,6 +78,16 @@ describe('IGNORED_WATCH_PATTERNS', () => {
       ['jest.config.js', p('repo', 'pkg', 'jest.config.js')],
       ['jest.config.ts', p('repo', 'pkg', 'jest.config.ts')],
       ['jest.integration.config.js', p('repo', 'pkg', 'jest.integration.config.js')],
+
+      [
+        'scout test artifacts',
+        p('repo', 'pkg', 'test', 'scout', 'ui', '.scout', 'test-artifacts', 'failed.png'),
+      ],
+      [
+        'scout playwright reports',
+        p('repo', 'pkg', 'test', 'scout', 'ui', '.scout', 'reports', 'index.html'),
+      ],
+      ['repo-root scout server config', p('repo', '.scout', 'servers', 'local.json')],
     ])('ignores %s', (_label, filePath) => {
       expect(matchesIgnored(filePath)).toBe(true);
     });
@@ -105,6 +115,9 @@ describe('IGNORED_WATCH_PATTERNS', () => {
       // Storybook config is a real .ts file (not part of prod graph either, but
       // the watcher seeing it is harmless and we don't want a too-greedy regex).
       ['storybook main.ts', p('repo', 'pkg', '.storybook', 'main.ts')],
+
+      // "scout" in a path is fine when it is not the `.scout` output dir
+      ['scout test source dir', p('repo', 'pkg', 'test', 'scout', 'ui', 'fixtures', 'index.ts')],
     ])('keeps %s', (_label, filePath) => {
       expect(matchesIgnored(filePath)).toBe(false);
     });

--- a/packages/kbn-rspack-optimizer/src/run_build.ts
+++ b/packages/kbn-rspack-optimizer/src/run_build.ts
@@ -29,6 +29,9 @@ export const IGNORED_WATCH_PATTERNS: RegExp[] = [
   /\.mock\.[jt]sx?$/,
   /[\\/]__(?:mocks|snapshots|fixtures|jest)__[\\/]/,
   /[\\/]jest(?:\.integration)?\.config\.[jt]s$/,
+  // Scout/Playwright output (test artifacts, reports, server configs) written
+  // into plugin dirs during test runs; must not trigger watch rebuilds.
+  /[\\/]\.scout[\\/]/,
 ];
 
 export interface BuildOptions {


### PR DESCRIPTION
## Summary

Dev-mode Kibana (`node scripts/scout start-server`, `yarn start`) runs `@kbn/rspack-optimizer` in watch mode. The watcher's ignore list did not cover Scout/Playwright output directories, so a Scout test run writing artifacts into the plugin tree — `test/scout/**/.scout/test-artifacts/**` (screenshots, traces, `error-context.md`), `.scout/reports/**`, and the repo-root `.scout/servers/**` — triggered incremental rebuilds mid-run:

```
proc [kibana]  np bld    log   [15:11:34.157] [success][@kbn/rspack-optimizer] Rebuilt in 1.2s
```

These rebuilds are effectively no-ops but stall bundle serving through the base-path proxy while tests are executing, which surfaced as hard-to-attribute Scout UI flakiness: pages stuck on the "Loading Elastic" boot screen mid-interaction and fresh tabs failing with "Elastic did not load properly".

This PR adds `/[\\/]\.scout[\\/]/` to `IGNORED_WATCH_PATTERNS`. Scout **source** under `test/scout/**` (specs, fixtures) remains watched — only the `.scout` output directory segment is ignored, and a regression test guards that distinction.

Changes:
- `packages/kbn-rspack-optimizer/src/run_build.ts`: add `.scout` dir segment to `IGNORED_WATCH_PATTERNS`
- `packages/kbn-rspack-optimizer/src/run_build.test.ts`: ignored cases for test-artifacts, reports, and `.scout/servers`; negative case keeping `test/scout/**` source watched

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes) — suggest `release_note:skip` (dev-only tooling change)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Over-greedy ignore pattern hides legitimate source changes** — severity: low. The pattern matches only a literal `.scout` path segment; real Scout test source lives under `test/scout/**` without a `.scout` segment and stays watched. A dedicated negative test (`keeps scout test source dir`) guards against regressions. Worst case, a developer editing files inside a `.scout` output dir would not trigger a rebuild — those directories are generated output and gitignored.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->