### PR TITLE
[Reporting][UX-POC] Add Light/Dark color mode for PDF and PNG exports

### DIFF
--- a/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.test.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.test.ts
@@ -282,6 +282,57 @@ describe('bootstrapRenderer', () => {
         })
       );
     });
+
+    it('overrides user settings when the report color mode header is light', async () => {
+      userSettingsService.getUserSettingDarkMode.mockResolvedValueOnce(true);
+
+      renderer = bootstrapRendererFactory({
+        auth,
+        packageInfo,
+        uiPlugins,
+        baseHref: '/base-path',
+        userSettingsService,
+        themeName$,
+      });
+
+      const request = httpServerMock.createKibanaRequest({
+        headers: { 'x-kbn-report-color-mode': 'light' },
+      });
+
+      await renderer({
+        request,
+        uiSettingsClient,
+      });
+
+      expect(renderTemplateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          colorMode: 'light',
+        })
+      );
+    });
+
+    it('overrides ui settings when the report color mode header is dark', async () => {
+      uiSettingsClient.get.mockImplementation(
+        getClientGetMockImplementation({
+          darkMode: false,
+        })
+      );
+
+      const request = httpServerMock.createKibanaRequest({
+        headers: { 'x-kbn-report-color-mode': 'dark' },
+      });
+
+      await renderer({
+        request,
+        uiSettingsClient,
+      });
+
+      expect(renderTemplateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          colorMode: 'dark',
+        })
+      );
+    });
   });
 
   describe('when the auth status is `unknown`', () => {

--- a/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.ts
@@ -26,6 +26,7 @@ import { getPluginsBundlePaths } from './get_plugin_bundle_paths';
 import { getJsDependencyPaths, getRspackDependencyPaths } from './get_js_dependency_paths';
 import { renderTemplate } from './render_template';
 import { getBundlesHref } from '../render_utils';
+import { getReportColorModeOverride } from '../report_color_mode';
 
 export type BootstrapRendererFactory = (factoryOptions: FactoryOptions) => BootstrapRenderer;
 export type BootstrapRenderer = (options: RenderedOptions) => Promise<RendererResult>;
@@ -132,6 +133,11 @@ export const bootstrapRendererFactory: BootstrapRendererFactory = ({
           darkMode = userSettingDarkMode;
         } else {
           darkMode = parseDarkModeValue(await uiSettingsClient.get('theme:darkMode'));
+        }
+
+        const reportColorMode = getReportColorModeOverride(request);
+        if (reportColorMode !== undefined) {
+          darkMode = reportColorMode;
         }
       }
     } catch (e) {

--- a/src/core/packages/rendering/server-internal/src/rendering_service.test.ts
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.test.ts
@@ -615,6 +615,56 @@ function renderDarkModeTestCases(
         });
         expect(uiSettings.client.getUserProvided).toHaveBeenCalledWith(true);
       });
+
+      it('report color mode header light should override User Settings darkMode', async () => {
+        mockRenderingSetupDeps.userSettings.getUserSettingDarkMode.mockReturnValueOnce(
+          Promise.resolve(true)
+        );
+        getSettingValueMock.mockImplementation((settingName: string) => {
+          if (settingName === 'theme:darkMode') {
+            return true;
+          }
+          return settingName;
+        });
+
+        const settings = { 'theme:darkMode': { userValue: true } };
+        uiSettings.client.getUserProvided.mockResolvedValue(settings);
+        const [render] = await getRender();
+        await render(
+          createKibanaRequest({ headers: { 'x-kbn-report-color-mode': 'light' } }),
+          uiSettings
+        );
+
+        expect(getThemeStylesheetPathsMock).toHaveBeenCalledWith({
+          darkMode: false,
+          baseHref: '/mock-server-basepath',
+        });
+      });
+
+      it('report color mode header dark should override User Settings lightMode', async () => {
+        mockRenderingSetupDeps.userSettings.getUserSettingDarkMode.mockReturnValueOnce(
+          Promise.resolve(false)
+        );
+        getSettingValueMock.mockImplementation((settingName: string) => {
+          if (settingName === 'theme:darkMode') {
+            return false;
+          }
+          return settingName;
+        });
+
+        const settings = { 'theme:darkMode': { userValue: false } };
+        uiSettings.client.getUserProvided.mockResolvedValue(settings);
+        const [render] = await getRender();
+        await render(
+          createKibanaRequest({ headers: { 'x-kbn-report-color-mode': 'dark' } }),
+          uiSettings
+        );
+
+        expect(getThemeStylesheetPathsMock).toHaveBeenCalledWith({
+          darkMode: true,
+          baseHref: '/mock-server-basepath',
+        });
+      });
     });
   });
 }

--- a/src/core/packages/rendering/server-internal/src/rendering_service.tsx
+++ b/src/core/packages/rendering/server-internal/src/rendering_service.tsx
@@ -52,6 +52,7 @@ import { filterUiPlugins } from './filter_ui_plugins';
 import { getApmConfig } from './get_apm_config';
 import type { InternalRenderingRequestHandlerContext } from './internal_types';
 import { isThemeBundled } from './theme';
+import { getReportColorModeOverride } from './report_color_mode';
 
 type RenderOptions =
   | RenderingSetupDeps
@@ -274,6 +275,11 @@ export class RenderingService {
       darkMode = userSettingDarkMode;
     } else {
       darkMode = getSettingValue<DarkModeValue>('theme:darkMode', settings, parseDarkModeValue);
+    }
+
+    const reportColorMode = getReportColorModeOverride(request);
+    if (reportColorMode !== undefined) {
+      darkMode = reportColorMode;
     }
 
     const themeStylesheetPaths = (mode: boolean) =>

--- a/src/core/packages/rendering/server-internal/src/report_color_mode.test.ts
+++ b/src/core/packages/rendering/server-internal/src/report_color_mode.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { getReportColorModeOverride, KBN_REPORT_COLOR_MODE_HEADER } from './report_color_mode';
+
+describe('getReportColorModeOverride', () => {
+  it('returns false for light', () => {
+    const request = httpServerMock.createKibanaRequest({
+      headers: { [KBN_REPORT_COLOR_MODE_HEADER]: 'light' },
+    });
+    expect(getReportColorModeOverride(request)).toBe(false);
+  });
+
+  it('returns true for dark', () => {
+    const request = httpServerMock.createKibanaRequest({
+      headers: { [KBN_REPORT_COLOR_MODE_HEADER]: 'dark' },
+    });
+    expect(getReportColorModeOverride(request)).toBe(true);
+  });
+
+  it('returns undefined when the header is absent or invalid', () => {
+    expect(getReportColorModeOverride(httpServerMock.createKibanaRequest())).toBeUndefined();
+    expect(
+      getReportColorModeOverride(
+        httpServerMock.createKibanaRequest({
+          headers: { [KBN_REPORT_COLOR_MODE_HEADER]: 'system' },
+        })
+      )
+    ).toBeUndefined();
+  });
+});

--- a/src/core/packages/rendering/server-internal/src/report_color_mode.ts
+++ b/src/core/packages/rendering/server-internal/src/report_color_mode.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License, v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { DarkModeValue } from '@kbn/core-ui-settings-common';
+
+/**
+ * Must match `KBN_REPORT_COLOR_MODE_HEADER` in `@kbn/reporting-common`.
+ * Core rendering cannot depend on the reporting package.
+ */
+export const KBN_REPORT_COLOR_MODE_HEADER = 'x-kbn-report-color-mode';
+
+/**
+ * When screenshotting a PDF/PNG report, Chromium sends this header so first-paint
+ * stylesheets match the theme stored on the job.
+ */
+export const getReportColorModeOverride = (request: KibanaRequest): DarkModeValue | undefined => {
+  const raw = request.headers[KBN_REPORT_COLOR_MODE_HEADER];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value === 'light') {
+    return false;
+  }
+  if (value === 'dark') {
+    return true;
+  }
+  return undefined;
+};

