### PR TITLE
[Fleet] Fix incorrect tooltip for offline agent CPU/Memory metrics

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -83,7 +83,7 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                         </span>
                       </EuiToolTip>
                     ),
-                    description: formatAgentCPU(agent.metrics, agentPolicy),
+                    description: formatAgentCPU(agent.metrics, agentPolicy, agent),
                   },
                   {
                     title: (
@@ -105,7 +105,7 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
                         </span>
                       </EuiToolTip>
                     ),
-                    description: formatAgentMemory(agent.metrics, agentPolicy),
+                    description: formatAgentMemory(agent.metrics, agentPolicy, agent),
                   },
                 ].map(({ title, description }) => {
                   const tooltip =

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
@@ -96,11 +96,11 @@ const PolicyCell = React.memo<{
 );
 
 const CpuCell = React.memo<{ agent: Agent; agentPolicy: AgentPolicy | undefined }>(
-  ({ agent, agentPolicy }) => <>{formatAgentCPU(agent.metrics, agentPolicy)}</>
+  ({ agent, agentPolicy }) => <>{formatAgentCPU(agent.metrics, agentPolicy, agent)}</>
 );
 
 const MemoryCell = React.memo<{ agent: Agent; agentPolicy: AgentPolicy | undefined }>(
-  ({ agent, agentPolicy }) => <>{formatAgentMemory(agent.metrics, agentPolicy)}</>
+  ({ agent, agentPolicy }) => <>{formatAgentMemory(agent.metrics, agentPolicy, agent)}</>
 );
 
 const LastCheckinCell = React.memo<{ lastCheckin: string | undefined }>(({ lastCheckin }) =>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/metric_non_available.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/metric_non_available.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+
+import type { Agent, AgentPolicy } from '../../../types';
+
+import { MetricNonAvailable } from './metric_non_available';
+
+jest.mock('@elastic/eui', () => {
+  return {
+    ...jest.requireActual('@elastic/eui'),
+    // Render the tooltip content inline so we can assert on the message
+    EuiIconTip: (props: any) => <div data-test-subj="iconTipContent">{props.content}</div>,
+  };
+});
+
+const renderComponent = ({
+  monitoringEnabled,
+  agentStatus,
+}: {
+  monitoringEnabled?: boolean;
+  agentStatus?: Agent['status'];
+}) => {
+  const agentPolicy =
+    monitoringEnabled === undefined
+      ? undefined
+      : ({
+          monitoring_enabled: monitoringEnabled ? ['metrics'] : [],
+        } as unknown as AgentPolicy);
+  const agent =
+    agentStatus === undefined ? undefined : ({ status: agentStatus } as unknown as Agent);
+
+  return render(
+    <I18nProvider>
+      <MetricNonAvailable agentPolicy={agentPolicy} agent={agent} />
+    </I18nProvider>
+  );
+};
+
+describe('MetricNonAvailable', () => {
+  it('should show the monitoring-not-enabled message when metrics monitoring is disabled', () => {
+    const result = renderComponent({ monitoringEnabled: false, agentStatus: 'online' });
+
+    expect(result.getByText(/Agent monitoring is not enabled for this agent policy/)).toBeTruthy();
+  });
+
+  it('should show the offline message when the agent is offline and monitoring is enabled', () => {
+    const result = renderComponent({ monitoringEnabled: true, agentStatus: 'offline' });
+
+    expect(
+      result.getByText(/This agent is offline, so metrics are not currently available/)
+    ).toBeTruthy();
+  });
+
+  it('should prioritize the monitoring-not-enabled message over the offline one', () => {
+    const result = renderComponent({ monitoringEnabled: false, agentStatus: 'offline' });
+
+    expect(result.getByText(/Agent monitoring is not enabled for this agent policy/)).toBeTruthy();
+    expect(result.queryByText(/This agent is offline/)).toBeNull();
+  });
+
+  it('should show the generic fallback message when monitoring is enabled and the agent is not offline', () => {
+    const result = renderComponent({ monitoringEnabled: true, agentStatus: 'online' });
+
+    expect(result.getByText(/That metric is not available/)).toBeTruthy();
+  });
+
+  it('should show the generic fallback message when no agent is passed and monitoring is enabled', () => {
+    const result = renderComponent({ monitoringEnabled: true });
+
+    expect(result.getByText(/That metric is not available/)).toBeTruthy();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/metric_non_available.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/metric_non_available.tsx
@@ -9,10 +9,14 @@ import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiIconTip, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import type { AgentPolicy } from '../../../types';
+import type { Agent, AgentPolicy } from '../../../types';
 
-export const MetricNonAvailable: React.FC<{ agentPolicy?: AgentPolicy }> = ({ agentPolicy }) => {
+export const MetricNonAvailable: React.FC<{ agentPolicy?: AgentPolicy; agent?: Agent }> = ({
+  agentPolicy,
+  agent,
+}) => {
   const isMonitoringEnabled = agentPolicy?.monitoring_enabled?.includes('metrics');
+  const isOffline = agent?.status === 'offline';
 
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
@@ -29,6 +33,11 @@ export const MetricNonAvailable: React.FC<{ agentPolicy?: AgentPolicy }> = ({ ag
               <FormattedMessage
                 id="xpack.fleet.agent.metricsNotAvailableMonitoringNotEnabled"
                 defaultMessage="Agent monitoring is not enabled for this agent policy. Visit agent policy settings to enable monitoring."
+              />
+            ) : isOffline ? (
+              <FormattedMessage
+                id="xpack.fleet.agentList.metricsNotAvailableOffline"
+                defaultMessage="This agent is offline, so metrics are not currently available. Metrics will resume once the agent reconnects."
               />
             ) : (
               <FormattedMessage

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/services/agent_metrics.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/services/agent_metrics.tsx
@@ -8,25 +8,29 @@
 import React from 'react';
 import { EuiToolTip } from '@elastic/eui';
 
-import type { AgentMetrics, AgentPolicy } from '../../../../../../common/types';
+import type { Agent, AgentMetrics, AgentPolicy } from '../../../../../../common/types';
 
 import { MetricNonAvailable } from '../components';
 
-export function formatAgentCPU(metrics?: AgentMetrics, agentPolicy?: AgentPolicy) {
+export function formatAgentCPU(metrics?: AgentMetrics, agentPolicy?: AgentPolicy, agent?: Agent) {
   return typeof metrics?.cpu_avg !== 'undefined' ? (
     <EuiToolTip content={`${(metrics.cpu_avg * 100).toFixed(4)} %`}>
       <span tabIndex={0}>{(metrics.cpu_avg * 100).toFixed(2)} %</span>
     </EuiToolTip>
   ) : (
-    <MetricNonAvailable agentPolicy={agentPolicy} />
+    <MetricNonAvailable agentPolicy={agentPolicy} agent={agent} />
   );
 }
 
-export function formatAgentMemory(metrics?: AgentMetrics, agentPolicy?: AgentPolicy) {
+export function formatAgentMemory(
+  metrics?: AgentMetrics,
+  agentPolicy?: AgentPolicy,
+  agent?: Agent
+) {
   return metrics?.memory_size_byte_avg ? (
     formatBytes(metrics.memory_size_byte_avg)
   ) : (
-    <MetricNonAvailable agentPolicy={agentPolicy} />
+    <MetricNonAvailable agentPolicy={agentPolicy} agent={agent} />
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #275500.

When an agent is Offline, its CPU and Memory columns (Agents list) and the CPU/Memory fields on the Agent Details page show "N/A" with a tooltip. Before this fix, that tooltip always said either "Agent monitoring is not enabled..." or a generic "you may not have the correct permission..." message — neither of which is true for an offline agent, and both are misleading since the agent is simply disconnected and metrics will resume once it reconnects.

Root cause: `MetricNonAvailable` (the shared component behind both `formatAgentCPU`/`formatAgentMemory`) only had two branches — monitoring-disabled vs. a generic fallback — and never received the `agent` object, so it had no way to detect the offline case.

## Changes

- `metric_non_available.tsx`: accept an optional `agent` prop and add a third tooltip branch for `agent.status === 'offline'` with a clear, accurate message.
- `agent_metrics.tsx`: thread an optional `agent` param through `formatAgentCPU`/`formatAgentMemory` into `MetricNonAvailable`.
- `agent_list_table.tsx` (Agents list, CPU/Memory cells) and `agent_details_overview.tsx` (Agent Details page) updated to pass `agent` through — both surfaces share this helper, so both needed the update for the fix to be complete.
- `metric_non_available.test.tsx` (new): regression coverage for the offline branch, the monitoring-disabled-over-offline priority ordering, and the generic fallback.

## Checklist

- [x] Reused existing `AgentStatus` type (`'offline'` was already a valid status) — no type changes needed.
- [x] `agent` param is optional everywhere it's threaded, so no other call sites break.
- [x] Unit test coverage for the offline branch and message priority ordering (`metric_non_available.test.tsx`).

## Identify risks

Low risk: purely additive optional prop/param, no behavior change for any non-offline case. Two call sites updated; verified via code search that these are the only two callers of `formatAgentCPU`/`formatAgentMemory`.


<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->