### PR TITLE
ci: fire eval smoke tests on inference and ai-infra changes

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -74,3 +74,5 @@
     - 'src/platform/packages/shared/kbn-tracing/**/*.*'
     - '.buildkite/pipelines/evals/**/*.*'
     - '.buildkite/scripts/steps/evals/**/*.*'
+    - 'x-pack/platform/plugins/shared/inference/**/*.*'
+    - 'x-pack/platform/packages/shared/ai-infra/**/*.*'


### PR DESCRIPTION
## Summary

Adds the inference plugin (`x-pack/platform/plugins/shared/inference`) and ai-infra packages (`x-pack/platform/packages/shared/ai-infra`) to the `evals:smoke-tests` block in `.github/paths-labeller.yml`, so PRs touching them auto-apply the label and run the eval smoke suite. Closes the CI gap that let the reasoning regression in #286109 slip through.

Closes elastic/nightshift-program#1208

## Testing

- Verified `paths-labeller.yml` parses and both globs sit inside the `evals:smoke-tests` list.