### PR TITLE
[Security Persona Matrix] Score the full expectedTools set in ExpectedToolCalled

### DIFF
--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-persona-matrix/src/evaluate_dataset.test.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-persona-matrix/src/evaluate_dataset.test.ts
@@ -170,13 +170,16 @@ describe('createPersonaMatrixTrajectoryEvaluator', () => {
 });
 
 describe('createPersonaMatrixExpectedToolCalledEvaluator', () => {
-  it('scores 1 when the primary expected tool was called', async () => {
+  it('scores 1 when every declared expected tool was called', async () => {
     const evaluator = createPersonaMatrixExpectedToolCalledEvaluator();
     const result = await evaluator.evaluate({
       input: { question: 'q' },
       expected: toDatasetExample(baseExample).output,
       output: {
-        steps: [{ type: 'tool_call', tool_id: 'security.alerts' }],
+        steps: [
+          { type: 'tool_call', tool_id: 'security.alerts' },
+          { type: 'tool_call', tool_id: 'security.get_related_alerts' },
+        ],
       } as unknown as TaskOutput,
       metadata: baseExample.metadata,
     } as unknown as Parameters<ReturnType<typeof createPersonaMatrixExpectedToolCalledEvaluator>['evaluate']>[0]);
@@ -197,6 +200,56 @@ describe('createPersonaMatrixExpectedToolCalledEvaluator', () => {
     } as unknown as Parameters<ReturnType<typeof createPersonaMatrixExpectedToolCalledEvaluator>['evaluate']>[0]);
     expect(result.score).toBeNull();
     expect(result.label).toBe('N/A');
+  });
+
+  // Regression: only `expectedTools[0]` used to be checked, so a run that
+  // skipped every later declared tool still scored a full 1.
+  it('scores 0 when a non-primary expected tool was skipped', async () => {
+    const evaluator = createPersonaMatrixExpectedToolCalledEvaluator();
+    const multiTool: PersonaMatrixExample = {
+      ...baseExample,
+      metadata: {
+        ...baseExample.metadata,
+        expectedTools: ['platform.core.generate_esql', 'platform.core.execute_esql'],
+      },
+    };
+    const result = await evaluator.evaluate({
+      input: { question: 'q' },
+      expected: toDatasetExample(multiTool).output,
+      output: {
+        steps: [{ type: 'tool_call', tool_id: 'platform.core.generate_esql' }],
+      } as unknown as TaskOutput,
+      metadata: multiTool.metadata,
+    } as unknown as Parameters<ReturnType<typeof createPersonaMatrixExpectedToolCalledEvaluator>['evaluate']>[0]);
+    expect(result.score).toBe(0);
+    expect((result.metadata as { missingToolIds: string[] }).missingToolIds).toEqual([
+      'platform.core.execute_esql',
+    ]);
+  });
+
+  it('scores 1 only when every declared expected tool was called', async () => {
+    const evaluator = createPersonaMatrixExpectedToolCalledEvaluator();
+    const multiTool: PersonaMatrixExample = {
+      ...baseExample,
+      metadata: {
+        ...baseExample.metadata,
+        expectedTools: ['platform.core.generate_esql', 'platform.core.execute_esql'],
+      },
+    };
+    const result = await evaluator.evaluate({
+      input: { question: 'q' },
+      expected: toDatasetExample(multiTool).output,
+      output: {
+        steps: [
+          { type: 'tool_call', tool_id: 'platform.core.generate_esql' },
+          { type: 'tool_call', tool_id: 'platform.core.list_indices' },
+          { type: 'tool_call', tool_id: 'platform.core.execute_esql' },
+        ],
+      } as unknown as TaskOutput,
+      metadata: multiTool.metadata,
+    } as unknown as Parameters<ReturnType<typeof createPersonaMatrixExpectedToolCalledEvaluator>['evaluate']>[0]);
+    expect(result.score).toBe(1);
+    expect((result.metadata as { missingToolIds: string[] }).missingToolIds).toEqual([]);
   });
 });
 

--- a/x-pack/solutions/security/packages/kbn-evals-suite-security-persona-matrix/src/evaluate_dataset.ts
+++ b/x-pack/solutions/security/packages/kbn-evals-suite-security-persona-matrix/src/evaluate_dataset.ts
@@ -67,9 +67,19 @@ export const toDatasetExample = (ex: PersonaMatrixExample): PersonaMatrixDataset
 };
 
 /**
- * ExpectedToolCalled — verifies the primary expected tool was invoked.
- * Reads `expectedTools` from example metadata (first entry) or `tool_sequence`
- * from the expected output.
+ * ExpectedToolCalled — verifies every declared expected tool was invoked.
+ * Reads `expectedTools` from example metadata, or `tool_sequence` from the
+ * expected output.
+ *
+ * Scores the whole declared set, not just `expectedTools[0]`. 16 of the 21
+ * examples declare more than one expected tool, so reading only the first
+ * entry left the rest unenforced: an example annotated
+ * `['platform.core.generate_esql', 'platform.core.execute_esql']` scored 1 for
+ * a run that generated a query and never executed it.
+ *
+ * All-or-nothing rather than a partial ratio: `Trajectory` already reports
+ * graded per-tool overlap. `missingToolIds` names what was skipped so a 0 is
+ * diagnosable without re-reading the trace.
  */
 export const createPersonaMatrixExpectedToolCalledEvaluator = (): Evaluator => ({
   name: 'ExpectedToolCalled',
@@ -88,14 +98,19 @@ export const createPersonaMatrixExpectedToolCalledEvaluator = (): Evaluator => (
       };
     }
 
-    const expectedToolId = expectedTools[0];
     const usedToolIds = getToolCallSteps(output as TaskOutput)
       .map((step) => step.tool_id)
       .filter((id): id is string => Boolean(id));
 
+    const usedToolIdSet = new Set(usedToolIds);
+    const missingToolIds = expectedTools.filter((toolId) => !usedToolIdSet.has(toolId));
+
     return {
-      score: usedToolIds.includes(expectedToolId) ? 1 : 0,
-      metadata: { expectedToolId, usedToolIds },
+      score: missingToolIds.length === 0 ? 1 : 0,
+      explanation: missingToolIds.length
+        ? `Expected tools not called: ${missingToolIds.join(', ')}.`
+        : `All expected tools called: ${expectedTools.join(', ')}.`,
+      metadata: { expectedToolIds: expectedTools, missingToolIds, usedToolIds },
     };
   },
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_hunting/threat_hunting_skill.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/threat_hunting/threat_hunting_skill.ts
@@ -42,7 +42,9 @@ Use this skill when:
 - Prefer ECS field names for cross-source portability
 
 ### 3. Explore Data Iteratively
-- Start with broad queries to establish baselines using 'platform.core.generate_esql' and 'platform.core.execute_esql'
+- Build every query with 'platform.core.generate_esql', then run it with 'platform.core.execute_esql'. This is required, not a shortcut to skip: 'generate_esql' validates syntax and resolves field names against the live mapping, so a hand-written query that looks correct can silently reference a field this deployment does not have. Do not hand-write ES|QL and pass it straight to 'platform.core.execute_esql'.
+- This applies to the query templates below too. They are starting points for a hypothesis, not runnable answers — pass the pattern you want through 'platform.core.generate_esql' to bind it to the actual indices and fields in this environment before executing.
+- Never report a finding from a query you did not execute. An unexecuted query is a hypothesis, not evidence.
 - Always scope queries with @timestamp ranges: WHERE @timestamp >= NOW() - 7 DAYS
 - Use STATS ... BY for aggregated views before drilling into raw events
 - Chain WHERE clauses to iteratively narrow down — avoid overly complex single queries
@@ -68,7 +70,7 @@ Use this skill when:
 
 ## Query Templates
 
-The following embedded query templates provide common hunting patterns (available as referenced content):
+The following embedded query templates provide common hunting patterns (available as referenced content). They are hypothesis starting points, not runnable answers — rebuild the pattern through 'platform.core.generate_esql' so it binds to this deployment's indices and fields, then execute it:
 - lateral-movement: Detect lateral movement via remote service creation and suspicious logon types
 - c2-beaconing: Identify C2 beaconing through periodic network connection analysis
 - brute-force: Detect brute force and credential spraying attempts
@@ -76,6 +78,7 @@ The following embedded query templates provide common hunting patterns (availabl
 
 ## Best Practices
 - Always start with a time-bounded hypothesis — do not explore without direction
+- Generate queries with 'platform.core.generate_esql' and execute them with 'platform.core.execute_esql'; report findings only from executed results
 - Use STATS and aggregations before raw event queries to understand data volume
 - Validate findings against known-good baselines before escalating
 - Hunt on 7-30 day windows for behavioral patterns; use shorter windows for IOC sweeps


### PR DESCRIPTION
## Summary

Two related fixes for the security persona-matrix eval suite, motivated by the
Opus 4.5 vs 4.8 comparison on the golden cluster:

### 1. ExpectedToolCalled now scores the full declared tool set

The evaluator only checked `expectedTools[0]`, so 16 of the 21 persona-matrix
examples had their remaining declared tools unenforced. An example annotated
`['platform.core.generate_esql', 'platform.core.execute_esql']` scored a full 1
for a run that generated a query and never executed it — and 0 for a run that
executed a correct query without generating it first.

It now requires every declared tool and reports `missingToolIds` in evaluator
metadata so a 0 is diagnosable without re-reading the trace. Deliberately
all-or-nothing rather than a partial ratio: `Trajectory` already reports graded
per-tool overlap, so ETC stays the strict "did the agent honour the full
declared contract" gate.

**Evidence (golden cluster):** across 9 anthropic-claude-4.8-opus threat-hunting
runs, `generate_esql` was called 2 times and `execute_esql` 8 — 4.8 hand-writes
ES|QL and executes it directly, skipping the schema-validating generator. The
dataset declares both tools; under the old check this collapse was invisible.
Re-scoring stored runs offline confirms the fix does not flip model ordering:
4.8-opus stays below 4.5-opus under first/any/all/fraction semantics.

### 2. Threat-hunting skill: make the generator step load-bearing

`Explore Data Iteratively` now requires building every query through
`generate_esql` before executing it, explicitly forbids hand-writing ES|QL
straight into `execute_esql`, and forbids reporting findings from unexecuted
queries. The embedded query templates are labeled hypothesis starting points
that must be re-bound through the generator, not runnable answers.

This is the product-side answer to the same finding: a frontier model was able
to route around the generator because the skill presented it as one option
among several rather than a required step.

## Testing

- [x] `node scripts/jest --config x-pack/solutions/security/packages/kbn-evals-suite-security-persona-matrix/jest.config.js` — 16/16 passed (includes two new regression tests for multi-tool scoring)
- [x] `node scripts/type_check --project .../tsconfig.json` — clean
- [x] eslint scoped to changed files — clean
