### PR TITLE
[8.19] [Uptime] Format certificate dates with Kibana/browser locale (#284348)

### DIFF
--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/certificates/certificates_list.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/certificates/certificates_list.tsx
@@ -14,6 +14,7 @@ import * as labels from './translations';
 import { Cert, CertMonitor, CertResult } from '../../../../common/runtime_types';
 import { FingerprintCol } from './fingerprint_col';
 import { LOADING_CERTIFICATES, NO_CERTS_AVAILABLE } from './translations';
+import { useDateFormat } from '../../hooks';
 
 interface Page {
   index: number;
@@ -46,6 +47,8 @@ interface Props {
 }
 
 export const CertificateList: React.FC<Props> = ({ page, certificates, sort, onChange }) => {
+  const dateFormatter = useDateFormat();
+
   const onTableChange = (newVal: Partial<Props>) => {
     onChange(newVal.page as Page, newVal.sort as CertSort);
   };
@@ -84,7 +87,7 @@ export const CertificateList: React.FC<Props> = ({ page, certificates, sort, onC
       name: labels.VALID_UNTIL_COL,
       field: 'not_after',
       sortable: true,
-      render: (value: string) => moment(value).format('L LT'),
+      render: dateFormatter,
     },
     {
       name: labels.AGE_COL,

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/columns/cert_status_column.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/overview/monitor_list/columns/cert_status_column.tsx
@@ -9,8 +9,8 @@ import React from 'react';
 import moment from 'moment';
 import styled from 'styled-components';
 import { EuiIcon, EuiText, EuiToolTip } from '@elastic/eui';
-import { X509Expiry } from '../../../../../../common/runtime_types';
-import { useCertStatus } from '../../../../hooks';
+import type { X509Expiry } from '../../../../../../common/runtime_types';
+import { useCertStatus, useDateFormat } from '../../../../hooks';
 import { EXPIRED, EXPIRES, EXPIRES_SOON } from '../../../certificates/translations';
 import { CERT_STATUS } from '../../../../../../common/constants';
 
@@ -35,12 +35,13 @@ const H4Text = styled.h4`
 export const CertStatusColumn: React.FC<Props> = ({ expiry, boldStyle = false }) => {
   const notAfter = expiry?.not_after;
   const certStatus = useCertStatus(notAfter);
+  const dateFormatter = useDateFormat();
 
   const relativeDate = moment(notAfter).fromNow();
 
   const CertStatus = ({ color, text }: { color: string; text: string }) => {
     return (
-      <EuiToolTip content={moment(notAfter).format('L LT')}>
+      <EuiToolTip content={dateFormatter(notAfter)}>
         <EuiText size="s">
           <EuiIcon color={color} type="lock" size="s" />
           {boldStyle ? (

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/hooks/index.ts
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/hooks/index.ts
@@ -10,5 +10,6 @@ export * from './use_update_kuery_string';
 export * from './use_monitor';
 export * from './use_search_text';
 export * from './use_cert_status';
+export * from './use_date_format';
 export * from './use_url_params';
 export { useUptimeDataView } from '../contexts/uptime_data_view_context';

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/hooks/use_date_format.test.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/hooks/use_date_format.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { i18n } from '@kbn/i18n';
+
+jest.mock('@kbn/i18n', () => ({
+  i18n: {
+    getLocale: jest.fn().mockReturnValue(undefined),
+  },
+}));
+
+import { useDateFormat } from './use_date_format';
+
+describe('useDateFormat', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  Object.defineProperty(global.navigator, 'language', {
+    value: 'en-US',
+    writable: true,
+  });
+
+  it('returns a formatter function that makes a date into the expected output', () => {
+    const response = renderHook(() => useDateFormat());
+    expect(response.result.current('2023-02-01 13:00:00')).toEqual('Feb 1, 2023 @ 1:00:00 PM');
+  });
+
+  it('adjusts formatter based on locale', () => {
+    Object.defineProperty(global.navigator, 'language', {
+      value: 'en-GB',
+      writable: true,
+    });
+    const response = renderHook(() => useDateFormat());
+    expect(response.result.current('2023-02-01 13:00:00')).toEqual('1 Feb 2023 @ 13:00:00');
+  });
+
+  it('prefers Kibana locale if set', () => {
+    jest.spyOn(i18n, 'getLocale').mockReturnValue('fr-FR');
+
+    Object.defineProperty(global.navigator, 'language', {
+      value: 'en-GB',
+      writable: true,
+    });
+    const response = renderHook(() => useDateFormat());
+    expect(response.result.current('2023-02-01 13:00:00')).toEqual('1 févr. 2023 @ 13:00:00');
+  });
+});

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/hooks/use_date_format.ts
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/hooks/use_date_format.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+import { i18n } from '@kbn/i18n';
+
+export type DateFormatter = (timestamp?: string) => string;
+
+/**
+ * Formats timestamps using the Kibana locale when set, otherwise the browser
+ * locale, instead of Moment's default US `L` (MM/DD/YYYY) format.
+ */
+export function useDateFormat(): DateFormatter {
+  const preferredLocale = i18n.getLocale() ?? navigator.language;
+
+  return (timestamp?: string) => {
+    if (!timestamp) return '';
+    const date = moment(timestamp).locale(preferredLocale);
+    return `${date.format('ll')} @ ${date.format('LTS')}`;
+  };
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Uptime] Format certificate dates with Kibana/browser locale (#284348)](https://github.com/elastic/kibana/pull/284348)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Anna Davydova","email":"ana.davydova@elastic.co"},"sourceCommit":{"committedDate":"2026-08-21T12:32:33Z","message":"[Uptime] Format certificate dates with Kibana/browser locale (#284348)\n\n## Summary\n- Fixes Uptime Certificates “Valid until” dates rendering as US\n`MM/DD/YYYY` via Moment’s default `L` format, ignoring locale.\n- Adds a small `useDateFormat` hook (Kibana locale → else browser\nlocale; `ll @ LTS`) and uses it on the Certificates table and\ncert-status tooltips.\n- Aligns Uptime with the Synthetics Certificates date formatting\napproach.\n\nCloses #252617\n\n## Test plan\n- [x] Unit: `use_date_format.test.tsx` (en-US / en-GB / Kibana fr-FR)\n- [x] Unit: `certificates_list.test.tsx`\n- [x] Optional: Observability → Uptime → Certificates with a non-US\nKibana language; confirm Valid until is locale-aware (not `MM/DD/YYYY`)\n\nMade with [Cursor](https://cursor.com)\n\n**Before**\n<img width=\"1264\" height=\"573\" alt=\"certificates_before\"\nsrc=\"https://github.com/user-attachments/assets/57aa1bb7-b1aa-4f9c-bbd5-4739165d3480\"\n/>\n\n**After**\n<img width=\"1263\" height=\"570\" alt=\"certificates_after\"\nsrc=\"https://github.com/user-attachments/assets/22a6505a-71ec-4fb8-87b3-2519ee44ebc6\"\n/>\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"a001da2109394ca735d4fa572218c55846758562","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","Team:actionable-obs","author:actionable-obs","bug-fixer","v9.6.0"],"title":"[Uptime] Format certificate dates with Kibana/browser locale","number":284348,"url":"https://github.com/elastic/kibana/pull/284348","mergeCommit":{"message":"[Uptime] Format certificate dates with Kibana/browser locale (#284348)\n\n## Summary\n- Fixes Uptime Certificates “Valid until” dates rendering as US\n`MM/DD/YYYY` via Moment’s default `L` format, ignoring locale.\n- Adds a small `useDateFormat` hook (Kibana locale → else browser\nlocale; `ll @ LTS`) and uses it on the Certificates table and\ncert-status tooltips.\n- Aligns Uptime with the Synthetics Certificates date formatting\napproach.\n\nCloses #252617\n\n## Test plan\n- [x] Unit: `use_date_format.test.tsx` (en-US / en-GB / Kibana fr-FR)\n- [x] Unit: `certificates_list.test.tsx`\n- [x] Optional: Observability → Uptime → Certificates with a non-US\nKibana language; confirm Valid until is locale-aware (not `MM/DD/YYYY`)\n\nMade with [Cursor](https://cursor.com)\n\n**Before**\n<img width=\"1264\" height=\"573\" alt=\"certificates_before\"\nsrc=\"https://github.com/user-attachments/assets/57aa1bb7-b1aa-4f9c-bbd5-4739165d3480\"\n/>\n\n**After**\n<img width=\"1263\" height=\"570\" alt=\"certificates_after\"\nsrc=\"https://github.com/user-attachments/assets/22a6505a-71ec-4fb8-87b3-2519ee44ebc6\"\n/>\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"a001da2109394ca735d4fa572218c55846758562"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/284348","number":284348,"mergeCommit":{"message":"[Uptime] Format certificate dates with Kibana/browser locale (#284348)\n\n## Summary\n- Fixes Uptime Certificates “Valid until” dates rendering as US\n`MM/DD/YYYY` via Moment’s default `L` format, ignoring locale.\n- Adds a small `useDateFormat` hook (Kibana locale → else browser\nlocale; `ll @ LTS`) and uses it on the Certificates table and\ncert-status tooltips.\n- Aligns Uptime with the Synthetics Certificates date formatting\napproach.\n\nCloses #252617\n\n## Test plan\n- [x] Unit: `use_date_format.test.tsx` (en-US / en-GB / Kibana fr-FR)\n- [x] Unit: `certificates_list.test.tsx`\n- [x] Optional: Observability → Uptime → Certificates with a non-US\nKibana language; confirm Valid until is locale-aware (not `MM/DD/YYYY`)\n\nMade with [Cursor](https://cursor.com)\n\n**Before**\n<img width=\"1264\" height=\"573\" alt=\"certificates_before\"\nsrc=\"https://github.com/user-attachments/assets/57aa1bb7-b1aa-4f9c-bbd5-4739165d3480\"\n/>\n\n**After**\n<img width=\"1263\" height=\"570\" alt=\"certificates_after\"\nsrc=\"https://github.com/user-attachments/assets/22a6505a-71ec-4fb8-87b3-2519ee44ebc6\"\n/>\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"a001da2109394ca735d4fa572218c55846758562"}},{"url":"https://github.com/elastic/kibana/pull/286529","number":286529,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/286530","number":286530,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->