### PR TITLE
[Entity Store][9.4] Require write privilege on target indices for install

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/constants.ts
@@ -11,7 +11,7 @@ import type { EntityStoreStatus } from './types';
 export const ECS_MAPPINGS_COMPONENT_TEMPLATE = 'ecs@mappings';
 
 export const ENTITY_STORE_SOURCE_INDICES_PRIVILEGES = ['read', 'view_index_metadata'];
-export const ENTITY_STORE_TARGET_INDICES_PRIVILEGES = ['read', 'manage'];
+export const ENTITY_STORE_TARGET_INDICES_PRIVILEGES = ['read', 'manage', 'write'];
 export const ENTITY_STORE_CLUSTER_PRIVILEGES = ['manage_index_templates'];
 
 export const ENGINE_STATUS: Record<Uppercase<EngineStatus>, EngineStatus> = {

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install_privileges.spec.ts
@@ -28,11 +28,13 @@ apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_
 
   interface RoleOptions {
     withTargetIndex?: boolean;
+    withWriteOnTargetIndex?: boolean;
     withSavedObjectCreate?: boolean;
   }
 
   const buildRoleDescriptor = ({
     withTargetIndex = true,
+    withWriteOnTargetIndex = true,
     withSavedObjectCreate = true,
   }: RoleOptions = {}): ElasticsearchRoleDescriptor => {
     const indices = [
@@ -41,9 +43,12 @@ apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_
     ];
 
     if (withTargetIndex) {
+      const targetPrivileges = withWriteOnTargetIndex
+        ? ENTITY_STORE_TARGET_INDICES_PRIVILEGES
+        : ENTITY_STORE_TARGET_INDICES_PRIVILEGES.filter((p) => p !== 'write');
       indices.push({
         names: [TARGET_INDEX_LATEST],
-        privileges: ENTITY_STORE_TARGET_INDICES_PRIVILEGES,
+        privileges: targetPrivileges,
       });
     }
 
@@ -64,6 +69,8 @@ apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_
 
   const getRoleWithAllPrivileges = () => buildRoleDescriptor();
   const getRoleWithoutTargetIndexPrivileges = () => buildRoleDescriptor({ withTargetIndex: false });
+  const getRoleWithoutWriteOnTargetIndex = () =>
+    buildRoleDescriptor({ withWriteOnTargetIndex: false });
   const getRoleWithoutSavedObjectCreate = () =>
     buildRoleDescriptor({ withSavedObjectCreate: false });
 
@@ -137,6 +144,34 @@ apiTest.describe('Entity Store install - privilege checks', { tag: ENTITY_STORE_
             {
               index: TARGET_INDEX_LATEST,
               privileges: expect.arrayContaining(ENTITY_STORE_TARGET_INDICES_PRIVILEGES),
+            },
+          ],
+        },
+      });
+    }
+  );
+
+  apiTest(
+    'Should fail when user lacks write privilege on target index patterns',
+    async ({ apiClient, requestAuth }) => {
+      const { apiKeyHeader } = await requestAuth.getApiKeyForCustomRole(
+        getRoleWithoutWriteOnTargetIndex()
+      );
+
+      const response = await apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+        headers: { ...PUBLIC_HEADERS, ...apiKeyHeader },
+        responseType: 'json',
+        body: {},
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.body.attributes).toMatchObject({
+        missing_elasticsearch_privileges: {
+          cluster: [],
+          index: [
+            {
+              index: TARGET_INDEX_LATEST,
+              privileges: expect.arrayContaining(['write']),
             },
           ],
         },


### PR DESCRIPTION
## Summary

Backport of #285970 to 9.4.

Maintainer tasks run as the user who triggered the install, using a stored API key captured at schedule time. Those tasks must write entity documents - including risk scores - into the target indices. The privilege check only validated `read` + `manage`, so an underprivileged user could pass the install gate and end up with a silently broken entity store where `entity.risk.calculated_score` is null for all entities.

Adds `write` to `ENTITY_STORE_TARGET_INDICES_PRIVILEGES` so the install route returns a `403` with the missing privilege listed before any installation work begins.

This was the confirmed root cause of customer escalation SDH [#1785](https://github.com/elastic/sdh-security-team/issues/1785).

## Changes

- **`server/domain/constants.ts`** - adds `'write'` to `ENTITY_STORE_TARGET_INDICES_PRIVILEGES`
- **`test/scout/api/tests/install_privileges.spec.ts`** - adds a test case asserting a `403` for a user holding `read` + `manage` but not `write` on target indices; extends `buildRoleDescriptor` with a `withWriteOnTargetIndex` option

## Notes

Paths differ from main: the plugin moved from `x-pack/platform/plugins/shared/entity_store` to `x-pack/solutions/security/plugins/entity_store` and the privilege constants live in `server/domain/constants.ts` rather than `common/privileges.ts`.