### PR TITLE
[Security Solution] Prevent MitreAttack to throw error when missing tactic, technique or sub-technique

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/threat_description.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/threat_description.test.tsx
@@ -198,4 +198,83 @@ describe('ThreatEuiFlexGroup', () => {
     await waitFor(() => expect(screen.getByText('Defense Evasion (TA0005)')).toBeInTheDocument());
     expect(screen.queryByTestId('threatUnsupportedMitreIdWarning-TA0005')).not.toBeInTheDocument();
   });
+
+  it('does not throw when technique contains a null hole and still renders valid siblings', async () => {
+    const threat = [
+      {
+        framework: MITRE_FRAMEWORK,
+        tactic: {
+          id: 'TA0005',
+          name: 'Defense Evasion',
+          reference: 'https://attack.mitre.org/tactics/TA0005/',
+        },
+        technique: [
+          null,
+          {
+            id: 'T1548',
+            name: 'Abuse Elevation Control Mechanism',
+            reference: 'https://attack.mitre.org/techniques/T1548/',
+          },
+        ],
+      },
+    ] as Threats;
+
+    renderThreat(threat);
+
+    expect(await screen.findByText('Defense Evasion (TA0005)')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Abuse Elevation Control Mechanism (T1548)')
+    ).toBeInTheDocument();
+  });
+
+  it('does not throw when a threat entry is missing tactic', async () => {
+    const threat = [
+      {
+        framework: MITRE_FRAMEWORK,
+        technique: [
+          {
+            id: 'T1548',
+            name: 'Abuse Elevation Control Mechanism',
+            reference: 'https://attack.mitre.org/techniques/T1548/',
+          },
+        ],
+      },
+    ] as Threats;
+
+    const { container } = renderThreat(threat);
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-test-subj="threatTechniqueLink"]')).not.toBeNull();
+    });
+    expect(container.querySelector('[data-test-subj="threatTacticLink"]')).toBeNull();
+    expect(container.textContent).toContain('Abuse Elevation Control Mechanism');
+  });
+
+  it('does not throw when the threat array contains a null hole and still renders valid siblings', async () => {
+    const threat = [
+      null,
+      {
+        framework: MITRE_FRAMEWORK,
+        tactic: {
+          id: 'TA0005',
+          name: 'Defense Evasion',
+          reference: 'https://attack.mitre.org/tactics/TA0005/',
+        },
+        technique: [
+          {
+            id: 'T1548',
+            name: 'Abuse Elevation Control Mechanism',
+            reference: 'https://attack.mitre.org/techniques/T1548/',
+          },
+        ],
+      },
+    ] as Threats;
+
+    renderThreat(threat);
+
+    expect(await screen.findByText('Defense Evasion (TA0005)')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Abuse Elevation Control Mechanism (T1548)')
+    ).toBeInTheDocument();
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/threat_description.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/threat_description.tsx
@@ -101,31 +101,37 @@ export const ThreatEuiFlexGroup = ({
   return (
     <EuiFlexGroup direction="column" data-test-subj={dataTestSubj} css={threatEuiFlexGroupStyles}>
       {threat.map((singleThreat, index) => {
-        const tactic = tacticsOptions.find((t) => t.id === singleThreat.tactic.id);
-        const tacticUnsupported = showUnsupportedWarnings && tactic == null;
+        const threatTactic = singleThreat?.tactic;
+        const tactic = threatTactic
+          ? tacticsOptions.find((t) => t.id === threatTactic.id)
+          : undefined;
+        const tacticUnsupported = showUnsupportedWarnings && threatTactic != null && tactic == null;
         return (
-          <EuiFlexItem key={`${singleThreat.tactic.name}-${index}`}>
-            <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false} wrap={false}>
-              <EuiFlexItem grow={false}>
-                <EuiLink
-                  data-test-subj="threatTacticLink"
-                  href={singleThreat.tactic.reference}
-                  target="_blank"
-                >
-                  {tactic != null
-                    ? tactic.label
-                    : `${singleThreat.tactic.name} (${singleThreat.tactic.id})`}
-                </EuiLink>
-              </EuiFlexItem>
-              {tacticUnsupported && (
+          <EuiFlexItem key={`${threatTactic?.name ?? 'threat'}-${index}`}>
+            {threatTactic ? (
+              <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false} wrap={false}>
                 <EuiFlexItem grow={false}>
-                  <UnsupportedMitreIdWarning id={singleThreat.tactic.id} />
+                  <EuiLink
+                    data-test-subj="threatTacticLink"
+                    href={threatTactic.reference}
+                    target="_blank"
+                  >
+                    {tactic != null ? tactic.label : `${threatTactic.name} (${threatTactic.id})`}
+                  </EuiLink>
                 </EuiFlexItem>
-              )}
-            </EuiFlexGroup>
+                {tacticUnsupported && (
+                  <EuiFlexItem grow={false}>
+                    <UnsupportedMitreIdWarning id={threatTactic.id} />
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
+            ) : null}
             <EuiFlexGroup gutterSize="none" alignItems="flexStart" direction="column">
-              {singleThreat.technique &&
+              {singleThreat?.technique &&
                 singleThreat.technique.map((technique, techniqueIndex) => {
+                  if (technique == null) {
+                    return null;
+                  }
                   const myTechnique = techniquesOptions.find((t) => t.id === technique.id);
                   const techniqueUnsupported = showUnsupportedWarnings && myTechnique == null;
                   return (
@@ -154,6 +160,9 @@ export const ThreatEuiFlexGroup = ({
                       <EuiFlexGroup gutterSize="none" alignItems="flexStart" direction="column">
                         {technique.subtechnique != null &&
                           technique.subtechnique.map((subtechnique, subtechniqueIndex) => {
+                            if (subtechnique == null) {
+                              return null;
+                            }
                             const mySubtechnique = subtechniquesOptions.find(
                               (t) => t.id === subtechnique.id
                             );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/mitre_attack.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/mitre_attack.test.tsx
@@ -124,4 +124,29 @@ describe('<MitreAttack />', () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('should still render when technique contains a null hole', () => {
+    const hit = createMockHit({
+      'kibana.alert.rule.parameters': [
+        {
+          threat: [
+            {
+              framework: 'MITRE ATT&CK',
+              tactic: {
+                id: 'TA0009',
+                name: 'Collection',
+                reference: 'https://attack.mitre.org/tactics/TA0009',
+              },
+              technique: [null],
+            },
+          ],
+        },
+      ],
+    });
+
+    const { getByTestId } = renderMitreAttack(hit);
+
+    expect(getByTestId(MITRE_ATTACK_TITLE_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(MITRE_ATTACK_DETAILS_TEST_ID)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

### Context

One customer had an issue opening the document flyout. The `MitreAttack` component under the `About` section was  crashing and throwing an error that was preventing the whole flyout to render.
```TypeError: Cannot read properties of undefined (reading 'reference')```

From the information provided, we determined that the crash comes from `ThreatEuiFlexGroup` mapping MITRE `technique` / `subtechnique` / `tactic` and reading `.reference` with no `null` check.

### Solution

Guard the MITRE renderer so sparse or incomplete threat entries don’t take down Overview:
- Skip `null` holes in technique` and `subtechnique` arrays; still render valid siblings.
- If `tactic` is missing, omit the `tactic` link and still render `techniques`.

## How to test

- Open a security alert whose MITRE mapping has a null technique (or missing tactic).
```
[{
  "framework": "MITRE ATTACK",
  "tactic": { "id": "TA0009", "name": "Collection", "reference": "attack.mitre.org/tactics/TA0009" },
  "technique": [null]
}]
``` 

Alert Overview should render instead of crashing. Table / JSON should still work.

A well-formed MITRE mappings should look the same as before.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/286380

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->