### PR TITLE
[Agent Builder] Fix Task Manager conversation owner resolution

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/utils.test.ts
@@ -343,6 +343,36 @@ describe('getUserFromRequest', () => {
     expect(esClient.security.authenticate).not.toHaveBeenCalled();
   });
 
+  it('recovers an API key creator profile uid for fake requests with username-only auth users', async () => {
+    const request = httpServerMock.createFakeKibanaRequest({});
+
+    security.authc.getCurrentUser.mockReturnValue({
+      username: 'originating-user',
+    } as any);
+    esClient.security.authenticate.mockResolvedValue({
+      username: 'originating-user',
+      authentication_type: 'api_key',
+      authentication_realm: { type: '_es_api_key', name: '_es_api_key' },
+      api_key: { id: 'task-api-key-id' },
+    } as any);
+    esClient.security.getApiKey.mockResolvedValue({
+      api_keys: [{ id: 'task-api-key-id', profile_uid: 'profile-from-task-api-key' }],
+    } as any);
+
+    const result = await getUserFromRequest({ request, security, esClient });
+
+    expect(result).toEqual({
+      id: 'profile-from-task-api-key',
+      username: 'originating-user',
+      isAdmin: false,
+    });
+    expect(esClient.security.authenticate).toHaveBeenCalled();
+    expect(esClient.security.getApiKey).toHaveBeenCalledWith({
+      with_profile_uid: true,
+      id: 'task-api-key-id',
+    });
+  });
+
   it('falls back to ES authenticate API for un-enriched fake requests', async () => {
     const request = httpServerMock.createFakeKibanaRequest({});
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
@@ -25,6 +25,10 @@ interface StableUserIdAuthUser {
   authentication_realm?: { type?: string; name?: string };
 }
 
+interface AuthenticatedApiKeyUser extends StableUserIdAuthUser {
+  api_key?: { id?: string };
+}
+
 /**
  * Builds a stable principal id for Agent Builder ownership checks.
  *
@@ -75,18 +79,13 @@ export const toStableUserId = async ({
  * sessions for the same user. Older keys or creators without an activated profile return
  * undefined and callers fall back to username matching.
  */
-const resolveApiKeyOwnerProfileUid = async ({
-  request,
+const getApiKeyOwnerProfileUid = async ({
+  id,
   esClient,
 }: {
-  request: KibanaRequest;
+  id: string;
   esClient: ElasticsearchClient;
 }): Promise<string | undefined> => {
-  const id = extractApiKeyIdFromAuthzHeader(request.headers.authorization);
-  if (!id) {
-    return undefined;
-  }
-
   try {
     const response = await esClient.security.getApiKey({
       with_profile_uid: true,
@@ -102,6 +101,40 @@ const resolveApiKeyOwnerProfileUid = async ({
   }
 };
 
+const resolveApiKeyOwnerProfileUid = async ({
+  request,
+  esClient,
+}: {
+  request: KibanaRequest;
+  esClient: ElasticsearchClient;
+}): Promise<string | undefined> => {
+  const id = extractApiKeyIdFromAuthzHeader(request.headers.authorization);
+  return id ? getApiKeyOwnerProfileUid({ id, esClient }) : undefined;
+};
+
+const resolveStableUserIdFromAuthenticate = async ({
+  username,
+  esClient,
+}: {
+  username: string;
+  esClient: ElasticsearchClient;
+}): Promise<string | undefined> => {
+  const authResponse = (await esClient.security.authenticate()) as AuthenticatedApiKeyUser;
+
+  return toStableUserId({
+    authUser: {
+      username,
+      profile_uid: authResponse.profile_uid,
+      authentication_type: authResponse.authentication_type,
+      authentication_realm: authResponse.authentication_realm,
+    },
+    resolveApiKeyProfileUid: () => {
+      const id = authResponse.api_key?.id;
+      return id ? getApiKeyOwnerProfileUid({ id, esClient }) : Promise.resolve(undefined);
+    },
+  });
+};
+
 /**
  * Resolves the current user from a request.
  *
@@ -114,7 +147,7 @@ const resolveApiKeyOwnerProfileUid = async ({
  * the API key owner's username does not match the originating user.
  *
  * For un-enriched fake requests (e.g. tasks scheduled before enrichment was available), we fall
- * back to the ES `_security/_authenticate` API for the username only.
+ * back through ES `_security/_authenticate` and, for API keys, the key lookup API.
  */
 export const getUserFromRequest = async ({
   request,
@@ -129,11 +162,17 @@ export const getUserFromRequest = async ({
   const isAdmin = await isAdminFromRequest({ esClient });
 
   if (authUser?.username) {
+    const stableUserId = await toStableUserId({
+      authUser,
+      resolveApiKeyProfileUid: () => resolveApiKeyOwnerProfileUid({ request, esClient }),
+    });
+
+    const fallbackStableUserId =
+      stableUserId ??
+      (await resolveStableUserIdFromAuthenticate({ username: authUser.username, esClient }));
+
     return {
-      id: await toStableUserId({
-        authUser,
-        resolveApiKeyProfileUid: () => resolveApiKeyOwnerProfileUid({ request, esClient }),
-      }),
+      id: fallbackStableUserId,
       username: authUser.username,
       isAdmin,
     };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
@@ -101,6 +101,9 @@ const getApiKeyOwnerProfileUid = async ({
   }
 };
 
+/**
+ * Resolves the API key creator profile uid from the request authorization header.
+ */
 const resolveApiKeyOwnerProfileUid = async ({
   request,
   esClient,
@@ -112,6 +115,9 @@ const resolveApiKeyOwnerProfileUid = async ({
   return id ? getApiKeyOwnerProfileUid({ id, esClient }) : undefined;
 };
 
+/**
+ * Resolves a stable user id from the authenticated ES principal when request auth is incomplete.
+ */
 const resolveStableUserIdFromAuthenticate = async ({
   username,
   esClient,
@@ -162,17 +168,20 @@ export const getUserFromRequest = async ({
   const isAdmin = await isAdminFromRequest({ esClient });
 
   if (authUser?.username) {
-    const stableUserId = await toStableUserId({
+    let stableUserId = await toStableUserId({
       authUser,
       resolveApiKeyProfileUid: () => resolveApiKeyOwnerProfileUid({ request, esClient }),
     });
 
-    const fallbackStableUserId =
-      stableUserId ??
-      (await resolveStableUserIdFromAuthenticate({ username: authUser.username, esClient }));
+    if (stableUserId === undefined) {
+      stableUserId = await resolveStableUserIdFromAuthenticate({
+        username: authUser.username,
+        esClient,
+      });
+    }
 
     return {
-      id: fallbackStableUserId,
+      id: stableUserId,
       username: authUser.username,
       isAdmin,
     };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/utils.ts
@@ -13,6 +13,7 @@ import {
 } from '@kbn/core-security-server';
 import type { CurrentUser } from '@kbn/agent-builder-common';
 import { errors } from '@elastic/elasticsearch';
+import type { SecurityAuthenticateResponse } from '@elastic/elasticsearch/lib/api/types';
 import { APPLICATION_PREFIX } from '@kbn/security-plugin/common/constants';
 import { apiPrivileges } from '../../common/features';
 
@@ -23,10 +24,6 @@ interface StableUserIdAuthUser {
   profile_uid?: string;
   authentication_type?: string;
   authentication_realm?: { type?: string; name?: string };
-}
-
-interface AuthenticatedApiKeyUser extends StableUserIdAuthUser {
-  api_key?: { id?: string };
 }
 
 /**
@@ -102,46 +99,6 @@ const getApiKeyOwnerProfileUid = async ({
 };
 
 /**
- * Resolves the API key creator profile uid from the request authorization header.
- */
-const resolveApiKeyOwnerProfileUid = async ({
-  request,
-  esClient,
-}: {
-  request: KibanaRequest;
-  esClient: ElasticsearchClient;
-}): Promise<string | undefined> => {
-  const id = extractApiKeyIdFromAuthzHeader(request.headers.authorization);
-  return id ? getApiKeyOwnerProfileUid({ id, esClient }) : undefined;
-};
-
-/**
- * Resolves a stable user id from the authenticated ES principal when request auth is incomplete.
- */
-const resolveStableUserIdFromAuthenticate = async ({
-  username,
-  esClient,
-}: {
-  username: string;
-  esClient: ElasticsearchClient;
-}): Promise<string | undefined> => {
-  const authResponse = (await esClient.security.authenticate()) as AuthenticatedApiKeyUser;
-
-  return toStableUserId({
-    authUser: {
-      username,
-      profile_uid: authResponse.profile_uid,
-      authentication_type: authResponse.authentication_type,
-      authentication_realm: authResponse.authentication_realm,
-    },
-    resolveApiKeyProfileUid: () => {
-      const id = authResponse.api_key?.id;
-      return id ? getApiKeyOwnerProfileUid({ id, esClient }) : Promise.resolve(undefined);
-    },
-  });
-};
-
-/**
  * Resolves the current user from a request.
  *
  * For real HTTP requests, `security.authc.getCurrentUser` returns the authenticated user
@@ -170,13 +127,28 @@ export const getUserFromRequest = async ({
   if (authUser?.username) {
     let stableUserId = await toStableUserId({
       authUser,
-      resolveApiKeyProfileUid: () => resolveApiKeyOwnerProfileUid({ request, esClient }),
+      resolveApiKeyProfileUid: async () => {
+        // Real HTTP API-key requests expose the key id in the Authorization header.
+        const id = extractApiKeyIdFromAuthzHeader(request.headers.authorization);
+        return id ? getApiKeyOwnerProfileUid({ id, esClient }) : undefined;
+      },
     });
 
     if (stableUserId === undefined) {
-      stableUserId = await resolveStableUserIdFromAuthenticate({
-        username: authUser.username,
-        esClient,
+      // Task Manager fake requests can authenticate with an API key without exposing that header.
+      const authResponse: SecurityAuthenticateResponse = await esClient.security.authenticate();
+
+      stableUserId = await toStableUserId({
+        authUser: {
+          username: authUser.username,
+          authentication_type: authResponse.authentication_type,
+          authentication_realm: authResponse.authentication_realm,
+        },
+        resolveApiKeyProfileUid: async () => {
+          // In that path, Elasticsearch can report the active API key id from _authenticate.
+          const id = authResponse.api_key?.id;
+          return id ? getApiKeyOwnerProfileUid({ id, esClient }) : undefined;
+        },
       });
     }
 

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/converse_callback_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/converse_callback_api.spec.ts
@@ -43,6 +43,7 @@ import {
   INTERNAL_AGENT_BUILDER,
   API_AGENT_BUILDER,
   ELASTIC_API_VERSION,
+  CHAT_CONVERSATIONS_INDEX,
 } from '../fixtures/constants';
 import { getConversation } from '../fixtures/converse_http';
 
@@ -161,7 +162,7 @@ apiTest.describe(
     const getExecutionId = (requests: CallbackTestServerRequest[]): string =>
       (requests[0].body as ChatCallbackEventResponse).execution_id;
 
-    apiTest('delivers completed response to callback URL', async ({ apiClient }) => {
+    apiTest('delivers completed response to callback URL', async ({ apiClient, esClient }) => {
       const mockedLlmResponse = 'Callback LLM response';
       const mockedLlmTitle = 'Callback Conversation Title';
       await setupAgentDirectAnswer({
@@ -223,6 +224,15 @@ apiTest.describe(
       expect(conversationId.length).toBeGreaterThan(0);
 
       conversationIds.add(conversationId);
+
+      const storedConversation = await esClient.get({
+        index: CHAT_CONVERSATIONS_INDEX,
+        id: conversationId,
+      });
+      const source = storedConversation._source as { user_id?: string } | undefined;
+
+      expect(typeof source?.user_id).toBe('string');
+      expect(source?.user_id?.length).toBeGreaterThan(0);
     });
 
     apiTest(


### PR DESCRIPTION
## Summary

- Recover the API key creator profile uid for Task Manager fake requests that only expose a username through `getCurrentUser`.
- Keep conversation ownership stable for background task-created conversations by falling back through `_security/_authenticate` and `getApiKey({ with_profile_uid: true })`.

## Why the existing helper was not enough

`resolveApiKeyOwnerProfileUid` was originally added in https://github.com/elastic/kibana/pull/280890. That helper works when the API key id can be extracted from the request `Authorization` header.

The failing path used Task Manager fake requests. Those requests could return a username from `security.authc.getCurrentUser(request)`, but they did not expose the API key through `request.headers.authorization`. As a result, `resolveApiKeyOwnerProfileUid` could not look up the key owner profile uid, `toStableUserId()` returned `undefined`, and conversations created by background tasks were persisted without `user_id`.

This PR adds a fallback through Elasticsearch `_security/_authenticate`, which can expose the active API key id for the scoped ES client. Once we have that id, the existing `getApiKey({ with_profile_uid: true })` lookup can recover the creator profile uid.

## Security review

- The username from Task Manager fake requests is not used to authenticate. `_security/_authenticate` runs with the already-scoped ES client, so Elasticsearch authenticates the current request/API key principal.
- For `cloneApiKey: true` Task Manager executions, `_authenticate` exposes the active API key id. The follow-up `getApiKey({ with_profile_uid: true })` lookup uses that key id, not a username, to recover the key creator profile uid.
- Same-username users in different realms should not be confused by this fallback when a stable id can be resolved. If no profile uid or API key owner profile can be resolved, the code continues to fall back to the existing username-only legacy behavior.

## References

Related: https://github.com/elastic/kibana/pull/281996
Related: https://github.com/elastic/kibana/pull/280890