### PR TITLE
feat(cases,agent-builder): deprecate cases attachments tool, split into read/write

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/tools/constants.ts
@@ -55,6 +55,8 @@ const casesTool = <TName extends string>(
  */
 export const platformCoreCasesTools = {
   manage: casesTool('manage'),
+  /** @deprecated Use `getAttachments` (read) and `manageAttachments` (write) instead. */
+  attachments: casesTool('attachments'),
   getAttachments: casesTool('get_attachments'),
   manageAttachments: casesTool('manage_attachments'),
   observables: casesTool('observables'),

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -39,7 +39,7 @@ import { createSmlTools } from './services/tools/builtin/sml';
 import { createConnectorTools } from './services/tools/builtin/connectors';
 import { createAdminPrivilegeSwitcher } from './capabilities/admin_privilege_switcher';
 import { registerInferenceFeatures } from './inference_features';
-import { runToolIdMigrations } from './services/agents/persisted/tool_id_migration';
+import { runToolIdBackfill } from './services/agents/persisted/tool_id_backfill';
 
 export class AgentBuilderPlugin
   implements
@@ -250,8 +250,8 @@ export class AgentBuilderPlugin
       this.logger.warn(`Failed to clean up legacy SML tasks: ${(error as Error).message}`);
     });
 
-    this.runMigrations(elasticsearch).catch((error) => {
-      this.logger.error(`Migration failed: ${(error as Error).message}`);
+    this.runBackfill(elasticsearch).catch((error) => {
+      this.logger.error(`Backfill failed: ${(error as Error).message}`);
     });
 
     const startServices = this.serviceManager.startServices({
@@ -339,12 +339,12 @@ export class AgentBuilderPlugin
   }
 
   /**
-   * Applies all registered migrations
+   * Applies all registered tool ID backfills.
    */
-  private async runMigrations(elasticsearch: CoreStart['elasticsearch']): Promise<void> {
-    const logger = this.logger.get('migrations');
+  private async runBackfill(elasticsearch: CoreStart['elasticsearch']): Promise<void> {
+    const logger = this.logger.get('backfill');
     const esClient = elasticsearch.client.asInternalUser;
-    await runToolIdMigrations(logger, esClient);
+    await runToolIdBackfill(logger, esClient);
   }
 
   /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/tool_id_backfill.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/tool_id_backfill.test.ts
@@ -9,14 +9,17 @@ import { loggingSystemMock } from '@kbn/core/server/mocks';
 import type { AgentProfileStorage, AgentProperties } from './client/storage';
 import type { SkillStorage, SkillProperties } from '../../skills/persisted/client/storage';
 import {
-  replaceToolIdsInToolSelection,
-  replaceToolIdsInArray,
-  migrateAgentToolIds,
-  migrateSkillToolIds,
-} from './tool_id_migration';
+  addToolIdsToToolSelection,
+  addToolIdsToArray,
+  backfillAgentToolIds,
+  backfillSkillToolIds,
+} from './tool_id_backfill';
 
 const OLD_ID = 'platform.core.cases.attachments';
-const NEW_IDS = ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments'];
+const SUPPLEMENTAL_IDS = [
+  'platform.core.cases.get_attachments',
+  'platform.core.cases.manage_attachments',
+];
 
 const makeAgentSource = (toolIds: string[]): AgentProperties => ({
   id: 'agent-1',
@@ -69,126 +72,162 @@ const buildSkillStorageMock = (pages: SkillProperties[][]): SkillStorage => {
   return { getClient: () => ({ search, bulk }) } as unknown as SkillStorage;
 };
 
-describe('replaceToolIdsInToolSelection', () => {
-  it('replaces old id with new ids', () => {
-    const tools = [{ tool_ids: ['other.tool', 'platform.core.cases.attachments'] }];
-    const result = replaceToolIdsInToolSelection(tools, 'platform.core.cases.attachments', [
+describe('addToolIdsToToolSelection', () => {
+  it('adds new IDs alongside the old ID without removing it', () => {
+    const tools = [{ tool_ids: ['platform.core.cases.attachments', 'platform.core.search'] }];
+    const result = addToolIdsToToolSelection(
+      tools,
+      'platform.core.cases.attachments',
+      ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments']
+    );
+    expect(result[0].tool_ids).toEqual([
+      'platform.core.cases.attachments',
+      'platform.core.search',
       'platform.core.cases.get_attachments',
       'platform.core.cases.manage_attachments',
     ]);
-    expect(result).toEqual([
-      {
-        tool_ids: [
-          'other.tool',
-          'platform.core.cases.get_attachments',
-          'platform.core.cases.manage_attachments',
-        ],
-      },
-    ]);
   });
 
-  it('returns unchanged array when old id is not present', () => {
-    const tools = [{ tool_ids: ['other.tool'] }];
-    const result = replaceToolIdsInToolSelection(tools, 'platform.core.cases.attachments', [
-      'platform.core.cases.get_attachments',
-      'platform.core.cases.manage_attachments',
-    ]);
-    expect(result).toEqual([{ tool_ids: ['other.tool'] }]);
-  });
-
-  it('does not duplicate if new ids already present', () => {
+  it('does not duplicate IDs that already exist', () => {
     const tools = [
       {
         tool_ids: ['platform.core.cases.attachments', 'platform.core.cases.get_attachments'],
       },
     ];
-    const result = replaceToolIdsInToolSelection(tools, 'platform.core.cases.attachments', [
+    const result = addToolIdsToToolSelection(
+      tools,
+      'platform.core.cases.attachments',
+      ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments']
+    );
+    expect(result[0].tool_ids).toEqual([
+      'platform.core.cases.attachments',
       'platform.core.cases.get_attachments',
       'platform.core.cases.manage_attachments',
-    ]);
-    expect(result).toEqual([
-      {
-        tool_ids: ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments'],
-      },
     ]);
   });
 
+  it('is a no-op when old ID is not present', () => {
+    const tools = [{ tool_ids: ['platform.core.search'] }];
+    const result = addToolIdsToToolSelection(
+      tools,
+      'platform.core.cases.attachments',
+      ['platform.core.cases.get_attachments']
+    );
+    expect(result).toBe(tools); // same reference
+  });
+
+  it('is a no-op when all supplemental IDs already exist', () => {
+    const tools = [
+      {
+        tool_ids: [
+          'platform.core.cases.attachments',
+          'platform.core.cases.get_attachments',
+          'platform.core.cases.manage_attachments',
+        ],
+      },
+    ];
+    const result = addToolIdsToToolSelection(
+      tools,
+      'platform.core.cases.attachments',
+      ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments']
+    );
+    expect(result).toBe(tools); // same reference — nothing to add
+  });
+
   it('handles multiple selections', () => {
-    const tools = [{ tool_ids: ['platform.core.cases.attachments'] }, { tool_ids: ['other.tool'] }];
-    const result = replaceToolIdsInToolSelection(tools, 'platform.core.cases.attachments', [
-      'platform.core.cases.get_attachments',
-      'platform.core.cases.manage_attachments',
-    ]);
+    const tools = [
+      { tool_ids: ['platform.core.cases.attachments'] },
+      { tool_ids: ['other.tool'] },
+    ];
+    const result = addToolIdsToToolSelection(
+      tools,
+      'platform.core.cases.attachments',
+      ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments']
+    );
     expect(result).toEqual([
       {
-        tool_ids: ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments'],
+        tool_ids: [
+          'platform.core.cases.attachments',
+          'platform.core.cases.get_attachments',
+          'platform.core.cases.manage_attachments',
+        ],
       },
       { tool_ids: ['other.tool'] },
     ]);
   });
 });
 
-describe('replaceToolIdsInArray', () => {
-  it('replaces old id with new ids', () => {
-    const result = replaceToolIdsInArray(
-      ['other.tool', 'platform.core.cases.attachments'],
+describe('addToolIdsToArray', () => {
+  it('adds new IDs alongside old without removing it', () => {
+    const result = addToolIdsToArray(
+      ['platform.core.cases.attachments', 'other'],
       'platform.core.cases.attachments',
-      ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments']
+      ['platform.core.cases.get_attachments']
     );
     expect(result).toEqual([
-      'other.tool',
+      'platform.core.cases.attachments',
+      'other',
       'platform.core.cases.get_attachments',
-      'platform.core.cases.manage_attachments',
     ]);
   });
 
   it('returns unchanged array when old id is not present', () => {
-    const result = replaceToolIdsInArray(['other.tool'], 'platform.core.cases.attachments', [
+    const original = ['other.tool'];
+    const result = addToolIdsToArray(original, 'platform.core.cases.attachments', [
       'platform.core.cases.get_attachments',
       'platform.core.cases.manage_attachments',
     ]);
-    expect(result).toEqual(['other.tool']);
+    expect(result).toBe(original); // same reference
   });
 
-  it('does not duplicate if new ids already present', () => {
-    const result = replaceToolIdsInArray(
-      ['platform.core.cases.attachments', 'platform.core.cases.get_attachments'],
+  it('does not duplicate if supplemental ids already present', () => {
+    const result = addToolIdsToArray(
+      [
+        'platform.core.cases.attachments',
+        'platform.core.cases.get_attachments',
+        'platform.core.cases.manage_attachments',
+      ],
       'platform.core.cases.attachments',
       ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments']
     );
     expect(result).toEqual([
+      'platform.core.cases.attachments',
       'platform.core.cases.get_attachments',
       'platform.core.cases.manage_attachments',
     ]);
   });
 
-  it('returns same reference when old id is absent', () => {
-    const original = ['other.tool'];
-    const result = replaceToolIdsInArray(original, 'platform.core.cases.attachments', [
+  it('returns same reference when all supplemental IDs already present', () => {
+    const original = [
+      'platform.core.cases.attachments',
+      'platform.core.cases.get_attachments',
+      'platform.core.cases.manage_attachments',
+    ];
+    const result = addToolIdsToArray(original, 'platform.core.cases.attachments', [
       'platform.core.cases.get_attachments',
       'platform.core.cases.manage_attachments',
     ]);
-    expect(result).toBe(original);
+    expect(result).toBe(original); // same reference — nothing to add
   });
 });
 
-describe('migrateAgentToolIds', () => {
+describe('backfillAgentToolIds', () => {
   const logger = loggingSystemMock.createLogger();
 
-  it('bulk-indexes agents that contain the old tool ID', async () => {
+  it('bulk-indexes agents that contain the old tool ID, keeping the old ID', async () => {
     const source = makeAgentSource([OLD_ID]);
     const storage = buildAgentStorageMock([[source], []]);
     const client = storage.getClient();
 
-    await migrateAgentToolIds({ storage, logger });
+    await backfillAgentToolIds({ storage, logger });
 
     expect((client.bulk as jest.Mock).mock.calls).toHaveLength(1);
     const ops = (client.bulk as jest.Mock).mock.calls[0][0].operations;
     expect(ops).toHaveLength(1);
     const { document } = ops[0].index;
     const toolIds = (document.config ?? document.configuration).tools[0].tool_ids;
-    expect(toolIds).toEqual(expect.arrayContaining(NEW_IDS));
-    expect(toolIds).not.toContain(OLD_ID);
+    expect(toolIds).toEqual(expect.arrayContaining(SUPPLEMENTAL_IDS));
+    expect(toolIds).toContain(OLD_ID); // old ID is kept
   });
 
   it('skips agents that do not contain the old tool ID', async () => {
@@ -196,7 +235,7 @@ describe('migrateAgentToolIds', () => {
     const storage = buildAgentStorageMock([[source], []]);
     const client = storage.getClient();
 
-    await migrateAgentToolIds({ storage, logger });
+    await backfillAgentToolIds({ storage, logger });
 
     expect(client.bulk as jest.Mock).not.toHaveBeenCalled();
   });
@@ -210,7 +249,7 @@ describe('migrateAgentToolIds', () => {
     const storage = buildAgentStorageMock([[source], []]);
     const client = storage.getClient();
 
-    await migrateAgentToolIds({ storage, logger });
+    await backfillAgentToolIds({ storage, logger });
 
     expect((client.bulk as jest.Mock).mock.calls).toHaveLength(1);
     const ops = (client.bulk as jest.Mock).mock.calls[0][0].operations;
@@ -228,19 +267,19 @@ describe('migrateAgentToolIds', () => {
     const storage = buildAgentStorageMock([fullPage, page2]);
     const client = storage.getClient();
 
-    await migrateAgentToolIds({ storage, logger });
+    await backfillAgentToolIds({ storage, logger });
 
     expect((client.search as jest.Mock).mock.calls).toHaveLength(2);
     const totalBulkOps = (client.bulk as jest.Mock).mock.calls.flatMap(([req]) => req.operations);
     expect(totalBulkOps).toHaveLength(2);
   });
 
-  it('is idempotent — does not duplicate new IDs already present', async () => {
+  it('is idempotent — does not duplicate supplemental IDs already present', async () => {
     const source = makeAgentSource([OLD_ID, 'platform.core.cases.get_attachments']);
     const storage = buildAgentStorageMock([[source], []]);
     const client = storage.getClient();
 
-    await migrateAgentToolIds({ storage, logger });
+    await backfillAgentToolIds({ storage, logger });
 
     const ops = (client.bulk as jest.Mock).mock.calls[0][0].operations;
     const toolIds = (ops[0].index.document.config ?? ops[0].index.document.configuration).tools[0]
@@ -249,24 +288,34 @@ describe('migrateAgentToolIds', () => {
       toolIds.filter((id: string) => id === 'platform.core.cases.get_attachments')
     ).toHaveLength(1);
   });
+
+  it('skips agents where all supplemental IDs are already present', async () => {
+    const source = makeAgentSource([OLD_ID, ...SUPPLEMENTAL_IDS]);
+    const storage = buildAgentStorageMock([[source], []]);
+    const client = storage.getClient();
+
+    await backfillAgentToolIds({ storage, logger });
+
+    expect(client.bulk as jest.Mock).not.toHaveBeenCalled();
+  });
 });
 
-describe('migrateSkillToolIds', () => {
+describe('backfillSkillToolIds', () => {
   const logger = loggingSystemMock.createLogger();
 
-  it('bulk-indexes skills that contain the old tool ID', async () => {
+  it('bulk-indexes skills that contain the old tool ID, keeping the old ID', async () => {
     const source = makeSkillSource([OLD_ID]);
     const storage = buildSkillStorageMock([[source], []]);
     const client = storage.getClient();
 
-    await migrateSkillToolIds({ storage, logger });
+    await backfillSkillToolIds({ storage, logger });
 
     expect((client.bulk as jest.Mock).mock.calls).toHaveLength(1);
     const ops = (client.bulk as jest.Mock).mock.calls[0][0].operations;
     expect(ops).toHaveLength(1);
     const { document } = ops[0].index;
-    expect(document.tool_ids).toEqual(expect.arrayContaining(NEW_IDS));
-    expect(document.tool_ids).not.toContain(OLD_ID);
+    expect(document.tool_ids).toEqual(expect.arrayContaining(SUPPLEMENTAL_IDS));
+    expect(document.tool_ids).toContain(OLD_ID); // old ID is kept
   });
 
   it('skips skills that do not contain the old tool ID', async () => {
@@ -274,7 +323,7 @@ describe('migrateSkillToolIds', () => {
     const storage = buildSkillStorageMock([[source], []]);
     const client = storage.getClient();
 
-    await migrateSkillToolIds({ storage, logger });
+    await backfillSkillToolIds({ storage, logger });
 
     expect(client.bulk as jest.Mock).not.toHaveBeenCalled();
   });
@@ -290,10 +339,20 @@ describe('migrateSkillToolIds', () => {
     const storage = buildSkillStorageMock([fullPage, page2]);
     const client = storage.getClient();
 
-    await migrateSkillToolIds({ storage, logger });
+    await backfillSkillToolIds({ storage, logger });
 
     expect((client.search as jest.Mock).mock.calls).toHaveLength(2);
     const totalBulkOps = (client.bulk as jest.Mock).mock.calls.flatMap(([req]) => req.operations);
     expect(totalBulkOps).toHaveLength(2);
+  });
+
+  it('skips skills where all supplemental IDs are already present', async () => {
+    const source = makeSkillSource([OLD_ID, ...SUPPLEMENTAL_IDS]);
+    const storage = buildSkillStorageMock([[source], []]);
+    const client = storage.getClient();
+
+    await backfillSkillToolIds({ storage, logger });
+
+    expect(client.bulk as jest.Mock).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/tool_id_backfill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/tool_id_backfill.ts
@@ -18,68 +18,80 @@ import { updateRequestToEs } from './client/converters';
 
 const PAGE_SIZE = 1000;
 
-export interface ToolIdMigrationEntry {
+export interface ToolIdBackfillEntry {
   oldId: string;
-  newIds: string[];
+  supplementalIds: string[];
 }
 
 /**
- * Registry of tool ID migrations. Add new entries here when tool IDs are
- * renamed or split. Each entry maps an old ID to one or more replacement IDs.
- * The migration runner applies all entries idempotently on every startup.
+ * Registry of tool ID backfills. Add new entries here when tool IDs are
+ * renamed or split. Each entry maps an old ID to one or more supplemental IDs
+ * that should be added alongside it. The backfill runner applies all entries
+ * idempotently on every startup.
  */
-const TOOL_ID_MIGRATIONS: ToolIdMigrationEntry[] = [
+const TOOL_ID_BACKFILLS: ToolIdBackfillEntry[] = [
   {
     oldId: 'platform.core.cases.attachments',
-    newIds: ['platform.core.cases.get_attachments', 'platform.core.cases.manage_attachments'],
+    supplementalIds: [
+      'platform.core.cases.get_attachments',
+      'platform.core.cases.manage_attachments',
+    ],
   },
 ];
 
 /**
- * Replaces an old tool ID with one or more new IDs in a ToolSelection array.
- * Idempotent: if any new IDs already exist, they are not duplicated.
+ * Appends supplemental tool IDs alongside an old ID in a ToolSelection array.
+ * The old ID is kept. Idempotent: if all supplemental IDs already exist, the
+ * original reference is returned unchanged.
  */
-export const replaceToolIdsInToolSelection = (
+export const addToolIdsToToolSelection = (
   tools: ToolSelection[],
   oldId: string,
-  newIds: string[]
+  supplementalIds: string[]
 ): ToolSelection[] => {
-  return tools.map((selection) => {
+  let changed = false;
+  const result = tools.map((selection) => {
     const ids = selection.tool_ids ?? [];
     if (!ids.includes(oldId)) {
       return selection;
     }
-    const withoutOld = ids.filter((id) => id !== oldId);
-    const existingSet = new Set(withoutOld);
-    const toAdd = newIds.filter((id) => !existingSet.has(id));
-    return { ...selection, tool_ids: [...withoutOld, ...toAdd] };
+    const existingSet = new Set(ids);
+    const toAdd = supplementalIds.filter((id) => !existingSet.has(id));
+    if (toAdd.length === 0) {
+      return selection;
+    }
+    changed = true;
+    return { ...selection, tool_ids: [...ids, ...toAdd] };
   });
+  return changed ? result : tools;
 };
 
 /**
- * Replaces an old tool ID with one or more new IDs in a flat string array.
- * Idempotent: if any new IDs already exist, they are not duplicated.
- * Returns the same reference if oldId is not present.
+ * Appends supplemental tool IDs alongside an old ID in a flat string array.
+ * The old ID is kept. Idempotent: returns the same reference if oldId is not
+ * present or all supplemental IDs already exist.
  */
-export const replaceToolIdsInArray = (
+export const addToolIdsToArray = (
   toolIds: string[],
   oldId: string,
-  newIds: string[]
+  supplementalIds: string[]
 ): string[] => {
   if (!toolIds.includes(oldId)) {
     return toolIds;
   }
-  const withoutOld = toolIds.filter((id) => id !== oldId);
-  const existingSet = new Set(withoutOld);
-  const toAdd = newIds.filter((id) => !existingSet.has(id));
-  return [...withoutOld, ...toAdd];
+  const existingSet = new Set(toolIds);
+  const toAdd = supplementalIds.filter((id) => !existingSet.has(id));
+  if (toAdd.length === 0) {
+    return toolIds;
+  }
+  return [...toolIds, ...toAdd];
 };
 
 const getToolsFromAgentSource = (source: AgentProperties): ToolSelection[] => {
   return source.configuration?.tools ?? source.config?.tools ?? [];
 };
 
-interface MigrationClient<TDoc> {
+interface BackfillClient<TDoc> {
   search: (req: StorageClientSearchRequest) => Promise<{
     hits: { hits: Array<{ _id: string; _source?: TDoc; sort?: SortResults }> };
   }>;
@@ -95,13 +107,13 @@ interface MigrationClient<TDoc> {
  * any that need updating. The `processHits` callback receives one page of hits and returns
  * the bulk operations to apply (empty array = nothing to update for that page).
  */
-const paginatedMigration = async <TDoc>({
+const paginatedUpdate = async <TDoc>({
   client,
   label,
   logger,
   processHits,
 }: {
-  client: MigrationClient<TDoc>;
+  client: BackfillClient<TDoc>;
   label: string;
   logger: Logger;
   processHits: (
@@ -137,7 +149,7 @@ const paginatedMigration = async <TDoc>({
         totalUpdated += bulkOperations.length;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        logger.error(`${label} tool ID migration: bulk update failed. ${message}`);
+        logger.error(`${label} tool ID backfill: bulk update failed. ${message}`);
       }
     }
 
@@ -147,25 +159,23 @@ const paginatedMigration = async <TDoc>({
   } while (true);
 
   if (totalUpdated > 0) {
-    logger.info(`${label} tool ID migration: updated ${totalUpdated} document(s).`);
+    logger.info(`${label} tool ID backfill: updated ${totalUpdated} document(s).`);
   }
 };
 
 /**
- * Scans all agents in .chat-agents and replaces old tool IDs with new ones.
+ * Scans all agents in .chat-agents and appends supplemental tool IDs alongside old ones.
  * Operates across all spaces (no space filter). Fire-and-forget safe.
  */
-export const migrateAgentToolIds = async ({
+export const backfillAgentToolIds = async ({
   storage,
   logger,
 }: {
   storage: AgentProfileStorage;
   logger: Logger;
 }): Promise<void> => {
-  const oldIdSet = new Set(TOOL_ID_MIGRATIONS.map((m) => m.oldId));
-
-  await paginatedMigration<AgentProperties>({
-    client: storage.getClient() as MigrationClient<AgentProperties>,
+  await paginatedUpdate<AgentProperties>({
+    client: storage.getClient() as BackfillClient<AgentProperties>,
     label: 'Agent',
     logger,
     processHits: (hits, now) => {
@@ -175,14 +185,12 @@ export const migrateAgentToolIds = async ({
         if (!source) continue;
 
         const currentTools = getToolsFromAgentSource(source);
-        if (!currentTools.some((sel) => (sel.tool_ids ?? []).some((id) => oldIdSet.has(id)))) {
-          continue;
+        let newTools = currentTools;
+        for (const { oldId, supplementalIds } of TOOL_ID_BACKFILLS) {
+          newTools = addToolIdsToToolSelection(newTools, oldId, supplementalIds);
         }
 
-        let newTools = currentTools;
-        for (const { oldId, newIds } of TOOL_ID_MIGRATIONS) {
-          newTools = replaceToolIdsInToolSelection(newTools, oldId, newIds);
-        }
+        if (newTools === currentTools) continue; // reference equality — nothing changed
 
         ops.push({
           index: {
@@ -202,20 +210,18 @@ export const migrateAgentToolIds = async ({
 };
 
 /**
- * Scans all skills in .kibana_ai_infra-skills and replaces old tool IDs with new ones.
+ * Scans all skills in .kibana_ai_infra-skills and appends supplemental tool IDs alongside old ones.
  * Operates across all spaces (no space filter). Fire-and-forget safe.
  */
-export const migrateSkillToolIds = async ({
+export const backfillSkillToolIds = async ({
   storage,
   logger,
 }: {
   storage: SkillStorage;
   logger: Logger;
 }): Promise<void> => {
-  const oldIdSet = new Set(TOOL_ID_MIGRATIONS.map((m) => m.oldId));
-
-  await paginatedMigration<SkillProperties>({
-    client: storage.getClient() as MigrationClient<SkillProperties>,
+  await paginatedUpdate<SkillProperties>({
+    client: storage.getClient() as BackfillClient<SkillProperties>,
     label: 'Skill',
     logger,
     processHits: (hits, now) => {
@@ -225,12 +231,12 @@ export const migrateSkillToolIds = async ({
         if (!source) continue;
 
         const currentToolIds = source.tool_ids ?? [];
-        if (!currentToolIds.some((id) => oldIdSet.has(id))) continue;
-
         let newToolIds = currentToolIds;
-        for (const { oldId, newIds } of TOOL_ID_MIGRATIONS) {
-          newToolIds = replaceToolIdsInArray(newToolIds, oldId, newIds);
+        for (const { oldId, supplementalIds } of TOOL_ID_BACKFILLS) {
+          newToolIds = addToolIdsToArray(newToolIds, oldId, supplementalIds);
         }
+
+        if (newToolIds === currentToolIds) continue; // reference equality — nothing changed
 
         ops.push({
           index: {
@@ -245,20 +251,20 @@ export const migrateSkillToolIds = async ({
 };
 
 /**
- * Applies all registered tool ID migrations
+ * Applies all registered tool ID backfills
  * to persisted agent configs and skill definitions. Idempotent — safe to run
  * on every startup.
  */
-export const runToolIdMigrations = async (
+export const runToolIdBackfill = async (
   logger: Logger,
   esClient: ElasticsearchClient
 ): Promise<void> => {
-  await migrateAgentToolIds({
+  await backfillAgentToolIds({
     storage: createAgentStorage({ logger, esClient }),
     logger,
   });
 
-  await migrateSkillToolIds({
+  await backfillSkillToolIds({
     storage: createSkillStorage({ logger, esClient }),
     logger,
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/tool_id_migration.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/tool_id_migration.test.ts
@@ -198,7 +198,7 @@ describe('migrateAgentToolIds', () => {
 
     await migrateAgentToolIds({ storage, logger });
 
-    expect((client.bulk as jest.Mock)).not.toHaveBeenCalled();
+    expect(client.bulk as jest.Mock).not.toHaveBeenCalled();
   });
 
   it('reads the old tool ID from the legacy configuration field', async () => {
@@ -231,9 +231,7 @@ describe('migrateAgentToolIds', () => {
     await migrateAgentToolIds({ storage, logger });
 
     expect((client.search as jest.Mock).mock.calls).toHaveLength(2);
-    const totalBulkOps = (client.bulk as jest.Mock).mock.calls.flatMap(
-      ([req]) => req.operations
-    );
+    const totalBulkOps = (client.bulk as jest.Mock).mock.calls.flatMap(([req]) => req.operations);
     expect(totalBulkOps).toHaveLength(2);
   });
 
@@ -247,7 +245,9 @@ describe('migrateAgentToolIds', () => {
     const ops = (client.bulk as jest.Mock).mock.calls[0][0].operations;
     const toolIds = (ops[0].index.document.config ?? ops[0].index.document.configuration).tools[0]
       .tool_ids;
-    expect(toolIds.filter((id: string) => id === 'platform.core.cases.get_attachments')).toHaveLength(1);
+    expect(
+      toolIds.filter((id: string) => id === 'platform.core.cases.get_attachments')
+    ).toHaveLength(1);
   });
 });
 
@@ -276,7 +276,7 @@ describe('migrateSkillToolIds', () => {
 
     await migrateSkillToolIds({ storage, logger });
 
-    expect((client.bulk as jest.Mock)).not.toHaveBeenCalled();
+    expect(client.bulk as jest.Mock).not.toHaveBeenCalled();
   });
 
   it('paginates across multiple pages', async () => {
@@ -293,9 +293,7 @@ describe('migrateSkillToolIds', () => {
     await migrateSkillToolIds({ storage, logger });
 
     expect((client.search as jest.Mock).mock.calls).toHaveLength(2);
-    const totalBulkOps = (client.bulk as jest.Mock).mock.calls.flatMap(
-      ([req]) => req.operations
-    );
+    const totalBulkOps = (client.bulk as jest.Mock).mock.calls.flatMap(([req]) => req.operations);
     expect(totalBulkOps).toHaveLength(2);
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/tool_id_migration.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/tool_id_migration.ts
@@ -79,10 +79,81 @@ const getToolsFromAgentSource = (source: AgentProperties): ToolSelection[] => {
   return source.configuration?.tools ?? source.config?.tools ?? [];
 };
 
+interface MigrationClient<TDoc> {
+  search: (req: StorageClientSearchRequest) => Promise<{
+    hits: { hits: Array<{ _id: string; _source?: TDoc; sort?: SortResults }> };
+  }>;
+  bulk: (req: {
+    operations: Array<{ index: { _id: string; document: TDoc } }>;
+    refresh: 'wait_for';
+    throwOnFail: boolean;
+  }) => Promise<unknown>;
+}
+
+/**
+ * Paginates through all documents in a storage index via search_after and bulk-indexes
+ * any that need updating. The `processHits` callback receives one page of hits and returns
+ * the bulk operations to apply (empty array = nothing to update for that page).
+ */
+const paginatedMigration = async <TDoc>({
+  client,
+  label,
+  logger,
+  processHits,
+}: {
+  client: MigrationClient<TDoc>;
+  label: string;
+  logger: Logger;
+  processHits: (
+    hits: Array<{ _id: string; _source?: TDoc }>,
+    now: Date
+  ) => Array<{ index: { _id: string; document: TDoc } }>;
+}): Promise<void> => {
+  const now = new Date();
+  let totalUpdated = 0;
+  let searchAfter: SortResults | undefined;
+
+  do {
+    const searchRequest: StorageClientSearchRequest = {
+      track_total_hits: false,
+      size: PAGE_SIZE,
+      sort: [{ _id: 'asc' }],
+      ...(searchAfter && { search_after: searchAfter }),
+    };
+    const response = await client.search(searchRequest);
+
+    const hits = response.hits.hits;
+    if (hits.length === 0) break;
+
+    const bulkOperations = processHits(hits, now);
+
+    if (bulkOperations.length > 0) {
+      try {
+        await client.bulk({
+          operations: bulkOperations,
+          refresh: 'wait_for',
+          throwOnFail: true,
+        });
+        totalUpdated += bulkOperations.length;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error(`${label} tool ID migration: bulk update failed. ${message}`);
+      }
+    }
+
+    searchAfter = hits[hits.length - 1].sort as SortResults | undefined;
+
+    if (hits.length < PAGE_SIZE) break;
+  } while (true);
+
+  if (totalUpdated > 0) {
+    logger.info(`${label} tool ID migration: updated ${totalUpdated} document(s).`);
+  }
+};
+
 /**
  * Scans all agents in .chat-agents and replaces old tool IDs with new ones.
  * Operates across all spaces (no space filter). Fire-and-forget safe.
- * Uses search_after pagination so every agent is visited regardless of total count.
  */
 export const migrateAgentToolIds = async ({
   storage,
@@ -92,80 +163,47 @@ export const migrateAgentToolIds = async ({
   logger: Logger;
 }): Promise<void> => {
   const oldIdSet = new Set(TOOL_ID_MIGRATIONS.map((m) => m.oldId));
-  const client = storage.getClient();
-  const now = new Date();
-  let totalUpdated = 0;
-  let searchAfter: SortResults | undefined;
 
-  do {
-    const searchRequest: StorageClientSearchRequest = {
-      track_total_hits: false,
-      size: PAGE_SIZE,
-      sort: [{ _id: 'asc' }],
-      ...(searchAfter && { search_after: searchAfter }),
-    };
-    const response = await client.search(searchRequest);
+  await paginatedMigration<AgentProperties>({
+    client: storage.getClient() as MigrationClient<AgentProperties>,
+    label: 'Agent',
+    logger,
+    processHits: (hits, now) => {
+      const ops: Array<{ index: { _id: string; document: AgentProperties } }> = [];
+      for (const hit of hits) {
+        const source = hit._source;
+        if (!source) continue;
 
-    const hits = response.hits.hits;
-    if (hits.length === 0) break;
+        const currentTools = getToolsFromAgentSource(source);
+        if (!currentTools.some((sel) => (sel.tool_ids ?? []).some((id) => oldIdSet.has(id)))) {
+          continue;
+        }
 
-    const bulkOperations: Array<{ index: { _id: string; document: AgentProperties } }> = [];
+        let newTools = currentTools;
+        for (const { oldId, newIds } of TOOL_ID_MIGRATIONS) {
+          newTools = replaceToolIdsInToolSelection(newTools, oldId, newIds);
+        }
 
-    for (const hit of hits) {
-      const source = hit._source;
-      if (!source) continue;
-
-      const currentTools = getToolsFromAgentSource(source);
-      const hasOldIds = currentTools.some((sel) =>
-        (sel.tool_ids ?? []).some((id) => oldIdSet.has(id))
-      );
-      if (!hasOldIds) continue;
-
-      let newTools = currentTools;
-      for (const { oldId, newIds } of TOOL_ID_MIGRATIONS) {
-        newTools = replaceToolIdsInToolSelection(newTools, oldId, newIds);
-      }
-
-      const updated = updateRequestToEs({
-        agentId: source.id ?? hit._id,
-        currentProps: source,
-        update: { configuration: { tools: newTools } },
-        updateDate: now,
-      });
-      bulkOperations.push({
-        index: { _id: String(hit._id), document: updated },
-      });
-    }
-
-    if (bulkOperations.length > 0) {
-      try {
-        await client.bulk({
-          operations: bulkOperations,
-          refresh: 'wait_for',
-          throwOnFail: true,
+        ops.push({
+          index: {
+            _id: String(hit._id),
+            document: updateRequestToEs({
+              agentId: source.id ?? hit._id,
+              currentProps: source,
+              update: { configuration: { tools: newTools } },
+              updateDate: now,
+            }),
+          },
         });
-        totalUpdated += bulkOperations.length;
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        logger.error(`Agent tool ID migration: bulk update failed. ${message}`);
       }
-    }
-
-    const lastHit = hits[hits.length - 1];
-    searchAfter = lastHit.sort as SortResults | undefined;
-
-    if (hits.length < PAGE_SIZE) break;
-  } while (true);
-
-  if (totalUpdated > 0) {
-    logger.info(`Agent tool ID migration: updated ${totalUpdated} agent(s).`);
-  }
+      return ops;
+    },
+  });
 };
 
 /**
  * Scans all skills in .kibana_ai_infra-skills and replaces old tool IDs with new ones.
  * Operates across all spaces (no space filter). Fire-and-forget safe.
- * Uses search_after pagination so every skill is visited regardless of total count.
  */
 export const migrateSkillToolIds = async ({
   storage,
@@ -175,71 +213,35 @@ export const migrateSkillToolIds = async ({
   logger: Logger;
 }): Promise<void> => {
   const oldIdSet = new Set(TOOL_ID_MIGRATIONS.map((m) => m.oldId));
-  const client = storage.getClient();
-  const now = new Date();
-  let totalUpdated = 0;
-  let searchAfter: SortResults | undefined;
 
-  do {
-    const searchRequest: StorageClientSearchRequest = {
-      track_total_hits: false,
-      size: PAGE_SIZE,
-      sort: [{ _id: 'asc' }],
-      ...(searchAfter && { search_after: searchAfter }),
-    };
-    const response = await client.search(searchRequest);
+  await paginatedMigration<SkillProperties>({
+    client: storage.getClient() as MigrationClient<SkillProperties>,
+    label: 'Skill',
+    logger,
+    processHits: (hits, now) => {
+      const ops: Array<{ index: { _id: string; document: SkillProperties } }> = [];
+      for (const hit of hits) {
+        const source = hit._source;
+        if (!source) continue;
 
-    const hits = response.hits.hits;
-    if (hits.length === 0) break;
+        const currentToolIds = source.tool_ids ?? [];
+        if (!currentToolIds.some((id) => oldIdSet.has(id))) continue;
 
-    const bulkOperations: Array<{ index: { _id: string; document: SkillProperties } }> = [];
+        let newToolIds = currentToolIds;
+        for (const { oldId, newIds } of TOOL_ID_MIGRATIONS) {
+          newToolIds = replaceToolIdsInArray(newToolIds, oldId, newIds);
+        }
 
-    for (const hit of hits) {
-      const source = hit._source;
-      if (!source) continue;
-
-      const currentToolIds = source.tool_ids ?? [];
-      const hasOldIds = currentToolIds.some((id) => oldIdSet.has(id));
-      if (!hasOldIds) continue;
-
-      let newToolIds = currentToolIds;
-      for (const { oldId, newIds } of TOOL_ID_MIGRATIONS) {
-        newToolIds = replaceToolIdsInArray(newToolIds, oldId, newIds);
-      }
-
-      const updated: SkillProperties = {
-        ...source,
-        tool_ids: newToolIds,
-        updated_at: now.toISOString(),
-      };
-      bulkOperations.push({
-        index: { _id: String(hit._id), document: updated },
-      });
-    }
-
-    if (bulkOperations.length > 0) {
-      try {
-        await client.bulk({
-          operations: bulkOperations,
-          refresh: 'wait_for',
-          throwOnFail: true,
+        ops.push({
+          index: {
+            _id: String(hit._id),
+            document: { ...source, tool_ids: newToolIds, updated_at: now.toISOString() },
+          },
         });
-        totalUpdated += bulkOperations.length;
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        logger.error(`Skill tool ID migration: bulk update failed. ${message}`);
       }
-    }
-
-    const lastHit = hits[hits.length - 1];
-    searchAfter = lastHit.sort as SortResults | undefined;
-
-    if (hits.length < PAGE_SIZE) break;
-  } while (true);
-
-  if (totalUpdated > 0) {
-    logger.info(`Skill tool ID migration: updated ${totalUpdated} skill(s).`);
-  }
+      return ops;
+    },
+  });
 };
 
 /**

--- a/x-pack/platform/plugins/shared/cases/server/agent_builder/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/agent_builder/index.ts
@@ -12,6 +12,7 @@ import type { CasesServerStartDependencies } from '../types';
 import type { UnifiedAttachmentTypeRegistry } from '../attachment_framework/unified_attachment_registry';
 import { searchCasesTool } from './tools/search_cases';
 import { manageCasesTool } from './tools/manage_cases';
+import { attachmentsTool } from './tools/attachment_tools';
 import { getAttachmentsTool } from './tools/get_attachments_tool';
 import { manageAttachmentsTool } from './tools/manage_attachments_tool';
 import { observablesTool } from './tools/observable_tools';
@@ -25,9 +26,10 @@ import { createCasesAttachmentType } from './attachments/cases_attachment_type';
  *
  * 1. `platform.core.cases` — read/search (get by ID, bulk get, find similar, by alert IDs, search/filter)
  * 2. `platform.core.cases.manage` — create, update, delete, assign, unassign, add tags, set custom field
- * 3. `platform.core.cases.get_attachments` — get all attachments
- * 4. `platform.core.cases.manage_attachments` — add comment/alerts/events/attachments
- * 5. `platform.core.cases.observables` — add, update, delete observables
+ * 3. `platform.core.cases.get_attachments` — get all attachments (read-only)
+ * 4. `platform.core.cases.manage_attachments` — add comment/alerts/events/attachments (write)
+ * 5. `platform.core.cases.attachments` — DEPRECATED: combined read+write, retained for backward compatibility
+ * 6. `platform.core.cases.observables` — add, update, delete observables
  *
  * Also registers the `cases-management` skill, and — only when Cases-as-Data v2
  * is enabled — the `cases-analytics` skill (ES|QL analytics + visualizations over
@@ -50,6 +52,9 @@ export function registerCasesAgentBuilderTools(
   agentBuilder.tools.register(getAttachmentsTool(getCasesClient));
   agentBuilder.tools.register(
     manageAttachmentsTool(getCasesClient, unifiedAttachmentTypeRegistry, attachmentsEnabled)
+  );
+  agentBuilder.tools.register(
+    attachmentsTool(getCasesClient, unifiedAttachmentTypeRegistry, attachmentsEnabled)
   );
   agentBuilder.tools.register(observablesTool(getCasesClient));
   agentBuilder.skills.register(casesSkill);

--- a/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/attachment_tools.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/attachment_tools.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import type { ToolHandlerContext } from '@kbn/agent-builder-server/tools';
+import { createCasesClientMock, type CasesClientMock } from '../../client/mocks';
+import type { UnifiedAttachmentTypeRegistry } from '../../attachment_framework/unified_attachment_registry';
+import { attachmentsTool } from './attachment_tools';
+
+const buildMockAttachments = () => ({
+  add: jest.fn().mockResolvedValue({ id: 'att-1' }),
+  get: jest.fn(),
+  delete: jest.fn(),
+  update: jest.fn(),
+  list: jest.fn(),
+});
+
+const buildToolContext = (attachments = buildMockAttachments()): ToolHandlerContext =>
+  ({
+    request: httpServerMock.createKibanaRequest(),
+    spaceId: 'default',
+    logger: loggingSystemMock.createLogger(),
+    attachments,
+  } as unknown as ToolHandlerContext);
+
+const buildRegistry = (
+  entries: Array<{ id: string; schema?: z.ZodType }>
+): UnifiedAttachmentTypeRegistry =>
+  ({ list: () => entries } as unknown as UnifiedAttachmentTypeRegistry);
+
+const commentSchema = z.object({
+  type: z.literal('comment'),
+  owner: z.string(),
+  data: z.object({ content: z.string() }),
+});
+
+describe('attachmentsTool (deprecated)', () => {
+  let casesClient: CasesClientMock;
+
+  beforeEach(() => {
+    casesClient = createCasesClientMock();
+  });
+
+  const buildTool = (registry: UnifiedAttachmentTypeRegistry, enabled: boolean) =>
+    attachmentsTool(jest.fn().mockResolvedValue(casesClient), registry, enabled);
+
+  it('has a description that directs agents to the replacement tools', () => {
+    const tool = buildTool(buildRegistry([]), true);
+    expect(tool.description).toContain('DEPRECATED');
+    expect(tool.description).toContain('platform.core.cases.get_attachments');
+    expect(tool.description).toContain('platform.core.cases.manage_attachments');
+    expect(tool.description).toContain('retrieve attachments');
+    expect(tool.description).toContain('add attachments');
+  });
+
+  it('uses the old tool ID platform.core.cases.attachments', () => {
+    const tool = buildTool(buildRegistry([]), true);
+    expect(tool.id).toBe('platform.core.cases.attachments');
+  });
+
+  it('surfaces registered authorable type ids in the attachments field description', () => {
+    const dashboardSchema = z.object({ type: z.literal('dashboard'), owner: z.string() });
+    const tool = buildTool(
+      buildRegistry([
+        { id: 'comment', schema: commentSchema },
+        { id: 'dashboard', schema: dashboardSchema },
+      ]),
+      true
+    );
+    const description = tool.schema.shape.attachments.description ?? '';
+    expect(description).toContain('comment');
+    expect(description).toContain('dashboard');
+  });
+
+  it('throws when attachments are disabled', async () => {
+    const tool = buildTool(buildRegistry([{ id: 'comment', schema: commentSchema }]), false);
+    await expect(
+      tool.handler(
+        { mode: 'add_attachments', case_id: 'case-1', attachments: [{ type: 'comment' }] } as never,
+        buildToolContext()
+      )
+    ).rejects.toThrow(/disabled/i);
+  });
+
+  it('throws when no authorable attachment types are registered', async () => {
+    const tool = buildTool(buildRegistry([]), true);
+    await expect(
+      tool.handler(
+        { mode: 'add_attachments', case_id: 'case-1', attachments: [{ type: 'comment' }] } as never,
+        buildToolContext()
+      )
+    ).rejects.toThrow(/no authorable attachment types/i);
+  });
+
+  it('bulk-creates attachments and emits a case attachment when enabled', async () => {
+    const theCase = {
+      id: 'case-1',
+      title: 'Test Case',
+      description: 'desc',
+      status: 'open',
+      severity: 'low',
+      owner: 'securitySolution',
+      tags: [],
+      assignees: [],
+      totalAlerts: 0,
+      totalComment: 1,
+      connector: { id: 'none', name: 'none', type: '.none', fields: null },
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: null,
+    };
+    casesClient.cases.get.mockResolvedValue(theCase as never);
+    casesClient.attachments.bulkCreate.mockResolvedValue(theCase as never);
+
+    const attachments = buildMockAttachments();
+    const tool = buildTool(buildRegistry([{ id: 'comment', schema: commentSchema }]), true);
+    const result = await tool.handler(
+      {
+        mode: 'add_attachments',
+        case_id: 'case-1',
+        attachments: [{ type: 'comment', data: { content: 'hi' } }],
+      } as never,
+      buildToolContext(attachments)
+    );
+
+    expect(casesClient.attachments.bulkCreate).toHaveBeenCalledWith({
+      caseId: 'case-1',
+      attachments: [{ type: 'comment', data: { content: 'hi' }, owner: 'securitySolution' }],
+    });
+    expect(attachments.add).toHaveBeenCalledTimes(1);
+    const { results } = result as unknown as { results: Array<{ data: Record<string, unknown> }> };
+    expect(results[0].data.attachment_ids).toEqual(['att-1']);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/attachment_tools.ts
+++ b/x-pack/platform/plugins/shared/cases/server/agent_builder/tools/attachment_tools.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import { platformCoreCasesTools, ToolType } from '@kbn/agent-builder-common';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server/tools';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import { addCommentStepCommonDefinition } from '../../../common/workflows/steps/add_comment';
+import { addAlertsStepCommonDefinition } from '../../../common/workflows/steps/add_alerts';
+import { addEventsStepCommonDefinition } from '../../../common/workflows/steps/add_events';
+import { addCommentStepDefinition } from '../../workflows/steps/add_comment';
+import { addAlertsStepDefinition } from '../../workflows/steps/add_alerts';
+import { addEventsStepDefinition } from '../../workflows/steps/add_events';
+import { getAllAttachmentsStepDefinition } from '../../workflows/steps/get_all_attachments';
+import { addAttachmentsStepDefinition } from '../../workflows/steps/add_attachments';
+import type { UnifiedAttachmentTypeRegistry } from '../../attachment_framework/unified_attachment_registry';
+import { MAX_BULK_CREATE_ATTACHMENTS } from '../../../common/constants';
+import type { CasesClient } from '../../client';
+import { invokeStepHandler } from '../utils/invoke_step';
+import {
+  CASES_TOOL_TEXT_INSTRUCTION,
+  CASES_SOLUTION_CONTEXT_INSTRUCTION,
+} from '../utils/tool_instructions';
+import { emitFromStepResult, injectAttachmentIds } from '../attachments/emit_attachments';
+
+type GetCasesClientFn = (request: KibanaRequest) => Promise<CasesClient>;
+
+const describeAttachmentsField = (authorableTypeIds: string[]): string => {
+  const lines = [
+    'For add_attachments: generic bulk attachment payloads (NOT limited to comments and alerts).',
+  ];
+  if (authorableTypeIds.length > 0) {
+    lines.push(
+      `Supported \`type\` values: ${authorableTypeIds.join(
+        ', '
+      )} (plus any solution-registered types).`
+    );
+  }
+  lines.push(
+    'Each item is discriminated by `type`; never set `owner` (it is derived from the case). Common shapes:',
+    '- comment: { type: "comment", data: { content: string } }',
+    '- alert: { type: "stack.alert", attachmentId: "<alertId>", metadata: { index: string, rule?: { id: string, name?: string } } }',
+    '- saved object (e.g. dashboard, discoverSession, lens, map): { type, attachmentId: "<savedObjectId>", metadata: { title: string, soType: string } }'
+  );
+  return lines.join('\n');
+};
+
+const buildAttachmentsSchema = (authorableTypeIds: string[]) =>
+  z.object({
+    mode: z
+      .enum(['add_comment', 'add_alerts', 'add_events', 'add_attachments', 'get_all'])
+      .describe(
+        'Required fields per mode:\n' +
+          '- add_comment: case_id, comment\n' +
+          '- add_alerts: case_id, alerts ({alertId, index, rule?}[])\n' +
+          '- add_events: case_id, events ({eventId, index}[])\n' +
+          '- add_attachments: case_id, attachments (generic bulk; supports comments, alerts, and saved-object types like dashboards — see the `attachments` field)\n' +
+          '- get_all: case_id'
+      ),
+    ...addCommentStepCommonDefinition.inputSchema.partial().shape,
+    ...addAlertsStepCommonDefinition.inputSchema.partial().shape,
+    ...addEventsStepCommonDefinition.inputSchema.partial().shape,
+    attachments: z
+      .array(z.object({ type: z.string() }).loose())
+      .min(1)
+      .max(MAX_BULK_CREATE_ATTACHMENTS)
+      .optional()
+      .describe(describeAttachmentsField(authorableTypeIds)),
+  });
+
+const attachmentsSchema = buildAttachmentsSchema([]);
+
+const getAuthorableTypeIds = (registry: UnifiedAttachmentTypeRegistry): string[] =>
+  registry
+    .list()
+    .filter(({ workflowSchema, schema }) => (workflowSchema ?? schema) instanceof z.ZodObject)
+    .map(({ id }) => id)
+    .sort();
+
+/**
+ * @deprecated Use `getAttachmentsTool` (read) and `manageAttachmentsTool` (write) instead.
+ * Retained for backward compatibility with agents that reference the old tool ID.
+ */
+export const attachmentsTool = (
+  getCasesClientFn: GetCasesClientFn,
+  unifiedAttachmentTypeRegistry: UnifiedAttachmentTypeRegistry,
+  isCasesAttachmentsEnabled: boolean
+): BuiltinToolDefinition<typeof attachmentsSchema> => {
+  const addCommentStepDef = addCommentStepDefinition(getCasesClientFn);
+  const addAlertsStepDef = addAlertsStepDefinition(getCasesClientFn);
+  const addEventsStepDef = addEventsStepDefinition(getCasesClientFn);
+  const getAllAttachmentsStepDef = getAllAttachmentsStepDefinition(getCasesClientFn);
+
+  let addAttachmentsStepDef: ReturnType<typeof addAttachmentsStepDefinition>;
+  const getAddAttachmentsStepDef = () => {
+    if (addAttachmentsStepDef === undefined) {
+      addAttachmentsStepDef = addAttachmentsStepDefinition(
+        unifiedAttachmentTypeRegistry,
+        getCasesClientFn
+      );
+    }
+    return addAttachmentsStepDef;
+  };
+
+  const schema = buildAttachmentsSchema(
+    getAuthorableTypeIds(unifiedAttachmentTypeRegistry)
+  ) as typeof attachmentsSchema;
+
+  return {
+    id: platformCoreCasesTools.attachments,
+    type: ToolType.builtin,
+    description: `DEPRECATED — this tool will be removed in a future release. Use these tools instead:
+- To retrieve attachments for a case: \`${platformCoreCasesTools.getAttachments}\`
+- To add attachments (comments, alerts, events, or other): \`${platformCoreCasesTools.manageAttachments}\`
+
+This tool still works but combines read and write operations. Prefer the dedicated tools above.
+
+Modes: \`add_comment\`, \`add_alerts\`, \`add_events\`, \`add_attachments\`, \`get_all\`. See \`mode\` field for required inputs.
+
+${CASES_SOLUTION_CONTEXT_INSTRUCTION}${CASES_TOOL_TEXT_INSTRUCTION}`,
+    annotations: {
+      title: 'Case Attachments (Deprecated)',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    schema,
+    tags: ['cases'],
+    handler: async (args, toolContext) => {
+      const { mode, case_id, attachments, ...rest } = args;
+
+      const runStep = async () => {
+        switch (mode) {
+          case 'add_comment':
+            return invokeStepHandler(addCommentStepDef, { case_id, ...rest }, toolContext);
+          case 'add_alerts':
+            return invokeStepHandler(addAlertsStepDef, { case_id, ...rest }, toolContext);
+          case 'add_events':
+            return invokeStepHandler(addEventsStepDef, { case_id, ...rest }, toolContext);
+          case 'add_attachments': {
+            if (!isCasesAttachmentsEnabled) {
+              throw new Error(
+                'Adding attachments is disabled. Enable `xpack.cases.attachments` to use `add_attachments`.'
+              );
+            }
+            const stepDef = getAddAttachmentsStepDef();
+            if (!stepDef) {
+              throw new Error('No authorable attachment types are registered.');
+            }
+            return invokeStepHandler(stepDef, { case_id, attachments }, toolContext);
+          }
+          case 'get_all':
+            return invokeStepHandler(getAllAttachmentsStepDef, { case_id }, toolContext);
+          default: {
+            const _exhaustive: never = mode;
+            throw new Error(`Unknown attachments mode: ${_exhaustive}`);
+          }
+        }
+      };
+
+      const result = await runStep();
+      if (mode !== 'get_all') {
+        const attachmentIds = await emitFromStepResult(toolContext.attachments, result);
+        return injectAttachmentIds(result, attachmentIds);
+      }
+      return result;
+    },
+  };
+};


### PR DESCRIPTION
## Summary

Alternative approach to #286133 — instead of removing the old `platform.core.cases.attachments` tool and running a data migration, this keeps the old tool registered (deprecated) alongside two new split tools:

- `platform.core.cases.get_attachments` — read-only (retrieve all attachments for a case)
- `platform.core.cases.manage_attachments` — write (add comments, alerts, events, attachments)

This satisfies the MCP requirement to separate read and write tools while maintaining backward compatibility for rolling upgrades and rollbacks.

### Key design decisions (from [Slack thread](https://elastic.slack.com/archives/C08RSJUPCC8/p1786999562.272859)):

- **No data migration at startup** — avoids setting a dangerous precedent of ad-hoc migrations on every node start
- **Startup backfill** adds the new tool IDs to existing agents/skills without removing the old one — additive only
- **Rolling upgrade safe** — old nodes understand the old tool, new nodes register all three
- **Rollback safe** — old tool ID never removed from persisted data; new IDs become "unknown" and are silently ignored
- **Deprecated tool description** explicitly names the replacement tools so the LLM knows where to redirect

### Changes

- Restore deprecated `attachment_tools.ts` with `DEPRECATED` description naming both replacements
- Add `attachments` constant back to `platformCoreCasesTools` alongside `getAttachments`/`manageAttachments`
- Register all three tools in the Cases plugin
- Rename `tool_id_migration.ts` to `tool_id_backfill.ts` with add-only behavior (no removal of old IDs)
- Update `plugin.ts` to call `runToolIdBackfill` instead of `runToolIdMigrations`

## Test plan

- [x] Deprecated tool tests pass (6/6) — verifies description, ID, modes, error handling
- [x] Backfill tests pass (19/19) — verifies add-only behavior, reference equality on no-op, pagination
- [x] New split tool tests pass (get_attachments + manage_attachments)
- [x] Type checks pass (agent-builder-common, agent-builder-server, agent_builder plugin, cases plugin)
- [ ] Verify deprecated tool appears in MCP tool list with `(Deprecated)` title
- [ ] Verify existing agents with old tool ID get new IDs appended on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
