### PR TITLE
Improve buildkite pipelines for GenAI Product doc artifacts

### DIFF
--- a/.buildkite/pipelines/gen_ai_product_docs.yml
+++ b/.buildkite/pipelines/gen_ai_product_docs.yml
@@ -33,6 +33,8 @@ steps:
       FTR_CONFIG_GROUP_KEY: 'ftr-ai-infra-gen-ai-inference-api'
       FTR_GEN_AI: '1'
       FTR_EIS_CCM: '1'
+      # Keep ES/Kibana server logs on disk so mocha log capture does not OOM on ML-heavy suites
+      FTR_EXTRA_ARGS: '--writeLogsToPath=data/ftr_servers_logs'
     timeout_in_minutes: 180
     parallelism: 1
     agents:
@@ -40,6 +42,8 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
+      # ES|QL enrichment + multi-product semantic indices need more than the default boot disk
+      diskSizeGb: 180
       preemptible: true
     retry:
       automatic:

--- a/.buildkite/pipelines/gen_ai_security_labs.yml
+++ b/.buildkite/pipelines/gen_ai_security_labs.yml
@@ -41,7 +41,6 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 180
       preemptible: true
     retry:
       automatic:

--- a/.buildkite/pipelines/gen_ai_security_labs.yml
+++ b/.buildkite/pipelines/gen_ai_security_labs.yml
@@ -32,6 +32,8 @@ steps:
       FTR_CONFIG_GROUP_KEY: 'ftr-ai-infra-gen-ai-security-labs'
       FTR_GEN_AI: '1'
       FTR_EIS_CCM: '1'
+      # Keep ES/Kibana server logs on disk so mocha log capture does not OOM on ML-heavy suites
+      FTR_EXTRA_ARGS: '--writeLogsToPath=data/ftr_servers_logs'
     timeout_in_minutes: 120
     parallelism: 1
     agents:
@@ -39,6 +41,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
+      diskSizeGb: 180
       preemptible: true
     retry:
       automatic:

--- a/.buildkite/pipelines/gen_ai_testing.yml
+++ b/.buildkite/pipelines/gen_ai_testing.yml
@@ -39,6 +39,8 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
+      # Product-doc installs (ELSER/E5) are disk-heavy; avoid ES flood-stage / merge stalls
+      diskSizeGb: 130
       preemptible: true
     retry:
       automatic:

--- a/.buildkite/pipelines/gen_ai_testing.yml
+++ b/.buildkite/pipelines/gen_ai_testing.yml
@@ -28,6 +28,8 @@ steps:
       FTR_CONFIG: 'x-pack/platform/test/functional_gen_ai/inference/config.ts'
       FTR_CONFIG_GROUP_KEY: 'ftr-ai-infra-gen-ai-inference-api'
       FTR_GEN_AI: '1'
+      # Keep ES/Kibana server logs on disk so mocha log capture does not OOM on ML-heavy suites
+      FTR_EXTRA_ARGS: '--writeLogsToPath=data/ftr_servers_logs'
     label: AppEx AI-Infra Inference APIs FTR tests
     key: ai-infra-gen-ai-inference-api
     timeout_in_minutes: 50

--- a/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
+++ b/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
@@ -17,6 +17,8 @@ steps:
         parallelism: 1
         agents:
           machineType: n2-standard-4
+          # Product-doc installs (ELSER/E5) are disk-heavy; avoid ES flood-stage / merge stalls
+          diskSizeGb: 130
           preemptible: true
           spotZones: us-central1-f,us-central1-c,us-central1-a
         retry:

--- a/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
+++ b/.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml
@@ -9,6 +9,8 @@ steps:
           FTR_CONFIG: 'x-pack/platform/test/functional_gen_ai/inference/config.ts'
           FTR_CONFIG_GROUP_KEY: 'ftr-ai-infra-gen-ai-inference-api'
           FTR_GEN_AI: '1'
+          # Keep ES/Kibana server logs on disk so mocha log capture does not OOM on ML-heavy suites
+          FTR_EXTRA_ARGS: '--writeLogsToPath=data/ftr_servers_logs'
         label: AppEx AI-Infra Inference APIs FTR tests
         key: ai-infra-gen-ai-inference-api
         timeout_in_minutes: 50

--- a/.buildkite/scripts/steps/gen_ai/run_ai_infra_inference_api_ftr.sh
+++ b/.buildkite/scripts/steps/gen_ai/run_ai_infra_inference_api_ftr.sh
@@ -32,9 +32,10 @@ export FTR_EIS_CCM="${FTR_EIS_CCM:-1}"
 
 .buildkite/scripts/steps/test/ftr_configs.sh
 
+# Mirror security labs: upload zips immediately after FTR so GCS gets artifacts
+# even if the ES|QL docs PR step fails or exits early.
+echo "--- Upload GenAI product docs artifacts to GCS"
+bash .buildkite/scripts/steps/gen_ai/upload_kb_artifacts.sh
+
 echo "--- Make PR for GenAI ES|QL docs sync update"
 .buildkite/scripts/steps/gen_ai/esql_docs_sync.sh
