### PR TITLE
[CPS][Transforms][ML] Fix full date range error toast

### DIFF
--- a/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.test.tsx
+++ b/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.test.tsx
@@ -161,4 +161,38 @@ describe('FullTimeRangeSelector', () => {
     );
     expect(getProjectRouting).not.toHaveBeenCalled();
   });
+
+  it('falls back to the CPS context project routing', async () => {
+    const projectRouting = '_id:context-project';
+    const getProjectRouting = jest.fn(() => projectRouting);
+    const cps = {
+      isTierEligible: true,
+      cpsManager: { getProjectRouting },
+    } as unknown as DatePickerDependencies['cps'];
+    (setFullTimeRange as jest.MockedFunction<any>).mockImplementationOnce(() => undefined);
+
+    const { getByText } = render(
+      <IntlProvider locale="en">
+        <DatePickerContextProvider {...mockDependencies} cps={cps}>
+          <FullTimeRangeSelector {...props} />
+        </DatePickerContextProvider>
+      </IntlProvider>
+    );
+
+    await act(async () => {
+      fireEvent.click(getByText(/use full data/i));
+    });
+
+    expect(setFullTimeRange).toHaveBeenCalledWith(
+      props.timefilter,
+      dataView,
+      undefined,
+      undefined,
+      query,
+      true,
+      undefined,
+      projectRouting
+    );
+    expect(getProjectRouting).toHaveBeenCalledTimes(1);
+  });
 });

--- a/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.test.tsx
+++ b/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.test.tsx
@@ -127,4 +127,38 @@ describe('FullTimeRangeSelector', () => {
       success: true,
     });
   });
+
+  it('passes the explicit project routing to setFullTimeRange', async () => {
+    const projectRouting = '_id:linked-project';
+    const getProjectRouting = jest.fn(() => '_id:global-project');
+    const cps = {
+      isTierEligible: true,
+      cpsManager: { getProjectRouting },
+    } as unknown as DatePickerDependencies['cps'];
+    (setFullTimeRange as jest.MockedFunction<any>).mockImplementationOnce(() => undefined);
+
+    const { getByText } = render(
+      <IntlProvider locale="en">
+        <DatePickerContextProvider {...mockDependencies} cps={cps}>
+          <FullTimeRangeSelector {...props} projectRouting={projectRouting} />
+        </DatePickerContextProvider>
+      </IntlProvider>
+    );
+
+    await act(async () => {
+      fireEvent.click(getByText(/use full data/i));
+    });
+
+    expect(setFullTimeRange).toHaveBeenCalledWith(
+      props.timefilter,
+      dataView,
+      undefined,
+      undefined,
+      query,
+      true,
+      undefined,
+      projectRouting
+    );
+    expect(getProjectRouting).not.toHaveBeenCalled();
+  });
 });

