### PR TITLE
[Agent builder] Visual alignment between sidenavs

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/shared/sidebar_nav_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/shared/sidebar_nav_list.tsx
@@ -32,19 +32,24 @@ export const SidebarNavList: React.FC<SidebarNavListProps> = ({ items, isActive,
     padding: 6px ${euiTheme.size.s};
     border-radius: ${euiTheme.border.radius.small};
     text-decoration: none;
-    color: ${euiTheme.colors.textParagraph};
+    color: ${euiTheme.components.buttons.textColorText};
 
     &:hover {
-      background-color: ${euiTheme.colors.backgroundLightPrimary};
-      color: ${euiTheme.colors.textPrimary};
+      background-color: ${euiTheme.components.buttons.backgroundEmptyTextHover};
+      color: ${euiTheme.components.buttons.textColorText};
       text-decoration: none;
     }
   `;
 
   const activeLinkStyles = css`
     ${baseLinkStyles}
-    background-color: ${euiTheme.colors.backgroundLightPrimary};
-    color: ${euiTheme.colors.textPrimary};
+    background-color: ${euiTheme.components.buttons.backgroundPrimary};
+    color: ${euiTheme.components.buttons.textColorPrimary};
+
+    &:hover {
+      background-color: ${euiTheme.components.buttons.backgroundPrimaryHover};
+      color: ${euiTheme.components.buttons.textColorPrimary};
+    }
   `;
 
   return (


### PR DESCRIPTION
## Summary

Small fix to visually align the sidenav of AB with our secondary navigation in terms of active, hover and default item state. 

Before / After
<img width="4348" height="2402" alt="image" src="https://github.com/user-attachments/assets/f8afcd08-dfc7-44d3-984d-50ef50e8dd35" />


_Later we can improve this by using EuiGroupList or similar structure as we do in the secondary nav._