### PR TITLE
[Security Solution][CPS] Degrade gracefully when linked project is unresponsive in the flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_degraded_callout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_degraded_callout/index.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import { DataViewDegradedCallout } from '.';
+
+describe('DataViewDegradedCallout', () => {
+  it('renders the shared title, index pattern, and caller-provided details', () => {
+    const dataView = createStubDataView({ spec: { title: 'logs-*' } });
+
+    render(
+      <I18nProvider>
+        <DataViewDegradedCallout dataView={dataView} data-test-subj="my-degraded-callout">
+          {'Custom details.'}
+        </DataViewDegradedCallout>
+      </I18nProvider>
+    );
+
+    expect(screen.getByTestId('my-degraded-callout')).toBeInTheDocument();
+    expect(screen.getByText('Some data view fields are unavailable')).toBeInTheDocument();
+    expect(screen.getByText('logs-*')).toBeInTheDocument();
+    expect(screen.getByText(/Custom details/)).toBeInTheDocument();
+  });
+
+  it('omits the index pattern in compact mode', () => {
+    const dataView = createStubDataView({ spec: { title: 'logs-*' } });
+
+    render(
+      <I18nProvider>
+        <DataViewDegradedCallout compact dataView={dataView} data-test-subj="my-degraded-callout">
+          {'Custom details.'}
+        </DataViewDegradedCallout>
+      </I18nProvider>
+    );
+
+    expect(screen.getByText('Some data view fields are unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('logs-*')).not.toBeInTheDocument();
+    expect(screen.getByText(/Custom details/)).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_degraded_callout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_degraded_callout/index.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, type ReactNode } from 'react';
+import { EuiCode } from '@elastic/eui';
+import { KbnWarningCallout } from '@kbn/ui-callout';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export interface DataViewDegradedCalloutProps {
+  /** Data view whose field-caps request matched no indices. */
+  dataView: DataView;
+  /**
+   * Surface-specific follow-up shown after the shared "matched no indices" sentence.
+   * Callers must pass an i18n string (typically a FormattedMessage).
+   */
+  children: ReactNode;
+  /**
+   * When true, omits the index pattern list and uses a smaller callout.
+   * Use in narrow layouts such as the document flyout.
+   */
+  compact?: boolean;
+  /** Test subject unique to the call site. */
+  'data-test-subj': string;
+}
+
+const TITLE = i18n.translate(
+  'xpack.securitySolution.dataViewManager.dataViewDegradedCallout.unavailableFieldsTitle',
+  {
+    defaultMessage: 'Some data view fields are unavailable',
+  }
+);
+
+/**
+ * Warns that a data view loaded without matched indices so field metadata may be incomplete.
+ */
+export const DataViewDegradedCallout = memo(
+  ({
+    dataView,
+    children,
+    compact = false,
+    'data-test-subj': dataTestSubj,
+  }: DataViewDegradedCalloutProps) => (
+    <KbnWarningCallout
+      announceOnMount
+      size={compact ? 's' : 'm'}
+      title={TITLE}
+      data-test-subj={dataTestSubj}
+    >
+      {compact ? (
+        children
+      ) : (
+        <FormattedMessage
+          id="xpack.securitySolution.dataViewManager.dataViewDegradedCallout.noMatchedIndicesDescription"
+          defaultMessage="Index pattern {indexPattern} matched no indices. {details}"
+          values={{
+            indexPattern: <EuiCode>{dataView.getIndexPattern()}</EuiCode>,
+            details: children,
+          }}
+        />
+      )}
+    </KbnWarningCallout>
+  )
+);
+
+DataViewDegradedCallout.displayName = 'DataViewDegradedCallout';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.test.tsx
@@ -87,6 +87,11 @@ describe('<Wrapper />', () => {
     await waitFor(() => {
       expect(screen.getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
       expect(screen.getByTestId(DATA_VIEW_DEGRADED_TEST_ID)).toBeInTheDocument();
+      expect(screen.getByText('Some data view fields are unavailable')).toBeInTheDocument();
+      expect(screen.getByText('.alerts-security.alerts-default')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Alerts are still listed below, but field-dependent features/)
+      ).toBeInTheDocument();
       expect(screen.getByTestId('alerts-page-content')).toBeInTheDocument();
       expect(screen.queryByTestId(DATA_VIEW_ERROR_TEST_ID)).not.toBeInTheDocument();
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
@@ -7,7 +7,6 @@
 
 import React, { memo, useMemo } from 'react';
 import {
-  EuiCode,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,9 +17,9 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { KbnWarningCallout } from '@kbn/ui-callout';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { HeaderPage } from '../../../common/components/header_page';
+import { DataViewDegradedCallout } from '../../../data_view_manager/components/data_view_degraded_callout';
 import { AlertsPageContent } from './content';
 import { PAGE_TITLE } from '../../pages/alerts/translations';
 
@@ -32,11 +31,6 @@ export const SKELETON_TEST_ID = 'alerts-page-skeleton';
 const DATAVIEW_ERROR = i18n.translate('xpack.securitySolution.alertsPage.dataViewError', {
   defaultMessage: 'Unable to retrieve the data view',
 });
-
-const DATAVIEW_DEGRADED_TITLE = i18n.translate(
-  'xpack.securitySolution.alertsPage.dataViewDegraded.title',
-  { defaultMessage: 'Some alert data view fields are unavailable' }
-);
 
 interface WrapperProps {
   /** the alerts data view, retrieved once by the parent via useDataView(PageScope.alerts) */
@@ -78,18 +72,15 @@ export const Wrapper = memo(({ dataView, status }: WrapperProps) => {
       <>
         {isDataViewDegraded && (
           <>
-            <KbnWarningCallout
+            <DataViewDegradedCallout
+              dataView={dataView}
               data-test-subj={DATA_VIEW_DEGRADED_TEST_ID}
-              title={DATAVIEW_DEGRADED_TITLE}
             >
               <FormattedMessage
-                id="xpack.securitySolution.alertsPage.dataViewDegraded.body"
-                defaultMessage="Index pattern {indexPattern} matched no indices. Alerts are still listed below, but field-dependent features such as search suggestions, the fields browser and grouping options may be limited."
-                values={{
-                  indexPattern: <EuiCode>{dataView.getIndexPattern()}</EuiCode>,
-                }}
+                id="xpack.securitySolution.alertsPage.dataViewDegradedDetailsDescription"
+                defaultMessage="Alerts are still listed below, but field-dependent features such as search suggestions, the fields browser and grouping options may be limited."
               />
-            </KbnWarningCallout>
+            </DataViewDegradedCallout>
             <EuiSpacer size="m" />
           </>
         )}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/wrapper.test.tsx
@@ -161,6 +161,11 @@ describe('<Wrapper />', () => {
     await waitFor(() => {
       expect(screen.getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
       expect(screen.getByTestId(DATA_VIEW_DEGRADED_TEST_ID)).toBeInTheDocument();
+      expect(screen.getByText('Some data view fields are unavailable')).toBeInTheDocument();
+      expect(screen.getByText('my-pattern-*')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Attacks are still listed below, but field-dependent features/)
+      ).toBeInTheDocument();
       expect(screen.getByTestId('attacks-page-content')).toBeInTheDocument();
       expect(screen.queryByTestId(DATA_VIEW_ERROR_TEST_ID)).not.toBeInTheDocument();
       expect(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/wrapper.tsx
@@ -7,7 +7,6 @@
 
 import React, { useMemo } from 'react';
 import {
-  EuiCode,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,10 +17,10 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { KbnWarningCallout } from '@kbn/ui-callout';
 import { PageScope } from '../../../data_view_manager/constants';
 import { HeaderPage } from '../../../common/components/header_page';
 import { useIsCpsLinkedSearchSpace } from '../../../common/hooks/use_is_cps_linked_search_space';
+import { DataViewDegradedCallout } from '../../../data_view_manager/components/data_view_degraded_callout';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { AttacksPageContent } from './content';
 import { UninitializedDataViewEmptyState } from './uninitialized_empty_state/uninitialized_data_view_empty_state';
@@ -35,11 +34,6 @@ export const SKELETON_TEST_ID = 'attacks-page-skeleton';
 const DATAVIEW_ERROR = i18n.translate('xpack.securitySolution.attacksPage.dataViewError', {
   defaultMessage: 'Unable to retrieve the data view',
 });
-
-const DATAVIEW_DEGRADED_TITLE = i18n.translate(
-  'xpack.securitySolution.attacksPage.dataViewDegradedTitle',
-  { defaultMessage: 'Some attack data view fields are unavailable' }
-);
 
 /**
  * Renders the attacks page when the provided dataView is valid.
@@ -91,18 +85,15 @@ export const Wrapper = React.memo(() => {
       <>
         {isDataViewDegraded && (
           <>
-            <KbnWarningCallout
+            <DataViewDegradedCallout
+              dataView={dataView}
               data-test-subj={DATA_VIEW_DEGRADED_TEST_ID}
-              title={DATAVIEW_DEGRADED_TITLE}
             >
               <FormattedMessage
-                id="xpack.securitySolution.attacksPage.dataViewDegradedDescription"
-                defaultMessage="Index pattern {indexPattern} matched no indices. Attacks are still listed below, but field-dependent features such as search suggestions, the fields browser and grouping options may be limited."
-                values={{
-                  indexPattern: <EuiCode>{dataView.getIndexPattern()}</EuiCode>,
-                }}
+                id="xpack.securitySolution.attacksPage.dataViewDegradedDetailsDescription"
+                defaultMessage="Attacks are still listed below, but field-dependent features such as search suggestions, the fields browser and grouping options may be limited."
               />
-            </KbnWarningCallout>
+            </DataViewDegradedCallout>
             <EuiSpacer size="m" />
           </>
         )}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper.test.tsx
@@ -171,13 +171,10 @@ describe('DocumentFlyoutWrapper', () => {
     expect(getByTestId('document-overview-fetch-error')).toBeInTheDocument();
   });
 
-  it('renders data view error when the data view has no matched indices', () => {
+  it('renders data view error when the data view failed to load', () => {
     (useDataView as jest.Mock).mockReturnValue({
-      status: 'ready',
-      dataView: {
-        ...mockDataView,
-        hasMatchedIndices: () => false,
-      },
+      status: 'error',
+      dataView: mockDataView,
     });
     (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.NotFound, null, jest.fn()]);
 
@@ -189,6 +186,29 @@ describe('DocumentFlyoutWrapper', () => {
         skip: true,
       })
     );
+  });
+
+  it('still fetches the document when the data view has no matched indices', () => {
+    const hit = { id: '1', raw: {}, flattened: { 'event.kind': 'event' } } as DataTableRecord;
+    const degradedDataView = {
+      ...mockDataView,
+      hasMatchedIndices: () => false,
+    };
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: degradedDataView,
+    });
+    (useEsDocSearch as jest.Mock).mockReturnValue([ElasticRequestState.Found, hit, jest.fn()]);
+
+    const { getByTestId } = renderDocumentFlyoutWrapper();
+
+    expect(useEsDocSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: false,
+      })
+    );
+    expect(getByTestId('document-overview-wrapper-data-view-degraded')).toBeInTheDocument();
+    expect(getByTestId('documentFlyoutStub')).toBeInTheDocument();
   });
 
   it('renders nothing when the document request returns found without a hit', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper.tsx
@@ -8,6 +8,7 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { ElasticRequestState } from '@kbn/unified-doc-viewer';
 import { useEsDocSearch } from '@kbn/unified-doc-viewer-plugin/public';
 import { getFieldValue } from '@kbn/discover-utils';
@@ -16,8 +17,9 @@ import type { CellActionRenderer } from '../../shared/components/cell_actions';
 import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { FlyoutLoading } from '../../shared/components/flyout_loading';
 import { FlyoutMissingAlertsPrivilege } from './components/flyout_missing_alerts_privilege';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { DataViewDegradedCallout } from '../../../data_view_manager/components/data_view_degraded_callout';
 import { PageScope } from '../../../data_view_manager/constants';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { EventKind } from './constants/event_kinds';
 import { DocumentFlyout } from '.';
 
@@ -81,8 +83,8 @@ export const DocumentFlyoutWrapper = memo(
     const { dataView, status } = useDataView(PageScope.default);
 
     const isDataViewLoading = status === 'loading' || status === 'pristine';
-    const isDataViewInvalid =
-      status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices());
+    const isDataViewInvalid = status === 'error';
+    const isDataViewDegraded = status === 'ready' && !dataView.hasMatchedIndices();
 
     const shouldSkipSearch = useMemo(
       () => isDataViewLoading || isDataViewInvalid || !documentId || !indexName || !dataView,
@@ -135,12 +137,26 @@ export const DocumentFlyoutWrapper = memo(
 
     if (requestState === ElasticRequestState.Found && hit) {
       return (
-        <DocumentFlyout
-          hit={hit}
-          renderCellActions={renderCellActions}
-          onAlertUpdated={handleAlertUpdated}
-          dataTestSubj={dataTestSubj}
-        />
+        <>
+          {isDataViewDegraded && (
+            <DataViewDegradedCallout
+              compact
+              dataView={dataView}
+              data-test-subj="document-overview-wrapper-data-view-degraded"
+            >
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.document.overviewWrapper.dataViewDegradedDetailsDescription"
+                defaultMessage="The document is still shown below, but field-dependent features may be limited."
+              />
+            </DataViewDegradedCallout>
+          )}
+          <DocumentFlyout
+            hit={hit}
+            renderCellActions={renderCellActions}
+            onAlertUpdated={handleAlertUpdated}
+            dataTestSubj={dataTestSubj}
+          />
+        </>
       );
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
 import { DocumentFlyoutWrapperFromPattern } from './document_flyout_wrapper_from_pattern';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useTimelineEventsDetails } from '../../../timelines/containers/details';
@@ -34,11 +35,22 @@ const props = {
 const setEventsDetails = (tuple: unknown[]) =>
   (useTimelineEventsDetails as jest.Mock).mockReturnValue(tuple);
 
+const renderFromPattern = () =>
+  render(
+    <I18nProvider>
+      <DocumentFlyoutWrapperFromPattern {...props} />
+    </I18nProvider>
+  );
+
 describe('DocumentFlyoutWrapperFromPattern', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useDataView as jest.Mock).mockReturnValue({
-      dataView: { getRuntimeMappings: jest.fn(() => ({})), hasMatchedIndices: jest.fn(() => true) },
+      dataView: {
+        getRuntimeMappings: jest.fn(() => ({})),
+        getIndexPattern: jest.fn(() => 'logs-*'),
+        hasMatchedIndices: jest.fn(() => true),
+      },
       status: 'ready',
     });
     (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasAlertsRead: true, loading: false });
@@ -48,18 +60,59 @@ describe('DocumentFlyoutWrapperFromPattern', () => {
 
   it('shows the loading state while the document is being fetched', () => {
     setEventsDetails([true, [], undefined, null, jest.fn()]);
-    const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
+    const { getByTestId } = renderFromPattern();
     expect(getByTestId('document-from-pattern-wrapper-loading')).toBeInTheDocument();
   });
 
   it('renders the document flyout once the document is resolved', () => {
-    const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
+    const { getByTestId } = renderFromPattern();
     expect(getByTestId('document-flyout')).toBeInTheDocument();
   });
 
   it('shows a not-found callout when no document matches the id across the pattern', () => {
     setEventsDetails([false, [], undefined, null, jest.fn()]);
-    const { getByTestId } = render(<DocumentFlyoutWrapperFromPattern {...props} />);
+    const { getByTestId } = renderFromPattern();
     expect(getByTestId('document-from-pattern-wrapper-not-found')).toBeInTheDocument();
+  });
+
+  it('shows a data view error when the data view failed to load', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      dataView: {
+        getRuntimeMappings: jest.fn(() => ({})),
+        getIndexPattern: jest.fn(() => 'logs-*'),
+        hasMatchedIndices: jest.fn(() => true),
+      },
+      status: 'error',
+    });
+
+    const { getByTestId } = renderFromPattern();
+
+    expect(getByTestId('document-from-pattern-wrapper-data-view-error')).toBeInTheDocument();
+    expect(useTimelineEventsDetails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: true,
+      })
+    );
+  });
+
+  it('still fetches the document when the data view has no matched indices', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      dataView: {
+        getRuntimeMappings: jest.fn(() => ({})),
+        getIndexPattern: jest.fn(() => 'logs-*'),
+        hasMatchedIndices: jest.fn(() => false),
+      },
+      status: 'ready',
+    });
+
+    const { getByTestId } = renderFromPattern();
+
+    expect(useTimelineEventsDetails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: false,
+      })
+    );
+    expect(getByTestId('document-from-pattern-wrapper-data-view-degraded')).toBeInTheDocument();
+    expect(getByTestId('document-flyout')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/document_flyout_wrapper_from_pattern.tsx
@@ -8,16 +8,18 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { buildDataTableRecord, getFieldValue } from '@kbn/discover-utils';
 import type { EsHitRecord } from '@kbn/discover-utils/types';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import type { RunTimeMappings } from '../../../../common/api/search_strategy';
 import { useAlertsPrivileges } from '../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { useTimelineEventsDetails } from '../../../timelines/containers/details';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
-import { PageScope } from '../../../data_view_manager/constants';
 import { FlyoutLoading } from '../../shared/components/flyout_loading';
 import { FlyoutMissingAlertsPrivilege } from './components/flyout_missing_alerts_privilege';
+import { DataViewDegradedCallout } from '../../../data_view_manager/components/data_view_degraded_callout';
+import { PageScope } from '../../../data_view_manager/constants';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { EventKind } from './constants/event_kinds';
 import { DocumentFlyout } from '.';
 import type { DocumentFlyoutWrapperProps } from './document_flyout_wrapper';
@@ -57,8 +59,8 @@ export const DocumentFlyoutWrapperFromPattern = memo(
     const { dataView, status } = useDataView(PageScope.default);
 
     const isDataViewLoading = status === 'loading' || status === 'pristine';
-    const isDataViewInvalid =
-      status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices());
+    const isDataViewInvalid = status === 'error';
+    const isDataViewDegraded = status === 'ready' && !dataView.hasMatchedIndices();
 
     const shouldSkipSearch = useMemo(
       () => isDataViewLoading || isDataViewInvalid || !documentId || !indexName || !dataView,
@@ -114,12 +116,26 @@ export const DocumentFlyoutWrapperFromPattern = memo(
 
     if (hit) {
       return (
-        <DocumentFlyout
-          hit={hit}
-          renderCellActions={renderCellActions}
-          onAlertUpdated={handleAlertUpdated}
-          dataTestSubj={dataTestSubj}
-        />
+        <>
+          {isDataViewDegraded && (
+            <DataViewDegradedCallout
+              compact
+              dataView={dataView}
+              data-test-subj="document-from-pattern-wrapper-data-view-degraded"
+            >
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.document.fromPatternWrapper.dataViewDegradedDetailsDescription"
+                defaultMessage="The document is still shown below, but field-dependent features may be limited."
+              />
+            </DataViewDegradedCallout>
+          )}
+          <DocumentFlyout
+            hit={hit}
+            renderCellActions={renderCellActions}
+            onAlertUpdated={handleAlertUpdated}
+            dataTestSubj={dataTestSubj}
+          />
+        </>
       );
     }
 


### PR DESCRIPTION
> [!CAUTION]
> This PR follows the same pattern introduced in this prior [one](https://github.com/elastic/kibana/pull/285951) and that [one](https://github.com/elastic/kibana/pull/286459). It needs those PRs to be merged first

## Summary

This PR is the last taking care of degrading gracefully when data views are not fully working due to linked projects in non-working state in CPS environments.

We're now displaying a compact callout at the top of the flyout when the issue happens
<img width="672" height="858" alt="Screenshot 2026-08-21 at 11 18 27 AM" src="https://github.com/user-attachments/assets/517b5e77-887a-4434-9992-ba2918e44df3" />

In case where we load linked/remote alerts, we're displaying 2 callouts (we're preserving the already existing callout(
<img width="723" height="861" alt="Screenshot 2026-08-21 at 11 25 35 AM" src="https://github.com/user-attachments/assets/6dfd260d-9e48-467f-9d36-e466fe2ae160" />

### Changes

The PR extracts the data view degraded callout to a shared location, and reuses it between this flyout change, and the alerts and attacks pages

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
