### PR TITLE
[9.5][Synthetics] Enable Synthetics in alerting_and_reset UI specs

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/tests/custom_status_alert.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/tests/custom_status_alert.spec.ts
@@ -13,6 +13,7 @@ test.describe('CustomStatusAlert', { tag: tags.stateful.classic }, () => {
   let configId: string;
 
   test.beforeAll(async ({ syntheticsServices }) => {
+    await syntheticsServices.enable();
     await syntheticsServices.cleanUp();
   });
 

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/tests/custom_tls_alert.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/tests/custom_tls_alert.spec.ts
@@ -14,6 +14,7 @@ test.describe('Creates a custom TLS alert rule', { tag: tags.stateful.classic },
   let configId: string;
 
   test.beforeAll(async ({ syntheticsServices }) => {
+    await syntheticsServices.enable();
     await syntheticsServices.cleanUp();
     await syntheticsServices.deleteCustomRules();
     configId = await syntheticsServices.addMonitor(

--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/tests/default_status_alert.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/tests/default_status_alert.spec.ts
@@ -14,6 +14,7 @@ test.describe('DefaultStatusAlert', { tag: tags.stateful.classic }, () => {
   let locationId: string;
 
   test.beforeAll(async ({ syntheticsServices }) => {
+    await syntheticsServices.enable();
     await syntheticsServices.cleanUp();
     await syntheticsServices.deleteCustomRules();
     await syntheticsServices.deleteSettingsAndConnectors();


### PR DESCRIPTION
## Summary

Fixes the whole `alerting_and_reset/ui` Scout namespace for Synthetics by enabling Synthetics in the specs that drive the overview page.

Closes https://github.com/elastic/kibana/issues/258036
Closes https://github.com/elastic/kibana/issues/275493
Closes https://github.com/elastic/kibana/issues/275494
Closes https://github.com/elastic/kibana/issues/255548

> [!IMPORTANT]
> **Please retarget this to `main` before merging.** The three spec files are byte-identical between `upstream/9.5` and `upstream/main` (verified by blob SHA: `d4173eff2039`, `5f7f7bdb6e42`, `5e24075a3756` on both branches) and **neither branch** has the `enable()` call. So `main` is broken in exactly the same way, which matches the reported failure history (#275493/#275494 fail more often on `main` than on 9.5). Per Kibana convention this should land on `main` first with `backport:version` + `v9.5.x`/`v9.4.x`. It is raised against `9.5` only because that is where the failing lane was triaged; the diff cherry-picks cleanly (the only files that differ between the branches in this namespace — `global.setup.ts` and `alerting_default.spec.ts` — are untouched here).

## Root cause

Not a missing backport, and not stale es-archive data. The three suites all fail for one reason: **they never enable Synthetics, and Synthetics enablement is server-global state.**

`useEnablement()` navigates the app away from whatever route you are on when the enablement payload reports that the user can neither enable Synthetics nor is it already enabled:

```ts
// x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_enablement.ts:26
useEffect(() => {
  if (!enablement?.canEnable && !enablement?.isEnabled && !loading && enablement) {
    application?.navigateToApp('synthetics', {
      path: '/monitors',
    });
  }
}, [application, enablement, loading]);
```

`OverviewPage` calls `useEnablement()`. The Scout privileged user is `editor`, not a superuser, so `canManageApiKeys`/`canEnable` are always `false`. I captured the live response in the browser during a failing run:

```json
{"canEnable":false,"canManageApiKeys":false,"isEnabled":false,"isValidApiKey":false,"areApiKeysEnabled":true,"isServiceAllowed":true}
```

So `/app/synthetics` deterministically bounces to `/app/synthetics/monitors`, and every overview-only locator disappears:

| locator | rendered by | tests that need it |
| --- | --- | --- |
| `superDatePickerApplyTimeButton` | overview route's `pageHeader` (`monitors_page/route_config.tsx:57`) | `SyntheticsAppPage.refreshOverview()` — all 3 TLS tests + `CustomStatusAlert` |
| `syntheticsOverviewUp` / `syntheticsOverviewDown` | `OverviewStatus` on the overview route | `DefaultStatusAlert` |

Confirmed by patching `history.pushState` in the browser and dumping the stack — the navigation is a core `ApplicationService.navigate` from a synthetics `useEffect`, not a react-router `<Redirect>`:

```
at ApplicationService.navigate  (core.entry.js)
at Object.navigateToApp         (core.entry.js)
at <synthetics chunk>
at commitHookEffectListMount    (react-dom)
```

### Why it looked flaky rather than broken

Enablement is a server-global saved object, and in CI every Scout config in a lane runs against **one** Kibana/ES. Whether `alerting_and_reset/ui` passes therefore depends purely on what ran before it:

- `monitor_crud/ui/tests/*.spec.ts` (7 specs) and `project_monitors/ui/tests/project_monitor_read_only.spec.ts` each call `await syntheticsServices.enable()` in `beforeAll` → they leave Synthetics **enabled**.
- `alerting_and_reset/api/tests/synthetics_enablement.spec.ts` **deletes** enablement.
- `alerting_and_reset/ui/tests/*` called neither, so it inherited whatever the previous config left behind.

This is also independently corroborated on `main`: `alerting_default.spec.ts` in this same namespace was already fixed there with the identical one-liner, and its comment says as much — *"Sibling synthetics specs enable it in their own setup; this one relied on ordering."* The other three specs in the namespace were simply never given the same treatment.

### Hypotheses ruled out

- **Missing backport of `resetArchivedSyntheticsDataStreams` (#284478).** Real 9.5/`main` parity gap, but not the cause. That helper only deletes the `synthetics-browser-*` data streams from the `synthetics_data` archive (browser step documents); its own doc comment ties it to step metrics reporting `0 Bytes`, a `monitor_crud` concern. Nothing in `alerting_and_reset/ui` reads those data streams. Left for a separate parity PR.
- **`refreshOverview()` / `synthetics_app.ts` divergence.** The `page.evaluate` click fix from #286232 is present on both branches.

## Change

`await syntheticsServices.enable();` as the first statement of `beforeAll` in the three active specs, matching the existing `monitor_crud/ui` pattern exactly (`enable()` first, cleanup after). `alerting_default.spec.ts` is untouched — its suite is `test.describe.skip` on 9.5 (#286329) and is out of scope. Whoever un-skips it must carry the same line, as `main` already does.

`enable()` is idempotent and `cleanUp()` never touches the `uptime-synthetics-api-key` saved object, so the ordering is safe. Leaving Synthetics enabled cannot regress `alerting_and_reset/api/tests/synthetics_enablement.spec.ts` — that spec normalizes its own starting state in a `beforeEach` that deletes enablement whenever service API keys exist.

## Verification

All runs local, against a Scout stateful/classic stack started once with `node scripts/scout start-server --arch stateful --domain classic`. `node scripts/scout run-tests` boots its own servers on 9.5, so tests were driven through the same Playwright invocation it uses:

```
SCOUT_TARGET_LOCATION=local SCOUT_TARGET_ARCH=stateful SCOUT_TARGET_DOMAIN=classic \
node scripts/playwright test \
  --config=x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/playwright.config.ts \
  --grep=@local-stateful-classic --project=local
```

Before each full-config run I explicitly deleted enablement (`DELETE /internal/synthetics/service/enablement`) so every run started from the broken cold state rather than inheriting a previously enabled server.

**Baseline (before the fix, cold stack) — 5 failed, 1 passed:**

| test | result |
| --- | --- |
| `custom_status_alert` › creates a custom status alert rule | FAILED |
| `custom_tls_alert` › can filter monitors by KQL | FAILED |
| `custom_tls_alert` › can filter monitors by type | FAILED |
| `custom_tls_alert` › can create rule and fire alert | FAILED |
| `default_status_alert` › creates default alert, triggers on down status, and recovers | FAILED |
| `global.setup.ts` › Ingest Synthetics test data | passed |

**After the fix — 4 cold-start full-config runs + one `--repeat-each=5` full-config run = 9 executions per test:**

| test | result |
| --- | --- |
| `custom_tls_alert` › can create rule and fire alert (#258036) | **9 / 9 passed** |
| `custom_tls_alert` › can filter monitors by KQL (#275493) | **9 / 9 passed** |
| `custom_tls_alert` › can filter monitors by type (#275494) | **9 / 9 passed** |
| `default_status_alert` › creates default alert, triggers on down status, and recovers (#255548) | **9 / 9 passed** |
| `custom_status_alert` › creates a custom status alert rule (#268088) | 8 / 9 passed |
| `alerting_default` › 2 tests | skipped (`test.describe.skip`, #286329) |

The `--repeat-each=5` run on its own: `10 skipped, 26 passed (7.2m)`, zero failures — every test 5/5.

### One residual failure, disclosed

`CustomStatusAlert` failed once in 9 executions, on a **different** assertion from the enablement redirect — the last step, after the rule has been created:

```
custom_status_alert.spec.ts:73
  await expect(page.getByText('Synthetics monitor status rule')).toBeVisible();
  Error: element(s) not found   Timeout: 10000ms
```

`goToRulesPage()` does a bare `page.goto` with no wait for the rules table to finish loading, then asserts with the default 10s timeout. That is a distinct pre-existing weakness from the one #268088 fixed in `refreshOverview()` (#286232 / `74aad3b6e897`), so it is deliberately not touched here and #268088 is **not** claimed as closed by this PR. Worth a separate follow-up hardening `goToRulesPage()`.

### Other checks

```
node scripts/eslint --fix $(git diff --name-only)                                          # ✅ no eslint errors found
node scripts/type_check --project x-pack/solutions/observability/plugins/synthetics/tsconfig.json   # ✅ exited with 0
```

## Backporting

`9.4` needs the same fix — the specs are unchanged there too. Since the defect exists on `main`, the cleanest path is main-first plus `backport:version` with `v9.5.x` and `v9.4.x`, rather than three independent branch PRs.

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) — to be triggered on this branch
- [x] `release_note:skip` (test-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
