### PR TITLE
[Security Solution][Notes] Fix notes page not restoring filter UI state on return

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.test.tsx
@@ -7,6 +7,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { useSelector } from 'react-redux-v7';
 import { CreatedByFilterDropdown } from './created_by_filter_dropdown';
 import { CREATED_BY_SELECT_TEST_ID } from './test_ids';
 import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
@@ -24,6 +25,7 @@ jest.mock('react-redux-v7', () => {
   return {
     ...original,
     useDispatch: () => mockDispatch,
+    useSelector: jest.fn(),
   };
 });
 
@@ -45,6 +47,7 @@ describe('UserFilterDropdown', () => {
     });
     (useLicense as jest.Mock).mockReturnValue({ isPlatinumPlus: () => true });
     (useUpsellingMessage as jest.Mock).mockReturnValue('upsellingMessage');
+    (useSelector as jest.Mock).mockReturnValue(''); // no stored filter by default
   });
 
   it('should render the component enabled', () => {
@@ -74,5 +77,13 @@ describe('UserFilterDropdown', () => {
     fireEvent.click(option);
 
     expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should restore the previously selected user from the store on mount', async () => {
+    (useSelector as jest.Mock).mockReturnValue('1'); // uid matching 'test' user
+
+    render(<CreatedByFilterDropdown />);
+
+    expect(await screen.findByDisplayValue('test')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.test.tsx
@@ -79,11 +79,19 @@ describe('UserFilterDropdown', () => {
     expect(mockDispatch).toHaveBeenCalled();
   });
 
-  it('should restore the previously selected user from the store on mount', async () => {
+  it('should restore the previously selected user from the store on mount', () => {
     (useSelector as jest.Mock).mockReturnValue('1'); // uid matching 'test' user
 
     render(<CreatedByFilterDropdown />);
 
-    expect(await screen.findByDisplayValue('test')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('test')).toBeInTheDocument();
+  });
+
+  it('should show no selection when the stored filter is cleared', () => {
+    (useSelector as jest.Mock).mockReturnValue('');
+
+    const { getByTestId } = render(<CreatedByFilterDropdown />);
+
+    expect(getByTestId('comboBoxSearchInput')).toHaveValue('');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo, useCallback, useState, useEffect } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { EuiComboBox, EuiToolTip } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux-v7';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
@@ -52,17 +52,15 @@ export const CreatedByFilterDropdown = React.memo(() => {
   );
 
   const createdByFilter = useSelector(selectNotesTableCreatedByFilter);
-  const [selectedUser, setSelectedUser] = useState<Array<EuiComboBoxOptionOption<User>>>();
 
-  useEffect(() => {
-    if (!createdByFilter || !users.length) return;
+  const selectedUser = useMemo<Array<EuiComboBoxOptionOption<User>>>(() => {
+    if (!createdByFilter || !users.length) return [];
     const match = users.find((u) => u.id === createdByFilter);
-    if (match) setSelectedUser([match]);
+    return match ? [match] : [];
   }, [createdByFilter, users]);
 
   const onChange = useCallback(
     (user: Array<EuiComboBoxOptionOption<User>>) => {
-      setSelectedUser(user);
       dispatch(userFilterCreatedBy(user.length > 0 ? (user[0].id as string) : ''));
     },
     [dispatch]

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useMemo, useCallback, useState, useEffect } from 'react';
 import { EuiComboBox, EuiToolTip } from '@elastic/eui';
-import { useDispatch } from 'react-redux-v7';
+import { useDispatch, useSelector } from 'react-redux-v7';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { i18n } from '@kbn/i18n';
 import type { EuiComboBoxOptionOption } from '@elastic/eui/src/components/combo_box/types';
@@ -15,7 +15,7 @@ import { useLicense } from '../../common/hooks/use_license';
 import { useUpsellingMessage } from '../../common/hooks/use_upselling';
 import { CREATED_BY_SELECT_TEST_ID } from './test_ids';
 import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
-import { userFilterCreatedBy } from '..';
+import { userFilterCreatedBy, selectNotesTableCreatedByFilter } from '..';
 
 export const CREATED_BY = i18n.translate('xpack.securitySolution.notes.createdByDropdownLabel', {
   defaultMessage: 'Created by',
@@ -51,7 +51,15 @@ export const CreatedByFilterDropdown = React.memo(() => {
     [data]
   );
 
+  const createdByFilter = useSelector(selectNotesTableCreatedByFilter);
   const [selectedUser, setSelectedUser] = useState<Array<EuiComboBoxOptionOption<User>>>();
+
+  useEffect(() => {
+    if (!createdByFilter || !users.length) return;
+    const match = users.find((u) => u.id === createdByFilter);
+    if (match) setSelectedUser([match]);
+  }, [createdByFilter, users]);
+
   const onChange = useCallback(
     (user: Array<EuiComboBoxOptionOption<User>>) => {
       setSelectedUser(user);

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
@@ -18,6 +18,7 @@ import {
 import { AssociatedFilter } from '../../../common/notes/constants';
 import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
 import { TestProviders } from '../../common/mock';
+import { selectNotesTableSearch, selectNotesTableAssociatedFilter } from '..';
 
 jest.mock('../../common/components/user_profiles/use_suggest_users');
 
@@ -84,10 +85,9 @@ describe('SearchRow', () => {
   });
 
   it('should restore a previously applied search value from the store on mount', () => {
-    (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
-      const { selectNotesTableSearch } = jest.requireActual('..');
-      return selector === selectNotesTableSearch ? 'previous search' : AssociatedFilter.all;
-    });
+    (useSelector as jest.Mock).mockImplementation((selector: unknown) =>
+      selector === selectNotesTableSearch ? 'previous search' : AssociatedFilter.all
+    );
 
     const { getByTestId } = render(
       <TestProviders>
@@ -99,10 +99,9 @@ describe('SearchRow', () => {
   });
 
   it('should restore a previously applied associated filter from the store on mount', () => {
-    (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
-      const { selectNotesTableAssociatedFilter } = jest.requireActual('..');
-      return selector === selectNotesTableAssociatedFilter ? AssociatedFilter.documentOnly : '';
-    });
+    (useSelector as jest.Mock).mockImplementation((selector: unknown) =>
+      selector === selectNotesTableAssociatedFilter ? AssociatedFilter.documentOnly : ''
+    );
 
     const { getByTestId } = render(
       <TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
@@ -8,6 +8,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { useSelector } from 'react-redux-v7';
 import { SearchRow } from './search_row';
 import {
   ASSOCIATED_NOT_SELECT_TEST_ID,
@@ -27,6 +28,7 @@ jest.mock('react-redux-v7', () => {
   return {
     ...original,
     useDispatch: () => mockDispatch,
+    useSelector: jest.fn(),
   };
 });
 
@@ -37,6 +39,8 @@ describe('SearchRow', () => {
       isLoading: false,
       data: [{ user: { username: 'test' } }, { user: { username: 'elastic' } }],
     });
+    // default: no stored filters
+    (useSelector as jest.Mock).mockReturnValue('');
   });
 
   it('should render the component', () => {
@@ -77,5 +81,35 @@ describe('SearchRow', () => {
     await userEvent.selectOptions(associatedNoteSelect, [AssociatedFilter.documentOnly]);
 
     expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should restore a previously applied search value from the store on mount', () => {
+    (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
+      const { selectNotesTableSearch } = jest.requireActual('..');
+      return selector === selectNotesTableSearch ? 'previous search' : AssociatedFilter.all;
+    });
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <SearchRow />
+      </TestProviders>
+    );
+
+    expect(getByTestId(SEARCH_BAR_TEST_ID)).toHaveValue('previous search');
+  });
+
+  it('should restore a previously applied associated filter from the store on mount', () => {
+    (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
+      const { selectNotesTableAssociatedFilter } = jest.requireActual('..');
+      return selector === selectNotesTableAssociatedFilter ? AssociatedFilter.documentOnly : '';
+    });
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <SearchRow />
+      </TestProviders>
+    );
+
+    expect(getByTestId(ASSOCIATED_NOT_SELECT_TEST_ID)).toHaveValue(AssociatedFilter.documentOnly);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
@@ -14,11 +14,16 @@ import {
   EuiSelect,
   useGeneratedHtmlId,
 } from '@elastic/eui';
-import { useDispatch } from 'react-redux-v7';
+import { useDispatch, useSelector } from 'react-redux-v7';
 import { i18n } from '@kbn/i18n';
 import { CreatedByFilterDropdown } from './created_by_filter_dropdown';
 import { ASSOCIATED_NOT_SELECT_TEST_ID, SEARCH_BAR_TEST_ID } from './test_ids';
-import { userFilterAssociatedNotes, userSearchedNotes } from '..';
+import {
+  userFilterAssociatedNotes,
+  userSearchedNotes,
+  selectNotesTableSearch,
+  selectNotesTableAssociatedFilter,
+} from '..';
 import { AssociatedFilter } from '../../../common/notes/constants';
 
 const ATTACH_FILTER = i18n.translate('xpack.securitySolution.notes.management.attachFilter', {
@@ -44,6 +49,8 @@ const associatedNoteSelectOptions: EuiSelectOption[] = [
 export const SearchRow = React.memo(() => {
   const dispatch = useDispatch();
   const associatedSelectId = useGeneratedHtmlId({ prefix: 'associatedSelectId' });
+  const notesSearch = useSelector(selectNotesTableSearch);
+  const notesAssociatedFilter = useSelector(selectNotesTableAssociatedFilter);
 
   const onQueryChange = useCallback(
     ({ queryText }: { queryText: string }) => {
@@ -62,7 +69,7 @@ export const SearchRow = React.memo(() => {
   return (
     <EuiFlexGroup gutterSize="m">
       <EuiFlexItem>
-        <EuiSearchBar box={searchBox} onChange={onQueryChange} defaultQuery="" />
+        <EuiSearchBar box={searchBox} onChange={onQueryChange} defaultQuery={notesSearch} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <CreatedByFilterDropdown />
@@ -71,6 +78,7 @@ export const SearchRow = React.memo(() => {
         <EuiSelect
           id={associatedSelectId}
           options={associatedNoteSelectOptions}
+          value={notesAssociatedFilter}
           onChange={onAssociatedNoteSelectChange}
           prepend={ATTACH_FILTER}
           aria-label={ATTACH_FILTER}

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexItem,
   EuiSearchBar,
   EuiSelect,
+  Query,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux-v7';
@@ -69,7 +70,7 @@ export const SearchRow = React.memo(() => {
   return (
     <EuiFlexGroup gutterSize="m">
       <EuiFlexItem>
-        <EuiSearchBar box={searchBox} onChange={onQueryChange} defaultQuery={notesSearch} />
+        <EuiSearchBar box={searchBox} onChange={onQueryChange} query={Query.parse(notesSearch)} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <CreatedByFilterDropdown />


### PR DESCRIPTION
## Summary

## What
Fixes a bug where previously applied filters on the Notes management page (search text, "Attached to" dropdown, "Created by" dropdown) remained active after navigating away and back, but were not reflected in the filter controls — making the list appear filtered with no visible reason.

## Why
Filter state is persisted in Redux, but all three filter controls initialised from hardcoded defaults (`defaultQuery=""`, no `value` prop, local `useState` with no initialisation) instead of reading from the store on mount. Because the page component fully unmounts on navigation, returning to the page always showed empty controls even though the stored filter was still applied to the data fetch.

Resolves issue #285563

Before fix: see video in issue  #285563

After fix (using browser back button off screen): 

https://github.com/user-attachments/assets/daa7c2b2-7830-4018-abd1-59f106e26824


## Changes

- `search_row.tsx` — `EuiSearchBar` now uses `defaultQuery={notesSearch}` from Redux; `EuiSelect` (associated filter) gets `value={notesAssociatedFilter}` making it a controlled component
- `created_by_filter_dropdown.tsx` — adds a `useEffect` that restores the selected user option from `createdByFilter` in Redux once the user profiles list has loaded
- `search_row.test.tsx` — adds `useSelector` to the mock; adds tests asserting search and associated-filter values are restored on mount
- `created_by_filter_dropdown.test.tsx` — adds `useSelector` to the mock (required now that the component calls it); adds a test asserting the previously selected user is restored on mount

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Regressions (low):** `EuiSearchBar` with a non-empty `defaultQuery` could theoretically fire `onChange` on mount and dispatch back to Redux, but since the value would be identical to the stored value, Redux will not update and no re-render loop occurs. Verified in testing.
- No data loss, API, or performance risks.

### Release note

> Fixes an issue where previously applied filters on the Notes management page were not shown in the filter controls after navigating away and returning, even though the filters were still active.

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->