--- a/src/platform/packages/private/kbn-reporting/common/constants.ts
+++ b/src/platform/packages/private/kbn-reporting/common/constants.ts
@@ -82,6 +82,20 @@ export const REPORTING_REDIRECT_ALLOWED_LOCATOR_TYPES = [
 export const REPORTING_REDIRECT_APP = '/app/reportingRedirect';
 export const REPORTING_REDIRECT_LOCATOR_STORE_KEY = '__REPORTING_REDIRECT_LOCATOR_STORE_KEY__';
 
+/**
+ * Header Chromium sends when rendering PDF/PNG reports so Kibana bootstrap uses
+ * the job's stored color mode instead of the exporting user's Appearance preference.
+ * Keep in sync with `KBN_REPORT_COLOR_MODE_HEADER` in core rendering.
+ */
+export const KBN_REPORT_COLOR_MODE_HEADER = 'x-kbn-report-color-mode';
+
+export const getReportColorModeHeaders = (colorMode?: 'light' | 'dark'): Record<string, string> => {
+  if (!colorMode) {
+    return {};
+  }
+  return { [KBN_REPORT_COLOR_MODE_HEADER]: colorMode };
+};
+
 // Management UI route
 export const REPORTING_MANAGEMENT_HOME = '/app/management/insightsAndAlerting/reporting';
 export const REPORTING_MANAGEMENT_SCHEDULES =

--- a/src/platform/packages/private/kbn-reporting/common/types.ts
+++ b/src/platform/packages/private/kbn-reporting/common/types.ts
@@ -62,6 +62,12 @@ export interface ReportOutput extends TaskRunResult {
  */
 export type CsvPagingStrategy = 'pit' | 'scroll';
 
+/**
+ * Explicit light/dark setting stored on screenshot report jobs (PDF/PNG).
+ * Not used for CSV. Do not persist `system` or `space_default`.
+ */
+export type ReportColorMode = 'light' | 'dark';
+
 export interface BaseParams {
   browserTimezone: string; // to format dates in the user's time zone
   objectType: string;
@@ -70,6 +76,11 @@ export interface BaseParams {
   forceNow?: string;
   layout?: LayoutParams; // png & pdf only
   pagingStrategy?: CsvPagingStrategy; // csv only
+  /**
+   * PDF/PNG only. Theme used when Chromium renders the report.
+   * Stored on the job so scheduled runs stay stable if the creator later changes Appearance.
+   */
+  colorMode?: ReportColorMode;
 }
 
 /**

--- a/src/platform/packages/private/kbn-reporting/export_types/pdf/printable_pdf_v2.test.ts
+++ b/src/platform/packages/private/kbn-reporting/export_types/pdf/printable_pdf_v2.test.ts
@@ -108,6 +108,31 @@ test(`passes browserTimezone to getScreenshots`, async () => {
   );
 });
 
+test(`passes color mode headers to getScreenshots`, async () => {
+  await mockPdfExportType.runTask({
+    jobId: 'pdfJobId',
+    request: fakeRawRequest as unknown as KibanaRequest,
+    payload: getBasePayload({
+      forceNow: 'test',
+      layout: { dimensions: {} },
+      title: 'PDF Color Mode Test',
+      locatorParams: [{ version: 'test', id: 'test' }] as LocatorParams[],
+      browserTimezone: 'UTC',
+      headers: encryptedHeaders,
+      colorMode: 'dark',
+    }),
+    taskInstanceFields,
+    cancellationToken,
+    stream,
+  });
+
+  expect(getScreenshotsSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      headers: { 'x-kbn-report-color-mode': 'dark' },
+    })
+  );
+});
+
 test(`returns content_type of application/pdf`, async () => {
   const { content_type: contentType } = await mockPdfExportType.runTask({
     jobId: 'pdfJobId',

--- a/src/platform/packages/private/kbn-reporting/export_types/pdf/printable_pdf_v2.ts
+++ b/src/platform/packages/private/kbn-reporting/export_types/pdf/printable_pdf_v2.ts
@@ -19,6 +19,7 @@ import {
   LICENSE_TYPE_PLATINUM,
   LICENSE_TYPE_TRIAL,
   REPORTING_REDIRECT_LOCATOR_STORE_KEY,
+  getReportColorModeHeaders,
 } from '@kbn/reporting-common';
 import type { RunTaskOpts } from '@kbn/reporting-server';
 import { REPORTING_TRANSACTION_TYPE } from '@kbn/reporting-server';
@@ -133,6 +134,7 @@ export class PdfExportType extends ExportType<JobParamsPDFV2, TaskPayloadPDFV2> 
                         request,
                         browserTimezone,
                         layout,
+                        headers: getReportColorModeHeaders(payload.colorMode),
                         urls: urls.map((url) =>
                           typeof url === 'string'
                             ? url

--- a/src/platform/packages/private/kbn-reporting/export_types/png/png_v2.test.ts
+++ b/src/platform/packages/private/kbn-reporting/export_types/png/png_v2.test.ts
@@ -103,6 +103,30 @@ test(`passes browserTimezone to getScreenshots`, async () => {
   );
 });
 
+test(`passes color mode headers to getScreenshots`, async () => {
+  await mockPngExportType.runTask({
+    jobId: 'pngJobId',
+    request: fakeRawRequest as unknown as KibanaRequest,
+    payload: getBasePayload({
+      forceNow: 'test',
+      layout: { dimensions: {} },
+      locatorParams: [],
+      browserTimezone: 'UTC',
+      headers: encryptedHeaders,
+      colorMode: 'light',
+    }),
+    taskInstanceFields,
+    cancellationToken,
+    stream,
+  });
+
+  expect(getScreenshotsSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      headers: { 'x-kbn-report-color-mode': 'light' },
+    })
+  );
+});
+
 test(`returns content_type of application/png`, async () => {
   const { content_type: contentType } = await mockPngExportType.runTask({
     jobId: 'pngJobId',

--- a/src/platform/packages/private/kbn-reporting/export_types/png/png_v2.ts
+++ b/src/platform/packages/private/kbn-reporting/export_types/png/png_v2.ts
@@ -20,6 +20,7 @@ import {
   LICENSE_TYPE_PLATINUM,
   LICENSE_TYPE_TRIAL,
   REPORTING_REDIRECT_LOCATOR_STORE_KEY,
+  getReportColorModeHeaders,
 } from '@kbn/reporting-common';
 import type { TaskRunResult } from '@kbn/reporting-common/types';
 import type { JobParamsPNGV2, TaskPayloadPNGV2 } from '@kbn/reporting-export-types-png-common';
@@ -117,6 +118,7 @@ export class PngExportType extends ExportType<JobParamsPNGV2, TaskPayloadPNGV2> 
                 browserTimezone: payload.browserTimezone,
                 layout,
                 request,
+                headers: getReportColorModeHeaders(payload.colorMode),
                 urls: [[url, { [REPORTING_REDIRECT_LOCATOR_STORE_KEY]: locatorParams }]],
                 taskInstanceFields,
                 logger,

--- a/src/platform/packages/private/kbn-reporting/public/share/integrations/pdf/pdf_export_config.tsx
+++ b/src/platform/packages/private/kbn-reporting/public/share/integrations/pdf/pdf_export_config.tsx
@@ -45,9 +45,16 @@ export const getShareMenuItems =
 
     const requiresSavedState = sharingData.locatorParams === null;
 
-    const generateReportPDF = ({ intl, optimizedForPrinting = false }: ExportGenerationOpts) => {
+    const generateReportPDF = ({
+      intl,
+      optimizedForPrinting = false,
+      colorMode,
+    }: ExportGenerationOpts) => {
       const decoratedJobParams = apiClient.getDecoratedJobParams({
-        ...getJobParams({ ...jobProviderOptions, optimizedForPrinting }, 'printablePdfV2')(),
+        ...getJobParams(
+          { ...jobProviderOptions, optimizedForPrinting, colorMode },
+          'printablePdfV2'
+        )(),
       });
 
       return firstValueFrom(startServices$).then(([startServices]) => {
@@ -98,9 +105,9 @@ export const getShareMenuItems =
       });
     };
 
-    const generateExportUrlPDF = ({ optimizedForPrinting }: ExportGenerationOpts) => {
+    const generateExportUrlPDF = ({ optimizedForPrinting, colorMode }: ExportGenerationOpts) => {
       const jobParams = apiClient.getDecoratedJobParams(
-        getJobParams({ ...jobProviderOptions, optimizedForPrinting }, 'printablePdfV2')()
+        getJobParams({ ...jobProviderOptions, optimizedForPrinting, colorMode }, 'printablePdfV2')()
       );
       const relativePathPDF = apiClient.getReportingPublicJobPath('printablePdfV2', jobParams);
 
@@ -118,6 +125,7 @@ export const getShareMenuItems =
       exportType: 'printablePdfV2',
       requiresSavedState,
       renderLayoutOptionSwitch: objectType === 'dashboard',
+      renderColorModeOption: true,
       copyAssetURIConfig: {
         headingText: i18n.translate(
           'reporting.shareContextMenu.copyUriModal.pdfExportCopyUriHeading',

--- a/src/platform/packages/private/kbn-reporting/public/share/integrations/png/png_export_config.tsx
+++ b/src/platform/packages/private/kbn-reporting/public/share/integrations/png/png_export_config.tsx
@@ -45,18 +45,18 @@ export const getShareMenuItems =
 
     const requiresSavedState = sharingData.locatorParams === null;
 
-    const generateExportUrlPNG = () => {
+    const generateExportUrlPNG = ({ colorMode }: ExportGenerationOpts) => {
       const jobParams = apiClient.getDecoratedJobParams(
-        getJobParams(jobProviderOptions, 'pngV2')()
+        getJobParams({ ...jobProviderOptions, colorMode }, 'pngV2')()
       );
       const relativePathPNG = apiClient.getReportingPublicJobPath('pngV2', jobParams);
 
       return new URL(relativePathPNG, window.location.href).toString();
     };
 
-    const generateReportPNG = ({ intl }: ExportGenerationOpts) => {
+    const generateReportPNG = ({ intl, colorMode }: ExportGenerationOpts) => {
       const decoratedJobParams = apiClient.getDecoratedJobParams({
-        ...getJobParams(jobProviderOptions, 'pngV2')(),
+        ...getJobParams({ ...jobProviderOptions, colorMode }, 'pngV2')(),
       });
 
       return firstValueFrom(startServices$).then(([startServices]) => {
@@ -118,6 +118,7 @@ export const getShareMenuItems =
       generateAssetExport: generateReportPNG,
       exportType: 'pngV2',
       requiresSavedState,
+      renderColorModeOption: true,
       copyAssetURIConfig: {
         headingText: i18n.translate(
           'reporting.shareContextMenu.copyUriModal.pngExportCopyUriHeading',

--- a/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/index.ts
+++ b/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/index.ts
@@ -51,4 +51,5 @@ export interface JobParamsProviderOptions {
   shareableUrl?: string;
   objectType: string;
   optimizedForPrinting?: boolean;
+  colorMode?: 'light' | 'dark';
 }

--- a/src/platform/packages/private/kbn-reporting/public/share/shared/get_png_pdf_job_params.test.ts
+++ b/src/platform/packages/private/kbn-reporting/public/share/shared/get_png_pdf_job_params.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getJobParams, getPdfReportParams, getPngReportParams } from './get_png_pdf_job_params';
+
+const sharingData = {
+  title: 'Dashboard title',
+  locatorParams: { id: 'DASHBOARD_APP_LOCATOR', params: { dashboardId: 'abc' } },
+};
+
+describe('getPngPdfJobParams', () => {
+  it('includes colorMode on PNG params', () => {
+    const params = getPngReportParams({ sharingData, colorMode: 'dark' });
+    expect(params.colorMode).toBe('dark');
+    expect(params.layout.id).toBe('preserve_layout');
+  });
+
+  it('includes colorMode on PDF params and sets print layout', () => {
+    const params = getPdfReportParams({
+      sharingData,
+      optimizedForPrinting: true,
+      colorMode: 'light',
+    });
+    expect(params.colorMode).toBe('light');
+    expect(params.layout.id).toBe('print');
+  });
+
+  it('omits colorMode when it is not provided', () => {
+    const params = getPngReportParams({ sharingData });
+    expect(params.colorMode).toBeUndefined();
+  });
+
+  it('forwards colorMode from getJobParams', () => {
+    const params = getJobParams(
+      {
+        sharingData,
+        objectType: 'dashboard',
+        colorMode: 'dark',
+      },
+      'pngV2'
+    )();
+    expect(params.colorMode).toBe('dark');
+    expect(params.objectType).toBe('dashboard');
+    expect(params.title).toBe('Dashboard title');
+  });
+});

--- a/src/platform/packages/private/kbn-reporting/public/share/shared/get_png_pdf_job_params.ts
+++ b/src/platform/packages/private/kbn-reporting/public/share/shared/get_png_pdf_job_params.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ReportColorMode } from '@kbn/reporting-common/types';
 import type { ReportParamsGetter, ReportParamsGetterOptions } from '../../types';
 import type { JobParamsProviderOptions } from '../share_context_menu';
 
@@ -32,22 +33,29 @@ interface PngPdfReportBaseParams {
   layout: { dimensions: { height: number; width: number }; id: 'preserve_layout' | 'print' };
   objectType: string;
   locatorParams: any;
+  colorMode?: ReportColorMode;
 }
 
+type PngPdfParamsOptions = ReportParamsGetterOptions & {
+  optimizedForPrinting?: boolean;
+  colorMode?: ReportColorMode;
+};
+
 export const getPngReportParams: ReportParamsGetter<
-  ReportParamsGetterOptions,
+  PngPdfParamsOptions,
   PngPdfReportBaseParams
-> = ({ sharingData }): PngPdfReportBaseParams => {
+> = ({ sharingData, colorMode }): PngPdfReportBaseParams => {
   return {
     ...getBaseParams('pngV2'),
     locatorParams: sharingData.locatorParams,
+    ...(colorMode ? { colorMode } : {}),
   };
 };
 
 export const getPdfReportParams: ReportParamsGetter<
-  ReportParamsGetterOptions & { optimizedForPrinting?: boolean },
+  PngPdfParamsOptions,
   PngPdfReportBaseParams
-> = ({ sharingData, optimizedForPrinting = false }) => {
+> = ({ sharingData, optimizedForPrinting = false, colorMode }) => {
   const params = {
     ...getBaseParams('printablePdfV2'),
     locatorParams: [sharingData.locatorParams],
@@ -55,19 +63,20 @@ export const getPdfReportParams: ReportParamsGetter<
   if (optimizedForPrinting) {
     params.layout.id = 'print';
   }
-  return params;
+  return colorMode ? { ...params, colorMode } : params;
 };
 
 export const getJobParams =
   (opts: JobParamsProviderOptions, type: 'pngV2' | 'printablePdfV2') => () => {
-    const { objectType, sharingData, optimizedForPrinting } = opts;
+    const { objectType, sharingData, optimizedForPrinting, colorMode } = opts;
     let baseParams: PngPdfReportBaseParams;
     if (type === 'pngV2') {
-      baseParams = getPngReportParams({ sharingData });
+      baseParams = getPngReportParams({ sharingData, colorMode });
     } else {
       baseParams = getPdfReportParams({
         sharingData,
         optimizedForPrinting,
+        colorMode,
       });
     }
     return {

--- a/src/platform/plugins/shared/share/public/components/export_integrations/color_mode_keypad.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_integrations/color_mode_keypad.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { ColorModeKeyPad } from './color_mode_keypad';
+
+describe('ColorModeKeyPad', () => {
+  const onChange = jest.fn();
+
+  beforeEach(() => {
+    onChange.mockClear();
+  });
+
+  it('shows a description instead of a duplicate Color mode legend', () => {
+    render(<ColorModeKeyPad colorMode="light" onChange={onChange} />);
+
+    expect(screen.getByRole('heading', { name: 'Color mode' })).toBeInTheDocument();
+    expect(
+      screen.getByText('This setting applies to the export, not the current appearance.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('This report will use the light theme.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Light is recommended for printed reports.')).not.toBeInTheDocument();
+  });
+
+  it('does not show a Recommended badge when print format is off', () => {
+    render(<ColorModeKeyPad colorMode="light" onChange={onChange} />);
+
+    expect(screen.queryByTestId('reportColorModeRecommended')).not.toBeInTheDocument();
+  });
+
+  it('shows a Recommended badge next to Color mode when print format is on', async () => {
+    const user = userEvent.setup();
+    render(<ColorModeKeyPad colorMode="light" onChange={onChange} usePrintLayout />);
+
+    expect(screen.getByTestId('reportColorModeRecommended')).toHaveTextContent('Recommended');
+    expect(screen.queryByText('This report will use the light theme.')).not.toBeInTheDocument();
+
+    await user.hover(screen.getByTestId('reportColorModeRecommended'));
+
+    expect(
+      await screen.findByText('Light is recommended for printed reports.')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/platform/plugins/shared/share/public/components/export_integrations/color_mode_keypad.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_integrations/color_mode_keypad.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiIcon,
+  EuiKeyPadMenu,
+  EuiKeyPadMenuItem,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export type ReportColorMode = 'light' | 'dark';
+
+const colorModeTitle = i18n.translate('share.exportFlyoutContent.colorMode.legend', {
+  defaultMessage: 'Color mode',
+});
+
+const colorModeDescription = i18n.translate('share.exportFlyoutContent.colorMode.description', {
+  defaultMessage: 'This setting applies to the export, not the current appearance.',
+});
+
+const lightLabel = i18n.translate('share.exportFlyoutContent.colorMode.lightLabel', {
+  defaultMessage: 'Light',
+});
+
+const darkLabel = i18n.translate('share.exportFlyoutContent.colorMode.darkLabel', {
+  defaultMessage: 'Dark',
+});
+
+const recommendedBadgeLabel = i18n.translate(
+  'share.exportFlyoutContent.colorMode.recommendedBadge',
+  {
+    defaultMessage: 'Recommended',
+  }
+);
+
+const printRecommendedTooltip = i18n.translate(
+  'share.exportFlyoutContent.colorMode.printRecommendedTooltip',
+  {
+    defaultMessage: 'Light is recommended for printed reports.',
+  }
+);
+
+export interface ColorModeKeyPadProps {
+  colorMode: ReportColorMode;
+  onChange: (colorMode: ReportColorMode) => void;
+  usePrintLayout?: boolean;
+  isDisabled?: boolean;
+}
+
+export function ColorModeKeyPad({
+  colorMode,
+  onChange,
+  usePrintLayout = false,
+  isDisabled = false,
+}: ColorModeKeyPadProps) {
+  return (
+    <EuiFormRow
+      label={
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">
+              <h4>{colorModeTitle}</h4>
+            </EuiText>
+          </EuiFlexItem>
+          {usePrintLayout && (
+            <EuiFlexItem grow={false}>
+              <EuiToolTip content={printRecommendedTooltip}>
+                <EuiBadge color="success" tabIndex={0} data-test-subj="reportColorModeRecommended">
+                  {recommendedBadgeLabel}
+                </EuiBadge>
+              </EuiToolTip>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      }
+      fullWidth
+    >
+      <EuiFlexGroup direction="column">
+        <EuiFlexItem>
+          <EuiText size="s" color="subdued">
+            {colorModeDescription}
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiKeyPadMenu
+            data-test-subj="reportColorModeMenu"
+            checkable={{
+              ariaLegend: colorModeTitle,
+            }}
+          >
+            <EuiKeyPadMenuItem
+              name="reportColorMode"
+              label={lightLabel}
+              checkable="single"
+              isSelected={colorMode === 'light'}
+              isDisabled={isDisabled}
+              onChange={() => onChange('light')}
+              data-test-subj="reportColorModeLight"
+            >
+              <EuiIcon type="sun" size="l" aria-hidden={true} />
+            </EuiKeyPadMenuItem>
+            <EuiKeyPadMenuItem
+              name="reportColorMode"
+              label={darkLabel}
+              checkable="single"
+              isSelected={colorMode === 'dark'}
+              isDisabled={isDisabled}
+              onChange={() => onChange('dark')}
+              data-test-subj="reportColorModeDark"
+            >
+              <EuiIcon type="moon" size="l" aria-hidden={true} />
+            </EuiKeyPadMenuItem>
+          </EuiKeyPadMenu>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFormRow>
+  );
+}

--- a/src/platform/plugins/shared/share/public/components/export_integrations/export_integrations.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_integrations/export_integrations.test.tsx
@@ -235,5 +235,138 @@ describe('Export Integrations', () => {
         expect(screen.getByText('Test warning')).toBeInTheDocument();
       });
     });
+
+    it('shows the color mode keypad when renderColorModeOption is true', async () => {
+      const user = userEvent.setup();
+      const mockPdfConfigForFlyout = {
+        shareType: 'integration',
+        groupId: 'export',
+        id: 'pdf',
+        config: {
+          icon: 'empty',
+          label: 'PDF',
+          renderColorModeOption: true,
+          generateAssetExport: jest.fn(() => Promise.resolve()),
+        },
+      } as unknown as ExportShareConfig;
+
+      function PdfExportFlyoutRender() {
+        const [isFlyoutVisible, setIsFlyoutVisible] = React.useState(false);
+        let flyout;
+
+        if (isFlyoutVisible) {
+          flyout = (
+            <EuiFlyout ownFocus onClose={() => setIsFlyoutVisible(false)} aria-label="Export">
+              <ManagedExportFlyout
+                exportIntegration={mockPdfConfigForFlyout}
+                shareObjectType={mockShareContext.objectType}
+                shareObjectTypeMeta={mockCsvObjectTypeMeta}
+                isDirty={mockShareContext.isDirty}
+                publicAPIEnabled={true}
+                intl={null as any}
+                onCloseFlyout={jest.fn()}
+                onSave={jest.fn()}
+                isSaving={false}
+                sharingData={mockShareContext.sharingData}
+              />
+            </EuiFlyout>
+          );
+        }
+        return (
+          <IntlProvider locale="en">
+            <EuiButton onClick={() => setIsFlyoutVisible(true)}>Show flyout</EuiButton>
+            {flyout}
+          </IntlProvider>
+        );
+      }
+
+      render(<PdfExportFlyoutRender />);
+      await user.click(screen.getByText('Show flyout'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('reportColorModeMenu')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText('This setting applies to the export, not the current appearance.')
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('reportColorModeRecommended')).not.toBeInTheDocument();
+      expect(screen.queryByText('This report will use the light theme.')).not.toBeInTheDocument();
+    });
+
+    it('shows a Recommended badge next to Color mode when print format is on', async () => {
+      const user = userEvent.setup();
+      const mockPdfConfigForFlyout = {
+        shareType: 'integration',
+        groupId: 'export',
+        id: 'pdf',
+        config: {
+          icon: 'empty',
+          label: 'PDF',
+          renderColorModeOption: true,
+          renderLayoutOptionSwitch: true,
+          generateAssetExport: jest.fn(() => Promise.resolve()),
+        },
+      } as unknown as ExportShareConfig;
+
+      function PdfExportFlyoutRender() {
+        const [isFlyoutVisible, setIsFlyoutVisible] = React.useState(false);
+        let flyout;
+
+        if (isFlyoutVisible) {
+          flyout = (
+            <EuiFlyout ownFocus onClose={() => setIsFlyoutVisible(false)} aria-label="Export">
+              <ManagedExportFlyout
+                exportIntegration={mockPdfConfigForFlyout}
+                shareObjectType={mockShareContext.objectType}
+                shareObjectTypeMeta={mockCsvObjectTypeMeta}
+                isDirty={mockShareContext.isDirty}
+                publicAPIEnabled={true}
+                intl={null as any}
+                onCloseFlyout={jest.fn()}
+                onSave={jest.fn()}
+                isSaving={false}
+                sharingData={mockShareContext.sharingData}
+              />
+            </EuiFlyout>
+          );
+        }
+        return (
+          <IntlProvider locale="en">
+            <EuiButton onClick={() => setIsFlyoutVisible(true)}>Show flyout</EuiButton>
+            {flyout}
+          </IntlProvider>
+        );
+      }
+
+      render(<PdfExportFlyoutRender />);
+      await user.click(screen.getByText('Show flyout'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('usePrintLayout')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('reportColorModeRecommended')).not.toBeInTheDocument();
+
+      await user.click(screen.getByTestId('usePrintLayout'));
+
+      expect(screen.getByTestId('reportColorModeRecommended')).toBeInTheDocument();
+      expect(screen.queryByText('This report will use the light theme.')).not.toBeInTheDocument();
+
+      await user.hover(screen.getByTestId('reportColorModeRecommended'));
+      expect(
+        await screen.findByText('Light is recommended for printed reports.')
+      ).toBeInTheDocument();
+    });
+
+    it('does not show the color mode keypad for CSV exports', async () => {
+      const user = userEvent.setup();
+      render(<CsvExportFlyoutRender />);
+
+      await user.click(screen.getByText('Show flyout'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('exportItemDetailsFlyoutBody')).not.toBe(null);
+      });
+      expect(screen.queryByTestId('reportColorModeMenu')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/platform/plugins/shared/share/public/components/export_integrations/export_integrations.tsx
+++ b/src/platform/plugins/shared/share/public/components/export_integrations/export_integrations.tsx
@@ -29,6 +29,7 @@ import {
   type EuiSwitchEvent,
   EuiSwitch,
   EuiHorizontalRule,
+  useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { InjectedIntl } from '@kbn/i18n-react';
@@ -41,6 +42,7 @@ import {
 } from '../context';
 import type { ExportShareConfig, ExportShareDerivativesConfig, ShareContext } from '../../types';
 import { DraftModeCallout } from '../common/draft_mode_callout';
+import { ColorModeKeyPad, type ReportColorMode } from './color_mode_keypad';
 
 export const ExportMenu: FC<{ shareContext: IShareContext }> = ({ shareContext }) => {
   return (
@@ -97,7 +99,7 @@ function LayoutOptionsSwitch({ usePrintLayout, printLayoutChange }: LayoutOption
             <EuiText size="s" color="subdued">
               <FormattedMessage
                 id="share.exportFlyoutContent.optimizeForPrinting.helpText"
-                defaultMessage="Uses multiple pages, showing at most 2 visualizations per page "
+                defaultMessage="Uses multiple pages, showing at most 2 visualizations per page. Light color mode is recommended for printing."
               />
             </EuiText>
           }
@@ -142,7 +144,11 @@ export function ManagedExportFlyout({
   isSaving,
   sharingData,
 }: ManagedExportFlyoutProps) {
+  const { colorMode: euiColorMode } = useEuiTheme();
   const [usePrintLayout, setPrintLayout] = useState(false);
+  const [colorMode, setColorMode] = useState<ReportColorMode>(
+    euiColorMode === 'DARK' ? 'dark' : 'light'
+  );
   const [isCreatingExport, setIsCreatingExport] = useState<boolean>(false);
 
   const totalHitsSizeWarning = useMemo(() => {
@@ -160,12 +166,13 @@ export function ManagedExportFlyout({
       await exportIntegration.config.generateAssetExport({
         intl,
         optimizedForPrinting: usePrintLayout,
+        colorMode: exportIntegration.config.renderColorModeOption ? colorMode : undefined,
       });
     } finally {
       setIsCreatingExport(false);
       onCloseFlyout();
     }
-  }, [exportIntegration.config, intl, onCloseFlyout, usePrintLayout]);
+  }, [exportIntegration.config, intl, onCloseFlyout, usePrintLayout, colorMode]);
 
   const draftModeCallout = shareObjectTypeMeta.config?.[exportIntegration.id]?.draftModeCallOut;
   const draftModeCalloutContent = typeof draftModeCallout === 'object' ? draftModeCallout : {};
@@ -193,7 +200,22 @@ export function ManagedExportFlyout({
               <EuiFlexItem>
                 <LayoutOptionsSwitch
                   usePrintLayout={usePrintLayout}
-                  printLayoutChange={(evt) => setPrintLayout(evt.target.checked)}
+                  printLayoutChange={(evt) => {
+                    const checked = evt.target.checked;
+                    setPrintLayout(checked);
+                    if (checked) {
+                      setColorMode('light');
+                    }
+                  }}
+                />
+              </EuiFlexItem>
+            )}
+            {exportIntegration.config.renderColorModeOption && (
+              <EuiFlexItem>
+                <ColorModeKeyPad
+                  colorMode={colorMode}
+                  onChange={setColorMode}
+                  usePrintLayout={usePrintLayout}
                 />
               </EuiFlexItem>
             )}
@@ -229,6 +251,9 @@ export function ManagedExportFlyout({
                         {exportIntegration.config.copyAssetURIConfig.generateAssetURIValue({
                           intl,
                           optimizedForPrinting: usePrintLayout,
+                          colorMode: exportIntegration.config.renderColorModeOption
+                            ? colorMode
+                            : undefined,
                         })}
                       </EuiCodeBlock>
                     </EuiFlexItem>

--- a/src/platform/plugins/shared/share/public/index.ts
+++ b/src/platform/plugins/shared/share/public/index.ts
@@ -48,3 +48,9 @@ export function plugin(ctx: PluginInitializerContext) {
 }
 
 export { useShareTypeContext } from './components/context';
+
+export { ColorModeKeyPad } from './components/export_integrations/color_mode_keypad';
+export type {
+  ReportColorMode,
+  ColorModeKeyPadProps,
+} from './components/export_integrations/color_mode_keypad';

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -161,6 +161,10 @@ export interface ExportShare<S extends SharingData = SharingData>
       supportedLayoutOptions?: Array<'print'>;
       renderLayoutOptionSwitch?: boolean;
       /**
+       * When true, the export flyout shows a Light/Dark color mode keypad (PDF/PNG screenshots).
+       */
+      renderColorModeOption?: boolean;
+      /**
        * indicates if the export integration supports generating it exports with absolute time ranges
        */
       supportsAbsoluteTime?: boolean;
@@ -415,6 +419,7 @@ export interface ShareMenuItemLegacy extends ShareMenuItemBase {
 
 export interface ExportGenerationOpts {
   optimizedForPrinting?: boolean;
+  colorMode?: 'light' | 'dark';
   intl: InjectedIntl;
 }
 

--- a/x-pack/platform/plugins/private/reporting/public/management/components/create_scheduled_report_form.tsx
+++ b/x-pack/platform/plugins/private/reporting/public/management/components/create_scheduled_report_form.tsx
@@ -69,6 +69,7 @@ export const CreateScheduledReportForm = ({
         timezone,
         recurringSchedule,
         optimizedForPrinting,
+        colorMode,
         sendByEmail,
         emailRecipients,
         emailCcRecipients,
@@ -91,6 +92,7 @@ export const CreateScheduledReportForm = ({
           title,
           reportTypeId,
           ...(reportTypeId === 'printablePdfV2' ? { optimizedForPrinting } : {}),
+          ...(reportTypeId === 'printablePdfV2' || reportTypeId === 'pngV2' ? { colorMode } : {}),
         }),
         schedule: { rrule: rrule as Rrule },
         notification: sendByEmail

--- a/x-pack/platform/plugins/private/reporting/public/management/components/report_exports_table.test.tsx
+++ b/x-pack/platform/plugins/private/reporting/public/management/components/report_exports_table.test.tsx
@@ -111,6 +111,38 @@ describe('ReportExportsTable', () => {
     expect(await screen.findByTestId(`reportDownloadLink-${mockJobs[0].id}`)).toBeInTheDocument();
   });
 
+  it('renders color mode for screenshot reports and an em dash otherwise', async () => {
+    jest.spyOn(reportingAPIClient, 'list').mockImplementation(() =>
+      Promise.resolve([
+        new Job({
+          ...mockJobs[0],
+          payload: { ...mockJobs[0].payload, colorMode: 'dark' },
+        }),
+        new Job({
+          ...mockJobs[0],
+          id: 'light-color-mode-job',
+          payload: { ...mockJobs[0].payload, colorMode: 'light' },
+        }),
+        new Job(mockJobs[1]),
+      ])
+    );
+
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <ReportExportsTable {...defaultProps} />
+      </ThemeProvider>
+    );
+
+    expect(await screen.findByText('Color mode')).toBeInTheDocument();
+    const colorModeCells = await screen.findAllByTestId('reportJobColorMode');
+    expect(colorModeCells[0]).toHaveTextContent('Dark');
+    expect(colorModeCells[0].querySelector('[data-euiicon-type="moon"]')).toBeInTheDocument();
+    expect(colorModeCells[1]).toHaveTextContent('Light');
+    expect(colorModeCells[1].querySelector('[data-euiicon-type="sun"]')).toBeInTheDocument();
+    expect(colorModeCells[2]).toHaveTextContent('—');
+    expect(colorModeCells[2].querySelector('[data-euiicon-type]')).not.toBeInTheDocument();
+  });
+
   it('should show config flyout from table action', async () => {
     render(
       <ThemeProvider theme={mockTheme}>

--- a/x-pack/platform/plugins/private/reporting/public/management/components/report_exports_table.tsx
+++ b/x-pack/platform/plugins/private/reporting/public/management/components/report_exports_table.tsx
@@ -14,6 +14,7 @@ import {
   EuiBasicTable,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiIconTip,
   EuiLink,
   EuiSpacer,
@@ -34,6 +35,28 @@ import { NO_CREATED_REPORTS_DESCRIPTION } from '../../translations';
 import { TruncatedTitle } from './truncated_title';
 
 type TableColumn = EuiBasicTableColumn<Job>;
+
+const getReportColorModeDisplay = (
+  colorMode?: string
+): { icon?: 'sun' | 'moon'; label: string } => {
+  if (colorMode === 'light') {
+    return {
+      icon: 'sun',
+      label: i18n.translate('xpack.reporting.exports.colorMode.light', {
+        defaultMessage: 'Light',
+      }),
+    };
+  }
+  if (colorMode === 'dark') {
+    return {
+      icon: 'moon',
+      label: i18n.translate('xpack.reporting.exports.colorMode.dark', {
+        defaultMessage: 'Dark',
+      }),
+    };
+  }
+  return { label: '—' };
+};
 
 interface State {
   page: number;
@@ -220,10 +243,11 @@ export class ReportExportsTable extends Component<ListingPropsInternal, State> {
    */
   private readonly tableColumnWidths = {
     type: '5%',
-    title: '25%',
-    status: '20%',
-    createdAt: '21%',
+    title: '22%',
+    status: '18%',
+    createdAt: '18%',
     content: '7%',
+    colorMode: '8%',
     exportType: '12%',
     actions: '10%',
   };
@@ -333,6 +357,33 @@ export class ReportExportsTable extends Component<ListingPropsInternal, State> {
         render: (_status: string, job) => (
           <div data-test-subj="reportJobContent">{prettyPrintJobType(job.jobtype)}</div>
         ),
+        mobileOptions: {
+          show: false,
+        },
+      },
+      {
+        field: 'payload.colorMode',
+        width: tableColumnWidths.colorMode,
+        name: i18n.translate('xpack.reporting.exports.tableColumns.colorMode', {
+          defaultMessage: 'Color mode',
+        }),
+        render: (_colorMode: string | undefined, job) => {
+          const { icon, label } = getReportColorModeDisplay(job.payload.colorMode);
+          return (
+            <div data-test-subj="reportJobColorMode">
+              {icon ? (
+                <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                  <EuiFlexItem grow={false}>
+                    <EuiIcon type={icon} size="s" aria-hidden={true} />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>{label}</EuiFlexItem>
+                </EuiFlexGroup>
+              ) : (
+                label
+              )}
+            </div>
+          );
+        },
         mobileOptions: {
           show: false,
         },

--- a/x-pack/platform/plugins/private/reporting/public/management/components/scheduled_report_form.test.tsx
+++ b/x-pack/platform/plugins/private/reporting/public/management/components/scheduled_report_form.test.tsx
@@ -152,6 +152,8 @@ describe('ScheduledReportForm', () => {
           startDate: '2025-11-10T12:00:00.000Z',
           timezone: 'UTC',
           title: 'Scheduled report 1',
+          colorMode: 'light',
+          optimizedForPrinting: false,
         },
         true
       );
@@ -264,6 +266,8 @@ describe('ScheduledReportForm', () => {
             startDate: '2025-11-10T12:00:00.000Z',
             timezone: 'UTC',
             title: 'Updated scheduled report title',
+            colorMode: 'light',
+            optimizedForPrinting: false,
           },
           true
         );
@@ -357,5 +361,73 @@ describe('ScheduledReportForm', () => {
 
       expect(onSubmitForm).toHaveBeenCalled();
     });
+  });
+
+  it('shows the color mode keypad for PDF reports', async () => {
+    renderWithProviders(
+      <ScheduledReportForm
+        {...defaultProps}
+        availableReportTypes={[{ label: 'PDF', id: 'printablePdfV2' }]}
+      />
+    );
+
+    expect(await screen.findByTestId('reportColorModeMenu')).toBeInTheDocument();
+    expect(screen.getByTestId('reportColorModeLight')).toBeInTheDocument();
+    expect(screen.getByTestId('reportColorModeDark')).toBeInTheDocument();
+    expect(
+      screen.getByText('This setting applies to the export, not the current appearance.')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('reportColorModeRecommended')).not.toBeInTheDocument();
+    expect(screen.queryByText('This report will use the light theme.')).not.toBeInTheDocument();
+  });
+
+  it('shows a Recommended badge next to Color mode when print format is on', async () => {
+    user = userEvent.setup({ delay: null });
+    renderWithProviders(
+      <ScheduledReportForm
+        {...defaultProps}
+        availableReportTypes={[{ label: 'PDF', id: 'printablePdfV2' }]}
+      />
+    );
+
+    expect(await screen.findByTestId('usePrintLayout')).toBeInTheDocument();
+    expect(screen.queryByTestId('reportColorModeRecommended')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('usePrintLayout'));
+
+    expect(screen.getByTestId('reportColorModeRecommended')).toBeInTheDocument();
+    expect(screen.queryByText('This report will use the light theme.')).not.toBeInTheDocument();
+
+    await user.hover(screen.getByTestId('reportColorModeRecommended'));
+    expect(
+      await screen.findByText('Light is recommended for printed reports.')
+    ).toBeInTheDocument();
+  });
+
+  it('does not show a Recommended badge for PNG reports', async () => {
+    renderWithProviders(
+      <ScheduledReportForm
+        {...defaultProps}
+        scheduledReport={{ ...defaultProps.scheduledReport, reportTypeId: 'pngV2' }}
+        availableReportTypes={[{ label: 'PNG', id: 'pngV2' }]}
+      />
+    );
+
+    expect(await screen.findByTestId('reportColorModeMenu')).toBeInTheDocument();
+    expect(screen.queryByTestId('usePrintLayout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('reportColorModeRecommended')).not.toBeInTheDocument();
+  });
+
+  it('does not show the color mode keypad for CSV reports', async () => {
+    renderWithProviders(
+      <ScheduledReportForm
+        {...defaultProps}
+        scheduledReport={{ ...defaultProps.scheduledReport, reportTypeId: 'csv_v2' }}
+        availableReportTypes={[{ label: 'CSV', id: 'csv_v2' }]}
+      />
+    );
+
+    expect(await screen.findByTestId('scheduleExportForm')).toBeInTheDocument();
+    expect(screen.queryByTestId('reportColorModeMenu')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/private/reporting/public/management/components/scheduled_report_form.tsx
+++ b/x-pack/platform/plugins/private/reporting/public/management/components/scheduled_report_form.tsx
@@ -22,7 +22,9 @@ import {
   EuiLoadingSpinner,
   EuiSpacer,
   EuiTitle,
+  useEuiTheme,
 } from '@elastic/eui';
+import { ColorModeKeyPad } from '@kbn/share-plugin/public';
 import { useKibana } from '@kbn/reporting-public';
 import { REPORTING_MANAGEMENT_SCHEDULES } from '@kbn/reporting-common';
 import type { FormSchema } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
@@ -32,6 +34,7 @@ import {
   getUseField,
   useForm,
   useFormData,
+  UseField,
 } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { RecurringScheduleFormFields } from '@kbn/response-ops-recurring-schedule-form/components/recurring_schedule_form_fields';
 import { Field } from '@kbn/es-ui-shared-plugin/static/forms/components';
@@ -84,6 +87,7 @@ export type FormData = Pick<
   | 'emailSubject'
   | 'emailMessage'
   | 'optimizedForPrinting'
+  | 'colorMode'
 >;
 
 export interface ScheduledReportFormProps {
@@ -140,6 +144,8 @@ export const ScheduledReportForm = ({
     actions: { validateEmailAddresses },
     userProfile: userProfileService,
   } = useKibana().services;
+  const { colorMode: euiColorMode } = useEuiTheme();
+  const defaultColorMode = euiColorMode === 'DARK' ? 'dark' : 'light';
   const { data: userProfile, isLoading: isUserProfileLoading } = useGetUserProfileQuery({
     userProfileService,
   });
@@ -177,23 +183,36 @@ export const ScheduledReportForm = ({
     [availableReportTypes, validateEmailAddresses]
   );
   const { form } = useForm<FormData>({
-    defaultValue: scheduledReport,
+    defaultValue: {
+      ...scheduledReport,
+      colorMode: scheduledReport.colorMode ?? defaultColorMode,
+    },
     options: { stripEmptyFields: true },
     schema,
     onSubmit: onSubmitForm,
   });
-  const [{ reportTypeId, startDate, timezone, sendByEmail, emailSubject, emailMessage }] =
-    useFormData<FormData>({
-      form,
-      watch: [
-        'reportTypeId',
-        'startDate',
-        'timezone',
-        'sendByEmail',
-        'emailSubject',
-        'emailMessage',
-      ],
-    });
+  const [
+    {
+      reportTypeId,
+      startDate,
+      timezone,
+      sendByEmail,
+      emailSubject,
+      emailMessage,
+      optimizedForPrinting,
+    },
+  ] = useFormData<FormData>({
+    form,
+    watch: [
+      'reportTypeId',
+      'startDate',
+      'timezone',
+      'sendByEmail',
+      'emailSubject',
+      'emailMessage',
+      'optimizedForPrinting',
+    ],
+  });
   const now = useMemo(() => moment().set({ second: 0, millisecond: 0 }), []);
   const defaultStartDateValue = useMemo(() => now.toISOString(), [now]);
 
@@ -262,6 +281,14 @@ export const ScheduledReportForm = ({
     isUserProfileLoading,
     userProfile?.user.email,
   ]);
+
+  const previousPrintLayout = useRef(Boolean(scheduledReport.optimizedForPrinting));
+  useEffect(() => {
+    if (optimizedForPrinting && !previousPrintLayout.current) {
+      form.setFieldValue('colorMode', 'light');
+    }
+    previousPrintLayout.current = Boolean(optimizedForPrinting);
+  }, [form, optimizedForPrinting]);
 
   const isEmailActive = Boolean(sendByEmail);
 
@@ -347,15 +374,29 @@ export const ScheduledReportForm = ({
                   config={{
                     type: FIELD_TYPES.TOGGLE,
                     label: i18n.SCHEDULED_REPORT_FORM_OPTIMIZED_FOR_PRINTING_LABEL,
+                    defaultValue: false,
                   }}
                   componentProps={{
                     helpText: i18n.SCHEDULED_REPORT_FORM_OPTIMIZED_FOR_PRINTING_DESCRIPTION,
                     euiFieldProps: {
                       compressed: true,
                       readOnly: editMode || readOnly,
+                      'data-test-subj': 'usePrintLayout',
                     },
                   }}
                 />
+              )}
+              {(reportTypeId === 'printablePdfV2' || reportTypeId === 'pngV2') && (
+                <UseField path="colorMode">
+                  {(field) => (
+                    <ColorModeKeyPad
+                      colorMode={(field.value as 'light' | 'dark') ?? defaultColorMode}
+                      onChange={(nextColorMode) => field.setValue(nextColorMode)}
+                      usePrintLayout={Boolean(optimizedForPrinting)}
+                      isDisabled={editMode || readOnly}
+                    />
+                  )}
+                </UseField>
               )}
             </ResponsiveFormGroup>
             <ResponsiveFormGroup

--- a/x-pack/platform/plugins/private/reporting/public/management/report_params.ts
+++ b/x-pack/platform/plugins/private/reporting/public/management/report_params.ts
@@ -29,7 +29,12 @@ export interface GetReportParamsOptions {
   objectType: string;
   sharingData: any;
   title: string;
+  optimizedForPrinting?: boolean;
+  colorMode?: 'light' | 'dark';
 }
+
+const isScreenshotReportType = (reportTypeId: ReportTypeId) =>
+  reportTypeId === 'pngV2' || reportTypeId === 'printablePdfV2';
 
 export const getReportParams = ({
   apiClient,
@@ -37,6 +42,8 @@ export const getReportParams = ({
   objectType,
   sharingData,
   title,
+  optimizedForPrinting,
+  colorMode,
 }: GetReportParamsOptions) => {
   const getParams = reportParamsProviders[reportTypeId];
   if (!getParams) {
@@ -47,6 +54,8 @@ export const getReportParams = ({
       ...getParams({
         objectType,
         sharingData,
+        ...(reportTypeId === 'printablePdfV2' ? { optimizedForPrinting } : {}),
+        ...(isScreenshotReportType(reportTypeId) ? { colorMode } : {}),
       }),
       objectType,
       title,

--- a/x-pack/platform/plugins/private/reporting/public/management/schemas/scheduled_report_form_schema.ts
+++ b/x-pack/platform/plugins/private/reporting/public/management/schemas/scheduled_report_form_schema.ts
@@ -42,6 +42,13 @@ export const getScheduledReportFormSchema = (
       },
     ],
   },
+  optimizedForPrinting: {
+    type: FIELD_TYPES.TOGGLE,
+    defaultValue: false,
+  },
+  colorMode: {
+    defaultValue: 'light',
+  },
   startDate: {},
   timezone: {},
   recurringSchedule: getRecurringScheduleFormSchema({ allowInfiniteRecurrence: false }),

--- a/x-pack/platform/plugins/private/reporting/public/management/translations.ts
+++ b/x-pack/platform/plugins/private/reporting/public/management/translations.ts
@@ -66,7 +66,8 @@ export const SCHEDULED_REPORT_FORM_OPTIMIZED_FOR_PRINTING_LABEL = i18n.translate
 export const SCHEDULED_REPORT_FORM_OPTIMIZED_FOR_PRINTING_DESCRIPTION = i18n.translate(
   'xpack.reporting.scheduledReportingForm.optimizedForDescription',
   {
-    defaultMessage: 'Uses multiple pages, showing at most 2 visualizations per page',
+    defaultMessage:
+      'Uses multiple pages, showing at most 2 visualizations per page. Light color mode is recommended for printing.',
   }
 );
 

--- a/x-pack/platform/plugins/private/reporting/public/types.ts
+++ b/x-pack/platform/plugins/private/reporting/public/types.ts
@@ -73,6 +73,10 @@ export interface ScheduledReport {
    */
   optimizedForPrinting?: boolean;
   /**
+   * PDF/PNG screenshot color mode stored on the job.
+   */
+  colorMode?: 'light' | 'dark';
+  /**
    * The date when the report should be first generated
    */
   startDate: string;

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.test.ts
@@ -22,6 +22,34 @@ describe('validateJobParams', () => {
     expect(() => validateJobParams(validParams)).not.toThrow();
   });
 
+  it('accepts colorMode light and dark', () => {
+    const validParams = {
+      title: 'Monthly Report',
+      version: '8.0.0',
+      layout: { id: idSchema.enum.print, dimensions: { width: 800, height: 600 } },
+      browserTimezone: 'UTC',
+      objectType: 'dashboard',
+      forceNow: '2024-01-01T00:00:00Z',
+      colorMode: 'dark' as const,
+    };
+
+    expect(validateJobParams(validParams).colorMode).toBe('dark');
+  });
+
+  it('rejects invalid colorMode values', () => {
+    const invalidParams = {
+      title: 'Monthly Report',
+      version: '8.0.0',
+      layout: { id: idSchema.enum.print, dimensions: { width: 800, height: 600 } },
+      browserTimezone: 'UTC',
+      objectType: 'dashboard',
+      forceNow: '2024-01-01T00:00:00Z',
+      colorMode: 'system',
+    } as unknown as BaseParams;
+
+    expect(() => validateJobParams(invalidParams)).toThrow();
+  });
+
   it('accepts valid csv job params', () => {
     const validParams = {
       browserTimezone: 'America/Los_Angeles',

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.ts
@@ -141,6 +141,7 @@ const jobParamsSchema = z
     relativeUrls: relativeUrlsSchema.optional(), // used in tests could be legacy
     relativeUrl: relativeUrlSchema.optional(), // used in tests could be legacy
     isEsqlMode: z.boolean().optional(), // for CSV reports
+    colorMode: z.enum(['light', 'dark']).optional(), // PDF/PNG screenshot color mode
   })
   .strict();
 


### PR DESCRIPTION
> ⚠️ UX POC - not production ready

## Summary

PDF and PNG reports currently inherit the exporter's Kibana Appearance at screenshot time, so scheduled jobs can change look after someone updates their theme.

This adds an explicit Light/Dark **Color mode** control on Export and Schedule (PDF and PNG only; CSV is out of scope). The choice is stored on the job as `colorMode` and applied during Chromium rendering via `x-kbn-report-color-mode`, so later Appearance changes do not restyle already-scheduled reports.

- Default: the user's resolved appearance at generate/schedule time
- Print format on: auto-selects Light and shows a Recommended badge next to Color mode
- Exports table: new Color mode column with sun/moon icons

## Test plan

- [ ] Export a dashboard as PDF and PNG; confirm Light/Dark keypad appears and CSV does not show it
- [ ] With Print format off, default matches current Kibana appearance and can be overridden
- [ ] Turning Print format on selects Light and shows the Recommended badge; Dark remains selectable
- [ ] Generate PDF/PNG in Light and Dark and confirm the file matches the chosen mode
- [ ] Schedule a PDF, change Kibana Appearance, wait for a run; the report should keep the scheduled color mode
- [ ] Reporting > Exports shows Light/Dark with sun/moon icons; CSV and older jobs show an em dash

### Checklist

- [x] Any text added follows EUI writing guidelines, uses sentence case, and includes i18n support
- [ ] Documentation was added for features that require explanation or tutorials
- [x] Unit or functional tests were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the docker list
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] Flaky Test Runner was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied
- [ ] Review the backport guidelines and apply applicable `backport:*` labels.

### Identify risks

- Older PDF/PNG jobs without `colorMode` keep previous behavior (Appearance at screenshot time). Mitigation: treat missing `colorMode` as unset and do not send the override header.


Made with [Cursor](https://cursor.com)