### PR TITLE
[Agent Builder] Persist execution owners for Agent Builder tasks

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/execution/types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/execution/types.ts
@@ -20,6 +20,7 @@ import type {
   ConversationRoundAuthor,
   ExecutionStatus,
   SerializedExecutionError,
+  UserIdAndName,
 } from '@kbn/agent-builder-common';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ConnectorTelemetryMetadata } from '@kbn/inference-common';
@@ -121,6 +122,8 @@ interface BaseAgentExecution {
   agentId: string;
   /** Id of the space the execution was performed in. */
   spaceId: string;
+  /** User identity resolved from the request that created the execution. */
+  owner?: UserIdAndName;
   /** Error details, present when status is 'failed'. */
   error?: SerializedExecutionError;
   /** Number of events stored on the document (kept in sync with `events.length`). */

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/conversation_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/conversation_service.test.ts
@@ -65,6 +65,23 @@ describe('ConversationServiceImpl', () => {
         expect.objectContaining({ esClient: asCurrentUser })
       );
     });
+
+    it('uses an explicit user override without changing request-scoped dependencies', async () => {
+      const requestUser = { id: 'profile-1', username: 'jane', isAdmin: false };
+      const executionOwner = { id: 'profile-alice', username: 'alice', isAdmin: false };
+      getUserFromRequestMock.mockResolvedValue(requestUser);
+
+      await createService({ agents }).getScopedClient({ request, user: executionOwner });
+
+      expect(createClientMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: executionOwner,
+          esClient: asInternalUser,
+        })
+      );
+      expect(getUserFromRequestMock).not.toHaveBeenCalled();
+      expect(agents.getRegistry).toHaveBeenCalledWith({ request });
+    });
   });
 
   describe('getConversationRoundAuthor', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/conversation_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/conversation_service.ts
@@ -21,7 +21,10 @@ import type { ConversationClient } from './client';
 import { createClient } from './client';
 
 export interface ConversationService {
-  getScopedClient(options: { request: KibanaRequest }): Promise<ConversationClient>;
+  getScopedClient(options: {
+    request: KibanaRequest;
+    user?: CurrentUser;
+  }): Promise<ConversationClient>;
   getConversationRoundAuthor(options: {
     request: KibanaRequest;
     origin?: ExecutionConversationOrigin;
@@ -51,8 +54,14 @@ export class ConversationServiceImpl implements ConversationService {
     this.agents = agents;
   }
 
-  async getScopedClient({ request }: { request: KibanaRequest }): Promise<ConversationClient> {
-    const user = await this.getCurrentUser({ request });
+  async getScopedClient({
+    request,
+    user: userOverride,
+  }: {
+    request: KibanaRequest;
+    user?: CurrentUser;
+  }): Promise<ConversationClient> {
+    const user = userOverride ?? (await this.getCurrentUser({ request }));
     const esClient = this.getScopedEsClient(request).asInternalUser;
     const space = getCurrentSpaceId({ request, spaces: this.spaces });
     const agentRegistry = await this.agents.getRegistry({ request });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -258,6 +258,7 @@ export class ServiceManager {
     executionService = createAgentExecutionService({
       logger: logger.get('execution'),
       elasticsearch,
+      security,
       taskManager,
       spaces,
       inference,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_runner.ts
@@ -166,6 +166,7 @@ const handleConversationExecution = async ({
     connectorId,
     telemetryMetadata,
     request,
+    executionOwner: execution.owner,
     ...deps,
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
@@ -14,6 +14,7 @@ import { AgentExecutionMode } from '@kbn/agent-builder-common';
 import { ExecutionStatus } from '@kbn/agent-builder-common';
 import type { AgentExecutionClient } from './persistence';
 import type { AttachmentServiceStart } from '../attachments';
+import { getUserFromRequest } from '../utils';
 
 // Mock persistence module
 const mockExecutionClient: jest.Mocked<AgentExecutionClient> = {
@@ -30,6 +31,12 @@ const mockExecutionClient: jest.Mocked<AgentExecutionClient> = {
 jest.mock('./persistence', () => ({
   createAgentExecutionClient: () => mockExecutionClient,
 }));
+
+jest.mock('../utils', () => ({
+  getUserFromRequest: jest.fn(),
+}));
+
+const getUserFromRequestMock = getUserFromRequest as jest.MockedFunction<typeof getUserFromRequest>;
 
 const conflictError = () =>
   Object.assign(new Error('version conflict'), {
@@ -96,6 +103,7 @@ describe('AgentExecutionService', () => {
   const service = createAgentExecutionService({
     logger,
     elasticsearch,
+    security: {} as never,
     taskManager,
     inference: {} as any,
     conversationService: {} as any,
@@ -110,6 +118,11 @@ describe('AgentExecutionService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    getUserFromRequestMock.mockResolvedValue({
+      id: 'profile-1',
+      username: 'jane',
+      isAdmin: false,
+    });
     mockExecutionClient.create.mockResolvedValue({
       executionId: 'test-id',
       '@timestamp': new Date().toISOString(),
@@ -158,6 +171,38 @@ describe('AgentExecutionService', () => {
           scope: ['agent-builder'],
         }),
         { request, cloneApiKey: true }
+      );
+    });
+
+    it('stores the owner resolved from the original request before scheduling', async () => {
+      const request = httpServerMock.createKibanaRequest();
+      getUserFromRequestMock.mockResolvedValue({
+        id: 'realm:["native","native1","alice"]',
+        username: 'alice',
+        isAdmin: false,
+      });
+
+      await service.executeAgent({
+        mode: AgentExecutionMode.conversation,
+        request,
+        params: {
+          agentId: 'agent-1',
+          nextInput: { message: 'hello' },
+        },
+        useTaskManager: true,
+      });
+
+      expect(mockExecutionClient.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: { id: 'realm:["native","native1","alice"]', username: 'alice' },
+        })
+      );
+      expect(getUserFromRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request,
+          security: expect.anything(),
+          esClient: expect.anything(),
+        })
       );
     });
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
@@ -13,6 +13,7 @@ import type { ElasticsearchServiceStart } from '@kbn/core-elasticsearch-server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SecurityServiceStart } from '@kbn/core-security-server';
 import type { ChatEvent } from '@kbn/agent-builder-common';
 import { agentBuilderDefaultAgentId, createBadRequestError } from '@kbn/agent-builder-common';
 import type { Attachment, AttachmentInput } from '@kbn/agent-builder-common/attachments';
@@ -28,6 +29,7 @@ import { ExecutionStatus } from '@kbn/agent-builder-common';
 import { getCurrentSpaceId } from '../../utils/spaces';
 import { isVersionConflictError } from '../../utils/is_version_conflict_error';
 import type { AttachmentServiceStart } from '../attachments';
+import { getUserFromRequest } from '../utils';
 import { taskTypes } from './task';
 import { createAgentExecutionClient, type AgentExecutionClient } from './persistence';
 import {
@@ -42,6 +44,7 @@ import { followExecution$ } from './execution_follower';
 
 export interface AgentExecutionServiceDeps extends AgentExecutionDeps {
   elasticsearch: ElasticsearchServiceStart;
+  security: SecurityServiceStart;
   taskManager: TaskManagerStartContract;
   spaces?: SpacesPluginStart;
   attachmentsService: AttachmentServiceStart;
@@ -76,6 +79,11 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
     const executionId = providedExecutionId ?? uuidv4();
     const agentId = params.agentId ?? agentBuilderDefaultAgentId;
     const spaceId = getCurrentSpaceId({ request, spaces: this.deps.spaces });
+    const owner = await getUserFromRequest({
+      request,
+      security: this.deps.security,
+      esClient: this.deps.elasticsearch.client.asScoped(request).asCurrentUser,
+    });
 
     const executionClient = this.createExecutionClient();
 
@@ -97,6 +105,7 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
         agentParams: validatedParams,
         parentExecutionId: params.parentExecutionId,
         metadata,
+        owner: { id: owner.id, username: owner.username },
       });
     } catch (err) {
       if (isVersionConflictError(err)) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_client.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_client.test.ts
@@ -48,6 +48,23 @@ describe('AgentExecutionClient', () => {
       );
     });
 
+    it('persists and returns the execution owner', async () => {
+      const execution = await client.create({
+        ...createParams,
+        owner: { id: 'profile-alice', username: 'alice' },
+      });
+
+      expect(mockStorageClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            owner_user_id: 'profile-alice',
+            owner_user_name: 'alice',
+          }),
+        })
+      );
+      expect(execution.owner).toEqual({ id: 'profile-alice', username: 'alice' });
+    });
+
     it('propagates document conflicts to the caller', async () => {
       const conflict = Object.assign(new Error('version conflict'), {
         meta: { statusCode: 409 },

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_client.ts
@@ -24,6 +24,7 @@ type CreateExecutionParams = Pick<
   | 'metadata'
   | 'executionMode'
   | 'parentExecutionId'
+  | 'owner'
 >;
 
 /**
@@ -47,6 +48,9 @@ const fromEs = (source: AgentExecutionProperties): AgentExecution => {
     executionMode: source.execution_mode ?? AgentExecutionMode.conversation,
     ...(source.parent_execution_id ? { parentExecutionId: source.parent_execution_id } : {}),
     spaceId: source.space_id,
+    ...(source.owner_user_name
+      ? { owner: { id: source.owner_user_id, username: source.owner_user_name } }
+      : {}),
     agentParams: source.agent_params,
     eventCount: source.event_count ?? 0,
     events: source.events ?? [],
@@ -133,6 +137,7 @@ class AgentExecutionClientImpl implements AgentExecutionClient {
     metadata,
     executionMode,
     parentExecutionId,
+    owner,
   }: CreateExecutionParams): Promise<AgentExecution> {
     if (metadata) {
       for (const key of Object.keys(metadata)) {
@@ -152,6 +157,8 @@ class AgentExecutionClientImpl implements AgentExecutionClient {
       execution_mode: executionMode,
       parent_execution_id: parentExecutionId,
       space_id: spaceId,
+      owner_user_id: owner?.id,
+      owner_user_name: owner?.username,
       agent_params: agentParams,
       event_count: 0,
       events: [],

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_storage.ts
@@ -30,6 +30,8 @@ const storageSettings = {
       execution_mode: types.keyword({}),
       parent_execution_id: types.keyword({}),
       space_id: types.keyword({}),
+      owner_user_id: types.keyword({}),
+      owner_user_name: types.keyword({}),
       agent_params: types.object({ dynamic: false, properties: {} }),
       error: types.object({
         dynamic: false,
@@ -54,6 +56,8 @@ export interface AgentExecutionProperties {
   execution_mode?: string;
   parent_execution_id?: string;
   space_id: string;
+  owner_user_id?: string;
+  owner_user_name?: string;
   agent_params: AgentExecutionParams;
   error?: SerializedExecutionError;
   event_count?: number;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/resolve_services.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/resolve_services.test.ts
@@ -29,9 +29,11 @@ const createDeps = () => {
   const agentRegistry = createMockedAgentRegistry();
   const agentService = createAgentsServiceStartMock();
   agentService.getRegistry.mockResolvedValue(agentRegistry);
+  const conversationService = { getScopedClient: jest.fn().mockResolvedValue({ id: 'client' }) };
 
   return {
     agentRegistry,
+    conversationService,
     deps: {
       agentId: 'private-agent',
       connectorId: 'connector-1',
@@ -39,7 +41,9 @@ const createDeps = () => {
       request: httpServerMock.createKibanaRequest(),
       logger: loggingSystemMock.createLogger(),
       inference: inferenceMock.createStartContract(),
-      conversationService: {} as Parameters<typeof resolveServices>[0]['conversationService'],
+      conversationService: conversationService as unknown as Parameters<
+        typeof resolveServices
+      >[0]['conversationService'],
       agentService,
       uiSettings: uiSettingsServiceMock.createStartContract(),
       savedObjects: savedObjectsServiceMock.createStartContract(),
@@ -68,6 +72,21 @@ describe('resolveServices', () => {
         agentId: 'private-agent',
         statusCode: 404,
       },
+    });
+  });
+
+  it('passes the execution owner to the conversation client override', async () => {
+    const { agentRegistry, conversationService, deps } = createDeps();
+    agentRegistry.has.mockResolvedValue(true);
+
+    await resolveServices({
+      ...deps,
+      executionOwner: { id: 'profile-alice', username: 'alice' },
+    });
+
+    expect(conversationService.getScopedClient).toHaveBeenCalledWith({
+      request: deps.request,
+      user: { id: 'profile-alice', username: 'alice', isAdmin: false },
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/resolve_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/resolve_services.ts
@@ -12,6 +12,7 @@ import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import type { ConnectorTelemetryMetadata } from '@kbn/inference-common';
+import type { UserIdAndName } from '@kbn/agent-builder-common';
 import { createAgentNotFoundError } from '@kbn/agent-builder-common';
 import type { ConversationService } from '../../conversation';
 import type { AgentsServiceStart } from '../../agents';
@@ -30,6 +31,7 @@ export const resolveServices = async ({
   uiSettings,
   savedObjects,
   searchInferenceEndpoints,
+  executionOwner,
 }: {
   agentId: string;
   connectorId?: string;
@@ -42,6 +44,7 @@ export const resolveServices = async ({
   uiSettings: UiSettingsServiceStart;
   savedObjects: SavedObjectsServiceStart;
   searchInferenceEndpoints: SearchInferenceEndpointsPluginStart;
+  executionOwner?: UserIdAndName;
 }) => {
   const selectedConnectorId = await resolveSelectedConnectorId({
     request,
@@ -78,7 +81,10 @@ export const resolveServices = async ({
     searchInferenceEndpoints,
   });
 
-  const conversationClient = await conversationService.getScopedClient({ request });
+  const conversationClient = await conversationService.getScopedClient({
+    request,
+    ...(executionOwner ? { user: { ...executionOwner, isAdmin: false } } : {}),
+  });
 
   return {
     conversationClient,

--- a/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/conversations_access_control_api.spec.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/conversations_access_control_api.spec.ts
@@ -457,6 +457,45 @@ apiTest.describe(
     // ── public conversation access ──────────────────────────────────────────
 
     apiTest(
+      'default Task Manager converse persists the Basic-auth owner user id',
+      async ({ apiClient, esClient }) => {
+        const agentId = `${ACCESS_CONTROL_TEST_PREFIX}-tm-owner-agent-${testRunId.slice(0, 8)}`;
+        await createAgentAs(apiClient, alice, mockAgent(agentId, AgentAccessControlMode.Shared));
+        await setupAgentDirectAnswer({
+          proxy: llmProxy,
+          title: 'Task Manager Owner Conversation',
+          response: 'Task Manager owner response',
+        });
+
+        const response = await apiClient.post(`${accessControlApiBase}/converse`, {
+          headers: headersFor(alice),
+          body: {
+            agent_id: agentId,
+            input: 'Create a public conversation through Task Manager',
+            connector_id: connectorId,
+            access_control: { access_mode: ConversationAccessControlMode.Public },
+          },
+          responseType: 'json',
+        });
+        expect(response).toHaveStatusCode(200);
+        await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+        const { conversation_id: conversationId } = response.body as ChatResponse;
+        const storedConversation = await esClient.get({
+          index: CHAT_CONVERSATIONS_INDEX,
+          id: conversationId,
+        });
+        const source = storedConversation._source as
+          | { user_id?: string; user_name?: string }
+          | undefined;
+
+        expect(typeof source?.user_id).toBe('string');
+        expect(source?.user_id?.length).toBeGreaterThan(0);
+        expect(source?.user_name).toBe(alice.username);
+      }
+    );
+
+    apiTest(
       'public conversations require conversation access and agent use access',
       async ({ apiClient }) => {
         const agentId = `${ACCESS_CONTROL_TEST_PREFIX}-agent-${testRunId.slice(0, 8)}`;


### PR DESCRIPTION
## Summary
- Persists the Agent Builder execution owner resolved from the original `/converse` request before Task Manager scheduling.
- Uses the persisted execution owner when creating conversation clients during task execution, so Task Manager-created conversations retain a stable `user_id`.
- Adds unit and Scout API coverage for Basic-auth public `/converse` default Task Manager execution.

## References
- Related: elastic/kibana#281996
- Related: elastic/kibana#280890

## Test plan
- `node scripts/jest x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_client.test.ts x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts x-pack/platform/plugins/shared/agent_builder/server/services/conversation/conversation_service.test.ts x-pack/platform/plugins/shared/agent_builder/server/services/execution/utils/resolve_services.test.ts`
- `node scripts/type_check --project x-pack/platform/plugins/shared/agent_builder/tsconfig.json`
- `node scripts/eslint <changed files>`
- `node scripts/scout run-tests --arch stateful --domain classic --testFiles x-pack/platform/plugins/shared/agent_builder/test/scout_agent_builder/api/tests/conversations_access_control_api.spec.ts`