### PR TITLE
[8.19] [ResponseOps] Fix telemetry metric count (#283884)

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/action_type_registry.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/action_type_registry.test.ts
@@ -92,6 +92,7 @@ describe('actionTypeRegistry', () => {
               createTaskRunner: expect.any(Function),
               maxAttempts: 3,
               cost: TaskCost.Tiny,
+              taskTypeGroup: 'actions',
               title: 'My action type',
             },
           },

--- a/x-pack/platform/plugins/shared/actions/server/action_type_registry.ts
+++ b/x-pack/platform/plugins/shared/actions/server/action_type_registry.ts
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import type { RunContext, TaskManagerSetupContract } from '@kbn/task-manager-plugin/server';
 import { TaskCost } from '@kbn/task-manager-plugin/server';
 import type { LicensingPluginSetup } from '@kbn/licensing-plugin/server';
+import { TaskTypeGroup } from '@kbn/task-manager-plugin/server/task';
 import type { ActionType as CommonActionType } from '../common';
 import { areValidFeatures, MAX_FEATURE_ID_LENGTH } from '../common';
 import type { ActionsConfigurationUtilities } from './actions_config';
@@ -220,9 +221,11 @@ export class ActionTypeRegistry {
         title: actionType.name,
         maxAttempts,
         cost: TaskCost.Tiny,
+        taskTypeGroup: TaskTypeGroup.Actions,
         createTaskRunner: (context: RunContext) => this.taskRunnerFactory.create(context),
       },
     });
+
     // No need to notify usage on basic action types
     if (actionType.minimumLicenseRequired !== 'basic') {
       this.licensing.featureUsage.register(

--- a/x-pack/platform/plugins/shared/alerting/server/backfill_client/backfill_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/backfill_client/backfill_client.test.ts
@@ -253,6 +253,7 @@ describe('BackfillClient', () => {
         'ad_hoc_run-backfill': {
           title: 'Alerting Backfill Rule Run',
           priority: TaskPriority.Low,
+          taskTypeGroup: 'alerting',
           createTaskRunner: expect.any(Function),
         },
       });

--- a/x-pack/platform/plugins/shared/alerting/server/backfill_client/backfill_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/backfill_client/backfill_client.ts
@@ -27,6 +27,7 @@ import type { IEventLogger, IEventLogClient } from '@kbn/event-log-plugin/server
 import { isNumber } from 'lodash';
 import type { ActionsClient } from '@kbn/actions-plugin/server';
 import { withSpan } from '@kbn/apm-utils';
+import { TaskTypeGroup } from '@kbn/task-manager-plugin/server/task';
 import type {
   ScheduleBackfillError,
   ScheduleBackfillParams,
@@ -92,6 +93,7 @@ export class BackfillClient {
       [BACKFILL_TASK_TYPE]: {
         title: 'Alerting Backfill Rule Run',
         priority: TaskPriority.Low,
+        taskTypeGroup: TaskTypeGroup.Alerting,
         createTaskRunner: (context: RunContext) => opts.taskRunnerFactory.createAdHoc(context),
       },
     });

--- a/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.test.ts
@@ -576,6 +576,7 @@ describe('Create Lifecycle', () => {
         'alerting:test': {
           timeout: '20m',
           title: 'Test',
+          taskTypeGroup: 'alerting',
         },
       });
     });
@@ -610,6 +611,7 @@ describe('Create Lifecycle', () => {
           timeout: '20m',
           title: 'Test',
           cost: 10,
+          taskTypeGroup: 'alerting',
         },
       });
     });

--- a/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.ts
@@ -14,7 +14,7 @@ import type { Logger } from '@kbn/core/server';
 import type { LicensingPluginSetup } from '@kbn/licensing-plugin/server';
 import type { RunContext, TaskManagerSetupContract } from '@kbn/task-manager-plugin/server';
 import { stateSchemaByVersion } from '@kbn/alerting-state-types';
