### PR TITLE
[Fleet] Reject whitespace-only namespace values

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.test.ts
@@ -44,6 +44,14 @@ describe('Fleet - isValidNamespace', () => {
     expect(isValidNamespace('default', false, ['prod', 'qa']).valid).toBe(false);
   });
 
+  it('returns false for whitespace-only namespaces, even when blank namespaces are allowed', () => {
+    // Regression test for https://github.com/elastic/kibana/issues/276589 - a whitespace-only
+    // namespace (e.g. " ") must not be treated the same as a genuinely blank namespace.
+    expect(isValidNamespace(' ', true).valid).toBe(false);
+    expect(isValidNamespace('   ', true).valid).toBe(false);
+    expect(isValidNamespace(' ', true, ['test']).valid).toBe(false);
+  });
+
   it('accepts a namespace matching any of multiple allowed prefixes', () => {
     expect(isValidNamespace('prod', false, ['prod', 'qa']).valid).toBe(true);
     expect(isValidNamespace('qa', false, ['prod', 'qa']).valid).toBe(true);

--- a/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.ts
@@ -17,7 +17,10 @@ export function isValidNamespace(
   allowBlankNamespace?: boolean,
   allowedNamespacePrefixes?: string[]
 ): { valid: boolean; error?: string } {
-  if (!namespace.trim() && allowBlankNamespace) {
+  // Only a truly empty string is treated as "blank" here. A whitespace-only value (e.g. " ")
+  // must continue on to isValidEntity below so it gets rejected by INVALID_NAMESPACE_CHARACTERS,
+  // instead of being short-circuited as if the namespace were intentionally left blank.
+  if (namespace === '' && allowBlankNamespace) {
     return { valid: true };
   }
 


### PR DESCRIPTION
## Summary

A namespace consisting only of whitespace (e.g. a single space `" "`) was accepted by validation for package/integration policies. The agent then remained "Healthy" while ingestion silently failed (`security_exception`, 403, empty index name), since the whitespace namespace produced an invalid/empty index target.

Root cause: `isValidNamespace()` in `x-pack/platform/plugins/shared/fleet/common/services/is_valid_namespace.ts` short-circuits to `valid: true` whenever `allowBlankNamespace` is `true` and the *trimmed* namespace is empty:

```ts
if (!namespace.trim() && allowBlankNamespace) {
  return { valid: true };
}
```

This conflates "namespace is genuinely blank" (`''`, meaning "inherit/leave unset") with "namespace is a non-empty, whitespace-only string" (`' '`). The former is a legitimate blank value; the latter should be rejected by the existing `INVALID_NAMESPACE_CHARACTERS` regex (which already disallows `\s`) — but that check is never reached because of the early return.

This path is hit by package policy validation, both client-side (`validate_package_policy.ts`, used by the create/edit package policy forms) and server-side (`package_policy_schema.ts`, used by the create/update package policy API routes), both of which call `isValidNamespace(value, true, ...)`.

## Fix

Narrow the early-return guard to only treat a truly empty string as blank:

```diff
-  if (!namespace.trim() && allowBlankNamespace) {
+  if (namespace === '' && allowBlankNamespace) {
     return { valid: true };
   }
```

A whitespace-only namespace now falls through to `isValidEntity`, which rejects it via `INVALID_NAMESPACE_CHARACTERS` with a "Namespace contains invalid characters" error — surfaced by both the UI form validation and the API schema validation.

Also added regression tests covering `isValidNamespace(' ', true)` and `isValidNamespace('   ', true, [...])`, since the existing test suite only exercised the whitespace case without `allowBlankNamespace: true` (which happened to already work).

Fixes #276589

## Test plan

- [ ] Create/edit a package policy (e.g. System integration) and set the namespace to a single space. Confirm the form now shows a validation error and blocks saving.
- [ ] Confirm a genuinely blank namespace (inheriting from the agent policy) is still accepted where that's expected.
- [ ] `isValidNamespace` unit tests pass, including the new whitespace-only + `allowBlankNamespace: true` cases.


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->