### PR TITLE
[Notification Center] Migrate read-state storage to per-id overrides

### DIFF
--- a/x-pack/platform/plugins/shared/notification_center/server/lib/read_state.test.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/lib/read_state.test.ts
@@ -6,12 +6,17 @@
  */
 
 import type { IUserStorageClient } from '@kbn/core-user-storage-common';
-import { MAX_READ_IDS, READ_ALL_BEFORE_KEY, READ_KEY } from '../storage/user_storage';
+import {
+  MAX_OVERRIDES,
+  OVERRIDES_KEY,
+  READ_ALL_BEFORE_KEY,
+  type ReadOverrides,
+} from '../storage/user_storage';
 import { markRead, markAllRead } from './read_state';
 
-const createClient = (initial: { read?: string[]; readAllBefore?: string } = {}) => {
+const createClient = (initial: { overrides?: ReadOverrides; readAllBefore?: string } = {}) => {
   const store: Record<string, unknown> = {
-    [READ_KEY]: initial.read ?? [],
+    [OVERRIDES_KEY]: initial.overrides ?? {},
     ...(initial.readAllBefore ? { [READ_ALL_BEFORE_KEY]: initial.readAllBefore } : {}),
   };
   const client: IUserStorageClient = {
@@ -26,50 +31,68 @@ const createClient = (initial: { read?: string[]; readAllBefore?: string } = {})
   return { client, store };
 };
 
+const readOverride = (markedAt: string) => ({ read: true, markedAt });
+
 describe('markRead', () => {
-  it('appends an unseen id to the read list', async () => {
-    const { client, store } = createClient({ read: ['a'] });
+  it('records a read override for an unseen id', async () => {
+    const { client, store } = createClient({
+      overrides: { a: readOverride('2026-07-01T00:00:00.000Z') },
+    });
     await markRead(client, 'b');
-    expect(store[READ_KEY]).toEqual(['a', 'b']);
+
+    const stored = store[OVERRIDES_KEY] as ReadOverrides;
+    expect(Object.keys(stored)).toEqual(['a', 'b']);
+    expect(stored.b.read).toBe(true);
+    expect(Date.parse(stored.b.markedAt)).not.toBeNaN();
   });
 
   it('is a no-op when the id is already read', async () => {
-    const { client, store } = createClient({ read: ['a'] });
+    const { client, store } = createClient({
+      overrides: { a: readOverride('2026-07-01T00:00:00.000Z') },
+    });
     await markRead(client, 'a');
-    expect(store[READ_KEY]).toEqual(['a']);
+
+    expect(store[OVERRIDES_KEY]).toEqual({ a: readOverride('2026-07-01T00:00:00.000Z') });
     expect(client.set).not.toHaveBeenCalled();
   });
 
-  it('caps the list at MAX_READ_IDS, dropping the oldest ids', async () => {
-    const read = Array.from({ length: MAX_READ_IDS }, (_, i) => `id-${i}`);
-    const { client, store } = createClient({ read });
+  it('caps overrides at MAX_OVERRIDES, dropping the oldest by markedAt', async () => {
+    const base = Date.parse('2020-01-01T00:00:00.000Z');
+    const overrides: ReadOverrides = Object.fromEntries(
+      Array.from({ length: MAX_OVERRIDES }, (_, i) => [
+        `id-${i}`,
+        readOverride(new Date(base + i * 1000).toISOString()),
+      ])
+    );
+    const { client, store } = createClient({ overrides });
     await markRead(client, 'newest');
 
-    const stored = store[READ_KEY] as string[];
-    expect(stored).toHaveLength(MAX_READ_IDS);
-    expect(stored[0]).toBe('id-1');
-    expect(stored[stored.length - 1]).toBe('newest');
+    const stored = store[OVERRIDES_KEY] as ReadOverrides;
+    expect(Object.keys(stored)).toHaveLength(MAX_OVERRIDES);
+    expect(stored['id-0']).toBeUndefined();
+    expect(stored['id-1']).toBeDefined();
+    expect(stored.newest.read).toBe(true);
   });
 });
 
 describe('markAllRead', () => {
-  it('advances readAllBefore and clears the read list', async () => {
+  it('advances readAllBefore and clears the overrides', async () => {
     const { client, store } = createClient({
-      read: ['a', 'b'],
+      overrides: { a: readOverride('2026-07-01T00:00:00.000Z') },
       readAllBefore: '1970-01-01T00:00:00.000Z',
     });
     const marker = await markAllRead(client);
 
     expect(store[READ_ALL_BEFORE_KEY]).toBe(marker);
     expect(Date.parse(marker)).not.toBeNaN();
-    expect(store[READ_KEY]).toEqual([]);
+    expect(store[OVERRIDES_KEY]).toEqual({});
   });
 
-  it('writes the marker before clearing the list', async () => {
-    const { client } = createClient({ read: ['a'] });
+  it('writes the marker before clearing the overrides', async () => {
+    const { client } = createClient({ overrides: { a: readOverride('2026-07-01T00:00:00.000Z') } });
     await markAllRead(client);
 
     const setKeys = (client.set as jest.Mock).mock.calls.map(([key]) => key);
-    expect(setKeys).toEqual([READ_ALL_BEFORE_KEY, READ_KEY]);
+    expect(setKeys).toEqual([READ_ALL_BEFORE_KEY, OVERRIDES_KEY]);
   });
 });

--- a/x-pack/platform/plugins/shared/notification_center/server/lib/read_state.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/lib/read_state.ts
@@ -13,15 +13,17 @@ import {
   type ReadOverrides,
 } from '../storage/user_storage';
 
-/** Keep the newest MAX_OVERRIDES entries, dropping the oldest by `markedAt` (ISO strings
- * sort chronologically) so the write stays within the schema ceiling. */
+/** Keep the newest MAX_OVERRIDES entries, dropping the oldest by `markedAt`, so the write
+ * stays within the schema ceiling. */
 const boundOverrides = (overrides: ReadOverrides): ReadOverrides => {
   const entries = Object.entries(overrides);
   if (entries.length <= MAX_OVERRIDES) {
     return overrides;
   }
   return Object.fromEntries(
-    entries.sort(([, a], [, b]) => a.markedAt.localeCompare(b.markedAt)).slice(-MAX_OVERRIDES)
+    entries
+      .sort(([, a], [, b]) => Date.parse(a.markedAt) - Date.parse(b.markedAt))
+      .slice(-MAX_OVERRIDES)
   );
 };
 

--- a/x-pack/platform/plugins/shared/notification_center/server/lib/read_state.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/lib/read_state.ts
@@ -13,8 +13,9 @@ import {
   type ReadOverrides,
 } from '../storage/user_storage';
 
-/** Keep the newest MAX_OVERRIDES entries, dropping the oldest by `markedAt`, so the write
- * stays within the schema ceiling. */
+/** Keep the newest MAX_OVERRIDES entries, dropping the oldest by `markedAt`
+ * Ensures the overrides object size stays within limits.
+ */
 const boundOverrides = (overrides: ReadOverrides): ReadOverrides => {
   const entries = Object.entries(overrides);
   if (entries.length <= MAX_OVERRIDES) {

--- a/x-pack/platform/plugins/shared/notification_center/server/lib/read_state.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/lib/read_state.ts
@@ -6,22 +6,38 @@
  */
 
 import type { IUserStorageClient } from '@kbn/core-user-storage-common';
-import { MAX_READ_IDS, READ_ALL_BEFORE_KEY, READ_KEY } from '../storage/user_storage';
+import {
+  MAX_OVERRIDES,
+  OVERRIDES_KEY,
+  READ_ALL_BEFORE_KEY,
+  type ReadOverrides,
+} from '../storage/user_storage';
+
+/** Keep the newest MAX_OVERRIDES entries, dropping the oldest by `markedAt` (ISO strings
+ * sort chronologically) so the write stays within the schema ceiling. */
+const boundOverrides = (overrides: ReadOverrides): ReadOverrides => {
+  const entries = Object.entries(overrides);
+  if (entries.length <= MAX_OVERRIDES) {
+    return overrides;
+  }
+  return Object.fromEntries(
+    entries.sort(([, a], [, b]) => a.markedAt.localeCompare(b.markedAt)).slice(-MAX_OVERRIDES)
+  );
+};
 
 /**
- * Append a notification id to the user's individually-read list.
+ * Record a read override for a notification id.
  */
 export const markRead = async (client: IUserStorageClient, id: string): Promise<void> => {
-  const read = await client.get<string[]>(READ_KEY);
-  if (read.includes(id)) {
+  const overrides = await client.get<ReadOverrides>(OVERRIDES_KEY);
+  if (overrides[id]?.read === true) {
     return;
   }
   // userStorage doesn't have consistency guarantee, so two concurrent marks from separate tabs
   // can lose one of the ids. This is a risk only for a single id, and will resolve itself
   // by the next mark-all-read or retry by the client.
-  // Cap at the newest MAX_READ_IDS (the schema's ceiling), silently dropping the oldest ids so
-  // the write stays valid; a mark-all-read clears the list entirely.
-  await client.set(READ_KEY, [...read, id].slice(-MAX_READ_IDS));
+  const next = { ...overrides, [id]: { read: true, markedAt: new Date().toISOString() } };
+  await client.set(OVERRIDES_KEY, boundOverrides(next));
 };
 
 /**
@@ -30,6 +46,6 @@ export const markRead = async (client: IUserStorageClient, id: string): Promise<
 export const markAllRead = async (client: IUserStorageClient): Promise<string> => {
   const readAllBefore = new Date().toISOString();
   await client.set(READ_ALL_BEFORE_KEY, readAllBefore);
-  await client.set(READ_KEY, []);
+  await client.set(OVERRIDES_KEY, {});
   return readAllBefore;
 };

--- a/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.test.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.test.ts
@@ -9,9 +9,10 @@ import { userStorageServiceMock } from '@kbn/core-user-storage-server-mocks';
 import {
   registerNotificationUserStorage,
   readAllBeforeSchema,
-  readSchema,
+  overridesSchema,
+  MAX_OVERRIDES,
   READ_ALL_BEFORE_KEY,
-  READ_KEY,
+  OVERRIDES_KEY,
   READ_ALL_BEFORE_DEFAULT,
 } from './user_storage';
 
@@ -22,10 +23,12 @@ const collectRegistrations = () => {
   return userStorage.register.mock.calls[0][0];
 };
 
+const readOverride = (markedAt: string) => ({ read: true, markedAt });
+
 describe('notification center user storage', () => {
   describe('registerNotificationUserStorage', () => {
     it('registers the read-state keys in a single call', () => {
-      expect(Object.keys(collectRegistrations())).toEqual([READ_ALL_BEFORE_KEY, READ_KEY]);
+      expect(Object.keys(collectRegistrations())).toEqual([READ_ALL_BEFORE_KEY, OVERRIDES_KEY]);
     });
 
     it('registers every key as global with no preload', () => {
@@ -35,10 +38,10 @@ describe('notification center user storage', () => {
       }
     });
 
-    it('defaults the marker to the epoch default and the read list to empty', () => {
+    it('defaults the marker to the epoch default and the overrides to empty', () => {
       const registrations = collectRegistrations();
       expect(registrations[READ_ALL_BEFORE_KEY].defaultValue).toBe(READ_ALL_BEFORE_DEFAULT);
-      expect(registrations[READ_KEY].defaultValue).toEqual([]);
+      expect(registrations[OVERRIDES_KEY].defaultValue).toEqual({});
     });
   });
 
@@ -79,23 +82,48 @@ describe('notification center user storage', () => {
     });
   });
 
-  describe('read notification ids schema', () => {
-    it('accepts an array of notification ids', () => {
-      expect(readSchema.safeParse([]).success).toBe(true);
-      expect(readSchema.safeParse(['inference:model-a:eol']).success).toBe(true);
+  describe('overrides schema', () => {
+    it('accepts an empty record', () => {
+      expect(overridesSchema.safeParse({}).success).toBe(true);
     });
 
-    it('rejects a non-array', () => {
-      expect(readSchema.safeParse('inference:model-a:eol').success).toBe(false);
+    it('accepts a record of id to read override', () => {
+      expect(
+        overridesSchema.safeParse({
+          'inference:model-a:eol': readOverride('2026-07-09T12:00:00.000Z'),
+        }).success
+      ).toBe(true);
     });
 
-    it('rejects an array holding non-string entries', () => {
-      expect(readSchema.safeParse([1, 2, 3]).success).toBe(false);
+    it('rejects a non-object', () => {
+      expect(overridesSchema.safeParse('inference:model-a:eol').success).toBe(false);
     });
 
-    it('rejects a list past the safety ceiling', () => {
-      const overCeiling = Array.from({ length: 501 }, (_, i) => `id-${i}`);
-      expect(readSchema.safeParse(overCeiling).success).toBe(false);
+    it('rejects an override missing markedAt', () => {
+      expect(overridesSchema.safeParse({ a: { read: true } }).success).toBe(false);
+    });
+
+    it('rejects an override with a non-ISO markedAt', () => {
+      expect(overridesSchema.safeParse({ a: { read: true, markedAt: 'yesterday' } }).success).toBe(
+        false
+      );
+    });
+
+    it('rejects an override with a non-boolean read', () => {
+      expect(
+        overridesSchema.safeParse({ a: { read: 'yes', markedAt: '2026-07-09T12:00:00.000Z' } })
+          .success
+      ).toBe(false);
+    });
+
+    it('rejects a record past the safety ceiling', () => {
+      const overCeiling = Object.fromEntries(
+        Array.from({ length: MAX_OVERRIDES + 1 }, (_, i) => [
+          `id-${i}`,
+          readOverride('2026-07-09T12:00:00.000Z'),
+        ])
+      );
+      expect(overridesSchema.safeParse(overCeiling).success).toBe(false);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.test.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.test.ts
@@ -116,6 +116,17 @@ describe('notification center user storage', () => {
       ).toBe(false);
     });
 
+    it('rejects a key that is not a valid notification id', () => {
+      expect(
+        overridesSchema.safeParse({ '': readOverride('2026-07-09T12:00:00.000Z') }).success
+      ).toBe(false);
+      expect(
+        overridesSchema.safeParse({
+          ['x'.repeat(513)]: readOverride('2026-07-09T12:00:00.000Z'),
+        }).success
+      ).toBe(false);
+    });
+
     it('rejects a record past the safety ceiling', () => {
       const overCeiling = Object.fromEntries(
         Array.from({ length: MAX_OVERRIDES + 1 }, (_, i) => [

--- a/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.ts
@@ -7,6 +7,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { UserStorageServiceSetup } from '@kbn/core-user-storage-server';
+import { notificationIdSchema } from '../../common/notification_schema';
 
 /**
  * Register the user storage keys needed for Notification Center.
@@ -18,10 +19,9 @@ import type { UserStorageServiceSetup } from '@kbn/core-user-storage-server';
  */
 export const READ_ALL_BEFORE_KEY = 'notificationCenter:readAllBefore';
 
-/** Per-id read overrides keyed by `notification_id`; each entry records the read
- * direction and when it was set, deviating from the `readAllBefore` marker.
- * Bounded by `MAX_OVERRIDES` (schema ceiling, enforced on write); `markAllRead`
- * clears the record entirely.
+/** Per-id read overrides keyed by `notification_id`.
+ * One entry for the read state of any given notification a user has manually marked.
+ * Size limited by `MAX_OVERRIDES`. `markAllRead` resets the overrides entirely.
  */
 export const OVERRIDES_KEY = 'notificationCenter:overrides';
 
@@ -33,13 +33,13 @@ export const MAX_OVERRIDES = 500;
 
 export const readAllBeforeSchema = z.iso.datetime();
 
-/** One per-id read override: the direction and the instant it was set. */
+/** An override for one ID */
 export const readOverrideSchema = z
   .object({ read: z.boolean(), markedAt: z.iso.datetime() })
   .strict();
 
 export const overridesSchema = z
-  .record(z.string(), readOverrideSchema)
+  .record(notificationIdSchema, readOverrideSchema)
   .refine((overrides) => Object.keys(overrides).length <= MAX_OVERRIDES, {
     message: `Cannot exceed ${MAX_OVERRIDES} read overrides`,
   });

--- a/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.ts
@@ -20,7 +20,8 @@ export const READ_ALL_BEFORE_KEY = 'notificationCenter:readAllBefore';
 
 /** Per-id read overrides keyed by `notification_id`; each entry records the read
  * direction and when it was set, deviating from the `readAllBefore` marker.
- * advancing the readAllBefore marker keeps this within a reasonable size.
+ * Bounded by `MAX_OVERRIDES` (schema ceiling, enforced on write); `markAllRead`
+ * clears the record entirely.
  */
 export const OVERRIDES_KEY = 'notificationCenter:overrides';
 

--- a/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.ts
+++ b/x-pack/platform/plugins/shared/notification_center/server/storage/user_storage.ts
@@ -18,19 +18,33 @@ import type { UserStorageServiceSetup } from '@kbn/core-user-storage-server';
  */
 export const READ_ALL_BEFORE_KEY = 'notificationCenter:readAllBefore';
 
-/** Individually-read ids newer than `readAllBefore`;
+/** Per-id read overrides keyed by `notification_id`; each entry records the read
+ * direction and when it was set, deviating from the `readAllBefore` marker.
  * advancing the readAllBefore marker keeps this within a reasonable size.
  */
-export const READ_KEY = 'notificationCenter:read';
+export const OVERRIDES_KEY = 'notificationCenter:overrides';
 
 /** userStorage doesn't allow null defaults for key values, so we use this default to represent an unset state. */
 export const READ_ALL_BEFORE_DEFAULT = '1970-01-01T00:00:00.000Z';
 
-/** Ceiling for the array of read ids */
-export const MAX_READ_IDS = 500;
+/** Ceiling for the number of per-id read overrides. */
+export const MAX_OVERRIDES = 500;
 
 export const readAllBeforeSchema = z.iso.datetime();
-export const readSchema = z.array(z.string()).max(MAX_READ_IDS);
+
+/** One per-id read override: the direction and the instant it was set. */
+export const readOverrideSchema = z
+  .object({ read: z.boolean(), markedAt: z.iso.datetime() })
+  .strict();
+
+export const overridesSchema = z
+  .record(z.string(), readOverrideSchema)
+  .refine((overrides) => Object.keys(overrides).length <= MAX_OVERRIDES, {
+    message: `Cannot exceed ${MAX_OVERRIDES} read overrides`,
+  });
+
+export type ReadOverride = z.infer<typeof readOverrideSchema>;
+export type ReadOverrides = z.infer<typeof overridesSchema>;
 
 /** Registers the read-state keys; core throws on a duplicate key, so call once. */
 export const registerNotificationUserStorage = (userStorage: UserStorageServiceSetup) => {
@@ -40,9 +54,9 @@ export const registerNotificationUserStorage = (userStorage: UserStorageServiceS
       defaultValue: READ_ALL_BEFORE_DEFAULT,
       scope: 'global',
     },
-    [READ_KEY]: {
-      schema: readSchema,
-      defaultValue: [],
+    [OVERRIDES_KEY]: {
+      schema: overridesSchema,
+      defaultValue: {},
       scope: 'global',
     },
   });


### PR DESCRIPTION
## Summary

After finding some sharp edges around the logic to mark notifications as read, I'm changing the schema in user storage to be more flexible and give us more control now and in the future around notification read state.

- Migrates from an array of ids (`read[]`) to a per-id overrides record. keyed by `notification_id`. each entry carrying `{ read, markedAt }`.
- Only changes the storage shape, no wider logic changes in this PR.

No backwards compatibility is required (plugin hasn't been deployed).

## Changes

- `user_storage.ts`: `OVERRIDES_KEY` + `overridesSchema` replace `READ_KEY` / `readSchema`. default `{}` instead of `[]`. Exports `ReadOverride` / `ReadOverrides` types.
- `read_state.ts`: `markRead` writes `{ read: true, markedAt }`, bounded by dropping the oldest entries by `markedAt`. `markAllRead` clears the record and advances the marker.
- Unit tests updated to the new shape.

## Testing

- `node scripts/jest x-pack/platform/plugins/shared/notification_center` — 136 passed
- `node scripts/type_check --project x-pack/platform/plugins/shared/notification_center/tsconfig.json` — clean
- eslint — clean