-import { TaskCost } from '@kbn/task-manager-plugin/server/task';
+import { TaskCost, TaskTypeGroup } from '@kbn/task-manager-plugin/server/task';
 import type { TaskRunnerFactory } from './task_runner';
 import type {
   RuleType,
@@ -300,6 +300,7 @@ export class RuleTypeRegistry {
         title: ruleType.name,
         timeout: ruleType.ruleTaskTimeout,
         stateSchemaByVersion,
+        taskTypeGroup: TaskTypeGroup.Alerting,
         createTaskRunner: (context: RunContext) =>
           this.taskRunnerFactory.create<
             Params,

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/create_aggregator.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/create_aggregator.test.ts
@@ -34,6 +34,8 @@ import { metricsAggregatorMock } from './metrics_aggregator.mock';
 import { getTaskManagerMetricEvent } from './task_overdue_metrics_aggregator.test';
 import type { TaskOverdueMetric } from './task_overdue_metrics_aggregator';
 import { TaskOverdueMetricsAggregator } from './task_overdue_metrics_aggregator';
+import type { TaskTypeDictionary } from '../task_type_dictionary';
+import { TaskTypeGroup } from '../task';
 
 const logger = loggingSystemMock.createLogger();
 const mockMetricsAggregator = metricsAggregatorMock.create();
@@ -769,25 +771,25 @@ describe('createAggregator', () => {
     test('returns a cumulative count of successful task runs, on time task runs and total task runs, broken down by type, along with histogram of run delays', async () => {
       const taskRunEvents = [
         getTaskManagerStatEvent(3.234),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(10.45),
         getTaskRunSuccessEvent('telemetry'),
         getTaskManagerStatEvent(3.454),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(35.45),
         getTaskRunSuccessEvent('report'),
         getTaskManagerStatEvent(8.85673),
-        getTaskRunFailedEvent('alerting:example'),
+        getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(4.5745),
-        getTaskRunSuccessEvent('alerting:.index-threshold'),
+        getTaskRunSuccessEvent('alerting:.index-threshold', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(11.564),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(3.78),
-        getTaskRunFailedEvent('alerting:example'),
+        getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(3.7863),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(3.245),
-        getTaskRunFailedEvent('actions:webhook'),
+        getTaskRunFailedEvent('actions:webhook', false, TaskTypeGroup.Actions),
       ];
       const events$ = new Subject<TaskLifecycleEvent>();
 
@@ -1794,28 +1796,28 @@ describe('createAggregator', () => {
       const reset$ = new Subject<boolean>();
       const taskRunEvents1 = [
         getTaskManagerStatEvent(3.234),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(10.45),
         getTaskRunSuccessEvent('telemetry'),
         getTaskManagerStatEvent(3.454),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(35.45),
         getTaskRunSuccessEvent('report'),
         getTaskManagerStatEvent(8.85673),
-        getTaskRunFailedEvent('alerting:example'),
+        getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting),
       ];
 
       const taskRunEvents2 = [
         getTaskManagerStatEvent(4.5745),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(11.564),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(3.78),
-        getTaskRunFailedEvent('alerting:example'),
+        getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(3.7863),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(3.245),
-        getTaskRunFailedEvent('actions:webhook'),
+        getTaskRunFailedEvent('actions:webhook', false, TaskTypeGroup.Actions),
       ];
       const events$ = new Subject<TaskLifecycleEvent>();
 
@@ -2756,28 +2758,28 @@ describe('createAggregator', () => {
       clock.tick(0);
       const taskRunEvents1 = [
         getTaskManagerStatEvent(3.234),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(10.45),
         getTaskRunSuccessEvent('telemetry'),
         getTaskManagerStatEvent(3.454),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(35.45),
         getTaskRunSuccessEvent('report'),
         getTaskManagerStatEvent(8.85673),
-        getTaskRunFailedEvent('alerting:example'),
+        getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting),
       ];
 
       const taskRunEvents2 = [
         getTaskManagerStatEvent(4.5745),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(11.564),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(3.78),
-        getTaskRunFailedEvent('alerting:example'),
+        getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(3.7863),
-        getTaskRunSuccessEvent('alerting:example'),
+        getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting),
         getTaskManagerStatEvent(3.245),
-        getTaskRunFailedEvent('actions:webhook'),
+        getTaskRunFailedEvent('actions:webhook', false, TaskTypeGroup.Actions),
       ];
       const events$ = new Subject<TaskLifecycleEvent>();
 
@@ -3720,6 +3722,11 @@ describe('createAggregator', () => {
   });
 
   describe('with TaskOverdueMetricsAggregator', () => {
+    const mockDefinitions = (overrides: Record<string, { taskTypeGroup?: string }> = {}) =>
+      ({
+        get: (type: string) => overrides[type],
+      } as unknown as TaskTypeDictionary);
+
     test('returns latest values for task overdue by time', async () => {
       const events = [
         getTaskManagerMetricEvent({
@@ -3774,7 +3781,14 @@ describe('createAggregator', () => {
         config,
         reset$: new Subject<boolean>(),
         eventFilter: (event: TaskLifecycleEvent) => isTaskManagerMetricEvent(event),
-        metricsAggregator: new TaskOverdueMetricsAggregator(),
+        metricsAggregator: new TaskOverdueMetricsAggregator(
+          mockDefinitions({
+            ['alerting:example']: { taskTypeGroup: TaskTypeGroup.Alerting },
+            ['alerting:.index-threshold']: { taskTypeGroup: TaskTypeGroup.Alerting },
+            ['actions:webhook']: { taskTypeGroup: TaskTypeGroup.Actions },
+            ['actions:.email']: { taskTypeGroup: TaskTypeGroup.Actions },
+          })
+        ),
       });
 
       return new Promise<void>((resolve) => {

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/index.ts
@@ -12,6 +12,7 @@ import type { Metrics } from './metrics_stream';
 import { createMetricsAggregators, createMetricsStream } from './metrics_stream';
 import type { TaskPollingLifecycle } from '../polling_lifecycle';
 import type { TaskManagerMetricsCollector } from './task_metrics_collector';
+import type { TaskTypeDictionary } from '../task_type_dictionary';
 export type { Metrics } from './metrics_stream';
 
 interface MetricsStreamOpts {
@@ -20,6 +21,7 @@ interface MetricsStreamOpts {
   reset$: Observable<boolean>; // emits when counter metrics should be reset
   taskPollingLifecycle?: TaskPollingLifecycle; // subscribe to task lifecycle events
   taskManagerMetricsCollector?: TaskManagerMetricsCollector; // subscribe to collected task manager metrics
+  definitions: TaskTypeDictionary;
 }
 
 export function metricsStream({
@@ -28,6 +30,7 @@ export function metricsStream({
   logger,
   taskPollingLifecycle,
   taskManagerMetricsCollector,
+  definitions,
 }: MetricsStreamOpts): Observable<Metrics> {
   return createMetricsStream(
     createMetricsAggregators({
@@ -36,6 +39,7 @@ export function metricsStream({
       reset$,
       taskPollingLifecycle,
       taskManagerMetricsCollector,
+      definitions,
     })
   );
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/lib/get_task_type_group.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/lib/get_task_type_group.test.ts
@@ -6,15 +6,12 @@
  */
 
 import { getTaskTypeGroup } from './get_task_type_group';
+import { TaskTypeGroup } from '../../task';
 
 describe('getTaskTypeGroup', () => {
-  test('should correctly group based on task type prefix', () => {
-    expect(getTaskTypeGroup('alerting:abc')).toEqual('alerting');
-    expect(getTaskTypeGroup('actions:def')).toEqual('actions');
-  });
-
-  test('should return undefined if no match', () => {
-    expect(getTaskTypeGroup('alerting-abc')).toBeUndefined();
-    expect(getTaskTypeGroup('fooalertingbar')).toBeUndefined();
+  test('should return taskTypeGroup when it is one of the accepted values', () => {
+    expect(getTaskTypeGroup('alerting')).toEqual(TaskTypeGroup.Alerting);
+    expect(getTaskTypeGroup('actions')).toEqual(TaskTypeGroup.Actions);
+    expect(getTaskTypeGroup('custom_group')).toBeUndefined();
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/lib/get_task_type_group.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/lib/get_task_type_group.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-const taskTypeGrouping = new Set<string>(['alerting:', 'actions:']);
+import { TaskTypeGroup } from '../../task';
 
-export function getTaskTypeGroup(taskType: string): string | undefined {
-  for (const group of taskTypeGrouping) {
-    if (taskType.startsWith(group)) {
-      return group.replace(':', '');
-    }
+const taskTypeGrouping = [TaskTypeGroup.Actions, TaskTypeGroup.Alerting];
+
+export function getTaskTypeGroup(taskTypeGroup?: string): TaskTypeGroup | undefined {
+  if (taskTypeGroup !== undefined && taskTypeGrouping.includes(taskTypeGroup as TaskTypeGroup)) {
+    return taskTypeGroup as TaskTypeGroup;
   }
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/metrics_stream.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/metrics_stream.ts
@@ -28,6 +28,8 @@ import { TaskRunMetricsAggregator } from './task_run_metrics_aggregator';
 import type { TaskOverdueMetric } from './task_overdue_metrics_aggregator';
 import { TaskOverdueMetricsAggregator } from './task_overdue_metrics_aggregator';
 import type { TaskManagerMetricsCollector } from './task_metrics_collector';
+import type { TaskTypeDictionary } from '../task_type_dictionary';
+
 export interface Metrics {
   last_update: string;
   metrics: {
@@ -48,6 +50,7 @@ interface CreateMetricsAggregatorsOpts {
   reset$: Observable<boolean>;
   taskPollingLifecycle?: TaskPollingLifecycle;
   taskManagerMetricsCollector?: TaskManagerMetricsCollector;
+  definitions: TaskTypeDictionary;
 }
 export function createMetricsAggregators({
   config,
@@ -55,6 +58,7 @@ export function createMetricsAggregators({
   logger,
   taskPollingLifecycle,
   taskManagerMetricsCollector,
+  definitions,
 }: CreateMetricsAggregatorsOpts): AggregatedStatProvider {
   const aggregators: AggregatedStatProvider[] = [];
   const debugLogger = createWrappedLogger({ logger, tags: ['metrics-debugger'] });
@@ -88,7 +92,7 @@ export function createMetricsAggregators({
         events$: taskManagerMetricsCollector.events,
         config,
         eventFilter: (event: TaskLifecycleEvent) => isTaskManagerMetricEvent(event),
-        metricsAggregator: new TaskOverdueMetricsAggregator(),
+        metricsAggregator: new TaskOverdueMetricsAggregator(definitions),
       })
     );
   }

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/task_overdue_metrics_aggregator.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/task_overdue_metrics_aggregator.test.ts
@@ -9,15 +9,28 @@ import { asOk } from '../lib/result_type';
 import { asTaskManagerMetricEvent } from '../task_events';
 import type { TaskManagerMetrics } from './task_metrics_collector';
 import { TaskOverdueMetricsAggregator } from './task_overdue_metrics_aggregator';
+import type { TaskTypeDictionary } from '../task_type_dictionary';
 
 export const getTaskManagerMetricEvent = (value: TaskManagerMetrics) => {
   return asTaskManagerMetricEvent(asOk(value));
 };
 
+const mockDefinitions = (overrides: Record<string, { taskTypeGroup?: string }> = {}) =>
+  ({
+    get: (type: string) => overrides[type],
+  } as unknown as TaskTypeDictionary);
+
 describe('TaskOverdueMetricsAggregator', () => {
   let taskOverdueMetricsAggregator: TaskOverdueMetricsAggregator;
   beforeEach(() => {
-    taskOverdueMetricsAggregator = new TaskOverdueMetricsAggregator();
+    taskOverdueMetricsAggregator = new TaskOverdueMetricsAggregator(
+      mockDefinitions({
+        ['alerting:example']: { taskTypeGroup: 'alerting' },
+        ['alerting:.index-threshold']: { taskTypeGroup: 'alerting' },
+        ['actions:webhook']: { taskTypeGroup: 'actions' },
+        ['actions:.email']: { taskTypeGroup: 'actions' },
+      })
+    );
   });
 
   test('should correctly initialize', () => {
@@ -196,6 +209,29 @@ describe('TaskOverdueMetricsAggregator', () => {
           overdue_by_values: [0, 0, 0],
         },
       },
+    });
+  });
+
+  test('should ignore when taskTypeGroup is undefined', () => {
+    const aggregator = new TaskOverdueMetricsAggregator(
+      mockDefinitions({
+        ['actions:oauth_state_cleanup']: { taskTypeGroup: undefined },
+      })
+    );
+    aggregator.processTaskLifecycleEvent(
+      getTaskManagerMetricEvent({
+        numOverdueTasks: {
+          'actions:oauth_state_cleanup': [{ key: 0, doc_count: 1 }],
+          total: [{ key: 0, doc_count: 1 }],
+        },
+      })
+    );
+    const result = aggregator.collect();
+
+    expect(result.by_type.actions).toBeUndefined();
+    expect(result.by_type['actions:oauth_state_cleanup']).toEqual({
+      overdue_by: { counts: [1], values: [10] },
+      overdue_by_values: [0],
     });
   });
 

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/task_overdue_metrics_aggregator.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/task_overdue_metrics_aggregator.ts
@@ -14,6 +14,7 @@ import type { TaskManagerMetric } from '../task_events';
 import { getTaskTypeGroup, type SerializedHistogram, SimpleHistogram } from './lib';
 import type { TaskManagerMetrics } from './task_metrics_collector';
 import type { ITaskMetricsAggregator } from './types';
+import type { TaskTypeDictionary } from '../task_type_dictionary';
 
 const HDR_HISTOGRAM_MAX = 5400; // 90 minutes
 const HDR_HISTOGRAM_BUCKET_SIZE = 10; // 10 seconds
@@ -39,6 +40,11 @@ export interface TaskOverdueMetric extends JsonObject {
 
 export class TaskOverdueMetricsAggregator implements ITaskMetricsAggregator<TaskOverdueMetric> {
   private histograms: Record<string, SimpleHistogram> = {};
+  private definitions: TaskTypeDictionary;
+
+  constructor(definitions: TaskTypeDictionary) {
+    this.definitions = definitions;
+  }
 
   public initialMetric(): TaskOverdueMetric {
     return {
@@ -85,7 +91,7 @@ export class TaskOverdueMetricsAggregator implements ITaskMetricsAggregator<Task
             this.histograms[`${TaskOverdueMetricKeys.OVERALL}.${OVERDUE_BY_KEY}`] = hist;
           } else {
             const taskType = key.replaceAll('.', '__');
-            const taskTypeGroup = getTaskTypeGroup(taskType);
+            const taskTypeGroup = getTaskTypeGroup(this.definitions.get(key)?.taskTypeGroup);
             this.histograms[`${TaskOverdueMetricKeys.BY_TYPE}.${taskType}.${OVERDUE_BY_KEY}`] =
               hist;
 

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/task_run_metrics_aggregator.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/task_run_metrics_aggregator.test.ts
@@ -8,7 +8,7 @@
 import * as uuid from 'uuid';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { asOk, asErr } from '../lib/result_type';
-import { TaskStatus } from '../task';
+import { TaskStatus, TaskTypeGroup } from '../task';
 import type { TaskManagerStats } from '../task_events';
 import { asTaskManagerStatEvent, asTaskRunEvent, TaskPersistence } from '../task_events';
 import { TaskRunResult } from '../task_running';
@@ -16,7 +16,11 @@ import { TaskRunMetricsAggregator } from './task_run_metrics_aggregator';
 
 const logger = loggingSystemMock.createLogger();
 
-export const getTaskRunSuccessEvent = (type: string, isExpired: boolean = false) => {
+export const getTaskRunSuccessEvent = (
+  type: string,
+  isExpired: boolean = false,
+  taskTypeGroup?: TaskTypeGroup
+) => {
   const id = uuid.v4();
   return asTaskRunEvent(
     id,
@@ -38,6 +42,7 @@ export const getTaskRunSuccessEvent = (type: string, isExpired: boolean = false)
       persistence: TaskPersistence.Recurring,
       result: TaskRunResult.Success,
       isExpired,
+      taskTypeGroup,
     }),
     {
       start: 1689698780490,
@@ -46,7 +51,11 @@ export const getTaskRunSuccessEvent = (type: string, isExpired: boolean = false)
   );
 };
 
-export const getTaskRunFailedEvent = (type: string, isExpired: boolean = false) => {
+export const getTaskRunFailedEvent = (
+  type: string,
+  isExpired: boolean = false,
+  taskTypeGroup?: TaskTypeGroup
+) => {
   const id = uuid.v4();
   return asTaskRunEvent(
     id,
@@ -69,6 +78,7 @@ export const getTaskRunFailedEvent = (type: string, isExpired: boolean = false) 
       persistence: TaskPersistence.Recurring,
       result: TaskRunResult.Failed,
       isExpired,
+      taskTypeGroup,
     })
   );
 };
@@ -299,20 +309,34 @@ describe('TaskRunMetricsAggregator', () => {
     taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('report'));
     taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunFailedEvent('telemetry'));
     taskRunMetricsAggregator.processTaskLifecycleEvent(
-      getTaskRunSuccessEvent('alerting:example', true)
+      getTaskRunSuccessEvent('alerting:example', true, TaskTypeGroup.Alerting)
     );
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('alerting:example'));
     taskRunMetricsAggregator.processTaskLifecycleEvent(
-      getTaskRunSuccessEvent('alerting:.index-threshold')
+      getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting)
     );
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('actions:webhook'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunFailedEvent('alerting:example'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('actions:webhook'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('alerting:example'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunFailedEvent('alerting:example'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('actions:.email'));
     taskRunMetricsAggregator.processTaskLifecycleEvent(
-      getTaskRunSuccessEvent('alerting:.index-threshold', true)
+      getTaskRunSuccessEvent('alerting:.index-threshold', false, TaskTypeGroup.Alerting)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('actions:webhook', false, TaskTypeGroup.Actions)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('actions:webhook', false, TaskTypeGroup.Actions)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('actions:.email', false, TaskTypeGroup.Actions)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('alerting:.index-threshold', true, TaskTypeGroup.Alerting)
     );
     expect(taskRunMetricsAggregator.collect()).toEqual({
       overall: {
@@ -405,20 +429,34 @@ describe('TaskRunMetricsAggregator', () => {
     taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('report'));
     taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunFailedEvent('telemetry'));
     taskRunMetricsAggregator.processTaskLifecycleEvent(
-      getTaskRunSuccessEvent('alerting:example', true)
+      getTaskRunSuccessEvent('alerting:example', true, TaskTypeGroup.Alerting)
     );
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('alerting:example'));
     taskRunMetricsAggregator.processTaskLifecycleEvent(
-      getTaskRunSuccessEvent('alerting:.index-threshold', true)
+      getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting)
     );
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('actions:webhook'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunFailedEvent('alerting:example'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('actions:webhook'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('alerting:example'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunFailedEvent('alerting:example'));
-    taskRunMetricsAggregator.processTaskLifecycleEvent(getTaskRunSuccessEvent('actions:.email'));
     taskRunMetricsAggregator.processTaskLifecycleEvent(
-      getTaskRunSuccessEvent('alerting:.index-threshold')
+      getTaskRunSuccessEvent('alerting:.index-threshold', true, TaskTypeGroup.Alerting)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('actions:webhook', false, TaskTypeGroup.Actions)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('actions:webhook', false, TaskTypeGroup.Actions)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('alerting:example', false, TaskTypeGroup.Alerting)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunFailedEvent('alerting:example', false, TaskTypeGroup.Alerting)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('actions:.email', false, TaskTypeGroup.Actions)
+    );
+    taskRunMetricsAggregator.processTaskLifecycleEvent(
+      getTaskRunSuccessEvent('alerting:.index-threshold', false, TaskTypeGroup.Alerting)
     );
     expect(taskRunMetricsAggregator.collect()).toEqual({
       overall: {

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/task_run_metrics_aggregator.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/task_run_metrics_aggregator.ts
@@ -110,7 +110,7 @@ export class TaskRunMetricsAggregator implements ITaskMetricsAggregator<TaskRunM
     const { task, isExpired } = taskRunResult;
     const success = isOk((taskEvent as TaskRun).event);
     const taskType = task.taskType.replaceAll('.', '__');
-    const taskTypeGroup = getTaskTypeGroup(taskType);
+    const taskTypeGroup = getTaskTypeGroup(taskRunResult.taskTypeGroup);
 
     // increment the total counters
     this.incrementCounters(TaskRunKeys.TOTAL, taskType, taskTypeGroup);

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -421,6 +421,7 @@ export class TaskManagerPlugin
       reset$: this.resetMetrics$,
       taskPollingLifecycle: this.taskPollingLifecycle,
       taskManagerMetricsCollector: this.taskManagerMetricsCollector,
+      definitions: this.definitions,
     }).subscribe((metric) => this.metrics$.next(metric));
 
     const taskScheduling = new TaskScheduling({

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -24,6 +24,11 @@ export enum TaskPriority {
   Normal = 50,
 }
 
+export enum TaskTypeGroup {
+  Alerting = 'alerting',
+  Actions = 'actions',
+}
+
 export enum TaskCost {
   Tiny = 1,
   Normal = 2,
@@ -196,6 +201,15 @@ export const taskDefinitionSchema = schema.object(
     ),
 
     paramsSchema: schema.maybe(schema.any()),
+
+    /**
+     * Used to group tasks for metrics calculated within task_manager.
+     * If value is defined, metrics will be included in the alerting/actions grouping metrics.
+     * If not set, metrics will only be calculated for the specific task type.
+     */
+    taskTypeGroup: schema.maybe(
+      schema.oneOf([schema.literal('alerting'), schema.literal('actions')])
+    ),
   },
   {
     validate({ timeout, priority, cost }) {
@@ -222,7 +236,10 @@ export const taskDefinitionSchema = schema.object(
  * Defines a task which can be scheduled and run by the Kibana
  * task manager.
  */
-export type TaskDefinition = Omit<TypeOf<typeof taskDefinitionSchema>, 'paramsSchema'> & {
+export type TaskDefinition = Omit<
+  TypeOf<typeof taskDefinitionSchema>,
+  'paramsSchema' | 'taskTypeGroup'
+> & {
   /**
    * Creates an object that has a run function which performs the task's work,
    * and an optional cancel function which cancels the task.
@@ -236,6 +253,7 @@ export type TaskDefinition = Omit<TypeOf<typeof taskDefinitionSchema>, 'paramsSc
     }
   >;
   paramsSchema?: ObjectType;
+  taskTypeGroup?: TaskTypeGroup;
 };
 
 export enum TaskStatus {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_events.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_events.ts
@@ -7,7 +7,7 @@
 
 import { monitorEventLoopDelay } from 'perf_hooks';
 
-import type { ConcreteTaskInstance } from './task';
+import type { ConcreteTaskInstance, TaskTypeGroup } from './task';
 
 import type { Result, Err } from './lib/result_type';
 import type { ClaimAndFillPoolResult } from './lib/fill_pool';
@@ -73,6 +73,7 @@ export interface RanTask {
   persistence: TaskPersistence;
   result: TaskRunResult;
   isExpired: boolean;
+  taskTypeGroup?: TaskTypeGroup;
 }
 export type ErroredTask = RanTask & {
   error: DecoratedError;

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -61,6 +61,7 @@ import type {
   RruleSchedule,
   SuccessfulRunResult,
   TaskDefinition,
+  TaskTypeGroup,
 } from '../task';
 import { isFailedRunResult, TaskStatus } from '../task';
 import type { TaskTypeDictionary } from '../task_type_dictionary';
@@ -843,12 +844,16 @@ export class TaskManagerRunner implements TaskRunner {
     const debugLogger = createWrappedLogger({ logger: this.logger, tags: [`metrics-debugger`] });
 
     const taskHasExpired = this.isExpired;
+    const taskTypeGroup = this.definitions.get(this.taskType)?.taskTypeGroup as
+      | TaskTypeGroup
+      | undefined;
 
     await eitherAsync(
       result,
       async ({ runAt, schedule, taskRunError }: SuccessfulRunResult) => {
         const taskPersistence =
           schedule || task.schedule ? TaskPersistence.Recurring : TaskPersistence.NonRecurring;
+
         try {
           const processedResult = {
             task,
@@ -867,7 +872,12 @@ export class TaskManagerRunner implements TaskRunner {
             this.onTaskEvent(
               asTaskRunEvent(
                 this.id,
-                asErr({ ...processedResult, isExpired: taskHasExpired, error: taskRunError }),
+                asErr({
+                  ...processedResult,
+                  isExpired: taskHasExpired,
+                  error: taskRunError,
+                  taskTypeGroup,
+                }),
                 taskTiming
               )
             );
@@ -875,7 +885,7 @@ export class TaskManagerRunner implements TaskRunner {
             this.onTaskEvent(
               asTaskRunEvent(
                 this.id,
-                asOk({ ...processedResult, isExpired: taskHasExpired }),
+                asOk({ ...processedResult, isExpired: taskHasExpired, taskTypeGroup }),
                 taskTiming
               )
             );
@@ -890,6 +900,7 @@ export class TaskManagerRunner implements TaskRunner {
                 result: TaskRunResult.Failed,
                 isExpired: taskHasExpired,
                 error: err,
+                taskTypeGroup,
               }),
               taskTiming
             )
@@ -908,6 +919,7 @@ export class TaskManagerRunner implements TaskRunner {
               result: await this.processResultForRecurringTask(result),
               isExpired: taskHasExpired,
               error,
+              taskTypeGroup,
             }),
             taskTiming
           )

--- a/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.test.ts
@@ -64,34 +64,32 @@ describe('taskTypeDictionary', () => {
       const taskDefinitions = getMockTaskDefinitions({ numTasks: 3 });
       const result = sanitizeTaskDefinitions(taskDefinitions);
 
-      expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "cost": 2,
-          "createTaskRunner": [Function],
-          "description": "one super cool task",
-          "timeout": "5m",
-          "title": "Test",
-          "type": "test_task_type_0",
+      expect(result).toEqual([
+        {
+          cost: 2,
+          createTaskRunner: expect.any(Function),
+          description: 'one super cool task',
+          timeout: '5m',
+          title: 'Test',
+          type: 'test_task_type_0',
         },
-        Object {
-          "cost": 2,
-          "createTaskRunner": [Function],
-          "description": "one super cool task",
-          "timeout": "5m",
-          "title": "Test",
-          "type": "test_task_type_1",
+        {
+          cost: 2,
+          createTaskRunner: expect.any(Function),
+          description: 'one super cool task',
+          timeout: '5m',
+          title: 'Test',
+          type: 'test_task_type_1',
         },
-        Object {
-          "cost": 2,
-          "createTaskRunner": [Function],
-          "description": "one super cool task",
-          "timeout": "5m",
-          "title": "Test",
-          "type": "test_task_type_2",
+        {
+          cost: 2,
+          createTaskRunner: expect.any(Function),
+          description: 'one super cool task',
+          timeout: '5m',
+          title: 'Test',
+          type: 'test_task_type_2',
         },
-      ]
-    `);
+      ]);
     });
 
     it('throws a validation exception for invalid task definition', () => {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_type_dictionary.ts
@@ -7,7 +7,13 @@
 
 import type { ObjectType } from '@kbn/config-schema';
 import type { Logger } from '@kbn/core/server';
-import type { TaskDefinition, TaskRunCreatorFunction, TaskPriority, TaskCost } from './task';
+import type {
+  TaskDefinition,
+  TaskRunCreatorFunction,
+  TaskPriority,
+  TaskCost,
+  TaskTypeGroup,
+} from './task';
 import { taskDefinitionSchema } from './task';
 import { CONCURRENCY_ALLOW_LIST_BY_TASK_TYPE } from './constants';
 
@@ -101,6 +107,7 @@ export interface TaskRegisterDefinition {
   >;
 
   paramsSchema?: ObjectType;
+  taskTypeGroup?: TaskTypeGroup;
 }
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps] Fix telemetry metric count (#283884)](https://github.com/elastic/kibana/pull/283884)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"lu(cia)","email":"lucia.petracca@elastic.co"},"sourceCommit":{"committedDate":"2026-08-21T08:30:04Z","message":"[ResponseOps] Fix telemetry metric count (#283884)\n\n## Summary\n\nResolves https://github.com/elastic/response-ops-team/issues/625\n\nCertain task execution failures were contributing to the success rate\nSLO, when they shouldn't be counted.\nTasks:\n`actions:oauth_state_cleanup`\n`actions:user_connector_token_cleanup`\n`actions_telemetry`\n`alerting_telemetry`\n\nThis PR adds an optional `taskTypeGroup` param to\n\"TaskRegisterDefinition\" which should be used for `actions:` and\n`alerting:` tasks to indicate which tasks should be counted for SLOs.\n\nWhen counting metrics, this field will be used as a filter\n(`x-pack/platform/plugins/shared/task_manager/server/metrics/lib/get_task_type_group.ts`)\nreplacing the prefix check.\nExisting alerting and action task definitions are also updated to\ninclude the value when appropriate\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3e3e48e6b15bfafa7caa561b54b7c99eac40e3e7","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","Feature:Alerting/RuleActions","backport:all-open","v9.6.0","v9.4.6","v9.5.2"],"title":"[ResponseOps] Fix telemetry metric count","number":283884,"url":"https://github.com/elastic/kibana/pull/283884","mergeCommit":{"message":"[ResponseOps] Fix telemetry metric count (#283884)\n\n## Summary\n\nResolves https://github.com/elastic/response-ops-team/issues/625\n\nCertain task execution failures were contributing to the success rate\nSLO, when they shouldn't be counted.\nTasks:\n`actions:oauth_state_cleanup`\n`actions:user_connector_token_cleanup`\n`actions_telemetry`\n`alerting_telemetry`\n\nThis PR adds an optional `taskTypeGroup` param to\n\"TaskRegisterDefinition\" which should be used for `actions:` and\n`alerting:` tasks to indicate which tasks should be counted for SLOs.\n\nWhen counting metrics, this field will be used as a filter\n(`x-pack/platform/plugins/shared/task_manager/server/metrics/lib/get_task_type_group.ts`)\nreplacing the prefix check.\nExisting alerting and action task definitions are also updated to\ninclude the value when appropriate\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3e3e48e6b15bfafa7caa561b54b7c99eac40e3e7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/283884","number":283884,"mergeCommit":{"message":"[ResponseOps] Fix telemetry metric count (#283884)\n\n## Summary\n\nResolves https://github.com/elastic/response-ops-team/issues/625\n\nCertain task execution failures were contributing to the success rate\nSLO, when they shouldn't be counted.\nTasks:\n`actions:oauth_state_cleanup`\n`actions:user_connector_token_cleanup`\n`actions_telemetry`\n`alerting_telemetry`\n\nThis PR adds an optional `taskTypeGroup` param to\n\"TaskRegisterDefinition\" which should be used for `actions:` and\n`alerting:` tasks to indicate which tasks should be counted for SLOs.\n\nWhen counting metrics, this field will be used as a filter\n(`x-pack/platform/plugins/shared/task_manager/server/metrics/lib/get_task_type_group.ts`)\nreplacing the prefix check.\nExisting alerting and action task definitions are also updated to\ninclude the value when appropriate\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3e3e48e6b15bfafa7caa561b54b7c99eac40e3e7"}},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/286464","number":286464,"state":"MERGED","mergeCommit":{"sha":"646e0e2a244ccc83d28e6923806c45a0b5c31a02","message":"[9.4] [ResponseOps] Fix telemetry metric count (#283884) (#286464)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[ResponseOps] Fix telemetry metric count\n(#283884)](https://github.com/elastic/kibana/pull/283884)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: lu(cia) <lucia.petracca@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/286465","number":286465,"state":"MERGED","mergeCommit":{"sha":"a5b51922bd02949de092c01602fbeee6f1a37960","message":"[9.5] [ResponseOps] Fix telemetry metric count (#283884) (#286465)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[ResponseOps] Fix telemetry metric count\n(#283884)](https://github.com/elastic/kibana/pull/283884)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: lu(cia) <lucia.petracca@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->