### PR TITLE
[UIAM OAuth] Support multiple remote redirect URIs

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/mcp_client_form.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/mcp_client_form.test.tsx
@@ -8,6 +8,7 @@
 import '@testing-library/jest-dom';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { FormProvider } from 'react-hook-form';
 import { McpClientForm } from './mcp_client_form';
@@ -52,4 +53,19 @@ describe('McpClientForm', () => {
       expect(screen.getByTestId('mcpClientRedirectTypeRadio')).toBeInTheDocument();
     }
   );
+
+  it('supports adding and removing remote redirect URLs', async () => {
+    const user = userEvent.setup();
+    render(<TestForm mode={McpClientFormMode.CREATE} />);
+
+    await user.click(screen.getByRole('radio', { name: /Remote/ }));
+    expect(screen.getByTestId('mcpClientRemoteUri-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('mcpClientRemoteUri-1')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('mcpClientAddUri'));
+    expect(screen.getByTestId('mcpClientRemoteUri-1')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('mcpClientRemoveUri-1'));
+    expect(screen.queryByTestId('mcpClientRemoteUri-1')).not.toBeInTheDocument();
+  });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/mcp_client_transform.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/mcp_client_transform.test.ts
@@ -337,8 +337,35 @@ describe('deriveRedirectConfig', () => {
     });
   });
 
