### PR TITLE
[Discover][Metrics] Fix flaky share_session scout step

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/metrics_experience/ui/parallel_tests/share_session.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/metrics_experience/ui/parallel_tests/share_session.spec.ts
@@ -91,8 +91,7 @@ spaceTest.describe(
         });
 
         await spaceTest.step('ES|QL query should be preserved', async () => {
-          const queryAfter = await discover.getEsqlQueryValue();
-          expect(queryAfter).toStrictEqual(queryBefore);
+          await expect.poll(() => discover.getEsqlQueryValue()).toBe(queryBefore);
         });
       }
     );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/278338

The `should preserve metrics view state through a shared URL` test was failing intermittently in MKI `security_complete` with:

```
Expected: "TS test-metrics-experience"
Received: ""
```

Root cause:

- After `page.goto(sharedUrl)`, `waitUntilSearchingHasFinished()` resolves when the search request completes
- Monaco model hydration is a separate async step, not tied to search completion
- In MKI (slower than local), `getEsqlQueryValue()` can fire before URL state is applied to the Monaco model, catching a transient `""`
- The screenshot in the CI report confirmed this: the correct query was already visible in the editor milliseconds after the assertion failed

<img width="1280" height="720" alt="download (8)" src="https://github.com/user-attachments/assets/90db4dee-385d-4152-bd51-d1d603f76317" />

Why only this call site:

- Every other `getEsqlQueryValue()` call reads after `waitUntilTabIsLoaded()` or a user interaction, which have different synchronization guarantees
- The timing gap is specific to post-`page.goto()` reads

Fix: replace the bare `await` with `expect.poll`, the established Scout pattern for eventually-consistent value reads after navigation, already widely used across Discover scout tests.

### How to test

Run the test locally against a security_complete serverless environment to confirm it passes:

Terminal 1 (server):
```bash
node scripts/scout.js start-server --arch serverless --domain security_complete
```

Terminal 2 (runner):
```bash
node scripts/playwright.js test \
  src/platform/plugins/shared/discover/test/scout/metrics_experience/ui/parallel_tests/share_session.spec.ts \
  --config src/platform/plugins/shared/discover/test/scout/metrics_experience/ui/parallel.playwright.config.ts \
  --project local --headed --trace on
```

The fix can also be verified by checking that the next MKI CI run for `security_complete` passes without the `""` vs `"TS test-metrics-experience"` assertion error.


<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->