### PR TITLE
[Security Solution][Dashboards] Remove Add to Timeline cell action

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/actions/add_to_timeline/lens/add_to_timeline.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/actions/add_to_timeline/lens/add_to_timeline.test.ts
@@ -17,6 +17,7 @@ import type { ActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import type { TimeRange } from '@kbn/es-query';
 import type { LensApi } from '@kbn/lens-plugin/public';
 import { getLensApiMock } from '@kbn/lens-plugin/public/react_embeddable/mocks';
+import { DASHBOARD_API_TYPE } from '@kbn/dashboard-plugin/public';
 
 jest.mock('../../../../common/lib/kibana');
 const currentAppId$ = new Subject<string | undefined>();
@@ -183,6 +184,22 @@ describe('createAddToTimelineLensAction', () => {
       ).read = true;
       const _action = createAddToTimelineLensAction({ store, order: 1 });
       expect(await _action.isCompatible(context)).toEqual(false);
+    });
+
+    it('should return true when the lens embeddable is not rendered inside a dashboard', async () => {
+      expect(await addToTimelineAction.isCompatible(context)).toEqual(true);
+    });
+
+    it('should return false when the lens embeddable is rendered inside a dashboard', async () => {
+      expect(
+        await addToTimelineAction.isCompatible({
+          ...context,
+          embeddable: {
+            ...getMockLensApi(),
+            parentApi: { type: DASHBOARD_API_TYPE },
+          },
+        })
+      ).toEqual(false);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/app/actions/add_to_timeline/lens/add_to_timeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/actions/add_to_timeline/lens/add_to_timeline.ts
@@ -7,7 +7,13 @@
 
 import type { CellValueContext } from '@kbn/embeddable-plugin/public';
 import { createAction } from '@kbn/ui-actions-plugin/public';
-import { apiPublishesUnifiedSearch, hasBlockingError } from '@kbn/presentation-publishing';
+import {
+  apiHasParentApi,
+  apiIsOfType,
+  apiPublishesUnifiedSearch,
+  hasBlockingError,
+} from '@kbn/presentation-publishing';
+import { DASHBOARD_API_TYPE } from '@kbn/dashboard-plugin/public';
 import { isLensApi } from '@kbn/lens-plugin/public';
 import { isInSecurityApp } from '../../../../common/hooks/is_in_security_app';
 import { KibanaServices } from '../../../../common/lib/kibana';
@@ -27,6 +33,17 @@ import {
 import { createDataProviders } from '../data_provider';
 
 export const ACTION_ID = 'embeddable_addToTimeline';
+
+/**
+ * Determines whether a Lens embeddable is rendered inside a Dashboard container.
+ * Security Dashboards render Lens panels through the platform Dashboard, so their
+ * `parentApi` is the Dashboard API. This lets us opt the "Add to Timeline" cell
+ * action out of the Security Dashboards surface without affecting other Security
+ * Lens surfaces (Overview, Explore, Entity Analytics, etc.).
+ */
+function isInsideDashboard(embeddable: CellValueContext['embeddable']): boolean {
+  return apiHasParentApi(embeddable) && apiIsOfType(embeddable.parentApi, DASHBOARD_API_TYPE);
+}
 
 function isDataColumnsFilterable(data?: CellValueContext['data']): boolean {
   return (
@@ -91,7 +108,10 @@ export const createAddToTimelineLensAction = ({
       isLensApi(embeddable) &&
       apiPublishesUnifiedSearch(embeddable) &&
       isDataColumnsFilterable(data) &&
-      isInSecurityApp(currentAppId),
+      isInSecurityApp(currentAppId) &&
+      // Security Dashboards use the platform Dashboard experience; the "Add to
+      // Timeline" cell action is intentionally excluded from that surface.
+      !isInsideDashboard(embeddable),
     execute: async ({ data }) => {
       const dataProviders = data.reduce<DataProvider[]>((acc, { columnMeta, value, eventId }) => {
         const dataProvider = createDataProviders({


### PR DESCRIPTION
## Summary

This PR is the first step aiming at deprecating the Dashboard experience specific to Security. It removes the `Add to Timeline` action that we show in the cell actions in the Lens embeddable components rendered in those Security dashboards.

#### Currently on `main` we show the action only when dashboards are loaded from Security

https://github.com/user-attachments/assets/b45fac8c-1296-4e89-83a2-cd4dcadb5806

#### The PR removes that action

https://github.com/user-attachments/assets/a98ebea4-ee57-4482-a623-205436f96193

#### Without changing the cell actions when the same dashboards are loaded from the platform Dashboard experience

https://github.com/user-attachments/assets/9681c553-c2f5-45ec-ade3-fb0eaf68d299

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/286389