-  it('treats multiple URIs as local, the only variant that accepts more than one', () => {
+  it('treats multiple non-loopback HTTPS URIs as remote', () => {
     const uris = ['https://example.com/callback', 'https://other.example.com/callback'];
+
+    expect(deriveRedirectConfig(uris)).toEqual({
+      type: RedirectUriType.REMOTE,
+      uris: uris.map((value) => ({ value })),
+    });
+  });
+
+  it('treats a mixed HTTP and HTTPS set as local', () => {
+    const uris = ['https://example.com/callback', 'http://example.com/callback'];
+
+    expect(deriveRedirectConfig(uris)).toEqual({
+      type: RedirectUriType.LOCAL,
+      uris: uris.map((value) => ({ value })),
+    });
+  });
+
+  it('treats a set of loopback HTTPS URIs as local', () => {
+    const uris = ['https://localhost:3000/callback', 'https://127.0.0.1:3000/callback'];
+
+    expect(deriveRedirectConfig(uris)).toEqual({
+      type: RedirectUriType.LOCAL,
+      uris: uris.map((value) => ({ value })),
+    });
+  });
+
+  it('treats a set with a single loopback HTTPS URI as local', () => {
+    const uris = ['https://example.com/callback', 'https://localhost:3000/callback'];
 
     expect(deriveRedirectConfig(uris)).toEqual({
       type: RedirectUriType.LOCAL,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/mcp_client_transform.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/mcp_client_transform.ts
@@ -99,7 +99,7 @@ export const deriveRedirectConfig = (redirectUris?: string[]): RedirectUriConfig
     return { type: RedirectUriType.LOCAL, uris: [{ value: '' }] };
   }
 
-  const isRemote = uris.length === 1 && uris[0].startsWith('https://') && !isLoopbackUri(uris[0]);
+  const isRemote = uris.every((uri) => uri.startsWith('https://') && !isLoopbackUri(uri));
 
   return {
     type: isRemote ? RedirectUriType.REMOTE : RedirectUriType.LOCAL,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/sections/redirect_uri_section.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/sections/redirect_uri_section.tsx
@@ -48,6 +48,7 @@ const REDIRECT_TYPE_CONFIG: Record<
     description: string;
     urlsLabel: string;
     helpText: string;
+    helpTextPlacement: 'above' | 'below';
     addButtonLabel: string;
     placeholder?: string;
     testSubjPrefix: string;
@@ -58,6 +59,7 @@ const REDIRECT_TYPE_CONFIG: Record<
     description: labels.tools.mcpClients.form.redirectLocalDescription,
     urlsLabel: labels.tools.mcpClients.form.localUrlsLabel,
     helpText: labels.tools.mcpClients.form.localUrlsHelpText,
+    helpTextPlacement: 'above',
     addButtonLabel: labels.tools.mcpClients.form.addLocalUrl,
     placeholder: 'http://localhost/callback',
     testSubjPrefix: 'mcpClientLocalUri',
@@ -67,6 +69,7 @@ const REDIRECT_TYPE_CONFIG: Record<
     description: labels.tools.mcpClients.form.redirectRemoteDescription,
     urlsLabel: labels.tools.mcpClients.form.remoteUrlsLabel,
     helpText: labels.tools.mcpClients.form.remoteUrlsHelpText,
+    helpTextPlacement: 'below',
     addButtonLabel: labels.tools.mcpClients.form.addRemoteUrl,
     placeholder: 'https://your-domain.com/callback',
     testSubjPrefix: 'mcpClientRemoteUri',
@@ -107,17 +110,12 @@ export const RedirectUriSection = () => {
       onTypeChange(id);
 
       const restored = redirectUrisByTypeRef.current[id];
-      if (id === RedirectUriType.REMOTE) {
-        replace(restored[0] ? [restored[0]] : [{ value: '' }]);
-      } else {
-        replace(restored.length > 0 ? restored : [{ value: '' }]);
-      }
+      replace(restored.length > 0 ? restored : [{ value: '' }]);
     },
     [getValues, replace]
   );
 
-  const isRemote = redirectUriType === RedirectUriType.REMOTE;
-  const { urlsLabel, helpText, addButtonLabel, placeholder, testSubjPrefix } =
+  const { urlsLabel, helpText, helpTextPlacement, addButtonLabel, placeholder, testSubjPrefix } =
     REDIRECT_TYPE_CONFIG[redirectUriType];
 
   return (
@@ -157,7 +155,7 @@ export const RedirectUriSection = () => {
       </EuiFormRow>
       <EuiSpacer size="m" />
       <EuiFormFieldset legend={{ children: urlsLabel }}>
-        {!isRemote && (
+        {helpTextPlacement === 'above' && (
           <>
             <EuiText size="xs" color="subdued">
               {helpText}
@@ -179,7 +177,7 @@ export const RedirectUriSection = () => {
                   placeholder={placeholder}
                   data-test-subj={`${testSubjPrefix}-${index}`}
                   append={
-                    !isRemote && fields.length > 1 ? (
+                    fields.length > 1 ? (
                       <EuiToolTip
                         content={labels.tools.mcpClients.form.removeUriAriaLabel}
                         disableScreenReaderOutput
@@ -199,7 +197,7 @@ export const RedirectUriSection = () => {
             )}
           />
         ))}
-        {isRemote && (
+        {helpTextPlacement === 'below' && (
           <>
             <EuiSpacer size="xs" />
             <EuiText size="xs" color="subdued">
@@ -208,19 +206,15 @@ export const RedirectUriSection = () => {
           </>
         )}
       </EuiFormFieldset>
-      {!isRemote && (
-        <>
-          <EuiSpacer size="m" />
-          <EuiButtonEmpty
-            size="s"
-            iconType="plusCircle"
-            onClick={handleAddUri}
-            data-test-subj="mcpClientAddUri"
-          >
-            {addButtonLabel}
-          </EuiButtonEmpty>
-        </>
-      )}
+      <EuiSpacer size="m" />
+      <EuiButtonEmpty
+        size="s"
+        iconType="plusCircle"
+        onClick={handleAddUri}
+        data-test-subj="mcpClientAddUri"
+      >
+        {addButtonLabel}
+      </EuiButtonEmpty>
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/use_mcp_client_form.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/mcp_clients/form/use_mcp_client_form.ts
@@ -65,22 +65,22 @@ const remoteRedirectUriSchema = z.object({
     }),
 });
 
+const redirectUrisSchema = <TUri extends z.ZodType>(uriSchema: TUri) =>
+  z
+    .array(uriSchema)
+    .min(1, mcpClientI18nMessages.redirectUri.requiredError)
+    .max(OAUTH_REDIRECT_URIS_MAX_SIZE, {
+      error: mcpClientI18nMessages.redirectUri.tooManyError(OAUTH_REDIRECT_URIS_MAX_SIZE),
+    });
+
 const redirectSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(RedirectUriType.LOCAL),
-    uris: z
-      .array(localRedirectUriSchema)
-      .min(1, mcpClientI18nMessages.redirectUri.requiredError)
-      .max(OAUTH_REDIRECT_URIS_MAX_SIZE, {
-        error: mcpClientI18nMessages.redirectUri.tooManyError(OAUTH_REDIRECT_URIS_MAX_SIZE),
-      }),
+    uris: redirectUrisSchema(localRedirectUriSchema),
   }),
   z.object({
     type: z.literal(RedirectUriType.REMOTE),
-    uris: z
-      .array(remoteRedirectUriSchema)
-      .min(1, mcpClientI18nMessages.redirectUri.requiredError)
-      .max(1),
+    uris: redirectUrisSchema(remoteRedirectUriSchema),
   }),
 ]);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
@@ -760,7 +760,7 @@ export const labels = {
           defaultMessage: 'For common local agent (Claude Desktop, Cursor etc) you can use:',
         }),
         remoteUrlsLabel: i18n.translate('xpack.agentBuilder.mcpClients.form.remoteUrlsLabel', {
-          defaultMessage: 'Remote URL',
+          defaultMessage: 'Remote URLs',
         }),
         remoteUrlsHelpText: i18n.translate(
           'xpack.agentBuilder.mcpClients.form.remoteUrlsHelpText',

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/mcp_clients.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/ui/tests/mcp_clients.spec.ts
@@ -200,16 +200,17 @@ test.describe.skip(
       await pageObjects.agentBuilder.closeMcpClientDetails();
     });
 
-    test('prefills the remote redirect type from a stored HTTPS URI', async ({
+    test('prefills the remote redirect type from stored HTTPS URIs', async ({
       apiClient,
       page,
       pageObjects,
     }) => {
       const clientName = uniqueClientName('scout-edit-remote');
+      const redirectUris = ['https://example.com/callback', 'https://other.example.com/callback'];
       const client = await createOAuthClient(apiClient, authHeaders, {
         clientName,
         clientType: 'confidential',
-        redirectUris: ['https://example.com/callback'],
+        redirectUris,
       });
       createdClientIds.push(client.id);
 
@@ -218,10 +219,9 @@ test.describe.skip(
       await pageObjects.agentBuilder.waitForMcpClientRow(client.id);
       await pageObjects.agentBuilder.openMcpClientEdit(client.id);
 
-      await expect(page.testSubj.locator('mcpClientRemoteUri-0')).toHaveValue(
-        'https://example.com/callback'
-      );
-      await expect(page.testSubj.locator('mcpClientRemoteUri-1')).toHaveCount(0);
+      await expect(page.testSubj.locator('mcpClientRemoteUri-0')).toHaveValue(redirectUris[0]);
+      await expect(page.testSubj.locator('mcpClientRemoteUri-1')).toHaveValue(redirectUris[1]);
+      await expect(page.testSubj.locator('mcpClientRemoteUri-2')).toHaveCount(0);
     });
 
     test('does not offer edit for a revoked client', async ({ apiClient, page, pageObjects }) => {


### PR DESCRIPTION
## Summary

Lifts the single-URL restriction on the remote redirect type when registering an MCP client, so a client can now be registered with multiple remote callback URLs.

### Demo
<img width="1477" height="1115" alt="Screenshot 2026-08-21 at 10 16 19" src="https://github.com/user-attachments/assets/a77e28d7-8405-44dc-80f4-07c85fbc310f" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI&#39;s writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