--- a/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.tsx
+++ b/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.tsx
@@ -64,6 +64,10 @@ export interface FullTimeRangeSelectorProps {
    */
   query?: QueryDslQueryContainer;
   /**
+   * Optional project routing to use for resolving the full time range.
+   */
+  projectRouting?: string;
+  /**
    * Optional callback.
    * @param value - The time field range response.
    */
@@ -90,6 +94,7 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
     timefilter,
     dataView,
     query,
+    projectRouting: projectRoutingProp,
     disabled,
     callback,
     apiPath,
@@ -105,7 +110,7 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
   // wrapper around setFullTimeRange to allow for the calling of the optional callBack prop
   const setRange = useCallback(async () => {
     try {
-      const projectRouting = cps?.cpsManager?.getProjectRouting();
+      const projectRouting = projectRoutingProp ?? cps?.cpsManager?.getProjectRouting();
       const fullTimeRange = await setFullTimeRange(
         timefilter,
         dataView,
@@ -138,6 +143,7 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
     toasts,
     http,
     query,
+    projectRoutingProp,
     showFrozenDataTierChoice,
     frozenDataPreference,
     apiPath,

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/data_drift/data_drift_page.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/data_drift/data_drift_page.tsx
@@ -73,6 +73,9 @@ interface PageHeaderProps {
 export const PageHeader: FC<PageHeaderProps> = ({ onRefresh, needsUpdate }) => {
   const [, setGlobalState] = useUrlState('_g');
   const { dataView } = useDataSource();
+  const {
+    services: { cps },
+  } = useDataVisualizerKibana();
 
   const [frozenDataPreference, setFrozenDataPreference] = useStorage<
     DVKey,
@@ -128,6 +131,7 @@ export const PageHeader: FC<PageHeaderProps> = ({ onRefresh, needsUpdate }) => {
                 disabled={false}
                 timefilter={timefilter}
                 callback={updateTimeState}
+                projectRouting={cps?.cpsManager?.getProjectRouting()}
               />
             </EuiFlexItem>
           )}

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_esql.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_esql.tsx
@@ -67,7 +67,7 @@ const maxInlineSizeStyles = css`
 
 export const IndexDataVisualizerESQL: FC<IndexDataVisualizerESQLProps> = (dataVisualizerProps) => {
   const { services } = useDataVisualizerKibana();
-  const { data, http } = services;
+  const { data, http, cps } = services;
   const { euiTheme } = useEuiTheme();
 
   // Query that has been typed, but has not submitted with cmd + enter
@@ -273,6 +273,7 @@ export const IndexDataVisualizerESQL: FC<IndexDataVisualizerESQLProps> = (dataVi
                   setFrozenDataPreference={() => {}}
                   dataView={currentDataView}
                   query={undefined}
+                  projectRouting={cps?.cpsManager?.getProjectRouting()}
                   disabled={false}
                   timefilter={timefilter}
                 />

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
@@ -541,6 +541,7 @@ export const IndexDataVisualizerView: FC<IndexDataVisualizerViewProps> = ({
                     setFrozenDataPreference={setFrozenDataPreference}
                     dataView={currentDataView}
                     query={undefined}
+                    projectRouting={cps?.cpsManager?.getProjectRouting()}
                     disabled={false}
                     timefilter={timefilter}
                   />

--- a/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/step_define/step_define_form.tsx
+++ b/x-pack/platform/plugins/private/transform/public/app/sections/create_transform/components/step_define/step_define_form.tsx
@@ -488,6 +488,7 @@ export const StepDefineForm: FC<StepDefineFormProps> = React.memo((props) => {
                   setFrozenDataPreference={setFrozenDataPreference}
                   dataView={dataView}
                   query={undefined}
+                  projectRouting={props.overrides?.projectRouting}
                   disabled={false}
                   timefilter={timefilter}
                 />

--- a/x-pack/platform/plugins/shared/aiops/public/components/page_header/page_header.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/page_header/page_header.tsx
@@ -23,6 +23,7 @@ import {
 
 import moment from 'moment';
 import { useDataSource } from '../../hooks/use_data_source';
+import { useAiopsAppContext } from '../../hooks/use_aiops_app_context';
 import {
   AIOPS_FROZEN_TIER_PREFERENCE,
   type AiOpsKey,
@@ -38,6 +39,7 @@ const maxInlineSizeStyles = css`
 export const PageHeader: FC = () => {
   const [, setGlobalState] = useUrlState('_g');
   const { dataView } = useDataSource();
+  const { cps } = useAiopsAppContext();
 
   const [frozenDataPreference, setFrozenDataPreference] = useStorage<
     AiOpsKey,
@@ -96,6 +98,7 @@ export const PageHeader: FC = () => {
                 disabled={false}
                 timefilter={timefilter}
                 callback={updateTimeState}
+                projectRouting={cps?.cpsManager?.getProjectRouting()}
               />
             </EuiFlexItem>
           )}

--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/time_range_step/time_range.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/pages/components/time_range_step/time_range.tsx
@@ -141,6 +141,7 @@ export const TimeRangeStep: FC<StepProps> = ({ setCurrentStep, isCurrentStep }) 
                 callback={fullTimeRangeCallback}
                 timefilter={timefilter}
                 apiPath={`${ML_INTERNAL_BASE_PATH}/fields_service/time_field_range`}
+                projectRouting={jobCreator.projectRouting ?? undefined}
               />
             </EuiFlexItem>
             <EuiFlexItem />


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/286364

## Summary

Fixes the **Use full data** time-range request so CPS project scope is preserved across all current consumers:

- Transform create flow now passes the selected project scope to `FullTimeRangeSelector`
- ML Anomaly job creation now passes the job creator's project scope to `FullTimeRangeSelector`
- Data Visualizer, Data Drift, and AIOps pages now pass the active CPS project scope to `FullTimeRangeSelector`
- AIOps coverage includes Log rate analysis, Log pattern analysis, and Change point detection because they share the same page header
- `FullTimeRangeSelector` accepts an explicit `projectRouting` prop and still falls back to the CPS context for existing consumers
- Adds unit coverage for both explicit project routing and the CPS-context fallback path

## Testing

1. Create first serverless project with CPS enabled. This project runs on `localhost:5620`:
```
node scripts/scout start-server --arch serverless \
    --domain security_complete --serverConfigSet cps_local
```

2. Create a second serverless project with CPS enabled, which is linked to the previous project. This project runs on `localhost:5621`:

```
yarn serverless-security --no-base-path \
  --server.port=5621 \
  --server.publicBaseUrl=http://localhost:5621 \
  --xpack.security.cookieName=sid_linked \
  --elasticsearch.hosts=https://localhost:9230 \
  --elasticsearch.ssl.verificationMode=none \
  --xpack.cloud.serverless.project_id=fedcba65432109876543210987654321 \
  --xpack.cloud.id=local-dev:ZG9ja2VyLmludGVybmFsOjkyMzAkaG9zdDo5MjMwJGtpYmFuYTo5MjMw \
  --cps.cpsEnabled=true \
  --xpack.alerting.rules.apiKeyType=uiam
```

3. Navigate to `localhost:5621` and install the `kibana_sample_data_ecommerce` data.
4. Navigate to `localhost:5620` project and navigate to Data views. Create a data view that matches the `kibana_sample_data_ecommerce` index. Let's call it `ecommerce`.
5. Still in `localhost:5620`, navigate to Transforms and start creating a transform. Click the "Use full data" button. Verify there is no error toast and the full data range is displayed. Verify creation of the transforms is successful.
6. For ML Anomaly jobs, navigate to the job creation page, select the ecommerce data view and single metric job type, then click the "Use full data" button. Verify that no error toast is displayed.
7. For Data Visualizer, navigate to `/app/ml/jobs/new_job/datavisualizer`, select the ecommerce data view, then click the "Use full data" button. Verify that no error toast is displayed.
8. For Data Drift, navigate to the Data Drift page, select the ecommerce data view, then click the "Use full data" button. Verify that no error toast is displayed.
9. For the AIOps pages, navigate to Log rate analysis (`/app/ml/aiops/log_rate_analysis`), Log pattern analysis (`/app/ml/aiops/log_categorization`), and Change point detection (`/app/ml/aiops/change_point_detection`), select the ecommerce data view on each page, then click the "Use full data" button. Verify that no error toast is displayed.

https://github.com/user-attachments/assets/2ed84746-bf3b-44e8-af6e-5c8b5a9598fa

https://github.com/user-attachments/assets/4c877b49-6f2e-40a4-8392-5d0048137367