### PR TITLE
[9.4] [Log threshold] Fix criteria API validation (#283965)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -82075,6 +82075,8 @@ components:
                         - comparator
                         - value
                     type: array
+                  maxItems: 2
+                  minItems: 2
                   type: array
                 groupBy:
                   items:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -93234,6 +93234,8 @@ components:
                         - comparator
                         - value
                     type: array
+                  maxItems: 2
+                  minItems: 2
                   type: array
                 groupBy:
                   items:

--- a/packages/kbn-api-contracts/allowlist.json
+++ b/packages/kbn-api-contracts/allowlist.json
@@ -3,6 +3,14 @@
   "description": "Approved API breaking changes that should be ignored by the contract checker",
   "entries": [
     {
+      "path": "/api/alerting/rule/{id}",
+      "method": "post",
+      "reason": "Intentional: require exactly two criterion groups for log threshold ratio criteria so API validation matches executor validation and rejects malformed criteria (e.g. a single nested array) that previously saved but broke rule execution and the edit UI.",
+      "approvedBy": "@elastic/actionable-obs-team",
+      "oasdiffId": "request-property-min-items-increased",
+      "prUrl": "https://github.com/elastic/kibana/pull/283965"
+    },
+    {
       "path": "/api/fleet/outputs",
       "method": "post",
       "reason": "POST request body uses NewOutputSchema with meta IDs, changing inline anyOf members to $ref components. Data shape is identical. Approved: https://github.com/elastic/kibana/pull/258986#discussion_r2978192160",

--- a/x-pack/platform/packages/shared/response-ops/rule_params/log_threshold/v1.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_params/log_threshold/v1.test.ts
@@ -44,6 +44,13 @@ describe('logThresholdParamsSchema', () => {
           value: 1,
         },
       ],
+      [
+        {
+          field: 'bytes',
+          comparator: 'less than',
+          value: 10,
+        },
+      ],
     ],
   };
 
@@ -139,5 +146,53 @@ describe('logThresholdParamsSchema', () => {
         ],
       })
     ).not.toThrow();
+  });
+
+  it('rejects ratio criteria with a single nested array', () => {
+    expect(() =>
+      logThresholdParamsSchema.validate({
+        ...base,
+        criteria: [
+          [
+            {
+              field: 'log.level',
+              comparator: 'does not equal',
+              value: 'test',
+            },
+          ],
+        ],
+      })
+    ).toThrow();
+  });
+
+  it('rejects ratio criteria with more than two nested arrays', () => {
+    expect(() =>
+      logThresholdParamsSchema.validate({
+        ...base,
+        criteria: [
+          [
+            {
+              field: 'bytes',
+              comparator: 'more than',
+              value: 1,
+            },
+          ],
+          [
+            {
+              field: 'bytes',
+              comparator: 'less than',
+              value: 10,
+            },
+          ],
+          [
+            {
+              field: 'bytes',
+              comparator: 'equals',
+              value: 5,
+            },
+          ],
+        ],
+      })
+    ).toThrow();
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/rule_params/log_threshold/v1.ts
+++ b/x-pack/platform/packages/shared/response-ops/rule_params/log_threshold/v1.ts
@@ -60,7 +60,8 @@ const criterionSchema = schema.object(
 );
 
 const countCriteriaSchema = schema.arrayOf(criterionSchema);
-const ratioCriteriaSchema = schema.arrayOf(countCriteriaSchema);
+// Ratio rules require exactly two criterion groups (numerator and denominator).
+const ratioCriteriaSchema = schema.arrayOf(countCriteriaSchema, { minSize: 2, maxSize: 2 });
 
 const timeUnitSchema = schema.oneOf([
   schema.literal('s'),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Log threshold] Fix criteria API validation (#283965)](https://github.com/elastic/kibana/pull/283965)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Anna Davydova","email":"ana.davydova@elastic.co"},"sourceCommit":{"committedDate":"2026-08-14T11:14:18Z","message":"[Log threshold] Fix criteria API validation (#283965)\n\n## Summary\n\n- Tightens log threshold ratio `criteria` validation so the API requires\nexactly two nested criterion groups (numerator and denominator),\nmatching executor/`io-ts` expectations.\n- Prevents creating rules with malformed criteria like `criteria:\n[[{...}]]`, which previously saved successfully but failed at execution\nand broke the edit rule UI.\n- Updates unit tests: corrects the ratio fixture and adds coverage for 1\nand 3 nested arrays.\n\nCloses #245517\n\n## Test plan\n\n- [ ] Unit tests: `node scripts/jest\nx-pack/platform/packages/shared/response-ops/rule_params/log_threshold/v1.test.ts`\n- [ ] API: create a log threshold rule with `criteria: [[{...}]]` →\nexpect **400** validation error\n- [ ] API: create with flat count criteria `[{...}]` → succeeds\n- [ ] API: create with valid ratio criteria `[[...], [...]]` → succeeds\n- [ ] Confirm edit rule UI still works for valid count and ratio rules\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c2e3342517e62e3cb5e4244432fdaaa1bdeb71f5","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","Team:actionable-obs","author:actionable-obs","v9.6.0"],"title":"[Log threshold] Fix criteria API validation","number":283965,"url":"https://github.com/elastic/kibana/pull/283965","mergeCommit":{"message":"[Log threshold] Fix criteria API validation (#283965)\n\n## Summary\n\n- Tightens log threshold ratio `criteria` validation so the API requires\nexactly two nested criterion groups (numerator and denominator),\nmatching executor/`io-ts` expectations.\n- Prevents creating rules with malformed criteria like `criteria:\n[[{...}]]`, which previously saved successfully but failed at execution\nand broke the edit rule UI.\n- Updates unit tests: corrects the ratio fixture and adds coverage for 1\nand 3 nested arrays.\n\nCloses #245517\n\n## Test plan\n\n- [ ] Unit tests: `node scripts/jest\nx-pack/platform/packages/shared/response-ops/rule_params/log_threshold/v1.test.ts`\n- [ ] API: create a log threshold rule with `criteria: [[{...}]]` →\nexpect **400** validation error\n- [ ] API: create with flat count criteria `[{...}]` → succeeds\n- [ ] API: create with valid ratio criteria `[[...], [...]]` → succeeds\n- [ ] Confirm edit rule UI still works for valid count and ratio rules\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c2e3342517e62e3cb5e4244432fdaaa1bdeb71f5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283965","number":283965,"mergeCommit":{"message":"[Log threshold] Fix criteria API validation (#283965)\n\n## Summary\n\n- Tightens log threshold ratio `criteria` validation so the API requires\nexactly two nested criterion groups (numerator and denominator),\nmatching executor/`io-ts` expectations.\n- Prevents creating rules with malformed criteria like `criteria:\n[[{...}]]`, which previously saved successfully but failed at execution\nand broke the edit rule UI.\n- Updates unit tests: corrects the ratio fixture and adds coverage for 1\nand 3 nested arrays.\n\nCloses #245517\n\n## Test plan\n\n- [ ] Unit tests: `node scripts/jest\nx-pack/platform/packages/shared/response-ops/rule_params/log_threshold/v1.test.ts`\n- [ ] API: create a log threshold rule with `criteria: [[{...}]]` →\nexpect **400** validation error\n- [ ] API: create with flat count criteria `[{...}]` → succeeds\n- [ ] API: create with valid ratio criteria `[[...], [...]]` → succeeds\n- [ ] Confirm edit rule UI still works for valid count and ratio rules\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c2e3342517e62e3cb5e4244432fdaaa1bdeb71f5"}}]}] BACKPORT-->