### PR TITLE
[One Workflow] Fix manual trigger event missing inputs in editor Liquid context

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.execute_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.execute_workflow.test.ts
@@ -142,8 +142,26 @@ describe('executeWorkflow – event/inputs synthesis', () => {
     expect(mockBuildWorkflowExecutionDocument).toHaveBeenCalledWith(
       expect.objectContaining({
         context: expect.objectContaining({
-          event: { type: 'manual', inputs },
+          event: { type: 'manual', inputs, spaceId: 'default' },
           inputs,
+        }),
+      })
+    );
+  });
+
+  it('includes spaceId in the synthesized manual event', async () => {
+    const inputs = { foo: 'bar' };
+
+    await pluginStart.executeWorkflow(
+      createWorkflow('wf-1'),
+      { spaceId: 'my-space', inputs },
+      request
+    );
+
+    expect(mockBuildWorkflowExecutionDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          event: expect.objectContaining({ type: 'manual', spaceId: 'my-space' }),
         }),
       })
     );

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.execute_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.execute_workflow.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import { coreMock } from '@kbn/core/server/mocks';
+import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import type { WorkflowExecutionEngineModel } from '@kbn/workflows';
+
+jest.mock('../common', () => ({
+  createIndexes: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('./lib/check_license', () => ({
+  checkLicense: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('./lib/get_user', () => ({
+  getAuthenticatedUser: jest.fn().mockResolvedValue('test-user'),
+}));
+
+const mockCreateWorkflowExecution = jest.fn().mockResolvedValue(undefined);
+jest.mock('./repositories/workflow_execution_repository', () => ({
+  WorkflowExecutionRepository: jest.fn().mockImplementation(() => ({
+    createWorkflowExecution: mockCreateWorkflowExecution,
+    getWorkflowExecutionById: jest.fn().mockResolvedValue(null),
+    bulkCreateWorkflowExecutions: jest.fn(),
+  })),
+}));
+
+const mockIsWorkflowEnabled = jest.fn().mockResolvedValue(true);
+jest.mock('@kbn/workflows', () => {
+  const actual = jest.requireActual('@kbn/workflows');
+  return {
+    ...actual,
+    WorkflowRepository: jest.fn().mockImplementation(() => ({
+      areWorkflowsEnabled: jest.fn().mockResolvedValue(new Map()),
+      isWorkflowEnabled: mockIsWorkflowEnabled,
+    })),
+  };
+});
+
+const mockCheckConcurrency = jest.fn().mockResolvedValue(true);
+jest.mock('./concurrency/concurrency_manager', () => ({
+  ConcurrencyManager: jest.fn().mockImplementation(() => ({
+    checkConcurrency: mockCheckConcurrency,
+    evaluateConcurrencyKey: jest.fn().mockReturnValue(null),
+  })),
+}));
+
+jest.mock('./concurrency/concurrency_queue_drainer', () => ({
+  maybeDrainConcurrencyQueueBeforeEnqueue: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./lib/validate_workflow_inputs', () => ({
+  validateWorkflowInputs: jest.fn().mockResolvedValue(true),
+}));
+
+const mockBuildWorkflowExecutionDocument = jest.fn();
+jest.mock('./lib/build_workflow_execution_document', () => ({
+  buildWorkflowExecutionDocument: (...args: unknown[]) =>
+    mockBuildWorkflowExecutionDocument(...args),
+}));
+
+import { WorkflowsExecutionEnginePlugin } from './plugin';
+
+const makeMinimalExecution = (overrides: Record<string, unknown> = {}) => ({
+  id: 'exec-1',
+  workflowId: 'wf-1',
+  spaceId: 'default',
+  createdAt: new Date().toISOString(),
+  concurrencyGroupKey: null,
+  ...overrides,
+});
+
+const createWorkflow = (
+  id: string,
+  overrides: Partial<WorkflowExecutionEngineModel> = {}
+): WorkflowExecutionEngineModel => ({
+  id,
+  name: `Workflow ${id}`,
+  enabled: true,
+  isEphemeral: true,
+  definition: {
+    name: `Workflow ${id}`,
+    enabled: true,
+    version: '1',
+    triggers: [{ type: 'manual' }],
+    steps: [],
+  },
+  yaml: `name: Workflow ${id}`,
+  isTestRun: false,
+  ...overrides,
+});
+
+describe('executeWorkflow – event/inputs synthesis', () => {
+  let pluginStart: Awaited<ReturnType<WorkflowsExecutionEnginePlugin['start']>>;
+  const request = { isFakeRequest: false } as unknown as KibanaRequest;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockIsWorkflowEnabled.mockResolvedValue(true);
+    mockCheckConcurrency.mockResolvedValue(true);
+    mockBuildWorkflowExecutionDocument.mockReturnValue(makeMinimalExecution());
+
+    const initializerContext = coreMock.createPluginInitializerContext({
+      logging: { console: false },
+      eventDriven: { enabled: true, logEvents: true, maxChainDepth: 10 },
+    });
+    const plugin = new WorkflowsExecutionEnginePlugin(initializerContext);
+
+    const coreSetup = coreMock.createSetup();
+    plugin.setup(coreSetup as any, {
+      taskManager: taskManagerMock.createSetup(),
+      cloud: {} as any,
+      workflowsExtensions: { registerConnectorAdapter: jest.fn() } as any,
+    });
+
+    const coreStart = coreMock.createStart();
+    pluginStart = plugin.start(coreStart, {
+      taskManager: taskManagerMock.createStart(),
+      actions: {} as any,
+      cloud: {} as any,
+      workflowsExtensions: {} as any,
+      licensing: licensingMock.createStart(),
+    });
+  });
+
+  it('synthesizes event from inputs when context has inputs but no event', async () => {
+    const inputs = { alertId: 'abc', severity: 'high' };
+
+    await pluginStart.executeWorkflow(
+      createWorkflow('wf-1'),
+      { spaceId: 'default', inputs },
+      request
+    );
+
+    expect(mockBuildWorkflowExecutionDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          event: { type: 'manual', inputs },
+          inputs,
+        }),
+      })
+    );
+  });
+
+  it('preserves the original event when context already has an event', async () => {
+    const event = { type: 'alert', id: 'alert-1' };
+    const inputs = { foo: 'bar' };
+
+    await pluginStart.executeWorkflow(
+      createWorkflow('wf-1'),
+      { spaceId: 'default', event, inputs },
+      request
+    );
+
+    expect(mockBuildWorkflowExecutionDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ event }),
+      })
+    );
+  });
+
+  it('does not synthesize event when inputs is an empty object', async () => {
+    await pluginStart.executeWorkflow(
+      createWorkflow('wf-1'),
+      { spaceId: 'default', inputs: {} },
+      request
+    );
+
+    expect(mockBuildWorkflowExecutionDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ event: undefined }),
+      })
+    );
+  });
+
+  it('does not synthesize event when context has neither event nor inputs', async () => {
+    await pluginStart.executeWorkflow(createWorkflow('wf-1'), { spaceId: 'default' }, request);
+
+    expect(mockBuildWorkflowExecutionDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ event: undefined }),
+      })
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -983,8 +983,21 @@ export class WorkflowsExecutionEnginePlugin
       authenticatedUser: string;
       now: Date;
     }): Promise<WorkflowExecutionForInputRendering> => {
+      const { event: eventFromRawContext, inputs } = args.context;
+      // Callers that pass inputs without an event are using the manual trigger path.
+      // Synthesize a minimal event so Liquid templates can access `event.inputs`.
+      const event =
+        !eventFromRawContext && inputs && Object.keys(inputs).length
+          ? { type: 'manual', inputs }
+          : eventFromRawContext;
+      const newContext = {
+        ...args.context,
+        event,
+      };
+
       return buildWorkflowExecutionDocument({
         ...args,
+        context: newContext,
         maxEventChainDepth: this.config.eventDriven.maxChainDepth,
         getConcurrencyGroupKey: (execution) =>
           this.getConcurrencyGroupKey(

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -988,7 +988,7 @@ export class WorkflowsExecutionEnginePlugin
       // Synthesize a minimal event so Liquid templates can access `event.inputs`.
       const event =
         !eventFromRawContext && inputs && Object.keys(inputs).length
-          ? { type: 'manual', inputs }
+          ? { type: 'manual', inputs, spaceId: args.context.spaceId }
           : eventFromRawContext;
       const newContext = {
         ...args.context,

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_workflow_context_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_workflow_context_schema.ts
@@ -17,6 +17,7 @@ import {
 } from '@kbn/workflows/spec/lib/field_conversion';
 import { BaseEventSchema } from '@kbn/workflows/spec/schema/common/base_event';
 import { AlertEventSchema } from '@kbn/workflows/spec/schema/triggers/alert_trigger_schema';
+import { isManualTrigger } from '@kbn/workflows/spec/schema/triggers/manual_trigger_schema';
 import { inferZodType } from '@kbn/workflows-yaml';
 import { z } from '@kbn/zod/v4';
 import { triggerSchemas } from '../../../trigger_schemas';
@@ -30,26 +31,38 @@ function isZodObject(schema: z.ZodType): schema is z.ZodObject<z.ZodRawShape> {
  * Custom trigger event schemas are resolved via the triggerSchemas singleton (same pattern as stepSchemas for steps).
  * Uses shape spread instead of deprecated Zod v4 .merge().
  */
-function buildEventSchemaFromTriggers(triggers: Array<{ type?: string }>): z.ZodType {
+function buildEventSchemaFromTriggers(
+  triggers: Array<{ type?: string }>,
+  inputsZodSchema: z.ZodType<Record<string, unknown>>
+): z.ZodType {
   const hasAlertTrigger = triggers.some((trigger) => trigger.type === 'alert');
   let eventSchema: z.ZodType = hasAlertTrigger
     ? z.object({
         ...(AlertEventSchema as z.ZodObject<z.ZodRawShape>).shape,
       })
     : BaseEventSchema;
+
   for (const trigger of triggers) {
-    const type = trigger?.type;
-    if (typeof type === 'string' && !isTriggerType(type)) {
-      const def = triggerSchemas.getTriggerDefinition(type);
-      if (def?.eventSchema && isZodObject(eventSchema) && isZodObject(def.eventSchema)) {
+    if (typeof trigger?.type === 'string' && isZodObject(eventSchema)) {
+      if (isTriggerType(trigger.type) && isManualTrigger(trigger)) {
         eventSchema = z.object({
           ...eventSchema.shape,
-          ...def.eventSchema.shape,
-          ...(EventTimestampSchema as z.ZodObject<z.ZodRawShape>).shape,
+          inputs: inputsZodSchema,
         });
+      } else {
+        const def = triggerSchemas.getTriggerDefinition(trigger.type);
+
+        if (def?.eventSchema && isZodObject(def.eventSchema)) {
+          eventSchema = z.object({
+            ...eventSchema.shape,
+            ...def.eventSchema.shape,
+            ...(EventTimestampSchema as z.ZodObject<z.ZodRawShape>).shape,
+          });
+        }
       }
     }
   }
+
   return eventSchema.optional();
 }
 
@@ -88,12 +101,14 @@ export function getWorkflowContextSchema(
   const outputs = extractFieldFromYaml(definition.outputs, yamlDocument, 'outputs');
 
   const normalizedInputs = normalizeFieldsToJsonSchema(inputs);
+  const inputsZodSchema: z.ZodType<Record<string, unknown>> =
+    buildFieldsZodValidator(normalizedInputs);
   const normalizedOutputs = normalizeFieldsToJsonSchema(outputs);
 
-  const eventSchema = buildEventSchemaFromTriggers(triggers ?? []);
+  const eventSchema = buildEventSchemaFromTriggers(triggers ?? [], inputsZodSchema);
 
   return DynamicWorkflowContextSchema.extend({
-    inputs: buildFieldsZodValidator(normalizedInputs),
+    inputs: inputsZodSchema,
     output: buildFieldsZodValidator(normalizedOutputs),
     consts: z.object({
       ...Object.fromEntries(

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_pseudo_step_context.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_detail/ui/workflow_pseudo_step_context.ts
@@ -41,6 +41,8 @@ export function buildTriggerContextFromExecution(
     const event = executionContext.event as Record<string, unknown>;
     if (event.alerts != null || event.type === 'alert') {
       triggerType = 'alert';
+    } else if (event.type === 'manual') {
+      triggerType = 'manual';
     } else if (isEventDrivenWorkflowTriggerSource(triggeredBy)) {
       triggerType = 'event';
     } else {


### PR DESCRIPTION
## Summary

- Fixes a bug where the editor's Liquid render context did not expose `event.inputs` for manual trigger workflows.
- The `buildEventSchemaFromTriggers` function now extends the event schema with the inputs Zod shape when the trigger is `manual`, so autocomplete and validation correctly reflect `event.inputs` in the YAML editor.
- The execution engine's `buildExecutionDocument` now synthesizes a minimal `{ type: 'manual', inputs }` event when callers pass `inputs` without an explicit `event`, making `event.inputs` accessible to Liquid templates at runtime.
- Adds focused Jest tests for the event/inputs synthesis logic in `executeWorkflow`.

## Test plan

- [ ] Open a workflow with a `manual` trigger that declares inputs — verify `event.inputs` appears in editor autocomplete.
- [ ] Execute such a workflow manually with inputs — verify `{{ event.inputs.myField }}` renders correctly in step output.
- [ ] Jest: `node scripts/jest src/platform/plugins/shared/workflows_execution_engine/server/plugin.execute_workflow.test.ts`

https://github.com/user-attachments/assets/29d5d977-384f-4ab9-845c-e2bf6b517cdc


