### PR TITLE
feat(cases): count template create/update/delete per client source

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/templates/client.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/templates/client.test.ts
@@ -7,9 +7,10 @@
 
 import type { SavedObject } from '@kbn/core/server';
 import Boom from '@hapi/boom';
+import { usageCollectionPluginMock } from '@kbn/usage-collection-plugin/server/mocks';
 import { createCasesClientMockArgs } from '../mocks';
 import { createTemplatesSubClient } from './client';
-import type { Template } from '../../../common/types/domain/template/latest';
+import type { CreateTemplateInput, Template } from '../../../common/types/domain/template/latest';
 import type { TemplatesFindRequest } from '../../../common/types/api/template/v1';
 
 describe('templates client', () => {
@@ -307,6 +308,115 @@ describe('templates client', () => {
         })
       ).rejects.toThrow('no manage on target owner');
       expect(clientArgs.services.templatesService.validateWriteInput).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('usage counters', () => {
+    const usageCounter = usageCollectionPluginMock
+      .createSetupContract()
+      .createUsageCounter('cases');
+    const writeInput: CreateTemplateInput = {
+      name: 'Template One',
+      owner: 'securitySolution',
+      definition: '',
+    };
+
+    const createClientArgsWithCounter = () => ({
+      ...createCasesClientMockArgs(),
+      usageCounter,
+    });
+
+    it.each([
+      {
+        method: 'createTemplate' as const,
+        counterName: 'create_template',
+        call: (client: ReturnType<typeof createTemplatesSubClient>) =>
+          client.createTemplate(writeInput),
+      },
+      {
+        method: 'updateTemplate' as const,
+        counterName: 'update_template',
+        call: (client: ReturnType<typeof createTemplatesSubClient>) =>
+          client.updateTemplate('template-1', writeInput),
+      },
+      {
+        method: 'deleteTemplate' as const,
+        counterName: 'delete_template',
+        call: (client: ReturnType<typeof createTemplatesSubClient>) =>
+          client.deleteTemplate('template-1'),
+      },
+    ])('$method increments $counterName once on success', async ({ counterName, call }) => {
+      const clientArgsWithCounter = createClientArgsWithCounter();
+      const template = createTemplateSavedObject('securitySolution');
+      clientArgsWithCounter.services.templatesService.getTemplate.mockResolvedValue(template);
+      clientArgsWithCounter.services.templatesService.createTemplate.mockResolvedValue(template);
+      clientArgsWithCounter.services.templatesService.updateTemplate.mockResolvedValue(template);
+      clientArgsWithCounter.services.templatesService.deleteTemplate.mockResolvedValue(undefined);
+
+      const subClient = createTemplatesSubClient(clientArgsWithCounter);
+      await call(subClient);
+
+      expect(usageCounter.incrementCounter).toHaveBeenCalledTimes(1);
+      expect(usageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName,
+        counterType: 'cases_client.rest_api',
+      });
+    });
+
+    it('increments the create counter on a failed write because the wrapper fires before the call', async () => {
+      const clientArgsWithCounter = createClientArgsWithCounter();
+      clientArgsWithCounter.authorization.ensureAuthorized.mockRejectedValueOnce(
+        Boom.forbidden('no manage')
+      );
+
+      const subClient = createTemplatesSubClient(clientArgsWithCounter);
+
+      await expect(subClient.createTemplate(writeInput)).rejects.toThrow('no manage');
+      expect(usageCounter.incrementCounter).toHaveBeenCalledTimes(1);
+      expect(usageCounter.incrementCounter).toHaveBeenCalledWith({
+        counterName: 'create_template',
+        counterType: 'cases_client.rest_api',
+      });
+    });
+
+    it('does not increment on reads or dry-run validators', async () => {
+      const clientArgsWithCounter = createClientArgsWithCounter();
+      const template = createTemplateSavedObject('securitySolution');
+      clientArgsWithCounter.authorization.getAuthorizationFilter.mockResolvedValue({
+        filter: undefined,
+        ensureSavedObjectsAreAuthorized: () => {},
+        authorizedOwners: undefined,
+      });
+      clientArgsWithCounter.services.templatesService.getAllTemplates.mockResolvedValue({
+        templates: [],
+        page: 1,
+        perPage: 20,
+        total: 0,
+      });
+      clientArgsWithCounter.services.templatesService.getTemplate.mockResolvedValue(template);
+      clientArgsWithCounter.services.templatesService.getTags.mockResolvedValue([]);
+      clientArgsWithCounter.services.templatesService.getAuthors.mockResolvedValue([]);
+
+      const subClient = createTemplatesSubClient(clientArgsWithCounter);
+
+      await subClient.getAllTemplates(findRequest());
+      await subClient.getTemplate('template-1');
+      await subClient.getTags();
+      await subClient.getAuthors();
+      await subClient.validateCreateTemplate(writeInput);
+      await subClient.validateUpdateTemplate('template-1', writeInput);
+
+      expect(usageCounter.incrementCounter).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when usageCounter is undefined', async () => {
+      const clientArgsWithoutCounter = createCasesClientMockArgs();
+      const template = createTemplateSavedObject('securitySolution');
+      clientArgsWithoutCounter.services.templatesService.createTemplate.mockResolvedValue(template);
+
+      const subClient = createTemplatesSubClient(clientArgsWithoutCounter);
+
+      await expect(subClient.createTemplate(writeInput)).resolves.toBe(template);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/client/templates/client.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/templates/client.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../../common/types/api/template/v1';
 import type { CasesClientArgs } from '../types';
 import { Operations } from '../../authorization';
+import { withUsageCounter } from '../usage_counters';
 
 /**
  * API for interacting with templates.
@@ -43,6 +44,24 @@ export interface TemplatesSubClient {
   getTags(): Promise<string[]>;
   getAuthors(): Promise<string[]>;
 }
+
+/**
+ * Keep this exhaustive so every new client method requires an explicit telemetry decision.
+ * Counters measure attempts: `withUsageCounter` increments before the wrapped call, matching
+ * cases and attachments. Bulk delete has no distinct client method — the HTTP route fans out
+ * to `deleteTemplate` per id, so `delete_template` increments once per template.
+ */
+const usageCounterByMethod = {
+  getAllTemplates: null,
+  getTemplate: null,
+  createTemplate: 'create_template',
+  updateTemplate: 'update_template',
+  deleteTemplate: 'delete_template',
+  validateCreateTemplate: null,
+  validateUpdateTemplate: null,
+  getTags: null,
+  getAuthors: null,
+} as const satisfies Record<keyof TemplatesSubClient, string | null>;
 
 /**
  * Creates the interface for templates.
@@ -142,33 +161,45 @@ export const createTemplatesSubClient = (clientArgs: CasesClientArgs): Templates
       return template;
     },
 
-    createTemplate: async (input: CreateTemplateInput) => {
-      const id = uuidv4();
-      await authorization.ensureAuthorized({
-        operation: Operations.manageTemplate,
-        entities: [{ owner: input.owner, id }],
-      });
-      return templatesService.createTemplate(input, user.username ?? 'unknown', id);
-    },
-
-    updateTemplate: async (templateId: string, input: UpdateTemplateInput) => {
-      const template = await templatesService.getTemplate(templateId);
-      if (!template) {
-        throw Boom.notFound(`Template with id ${templateId} not found`);
+    createTemplate: withUsageCounter(
+      usageCounterByMethod.createTemplate,
+      clientArgs,
+      async (input: CreateTemplateInput) => {
+        const id = uuidv4();
+        await authorization.ensureAuthorized({
+          operation: Operations.manageTemplate,
+          entities: [{ owner: input.owner, id }],
+        });
+        return templatesService.createTemplate(input, user.username ?? 'unknown', id);
       }
-      await ensureCanManageOrHideExistence(template, templateId);
-      await ensureCanManageTargetOwner(template, input);
-      return templatesService.updateTemplate(templateId, input);
-    },
+    ),
 
-    deleteTemplate: async (templateId: string) => {
-      const template = await templatesService.getTemplate(templateId);
-      if (!template) {
-        throw Boom.notFound(`Template with id ${templateId} not found`);
+    updateTemplate: withUsageCounter(
+      usageCounterByMethod.updateTemplate,
+      clientArgs,
+      async (templateId: string, input: UpdateTemplateInput) => {
+        const template = await templatesService.getTemplate(templateId);
+        if (!template) {
+          throw Boom.notFound(`Template with id ${templateId} not found`);
+        }
+        await ensureCanManageOrHideExistence(template, templateId);
+        await ensureCanManageTargetOwner(template, input);
+        return templatesService.updateTemplate(templateId, input);
       }
-      await ensureCanManageOrHideExistence(template, templateId);
-      return templatesService.deleteTemplate(templateId);
-    },
+    ),
+
+    deleteTemplate: withUsageCounter(
+      usageCounterByMethod.deleteTemplate,
+      clientArgs,
+      async (templateId: string) => {
+        const template = await templatesService.getTemplate(templateId);
+        if (!template) {
+          throw Boom.notFound(`Template with id ${templateId} not found`);
+        }
+        await ensureCanManageOrHideExistence(template, templateId);
+        return templatesService.deleteTemplate(templateId);
+      }
+    ),
 
     validateCreateTemplate: async (input: CreateTemplateInput) => {
       await authorization.ensureAuthorized({


### PR DESCRIPTION
## What & Why
Cases already counts case and attachment writes at the client boundary, tagged by caller source. Template create, update, and delete were skipped; this wraps those three methods the same way so management volume is visible from API, UI, and workflows. Counters measure attempts (`create_template`, `update_template`, `delete_template`), not successes; bulk delete fans out to single delete and counts once per template.

Closes elastic/security-team#18975

## How to Test
1. Run `node scripts/jest x-pack/platform/plugins/shared/cases/server/client/templates/client.test.ts`.
2. Confirm create, update, and delete each increment the matching counter once with `counterType: cases_client.<source>`.
3. Confirm a failed create still increments — the wrapper fires before the call.
4. Confirm reads and dry-run validators do not increment.

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->