### PR TITLE
[Observability Onboarding] Cap Add Data search results at two rows

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/add_data_grid/search_results/search_results.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/add_data_grid/search_results/search_results.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { renderWithI18n } from '@kbn/test-jest-helpers';
+import { I18nProvider } from '@kbn/i18n-react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -31,15 +32,14 @@ describe('AddDataSearchResults', () => {
     renderWithI18n(
       <AddDataSearchResults
         searchTerm="redis"
-        items={makeItems(8)}
+        items={makeItems(5)}
         isLoading={false}
         renderCard={renderCard}
       />
     );
     const count = screen.getByTestId('addDataSearchResultsCount');
-    expect(count).toHaveTextContent('Showing 8 integrations');
-    // Design: "Showing" stays regular weight, only the count and noun are bold.
-    expect(count.querySelector('strong')).toHaveTextContent('8 integrations');
+    expect(count).toHaveTextContent('Showing 5 integrations');
+    expect(count.querySelector('strong')).toHaveTextContent('5 integrations');
     expect(count.querySelector('strong')).not.toHaveTextContent('Showing');
   });
 
@@ -47,7 +47,7 @@ describe('AddDataSearchResults', () => {
     renderWithI18n(
       <AddDataSearchResults
         searchTerm="redis"
-        items={makeItems(8)}
+        items={makeItems(5)}
         isLoading={false}
         renderCard={renderCard}
       />
@@ -63,12 +63,12 @@ describe('AddDataSearchResults', () => {
     renderWithI18n(
       <AddDataSearchResults
         searchTerm="redis"
-        items={makeItems(8)}
+        items={makeItems(5)}
         isLoading={false}
         renderCard={renderCard}
       />
     );
-    expect(liveRegionTexts()).toContain('Showing 8 integrations');
+    expect(liveRegionTexts()).toContain('Showing 5 integrations');
   });
 
   it('announces the empty state in a live region', () => {
@@ -83,17 +83,178 @@ describe('AddDataSearchResults', () => {
     expect(liveRegionTexts()).toContain('No results for zzz-no-match');
   });
 
-  it('renders every item with no pagination control', () => {
+  it('caps visible results at two rows and paginates the rest', () => {
     renderWithI18n(
       <AddDataSearchResults
-        searchTerm="redis"
+        searchTerm="aws"
         items={makeItems(30)}
         isLoading={false}
         renderCard={renderCard}
       />
     );
-    expect(screen.getAllByTestId(/^card-item-/)).toHaveLength(30);
-    expect(screen.queryByTestId('addDataSearchResultsShowMore')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId(/^card-item-/)).toHaveLength(6);
+    expect(screen.getByTestId('card-item-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-item-6')).not.toBeInTheDocument();
+    expect(screen.getByTestId('addDataSearchResultsPagination')).toBeInTheDocument();
+  });
+
+  it('reports the visible range and the total when results exceed two rows', () => {
+    renderWithI18n(
+      <AddDataSearchResults
+        searchTerm="aws"
+        items={makeItems(8)}
+        isLoading={false}
+        renderCard={renderCard}
+      />
+    );
+    const count = screen.getByTestId('addDataSearchResultsCount');
+    expect(count).toHaveTextContent('Showing 1-6 of 8 integrations');
+    expect(count.querySelector('strong')).toHaveTextContent('1-6 of 8 integrations');
+    expect(count.querySelector('strong')).not.toHaveTextContent('Showing');
+    expect(liveRegionTexts()).toContain('Showing 1-6 of 8 integrations');
+  });
+
+  it('shows the next slice when the second page is selected', async () => {
+    const user = userEvent.setup();
+    renderWithI18n(
+      <AddDataSearchResults
+        searchTerm="aws"
+        items={makeItems(8)}
+        isLoading={false}
+        renderCard={renderCard}
+      />
+    );
+    await user.click(screen.getByTestId('pagination-button-1'));
+    expect(screen.getAllByTestId(/^card-item-/)).toHaveLength(2);
+    expect(screen.getByTestId('card-item-6')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-item-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('addDataSearchResultsCount')).toHaveTextContent(
+      'Showing 7-8 of 8 integrations'
+    );
+  });
+
+  it('does not write to the url when the page changes', async () => {
+    const user = userEvent.setup();
+    const hrefBefore = window.location.href;
+    renderWithI18n(
+      <AddDataSearchResults
+        searchTerm="aws"
+        items={makeItems(8)}
+        isLoading={false}
+        renderCard={renderCard}
+      />
+    );
+    await user.click(screen.getByTestId('pagination-button-1'));
+    expect(window.location.href).toBe(hrefBefore);
+  });
+
+  it('hides pagination when the match count fits in two rows', () => {
+    renderWithI18n(
+      <AddDataSearchResults
+        searchTerm="redis"
+        items={makeItems(6)}
+        isLoading={false}
+        renderCard={renderCard}
+      />
+    );
+    expect(screen.getAllByTestId(/^card-item-/)).toHaveLength(6);
+    expect(screen.queryByTestId('addDataSearchResultsPagination')).not.toBeInTheDocument();
+    expect(screen.getByTestId('addDataSearchResultsCount')).toHaveTextContent(
+      'Showing 6 integrations'
+    );
+  });
+
+  it('returns to the first page when the search term changes', async () => {
+    const user = userEvent.setup();
+    const view = renderWithI18n(
+      <AddDataSearchResults
+        searchTerm="aws"
+        items={makeItems(12)}
+        isLoading={false}
+        renderCard={renderCard}
+      />
+    );
+    await user.click(screen.getByTestId('pagination-button-1'));
+    expect(screen.getByTestId('card-item-6')).toBeInTheDocument();
+
+    view.rerender(
+      <I18nProvider>
+        <AddDataSearchResults
+          searchTerm="azure"
+          items={makeItems(12, 'azure')}
+          isLoading={false}
+          renderCard={renderCard}
+        />
+      </I18nProvider>
+    );
+
+    expect(screen.getByTestId('card-azure-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-azure-6')).not.toBeInTheDocument();
+    expect(screen.getByTestId('addDataSearchResultsCount')).toHaveTextContent(
+      'Showing 1-6 of 12 integrations'
+    );
+  });
+
+  it('returns to the first page when a new term has fewer pages', async () => {
+    const user = userEvent.setup();
+    const view = renderWithI18n(
+      <AddDataSearchResults
+        searchTerm="aws"
+        items={makeItems(30)}
+        isLoading={false}
+        renderCard={renderCard}
+      />
+    );
+    await user.click(screen.getByTestId('pagination-button-2'));
+
+    view.rerender(
+      <I18nProvider>
+        <AddDataSearchResults
+          searchTerm="azure"
+          items={makeItems(8, 'azure')}
+          isLoading={false}
+          renderCard={renderCard}
+        />
+      </I18nProvider>
+    );
+
+    expect(screen.getByTestId('card-azure-0')).toBeInTheDocument();
+    expect(screen.getByTestId('addDataSearchResultsCount')).toHaveTextContent(
+      'Showing 1-6 of 8 integrations'
+    );
+  });
+
+  it('clamps to the last page when the list shrinks under the same term', async () => {
+    const user = userEvent.setup();
+    const view = renderWithI18n(
+      <AddDataSearchResults
+        searchTerm="aws"
+        items={makeItems(8)}
+        isLoading={false}
+        renderCard={renderCard}
+      />
+    );
+    await user.click(screen.getByTestId('pagination-button-1'));
+    expect(screen.getByTestId('card-item-6')).toBeInTheDocument();
+
+    view.rerender(
+      <I18nProvider>
+        <AddDataSearchResults
+          searchTerm="aws"
+          items={makeItems(3)}
+          isLoading={false}
+          renderCard={renderCard}
+        />
+      </I18nProvider>
+    );
+
+    expect(screen.getAllByTestId(/^card-item-/)).toHaveLength(3);
+    expect(screen.getByTestId('card-item-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-item-6')).not.toBeInTheDocument();
+    expect(screen.getByTestId('addDataSearchResultsCount')).toHaveTextContent(
+      'Showing 3 integrations'
+    );
+    expect(screen.queryByTestId('addDataSearchResultsPagination')).not.toBeInTheDocument();
   });
 
   it('renders a loading skeleton', () => {
@@ -135,5 +296,7 @@ describe('AddDataSearchResults', () => {
       />
     );
     expect(screen.getByTestId('addDataSearchResultsEmpty')).toHaveTextContent('zzz-no-match');
+    expect(screen.queryByTestId('addDataSearchResultsPagination')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('addDataSearchResultsCount')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/add_data_grid/search_results/search_results.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/add_data_grid/search_results/search_results.tsx
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiButton,
   EuiCallOut,
   EuiEmptyPrompt,
   EuiFlexGrid,
+  EuiFlexGroup,
   EuiFlexItem,
+  EuiPagination,
   EuiScreenReaderLive,
   EuiSkeletonText,
   EuiSpacer,
@@ -22,6 +24,8 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 const COLUMNS = 3;
+const VISIBLE_ROWS = 2;
+const PAGE_SIZE = COLUMNS * VISIBLE_ROWS;
 
 export interface AddDataSearchResultsProps<TItem extends { id: string }> {
   searchTerm: string;
@@ -41,6 +45,14 @@ export function AddDataSearchResults<TItem extends { id: string }>({
   renderCard,
 }: AddDataSearchResultsProps<TItem>) {
   const countId = useGeneratedHtmlId({ prefix: 'addDataSearchResultsCount' });
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pagedTerm, setPagedTerm] = useState(searchTerm);
+  const isNewTerm = pagedTerm !== searchTerm;
+  // Reset during render (not an effect) so the stale page never paints for the new term.
+  if (isNewTerm) {
+    setPagedTerm(searchTerm);
+    setPageIndex(0);
+  }
 
   if (isError) {
     return (
@@ -83,11 +95,37 @@ export function AddDataSearchResults<TItem extends { id: string }>({
   }
 
   const isEmpty = items.length === 0;
+  const pageCount = Math.ceil(items.length / PAGE_SIZE);
+  const lastPageIndex = Math.max(pageCount - 1, 0);
+  // Clamp from the reset value, not the stale `pageIndex`: both writes land on this
+  // same render pass and React applies them in order, so starting from `pageIndex`
+  // here would let the shrink clamp overwrite the term-change reset above.
+  const requestedPageIndex = isNewTerm ? 0 : pageIndex;
+  const safePageIndex = Math.min(requestedPageIndex, lastPageIndex);
+  if (pageIndex !== safePageIndex) {
+    setPageIndex(safePageIndex);
+  }
+  const visibleItems = items.slice(safePageIndex * PAGE_SIZE, (safePageIndex + 1) * PAGE_SIZE);
+  const from = safePageIndex * PAGE_SIZE + 1;
+  const to = safePageIndex * PAGE_SIZE + visibleItems.length;
+  const isPaginated = items.length > PAGE_SIZE;
+
   const emptyLabel = i18n.translate(
     'xpack.observability_onboarding.addDataGrid.searchResults.emptyTitle',
     { defaultMessage: 'No results for {searchTerm}', values: { searchTerm } }
   );
-  const countContent = (
+  const countContent = isPaginated ? (
+    <FormattedMessage
+      id="xpack.observability_onboarding.addDataGrid.searchResults.countHeaderPaginated"
+      defaultMessage="Showing <strong>{from}-{to} of {total, plural, one {# integration} other {# integrations}}</strong>"
+      values={{
+        from,
+        to,
+        total: items.length,
+        strong: (chunks: React.ReactNode) => <strong>{chunks}</strong>,
+      }}
+    />
+  ) : (
     <FormattedMessage
       id="xpack.observability_onboarding.addDataGrid.searchResults.countHeader"
       defaultMessage="Showing <strong>{count, plural, one {# integration} other {# integrations}}</strong>"
@@ -116,10 +154,29 @@ export function AddDataSearchResults<TItem extends { id: string }>({
           </EuiText>
           <EuiSpacer size="m" />
           <EuiFlexGrid columns={COLUMNS} gutterSize="m">
-            {items.map((item) => (
+            {visibleItems.map((item) => (
               <EuiFlexItem key={item.id}>{renderCard(item)}</EuiFlexItem>
             ))}
           </EuiFlexGrid>
+          {isPaginated && (
+            <>
+              <EuiSpacer size="m" />
+              <EuiFlexGroup justifyContent="center">
+                <EuiFlexItem grow={false}>
+                  <EuiPagination
+                    aria-label={i18n.translate(
+                      'xpack.observability_onboarding.addDataGrid.searchResults.paginationAriaLabel',
+                      { defaultMessage: 'Search results pages' }
+                    )}
+                    pageCount={pageCount}
+                    activePage={safePageIndex}
+                    onPageClick={setPageIndex}
+                    data-test-subj="addDataSearchResultsPagination"
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </>
+          )}
         </section>
       )}
     </>


### PR DESCRIPTION
Closes: elastic/ingest-dev#9223

## Summary

Add Data search rendered every match in a three column `EuiFlexGrid`. Broad terms such as `aws` dumped dozens of tiles and pushed the curated grid below the fold.

`AddDataSearchResults` now caps the grid at 6 tiles (two rows of three) and paginates the rest with `EuiPagination`. Page index is local React state. Paging does not write to the URL, so `?search=` and `?collection=` are unchanged. A new search term returns to page 1. If Fleet's card list shrinks under the same term, the grid clamps to the last remaining page.

Paginated results use a range header ("Showing 1-6 of 24 integrations"). Six or fewer matches keep today's count copy and hide the pager. Loading, error, and empty states are the same as today.

## Test plan

Enable `observability.addDataPageV2Enabled` and open Observability Add Data.

1. Search `aws`. You should see 6 tiles, a range header, and page numbers. The curated grid should still be on screen.
2. Open page 2. The header should show the next slice. `search` (and `collection`, if a chooser is open) should still be the only query params.
3. Type a different term. Results should start on page 1.
4. Search a term with 6 or fewer matches. All tiles render, no pager, header stays "Showing N integrations".
5. Search a term with no matches. Empty prompt, no pager.
6. Shrink the window to phone width. The pager should collapse to EUI's compressed "1 of N" form. Six stacked cards is expected on a phone.

## Demo


https://github.com/user-attachments/assets/6685d8b9-50ea-48c1-8f36-f0411ea9e10c





## Release note

Caps Observability Add Data search results at two rows and paginates the rest so the curated integrations stay reachable under broad search terms.