-
-
-echo "--- Upload GenAI product docs artifacts to GCS"
-.buildkite/scripts/steps/gen_ai/upload_kb_artifacts.sh

--- a/.buildkite/scripts/steps/gen_ai/run_security_labs_artifacts_ftr.sh
+++ b/.buildkite/scripts/steps/gen_ai/run_security_labs_artifacts_ftr.sh
@@ -30,4 +30,4 @@ export FTR_EIS_CCM="${FTR_EIS_CCM:-1}"
 .buildkite/scripts/steps/test/ftr_configs.sh
 
 echo "--- Upload Security Labs KB artifacts to GCS"
-.buildkite/scripts/steps/gen_ai/upload_kb_artifacts.sh
+bash .buildkite/scripts/steps/gen_ai/upload_kb_artifacts.sh

--- a/.buildkite/scripts/steps/gen_ai/run_security_labs_artifacts_ftr.sh
+++ b/.buildkite/scripts/steps/gen_ai/run_security_labs_artifacts_ftr.sh
@@ -30,4 +30,4 @@ export FTR_EIS_CCM="${FTR_EIS_CCM:-1}"
 .buildkite/scripts/steps/test/ftr_configs.sh
 
 echo "--- Upload Security Labs KB artifacts to GCS"
-bash .buildkite/scripts/steps/gen_ai/upload_kb_artifacts.sh
+.buildkite/scripts/steps/gen_ai/upload_kb_artifacts.sh

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/create_artifact.ts
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/create_artifact.ts
@@ -7,6 +7,7 @@
 
 import Path from 'path';
 import AdmZip from 'adm-zip';
+import Fs from 'fs/promises';
 import type { ToolingLog } from '@kbn/tooling-log';
 import {
   LATEST_MANIFEST_FORMAT_VERSION,
@@ -36,6 +37,8 @@ export const createArtifact = async ({
   log.info(
     `Starting to create artifact from build folder [${buildFolder}] into target [${targetFolder}]`
   );
+
+  await Fs.mkdir(targetFolder, { recursive: true });
 
   const zip = new AdmZip();
 

--- a/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/process_documents.ts
+++ b/x-pack/packages/ai-infra/product-doc-artifact-builder/src/tasks/process_documents.ts
@@ -37,10 +37,11 @@ const EMPTY_DOC_TOKEN_LIMIT = 120;
 
 /**
  * Filter "this content has moved" or "deleted pages" type of documents, just based on token count.
+ * Allow special tokens (e.g. `<|endoftext|>` in LLM docs) so token counting does not abort the build.
  */
 const filterEmptyDocs = (documents: ExtractedDocument[]): ExtractedDocument[] => {
   return documents.filter((doc) => {
-    const tokenCount = encode(doc.content_body).length;
+    const tokenCount = encode(doc.content_body, { allowedSpecial: 'all' }).length;
     if (tokenCount < EMPTY_DOC_TOKEN_LIMIT) {
       return false;
     }

--- a/x-pack/platform/test/functional_gen_ai/inference/artifacts/product_docs.ts
+++ b/x-pack/platform/test/functional_gen_ai/inference/artifacts/product_docs.ts
@@ -153,6 +153,8 @@ export default function ({ getService }: FtrProviderContext) {
         `--embeddingClusterUrl=${embeddingClusterUrl}`,
         `--embeddingClusterUsername=${embeddingClusterUsername}`,
         `--embeddingClusterPassword=${embeddingClusterPassword}`,
+        // Match security_labs.ts: pin output so CI upload finds zips under build/kb-artifacts
+        `--targetFolder=${kbArtifactsDir}`,
       ];
 
       const commands = [
@@ -270,6 +272,7 @@ export default function ({ getService }: FtrProviderContext) {
           `--embedding-cluster-username=${embeddingClusterUsername}`,
           `--embedding-cluster-password=${embeddingClusterPassword}`,
           `--inference-id=${openApiInferenceId}`,
+          `--targetFolder=${kbArtifactsDir}`,
         ];
 
         const cmd = `${nodeBin} ${openApiArgs.join(' ')}`;


### PR DESCRIPTION
## Summary

This PR:

- Divert ES/Kibana FTR logs to disk (--writeLogsToPath) on gen-ai daily/PR jobs to avoid mocha log-cache OOM on ML-heavy suites (see [failures](https://buildkite.com/elastic/kibana-gen-ai-tests-daily/builds/618#01a0182d-c2dd-4878-97f1-da05b9f7eebe) here)
- Bump agent disk for gen-ai product-docs / security-labs (180GB) and inference FTR (130GB) to avoid ES flood-stage / merge stalls on the default 100GB boot disk
- Pin product-doc and OpenAPI artifact output to build/kb-artifacts (and ensure the dir exists) so GCS upload finds the zips
- Upload product-doc artifacts to GCS immediately after FTR (before ES|QL sync), matching the security-labs flow; invoke upload via bash for execute-bit resilience


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



