### PR TITLE
[9.4] [Console] Wait for request selection before Play in variables test (#285401)

### DIFF
--- a/src/platform/test/functional/apps/console/_variables.ts
+++ b/src/platform/test/functional/apps/console/_variables.ts
@@ -72,6 +72,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
 
         await PageObjects.console.clickClearInput();
         await PageObjects.console.enterText('\n GET ${index3}');
+        await PageObjects.console.waitForSelectedRequestsCount(1);
         await PageObjects.console.clickPlay();
         await PageObjects.header.waitUntilLoadingHasFinished();
 
@@ -90,6 +91,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
         await PageObjects.console.clickClearInput();
         await PageObjects.console.enterText('\n GET _search\n');
         await PageObjects.console.enterText(`{\n\t"query": "\${query1}"`);
+        await PageObjects.console.waitForSelectedRequestsCount(1);
         await PageObjects.console.clickPlay();
         await PageObjects.header.waitUntilLoadingHasFinished();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Console] Wait for request selection before Play in variables test (#285401)](https://github.com/elastic/kibana/pull/285401)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kibana Machine","email":"42973632+kibanamachine@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-08-20T09:07:22Z","message":"[Console] Wait for request selection before Play in variables test (#285401)\n\nFixes #285391\n\n### Summary\n\n- The `with variables in request body > should send a successful\nrequest` test timed out (120s) waiting for `consoleResponseStatusBadge`:\nthe single `clickPlay()` fired before Monaco finished parsing the typed\nrequest, so `sendRequests` had no selected request and nothing ran.\n- All three request-sending tests in this file type a request and\nimmediately click Play with no wait, so they race the async parse.\n- Each now waits on the editor's `data-currently-selected-requests`\nreadiness signal (via the existing `waitForSelectedRequestsCount(1)`\npage-object helper) before clicking Play, so Play only fires once the\nrequest is registered — no retry, no re-click.\n\n### Context\n\n- Follows the [Failed Test Investigator's proposed\nfix](https://github.com/elastic/kibana/issues/285391#issuecomment-5316363856)\n— wait on a real readiness signal before Play rather than retrying — but\nreuses the existing `waitForSelectedRequestsCount` helper (and the\n`data-currently-selected-requests` attribute) introduced by #283450\ninstead of adding a new near-duplicate helper.\n- The readiness attribute is set to the selected-request count only\nafter the async parse/selection settles\n(`monaco_editor_actions_provider.ts`), which is exactly the state\n`sendRequests` reads when Play is clicked.\n- First failure on `kibana-on-merge - main` ([build\n106598](https://buildkite.com/elastic/kibana-on-merge/builds/106598#01a00fa2-3459-4d7c-90b3-214d8f15ad05));\nthe investigator notes this is a latent race in a long-standing pattern,\nnot a recent regression, so no single introducing PR is confidently\nimplicated.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n✅ Passed: `node scripts/eslint\nsrc/platform/test/functional/apps/console/_variables.ts`\n\n#### Not verified locally\n\n- FTR execution: this is a Chrome UI functional test that needs a live\nElasticsearch + Kibana, which cannot run in this environment.\n- Behavior under CI parallel load.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:version` with `v9.5.2` only. The\n`waitForSelectedRequestsCount` helper and\n`data-currently-selected-requests` attribute this fix relies on were\nadded by #283450, which backported to `9.5` (v9.5.2) and `9.4` (v9.4.6)\nbut not `8.19`. On `9.5` the test file is byte-identical to `main`, so\nthis patch applies unchanged. On `9.4` the helper exists but the file\nlacks the third `with inline variable interpolation` block, so this\n3-hunk patch does not apply cleanly — a reviewer can backport the two\napplicable hunks manually if `9.4` proves flaky. `8.19` is excluded\nbecause the helper does not exist there. `9.3` is no longer an open\nrelease branch.\n\n</details>\n\n> [!NOTE]\n> Share feedback in #kibana-qa. Mention `@copilot` to make quick\nchanges.\n\n\n\n\n> [!WARNING]\n> <details>\n> <summary>Firewall blocked 2 domains</summary>\n>\n> The following domains were blocked by the firewall during workflow\nexecution:\n>\n> - `iojs.org`\n> - `nodejs.org`\n>> To allow these domains, add them to the `network.allowed` list in\nyour workflow frontmatter:\n>\n> ```yaml\n> network:\n>   allowed:\n>     - defaults\n>     - \"iojs.org\"\n>     - \"nodejs.org\"\n> ```\n>\n> See [Network\nConfiguration](https://github.github.com/gh-aw/reference/network/) for\nmore information.\n>\n> </details>\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/32032556466) for\n#285391 · 275.5 AIC · ⌖ 44.3 AIC · ⊞ 10.5K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\nCo-authored-by: Claude Opus 4 (1M context) <noreply@anthropic.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"18f36e4d01088a5ef3726cbe90917c51f080eb90","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","flaky-test-fixer","flaky-fix-check:passed","v9.6.0","v9.4.6","v9.5.2"],"title":"[Console] Wait for request selection before Play in variables test","number":285401,"url":"https://github.com/elastic/kibana/pull/285401","mergeCommit":{"message":"[Console] Wait for request selection before Play in variables test (#285401)\n\nFixes #285391\n\n### Summary\n\n- The `with variables in request body > should send a successful\nrequest` test timed out (120s) waiting for `consoleResponseStatusBadge`:\nthe single `clickPlay()` fired before Monaco finished parsing the typed\nrequest, so `sendRequests` had no selected request and nothing ran.\n- All three request-sending tests in this file type a request and\nimmediately click Play with no wait, so they race the async parse.\n- Each now waits on the editor's `data-currently-selected-requests`\nreadiness signal (via the existing `waitForSelectedRequestsCount(1)`\npage-object helper) before clicking Play, so Play only fires once the\nrequest is registered — no retry, no re-click.\n\n### Context\n\n- Follows the [Failed Test Investigator's proposed\nfix](https://github.com/elastic/kibana/issues/285391#issuecomment-5316363856)\n— wait on a real readiness signal before Play rather than retrying — but\nreuses the existing `waitForSelectedRequestsCount` helper (and the\n`data-currently-selected-requests` attribute) introduced by #283450\ninstead of adding a new near-duplicate helper.\n- The readiness attribute is set to the selected-request count only\nafter the async parse/selection settles\n(`monaco_editor_actions_provider.ts`), which is exactly the state\n`sendRequests` reads when Play is clicked.\n- First failure on `kibana-on-merge - main` ([build\n106598](https://buildkite.com/elastic/kibana-on-merge/builds/106598#01a00fa2-3459-4d7c-90b3-214d8f15ad05));\nthe investigator notes this is a latent race in a long-standing pattern,\nnot a recent regression, so no single introducing PR is confidently\nimplicated.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n✅ Passed: `node scripts/eslint\nsrc/platform/test/functional/apps/console/_variables.ts`\n\n#### Not verified locally\n\n- FTR execution: this is a Chrome UI functional test that needs a live\nElasticsearch + Kibana, which cannot run in this environment.\n- Behavior under CI parallel load.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:version` with `v9.5.2` only. The\n`waitForSelectedRequestsCount` helper and\n`data-currently-selected-requests` attribute this fix relies on were\nadded by #283450, which backported to `9.5` (v9.5.2) and `9.4` (v9.4.6)\nbut not `8.19`. On `9.5` the test file is byte-identical to `main`, so\nthis patch applies unchanged. On `9.4` the helper exists but the file\nlacks the third `with inline variable interpolation` block, so this\n3-hunk patch does not apply cleanly — a reviewer can backport the two\napplicable hunks manually if `9.4` proves flaky. `8.19` is excluded\nbecause the helper does not exist there. `9.3` is no longer an open\nrelease branch.\n\n</details>\n\n> [!NOTE]\n> Share feedback in #kibana-qa. Mention `@copilot` to make quick\nchanges.\n\n\n\n\n> [!WARNING]\n> <details>\n> <summary>Firewall blocked 2 domains</summary>\n>\n> The following domains were blocked by the firewall during workflow\nexecution:\n>\n> - `iojs.org`\n> - `nodejs.org`\n>> To allow these domains, add them to the `network.allowed` list in\nyour workflow frontmatter:\n>\n> ```yaml\n> network:\n>   allowed:\n>     - defaults\n>     - \"iojs.org\"\n>     - \"nodejs.org\"\n> ```\n>\n> See [Network\nConfiguration](https://github.github.com/gh-aw/reference/network/) for\nmore information.\n>\n> </details>\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/32032556466) for\n#285391 · 275.5 AIC · ⌖ 44.3 AIC · ⊞ 10.5K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\nCo-authored-by: Claude Opus 4 (1M context) <noreply@anthropic.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"18f36e4d01088a5ef3726cbe90917c51f080eb90"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/285401","number":285401,"mergeCommit":{"message":"[Console] Wait for request selection before Play in variables test (#285401)\n\nFixes #285391\n\n### Summary\n\n- The `with variables in request body > should send a successful\nrequest` test timed out (120s) waiting for `consoleResponseStatusBadge`:\nthe single `clickPlay()` fired before Monaco finished parsing the typed\nrequest, so `sendRequests` had no selected request and nothing ran.\n- All three request-sending tests in this file type a request and\nimmediately click Play with no wait, so they race the async parse.\n- Each now waits on the editor's `data-currently-selected-requests`\nreadiness signal (via the existing `waitForSelectedRequestsCount(1)`\npage-object helper) before clicking Play, so Play only fires once the\nrequest is registered — no retry, no re-click.\n\n### Context\n\n- Follows the [Failed Test Investigator's proposed\nfix](https://github.com/elastic/kibana/issues/285391#issuecomment-5316363856)\n— wait on a real readiness signal before Play rather than retrying — but\nreuses the existing `waitForSelectedRequestsCount` helper (and the\n`data-currently-selected-requests` attribute) introduced by #283450\ninstead of adding a new near-duplicate helper.\n- The readiness attribute is set to the selected-request count only\nafter the async parse/selection settles\n(`monaco_editor_actions_provider.ts`), which is exactly the state\n`sendRequests` reads when Play is clicked.\n- First failure on `kibana-on-merge - main` ([build\n106598](https://buildkite.com/elastic/kibana-on-merge/builds/106598#01a00fa2-3459-4d7c-90b3-214d8f15ad05));\nthe investigator notes this is a latent race in a long-standing pattern,\nnot a recent regression, so no single introducing PR is confidently\nimplicated.\n\n<details>\n<summary>Verification</summary>\n\n#### Verified locally\n\n✅ Passed: `node scripts/eslint\nsrc/platform/test/functional/apps/console/_variables.ts`\n\n#### Not verified locally\n\n- FTR execution: this is a Chrome UI functional test that needs a live\nElasticsearch + Kibana, which cannot run in this environment.\n- Behavior under CI parallel load.\n\n</details>\n\n<details>\n<summary>Backporting guidance</summary>\n\nApplied `backport:version` with `v9.5.2` only. The\n`waitForSelectedRequestsCount` helper and\n`data-currently-selected-requests` attribute this fix relies on were\nadded by #283450, which backported to `9.5` (v9.5.2) and `9.4` (v9.4.6)\nbut not `8.19`. On `9.5` the test file is byte-identical to `main`, so\nthis patch applies unchanged. On `9.4` the helper exists but the file\nlacks the third `with inline variable interpolation` block, so this\n3-hunk patch does not apply cleanly — a reviewer can backport the two\napplicable hunks manually if `9.4` proves flaky. `8.19` is excluded\nbecause the helper does not exist there. `9.3` is no longer an open\nrelease branch.\n\n</details>\n\n> [!NOTE]\n> Share feedback in #kibana-qa. Mention `@copilot` to make quick\nchanges.\n\n\n\n\n> [!WARNING]\n> <details>\n> <summary>Firewall blocked 2 domains</summary>\n>\n> The following domains were blocked by the firewall during workflow\nexecution:\n>\n> - `iojs.org`\n> - `nodejs.org`\n>> To allow these domains, add them to the `network.allowed` list in\nyour workflow frontmatter:\n>\n> ```yaml\n> network:\n>   allowed:\n>     - defaults\n>     - \"iojs.org\"\n>     - \"nodejs.org\"\n> ```\n>\n> See [Network\nConfiguration](https://github.github.com/gh-aw/reference/network/) for\nmore information.\n>\n> </details>\n\n\n> Generated by [Flaky Test\nFixer](https://github.com/elastic/kibana/actions/runs/32032556466) for\n#285391 · 275.5 AIC · ⌖ 44.3 AIC · ⊞ 10.5K ·\n[◷](https://github.com/search?q=repo%3Aelastic%2Fkibana+%22gh-aw-workflow-id%3A+flaky-test-fixer%22&type=pullrequests)\n\n\n\n\n\n\nCo-authored-by: Claude Opus 4 (1M context) <noreply@anthropic.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"18f36e4d01088a5ef3726cbe90917c51f080eb90"}},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/286240","number":286240,"state":"MERGED","mergeCommit":{"sha":"f8ed7e51f20b9587538a1bc8abe6570bd678c8ce","message":"[9.5] [Console] Wait for request selection before Play in variables test (#285401) (#286240)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Console] Wait for request selection before Play in variables test\n(#285401)](https://github.com/elastic/kibana/pull/285401)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Claude Opus 4 (1M context) <noreply@anthropic.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>"}}]}] BACKPORT-->