### PR TITLE
[9.4] [Entity Analytics] Requiring security `All` privilege in order to run EA migrations via API and only running on current space (#286375)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_migration_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_migration_client.test.ts
@@ -90,9 +90,32 @@ describe('AssetCriticalityMigrationClient', () => {
   });
 
   describe('migrateMappings', () => {
+    let createOrUpdateIndexSpy: jest.Mock;
+
+    beforeEach(() => {
+      // Replace createOrUpdateIndex with a fresh spy each time to avoid count bleed-over
+      // from previous tests sharing the same AssetCriticalityDataClient mock instance.
+      createOrUpdateIndexSpy = jest.fn();
+      assetCriticalityDataClient.createOrUpdateIndex = createOrUpdateIndexSpy;
+
+      migrationClient.getAllSpacesWithAssetCriticalityInstalled = jest
+        .fn()
+        .mockResolvedValue(['default', 'other-space']);
+    });
+
     it('should call createOrUpdateIndex on assetCriticalityDataClient', async () => {
       await migrationClient.migrateMappings();
-      expect(assetCriticalityDataClient.createOrUpdateIndex).toHaveBeenCalled();
+      expect(createOrUpdateIndexSpy).toHaveBeenCalled();
+    });
+
+    it('should call createOrUpdateIndex only for the matching space when filterSpaceId matches an installed space', async () => {
+      await migrationClient.migrateMappings('default');
+      expect(createOrUpdateIndexSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call createOrUpdateIndex when filterSpaceId does not match any installed space', async () => {
+      await migrationClient.migrateMappings('unknown-space');
+      expect(createOrUpdateIndexSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_migration_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_migration_client.ts
@@ -67,8 +67,11 @@ export class AssetCriticalityMigrationClient {
     return resp.hits.hits.length > 0;
   };
 
-  public migrateMappings = async () => {
-    const spaceIds = await this.getAllSpacesWithAssetCriticalityInstalled();
+  public migrateMappings = async (filterSpaceId?: string) => {
+    let spaceIds = await this.getAllSpacesWithAssetCriticalityInstalled();
+    if (filterSpaceId) {
+      spaceIds = spaceIds.filter((id) => id === filterSpaceId);
+    }
 
     for (const spaceId of spaceIds) {
       const assetCriticalityDataClient = new AssetCriticalityDataClient({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/update_asset_criticality_mappings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/update_asset_criticality_mappings.test.ts
@@ -14,7 +14,7 @@ const mockmigrateMappings = jest.fn();
 jest.mock('../asset_criticality_migration_client', () => ({
   AssetCriticalityMigrationClient: jest.fn().mockImplementation(() => ({
     isMappingsMigrationRequired: () => mockisMappingsMigrationRequired(),
-    migrateMappings: () => mockmigrateMappings(),
+    migrateMappings: (spaceId?: string) => mockmigrateMappings(spaceId),
   })),
 }));
 
@@ -56,5 +56,34 @@ describe('updateAssetCriticalityMappings', () => {
 
     expect(mockisMappingsMigrationRequired).toHaveBeenCalled();
     expect(mockLogger.info).not.toHaveBeenCalledWith('Migrating Asset Criticality mappings');
+  });
+
+  it('should pass spaceId to migrateMappings when defined', async () => {
+    mockisMappingsMigrationRequired.mockResolvedValue(true);
+
+    await updateAssetCriticalityMappings({
+      auditLogger: undefined,
+      logger: mockLogger,
+      getStartServices: mockGetStartServices,
+      kibanaVersion: '8.0.0',
+      hasEncryptionKey: true,
+      spaceId: 'my-space',
+    });
+
+    expect(mockmigrateMappings).toHaveBeenCalledWith('my-space');
+  });
+
+  it('should pass undefined to migrateMappings when spaceId is not defined', async () => {
+    mockisMappingsMigrationRequired.mockResolvedValue(true);
+
+    await updateAssetCriticalityMappings({
+      auditLogger: undefined,
+      logger: mockLogger,
+      getStartServices: mockGetStartServices,
+      kibanaVersion: '8.0.0',
+      hasEncryptionKey: true,
+    });
+
+    expect(mockmigrateMappings).toHaveBeenCalledWith(undefined);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/update_asset_criticality_mappings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/asset_criticality/migrations/update_asset_criticality_mappings.ts
@@ -13,6 +13,7 @@ export const updateAssetCriticalityMappings = async ({
   auditLogger,
   logger,
   getStartServices,
+  spaceId,
 }: EntityAnalyticsMigrationsParams) => {
   const [coreStart] = await getStartServices();
   const esClient = coreStart.elasticsearch.client.asInternalUser;
@@ -26,6 +27,6 @@ export const updateAssetCriticalityMappings = async ({
   const shouldMigrateMappings = await migrationClient.isMappingsMigrationRequired();
   if (shouldMigrateMappings) {
     logger.info('Migrating Asset Criticality mappings');
-    await migrationClient.migrateMappings();
+    await migrationClient.migrateMappings(spaceId);
   }
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/index.ts
@@ -27,6 +27,8 @@ export interface EntityAnalyticsMigrationsParams {
   kibanaVersion: string;
   experimentalFeatures?: ExperimentalFeatures;
   hasEncryptionKey: boolean;
+  /** When defined, migrations are scoped to this space only. When undefined, all spaces are migrated. */
+  spaceId?: string;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/routes/run_migrations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/routes/run_migrations.ts
@@ -30,7 +30,7 @@ export const entityAnalyticsRunMigrationsRoute = (
       path: ENTITY_ANALYTICS_INTERNAL_RUN_MIGRATIONS_ROUTE,
       security: {
         authz: {
-          requiredPrivileges: ['securitySolution', `${APP_ID}-entity-analytics`],
+          requiredPrivileges: ['securitySolution', `${APP_ID}-entity-analytics-manage`],
         },
       },
     })
@@ -41,7 +41,9 @@ export const entityAnalyticsRunMigrationsRoute = (
         const siemResponse = buildSiemResponse(response);
 
         try {
+          const spaceId = securitySolution.getSpaceId();
           await scheduleEntityAnalyticsMigration({
+            spaceId,
             /*
              * We cannot provide task manager here because the migrations require
              * the setup contract and we can only access the start contract.

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/migrations/check_if_entity_source_migration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/migrations/check_if_entity_source_migration.ts
@@ -13,6 +13,7 @@ export const shouldRunSourceMigrationFactory =
   async (namespace: string): Promise<boolean> => {
     const response = await deps.esClient.count({
       index: getPrivilegedMonitorUsersIndex(namespace),
+      ignore_unavailable: true,
       query: {
         bool: {
           must: [

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/migrations/update_source_index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/migrations/update_source_index.test.ts
@@ -128,6 +128,33 @@ describe('updatePrivilegedMonitoringSourceIndex', () => {
     expect(mockDeleteUsersWithSourceIndex).toHaveBeenCalledWith('*');
   });
 
+  describe('with spaceId defined', () => {
+    it('scopes the shouldRun check, SO query, and user deletion to the specified space', async () => {
+      const mockShouldRunMigration = jest.fn().mockResolvedValue(true);
+      mockShouldRunSourceMigrationFactory.mockReturnValue(mockShouldRunMigration);
+      mockGetStartServices.mockResolvedValue([
+        mockCore,
+        { security: mockSecurity, encryptedSavedObjects: mockEncryptedSavedObjects },
+      ]);
+      mockSoClient.find.mockResolvedValue({
+        saved_objects: [
+          { id: 'so-id-1', namespaces: ['my-space'], attributes: { indexPattern: 'pattern-1' } },
+        ],
+      });
+
+      await updatePrivilegedMonitoringSourceIndex({
+        ...DEFAULT_PARAMS,
+        spaceId: 'my-space',
+      });
+
+      expect(mockShouldRunMigration).toHaveBeenCalledWith('my-space');
+      expect(mockSoClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ namespaces: ['my-space'] })
+      );
+      expect(mockDeleteUsersWithSourceIndex).toHaveBeenCalledWith('my-space');
+    });
+  });
+
   it('logs error and skips if api key manager returns no client', async () => {
     mockShouldRunSourceMigrationFactory.mockReturnValue(jest.fn().mockResolvedValue(true));
     mockGetStartServices.mockResolvedValue([

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/migrations/update_source_index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/migrations/update_source_index.ts
@@ -20,6 +20,7 @@ export const MAX_PER_PAGE = 10_000;
 export const updatePrivilegedMonitoringSourceIndex = async ({
   logger,
   getStartServices,
+  spaceId,
 }: EntityAnalyticsMigrationsParams) => {
   const [core, { security, encryptedSavedObjects }] = await getStartServices();
 
@@ -28,7 +29,7 @@ export const updatePrivilegedMonitoringSourceIndex = async ({
   const shouldRunMigration = shouldRunSourceMigrationFactory({
     esClient: internalEsClient,
   });
-  const shouldRun = await shouldRunMigration('*');
+  const shouldRun = await shouldRunMigration(spaceId ?? '*');
   if (!shouldRun) {
     logger.info('Skipping migration for Privileged Monitoring Entity Source.');
     return;
@@ -39,7 +40,7 @@ export const updatePrivilegedMonitoringSourceIndex = async ({
   const savedObjectsResponse = await soClientGlobal.find<MonitoringEntitySource>({
     type: monitoringEntitySourceTypeName,
     perPage: MAX_PER_PAGE,
-    namespaces: ['*'],
+    namespaces: spaceId ? [spaceId] : ['*'],
   });
 
   await asyncForEach(savedObjectsResponse.saved_objects, async (savedObject) => {
@@ -78,5 +79,5 @@ export const updatePrivilegedMonitoringSourceIndex = async ({
   const deleteUsersWithSourceIndex = deleteUsersWithSourceIndexFactory({
     esClient: internalEsClient,
   });
-  await deleteUsersWithSourceIndex('*');
+  await deleteUsersWithSourceIndex(spaceId ?? '*');
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/migrations/upsert_entity_source.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/migrations/upsert_entity_source.ts
@@ -20,6 +20,7 @@ import { PrivilegeMonitoringEngineDescriptorClient } from '../saved_objects';
 export const upsertPrivilegedMonitoringEntitySource = async ({
   logger,
   getStartServices,
+  spaceId,
 }: EntityAnalyticsMigrationsParams) => {
   const [core, { security, encryptedSavedObjects }] = await getStartServices();
 
@@ -27,7 +28,7 @@ export const upsertPrivilegedMonitoringEntitySource = async ({
 
   const engineClient = new PrivilegeMonitoringEngineDescriptorClient({
     soClient: soClientGlobal,
-    namespace: '*', // get all engines from all namespaces
+    namespace: spaceId ?? '*',
   });
   const engines = await engineClient.find();
 
@@ -36,7 +37,6 @@ export const upsertPrivilegedMonitoringEntitySource = async ({
     return;
   }
 
-  // namespaces where engines are installed
   const namespaces = engines.saved_objects.map((savedObject) => first(savedObject.namespaces));
 
   await asyncForEach(namespaces, async (namespace) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/cleanup_previous_risk_engine.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/cleanup_previous_risk_engine.test.ts
@@ -190,6 +190,33 @@ describe('cleanupLegacyRiskEngine', () => {
     expect(mockRemoveRiskScoringTask).toHaveBeenCalledTimes(1);
   });
 
+  it('queries only the specified space when spaceId is defined', async () => {
+    soClient.find.mockResolvedValue({
+      ...mockSavedObjectsResponseDefaults,
+      saved_objects: [buildSavedObject('my-space')],
+    });
+
+    await cleanupLegacyRiskEngine({
+      logger,
+      getStartServices: getStartServicesMock,
+      auditLogger: undefined,
+      kibanaVersion: '9.0.0',
+      hasEncryptionKey: true,
+      spaceId: 'my-space',
+    });
+
+    expect(soClient.find).toHaveBeenCalledWith(
+      expect.objectContaining({ namespaces: ['my-space'] })
+    );
+    expect(mockStopTransform).toHaveBeenCalledTimes(1);
+    expect(mockStopTransform).toHaveBeenCalledWith(
+      expect.objectContaining({ transformId: getLatestTransformId('my-space') })
+    );
+    expect(mockRemoveRiskScoringTask).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: 'my-space' })
+    );
+  });
+
   it('processes the next namespace when one namespace hits a failure during task removal', async () => {
     mockRemoveRiskScoringTask
       .mockRejectedValueOnce(new Error('remove failed'))

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/cleanup_previous_risk_engine.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/cleanup_previous_risk_engine.ts
@@ -21,6 +21,7 @@ import { MAX_PER_PAGE } from './update_risk_score_mappings';
 export const cleanupLegacyRiskEngine = async ({
   logger,
   getStartServices,
+  spaceId,
 }: EntityAnalyticsMigrationsParams) => {
   try {
     const [coreStart, startPlugins] = await getStartServices();
@@ -39,7 +40,7 @@ export const cleanupLegacyRiskEngine = async ({
     const savedObjectsResponse = await soClientKibanaUser.find<RiskEngineConfiguration>({
       type: riskEngineConfigurationTypeName,
       perPage: MAX_PER_PAGE,
-      namespaces: ['*'],
+      namespaces: spaceId ? [spaceId] : ['*'],
     });
 
     if (savedObjectsResponse.saved_objects.length === 0) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/rename_risk_score_component_templates.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/rename_risk_score_component_templates.test.ts
@@ -238,4 +238,40 @@ describe('renameRiskScoreComponentTemplate', () => {
       { ignore: [404] }
     );
   });
+
+  describe('with spaceId defined', () => {
+    it('should query only the specified space', async () => {
+      mockEsClient.cluster.existsComponentTemplate.mockResolvedValue(true);
+      mockSoClient.find.mockResolvedValue(buildSavedObjectResponse(['my-space']));
+
+      await renameRiskScoreComponentTemplate({
+        auditLogger: mockAuditLogger,
+        logger: mockLogger,
+        getStartServices: mockGetStartServices,
+        kibanaVersion: '8.0.0',
+        hasEncryptionKey: true,
+        spaceId: 'my-space',
+      });
+
+      expect(mockSoClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ namespaces: ['my-space'] })
+      );
+    });
+
+    it('should not delete the legacy component template even when migration succeeds', async () => {
+      mockEsClient.cluster.existsComponentTemplate.mockResolvedValue(true);
+      mockSoClient.find.mockResolvedValue(buildSavedObjectResponse(['my-space']));
+
+      await renameRiskScoreComponentTemplate({
+        auditLogger: mockAuditLogger,
+        logger: mockLogger,
+        getStartServices: mockGetStartServices,
+        kibanaVersion: '8.0.0',
+        hasEncryptionKey: true,
+        spaceId: 'my-space',
+      });
+
+      expect(mockEsClient.cluster.deleteComponentTemplate).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/rename_risk_score_component_templates.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/rename_risk_score_component_templates.ts
@@ -24,6 +24,7 @@ export const renameRiskScoreComponentTemplate = async ({
   logger,
   getStartServices,
   kibanaVersion,
+  spaceId,
 }: EntityAnalyticsMigrationsParams) => {
   const [coreStart] = await getStartServices();
   const soClientKibanaUser = coreStart.savedObjects.createInternalRepository();
@@ -42,7 +43,7 @@ export const renameRiskScoreComponentTemplate = async ({
   const savedObjectsResponse = await soClientKibanaUser.find<RiskEngineConfiguration>({
     type: riskEngineConfigurationTypeName,
     perPage: MAX_PER_PAGE,
-    namespaces: ['*'],
+    namespaces: spaceId ? [spaceId] : ['*'],
   });
 
   const settledPromises = await Promise.allSettled(
@@ -78,15 +79,17 @@ export const renameRiskScoreComponentTemplate = async ({
     (promise) => promise.status === 'rejected'
   ) as PromiseRejectedResult[];
 
-  // Migration successfully ran on all spaces
   if (rejectedPromises.length === 0) {
-    // Delete the legacy component template without the namespace in the name
-    await esClient.cluster.deleteComponentTemplate(
-      {
-        name: mappingComponentName,
-      },
-      { ignore: [404] }
-    );
+    // Only delete the legacy global component template when migrating all spaces — when scoped
+    // to a single space, other spaces may still reference it.
+    if (!spaceId) {
+      await esClient.cluster.deleteComponentTemplate(
+        {
+          name: mappingComponentName,
+        },
+        { ignore: [404] }
+      );
+    }
   } else {
     const errorMessages = rejectedPromises.map((promise) => promise.reason?.message).join('\n');
     throw new Error(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/update_risk_score_mappings.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/update_risk_score_mappings.test.ts
@@ -136,6 +136,26 @@ describe('updateRiskScoreMappings', () => {
     expect(mockUpdateSavedObjectAttribute).not.toHaveBeenCalled();
   });
 
+  it('should query only the specified space when spaceId is defined', async () => {
+    soClient.find.mockResolvedValue({ ...mockSavedObjectsResponseDefaults, saved_objects: [] });
+    mockGetDefaultRiskEngineConfiguration.mockResolvedValue({
+      _meta: { mappingsVersion: '2.0.0' },
+    });
+
+    await updateRiskScoreMappings({
+      auditLogger: mockAuditLogger,
+      logger,
+      kibanaVersion,
+      getStartServices: getStartServicesMock,
+      hasEncryptionKey: true,
+      spaceId: 'my-space',
+    });
+
+    expect(soClient.find).toHaveBeenCalledWith(
+      expect.objectContaining({ namespaces: ['my-space'] })
+    );
+  });
+
   it('should update risk score mappings for every space when versions are different', async () => {
     const mockSavedObjectsResponse = {
       ...mockSavedObjectsResponseDefaults,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/update_risk_score_mappings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/update_risk_score_mappings.ts
@@ -22,6 +22,7 @@ export const updateRiskScoreMappings = async ({
   logger,
   getStartServices,
   kibanaVersion,
+  spaceId,
 }: EntityAnalyticsMigrationsParams) => {
   const [coreStart] = await getStartServices();
   const soClientKibanaUser = coreStart.savedObjects.createInternalRepository();
@@ -30,7 +31,7 @@ export const updateRiskScoreMappings = async ({
   const savedObjectsResponse = await soClientKibanaUser.find<RiskEngineConfiguration>({
     type: riskEngineConfigurationTypeName,
     perPage: MAX_PER_PAGE,
-    namespaces: ['*'],
+    namespaces: spaceId ? [spaceId] : ['*'],
   });
 
   await asyncForEach(savedObjectsResponse.saved_objects, async (savedObject) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/utils/event_ingested_pipeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/utils/event_ingested_pipeline.ts
@@ -86,9 +86,11 @@ export const createEventIngestedPipelineInAllNamespaces = async ({
   getStartServices,
   logger,
   auditLogger,
+  spaceId,
 }: EntityAnalyticsMigrationsParams) => {
   const [coreStart] = await getStartServices();
   const esClient = coreStart.elasticsearch.client.asInternalUser;
+
   const savedObjectsRepo = coreStart.savedObjects.createInternalRepository();
   const internalSoClient = new SavedObjectsClient(savedObjectsRepo);
   const assetCriticalityMigrationClient = new AssetCriticalityMigrationClient({
@@ -99,7 +101,10 @@ export const createEventIngestedPipelineInAllNamespaces = async ({
   const assetCriticalitySpaces =
     await assetCriticalityMigrationClient.getAllSpacesWithAssetCriticalityInstalled();
   const riskEngineSpaces = await getAllRiskEngineSpaces(internalSoClient);
-  const uniqueNamespaces = new Set([...assetCriticalitySpaces, ...riskEngineSpaces]);
+  const allNamespaces = new Set([...assetCriticalitySpaces, ...riskEngineSpaces]);
+  const uniqueNamespaces = spaceId
+    ? new Set([spaceId].filter((id) => allNamespaces.has(id)))
+    : allNamespaces;
 
   for (const namespace of uniqueNamespaces) {
     const pipelineExists = await hasEventIngestedPipeline(esClient, namespace);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.test.ts
@@ -69,6 +69,7 @@ describe('installPrebuiltWatchlists', function () {
   const mockLogger = loggingSystemMock.createLogger();
   const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
   const mockSoClient = mockSavedObjectsClient.create();
+  let mockCreateInternalRepository: jest.Mock;
 
   const callInstall = () =>
     installPrebuiltWatchlists({
@@ -94,10 +95,23 @@ describe('installPrebuiltWatchlists', function () {
     mockEntitySourceCreate.mockResolvedValue({ id: 'entity-source-id' });
     mockEntitySourceList.mockResolvedValue({ sources: [] });
     mockAddEntitySourceReference.mockResolvedValue(undefined);
+    // Mirror core `find` behavior: the hidden `space` type is only queryable when
+    // it is explicitly passed via `includedHiddenTypes`; otherwise `find` returns
+    // an empty result. This guards against regressing back to an un-scoped repo.
+    mockCreateInternalRepository = jest
+      .fn()
+      .mockImplementation((includedHiddenTypes?: string[]) => {
+        if (includedHiddenTypes?.includes('space')) {
+          return mockSoClient;
+        }
+        const repoWithoutSpaceAccess = mockSavedObjectsClient.create();
+        repoWithoutSpaceAccess.find.mockResolvedValue(buildEmptySpacesResponse());
+        return repoWithoutSpaceAccess;
+      });
     mockGetStartServices.mockResolvedValue([
       {
         savedObjects: {
-          createInternalRepository: jest.fn().mockReturnValue(mockSoClient),
+          createInternalRepository: mockCreateInternalRepository,
         },
         elasticsearch: {
           client: {
@@ -255,10 +269,5 @@ describe('installPrebuiltWatchlists', function () {
         id: getPrivilegedUserWatchlistSavedObjectId('my-space'),
       });
     });
-  });
-
-  it('has no duplicate prebuilt watchlist names', () => {
-    const names = getPrebuiltWatchlists('default').map((w) => w.name);
-    expect(new Set(names).size).toBe(names.length);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.test.ts
@@ -233,4 +233,32 @@ describe('installPrebuiltWatchlists', function () {
     // default is in the spaces response AND always added — should still only run twice, not three times
     expect(mockWatchlistCreate).toHaveBeenCalledTimes(2);
   });
+
+  describe('with spaceId defined', () => {
+    it('skips space discovery and installs only for the specified space', async () => {
+      mockWatchlistGet.mockRejectedValue(new Error('Saved object not found'));
+
+      await installPrebuiltWatchlists({
+        auditLogger: mockAuditLogger,
+        logger: mockLogger,
+        getStartServices: mockGetStartServices,
+        kibanaVersion: '9.0.0',
+        hasEncryptionKey: true,
+        spaceId: 'my-space',
+      });
+
+      // Space discovery should be skipped — no call with the hidden 'space' type
+      expect(mockCreateInternalRepository).not.toHaveBeenCalledWith(['space']);
+      // Only one watchlist created — for 'my-space', not for 'default' or any other space
+      expect(mockWatchlistCreate).toHaveBeenCalledTimes(1);
+      expect(mockWatchlistCreate).toHaveBeenCalledWith(expect.anything(), {
+        id: getPrivilegedUserWatchlistSavedObjectId('my-space'),
+      });
+    });
+  });
+
+  it('has no duplicate prebuilt watchlist names', () => {
+    const names = getPrebuiltWatchlists('default').map((w) => w.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.ts
@@ -214,20 +214,29 @@ export const installPrebuiltWatchlists = async ({
   logger,
   getStartServices,
   hasEncryptionKey,
+  spaceId,
 }: EntityAnalyticsMigrationsParams) => {
   const [coreStart] = await getStartServices();
-  const internalRepo = coreStart.savedObjects.createInternalRepository();
   const esClient = coreStart.elasticsearch.client.asInternalUser;
 
-  const spacesResponse = await internalRepo.find({
-    type: 'space',
-    perPage: 1000,
-  });
+  let namespaces: Set<string>;
 
-  // Always include 'default' — it may not have an explicit saved object
-  const namespaces = new Set<string>(['default']);
-  for (const so of spacesResponse.saved_objects) {
-    namespaces.add(so.id);
+  if (spaceId) {
+    namespaces = new Set([spaceId]);
+  } else {
+    // 'space' is a hidden saved object type, so it must be explicitly included or
+    // `find` silently returns an empty result and custom spaces are never discovered.
+    const internalRepo = coreStart.savedObjects.createInternalRepository(['space']);
+    const spacesResponse = await internalRepo.find({
+      type: 'space',
+      perPage: 1000,
+    });
+
+    // Always include 'default' — it may not have an explicit saved object
+    namespaces = new Set<string>(['default']);
+    for (const so of spacesResponse.saved_objects) {
+      namespaces.add(so.id);
+    }
   }
 
   for (const namespace of namespaces) {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/migrations.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/migrations.ts
@@ -20,7 +20,6 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
   const supertest = getService('supertest');
   const log = getService('log');
-  const entityAnalyticsRoutes = entityAnalyticsRouteHelpersFactory(supertest, log);
   const entityAnalyticsApi = getService('entityAnalyticsApi');
   const spacesService = getService('spaces');
 
@@ -95,6 +94,8 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     SPACES.forEach((namespace) => {
+      const entityAnalyticsRoutes = entityAnalyticsRouteHelpersFactory(supertest, log, namespace);
+
       describe(`source_index migration for space ${namespace}`, () => {
         it(`should run the migration when users have source_index field`, async () => {
           const indexPattern = 'INDEX1';

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/migrations.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/migrations.ts
@@ -83,7 +83,9 @@ export default ({ getService }: FtrProviderContext) => {
           await simulateMissingPipelineBug({ es, log, space });
         }
 
-        await entityAnalyticsRoutes.runMigrations();
+        for (const space of SPACE_TEST_SPACES) {
+          await entityAnalyticsRouteHelpersFactory(supertest, log, space).runMigrations();
+        }
 
         for (const space of SPACE_TEST_SPACES) {
           const pipelineExists = await doesEventIngestedPipelineExist({
@@ -134,7 +136,9 @@ export default ({ getService }: FtrProviderContext) => {
           await simulateMissingPipelineBug({ es, log, space });
         }
 
-        await entityAnalyticsRoutes.runMigrations();
+        for (const space of SPACE_TEST_SPACES) {
+          await entityAnalyticsRouteHelpersFactory(supertest, log, space).runMigrations();
+        }
 
         for (const space of SPACE_TEST_SPACES) {
           const pipelineExists = await doesEventIngestedPipelineExist({
@@ -282,7 +286,9 @@ export default ({ getService }: FtrProviderContext) => {
           await downgradeIndexVersion(space);
         }
 
-        await entityAnalyticsRoutes.runMigrations();
+        for (const space of SPACE_TEST_SPACES) {
+          await entityAnalyticsRouteHelpersFactory(supertest, log, space).runMigrations();
+        }
 
         for (const space of SPACE_TEST_SPACES) {
           const indexTemplate = await getRiskScoreIndexTemplate(es, space);
@@ -369,7 +375,9 @@ export default ({ getService }: FtrProviderContext) => {
           });
           await downgradeIndexVersion(space);
         }
-        await entityAnalyticsRoutes.runMigrations();
+        for (const space of SPACE_TEST_SPACES) {
+          await entityAnalyticsRouteHelpersFactory(supertest, log, space).runMigrations();
+        }
 
         for (const space of SPACE_TEST_SPACES) {
           expect(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Entity Analytics] Requiring security `All` privilege in order to run EA migrations via API and only running on current space (#286375)](https://github.com/elastic/kibana/pull/286375)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2026-08-21T15:47:00Z","message":"[Entity Analytics] Requiring security `All` privilege in order to run EA migrations via API and only running on current space (#286375)\n\n## Summary\n\nEntity analytics migrations are run automatically when Kibana starts up\nand run over all spaces.\nhttps://github.com/elastic/kibana/blob/9944c6e693a40c0fe4871a8852573aef9e936756/x-pack/solutions/security/plugins/security_solution/server/plugin.ts#L388\n\nThere is also an internal route for running migrations. This PR gates\nthis internal API behind the `securitySolution-entity-analytics-manage`\nproduct privilege (which is derived from the Security `All` role feature\nprivilege) and restricts migrations to running only against the current\nspace when called from the API. The plugin setup call to run migrations\nwill continue to operate over all spaces.\n\n## To Verify\n\n1. Start ES and Kibana and create 2 spaces. I created `accessible_space`\nand `hidden_space`. Enable Entity Analytics in both of these spaces.\n2. Create a low privilege user and role with Security `Read` privilege\nto `accessible_space` only.\n3. As your admin user in `hidden_space`, delete the EA ingest pipeline\n\n```\nDELETE _ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-${HIDDEN_spaceId}\n```\n\nYou may have to unlink it from existing indices first like\n\n```\nPUT risk-score.risk-score-${HIDDEN_spaceId}/_settings\n{\n    \"index.default_pipeline\":\"_none\"\n}\n```\n\nVerify no more ingest pipeline `GET\n_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-${HIDDEN_spaceId}`\n\n4. Run the migration as your low privilege user via CURL:\n\n```\ncurl -i -sS -u \"{low_priv_user}:{password}\" -H 'kbn-xsrf: 1' -H 'x-elastic-internal-origin: kibana' -H 'Elastic-Api-Version: 1' -X POST \"http://localhost:5601/s/${ACCESSIBLE_spaceId}/internal/entity_analytics/migrations/run\"\n```\n\nYou should (with this PR) get a 403 error\n\n```\n{\"statusCode\":403,\"error\":\"Forbidden\",\"message\":\"API [POST /internal/entity_analytics/migrations/run] is unauthorized for user, this action is granted by the Kibana privileges [securitySolution-entity-analytics-manage]\"}%\n```\n\n5. Modify this user to have Security `All` privilege and run the curl\ncommand again\n6. You should get a 200 `{\"success\":true}` and with this PR and the\ningest pipeline in the hidden space that we deleted above should NOT get\nrestored (Check with `GET\n_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-${HIDDEN_spaceId}`\n)","sha":"97707afacb3d4abb4628a802b88efc60e242b0a3","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Entity Analytics","backport:version","v9.6.0","v9.4.6","v9.5.2","v8.19.21"],"title":"[Entity Analytics] Requiring security `All` privilege in order to run EA migrations via API and only running on current space","number":286375,"url":"https://github.com/elastic/kibana/pull/286375","mergeCommit":{"message":"[Entity Analytics] Requiring security `All` privilege in order to run EA migrations via API and only running on current space (#286375)\n\n## Summary\n\nEntity analytics migrations are run automatically when Kibana starts up\nand run over all spaces.\nhttps://github.com/elastic/kibana/blob/9944c6e693a40c0fe4871a8852573aef9e936756/x-pack/solutions/security/plugins/security_solution/server/plugin.ts#L388\n\nThere is also an internal route for running migrations. This PR gates\nthis internal API behind the `securitySolution-entity-analytics-manage`\nproduct privilege (which is derived from the Security `All` role feature\nprivilege) and restricts migrations to running only against the current\nspace when called from the API. The plugin setup call to run migrations\nwill continue to operate over all spaces.\n\n## To Verify\n\n1. Start ES and Kibana and create 2 spaces. I created `accessible_space`\nand `hidden_space`. Enable Entity Analytics in both of these spaces.\n2. Create a low privilege user and role with Security `Read` privilege\nto `accessible_space` only.\n3. As your admin user in `hidden_space`, delete the EA ingest pipeline\n\n```\nDELETE _ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-${HIDDEN_spaceId}\n```\n\nYou may have to unlink it from existing indices first like\n\n```\nPUT risk-score.risk-score-${HIDDEN_spaceId}/_settings\n{\n    \"index.default_pipeline\":\"_none\"\n}\n```\n\nVerify no more ingest pipeline `GET\n_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-${HIDDEN_spaceId}`\n\n4. Run the migration as your low privilege user via CURL:\n\n```\ncurl -i -sS -u \"{low_priv_user}:{password}\" -H 'kbn-xsrf: 1' -H 'x-elastic-internal-origin: kibana' -H 'Elastic-Api-Version: 1' -X POST \"http://localhost:5601/s/${ACCESSIBLE_spaceId}/internal/entity_analytics/migrations/run\"\n```\n\nYou should (with this PR) get a 403 error\n\n```\n{\"statusCode\":403,\"error\":\"Forbidden\",\"message\":\"API [POST /internal/entity_analytics/migrations/run] is unauthorized for user, this action is granted by the Kibana privileges [securitySolution-entity-analytics-manage]\"}%\n```\n\n5. Modify this user to have Security `All` privilege and run the curl\ncommand again\n6. You should get a 200 `{\"success\":true}` and with this PR and the\ningest pipeline in the hidden space that we deleted above should NOT get\nrestored (Check with `GET\n_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-${HIDDEN_spaceId}`\n)","sha":"97707afacb3d4abb4628a802b88efc60e242b0a3"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/286375","number":286375,"mergeCommit":{"message":"[Entity Analytics] Requiring security `All` privilege in order to run EA migrations via API and only running on current space (#286375)\n\n## Summary\n\nEntity analytics migrations are run automatically when Kibana starts up\nand run over all spaces.\nhttps://github.com/elastic/kibana/blob/9944c6e693a40c0fe4871a8852573aef9e936756/x-pack/solutions/security/plugins/security_solution/server/plugin.ts#L388\n\nThere is also an internal route for running migrations. This PR gates\nthis internal API behind the `securitySolution-entity-analytics-manage`\nproduct privilege (which is derived from the Security `All` role feature\nprivilege) and restricts migrations to running only against the current\nspace when called from the API. The plugin setup call to run migrations\nwill continue to operate over all spaces.\n\n## To Verify\n\n1. Start ES and Kibana and create 2 spaces. I created `accessible_space`\nand `hidden_space`. Enable Entity Analytics in both of these spaces.\n2. Create a low privilege user and role with Security `Read` privilege\nto `accessible_space` only.\n3. As your admin user in `hidden_space`, delete the EA ingest pipeline\n\n```\nDELETE _ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-${HIDDEN_spaceId}\n```\n\nYou may have to unlink it from existing indices first like\n\n```\nPUT risk-score.risk-score-${HIDDEN_spaceId}/_settings\n{\n    \"index.default_pipeline\":\"_none\"\n}\n```\n\nVerify no more ingest pipeline `GET\n_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-${HIDDEN_spaceId}`\n\n4. Run the migration as your low privilege user via CURL:\n\n```\ncurl -i -sS -u \"{low_priv_user}:{password}\" -H 'kbn-xsrf: 1' -H 'x-elastic-internal-origin: kibana' -H 'Elastic-Api-Version: 1' -X POST \"http://localhost:5601/s/${ACCESSIBLE_spaceId}/internal/entity_analytics/migrations/run\"\n```\n\nYou should (with this PR) get a 403 error\n\n```\n{\"statusCode\":403,\"error\":\"Forbidden\",\"message\":\"API [POST /internal/entity_analytics/migrations/run] is unauthorized for user, this action is granted by the Kibana privileges [securitySolution-entity-analytics-manage]\"}%\n```\n\n5. Modify this user to have Security `All` privilege and run the curl\ncommand again\n6. You should get a 200 `{\"success\":true}` and with this PR and the\ningest pipeline in the hidden space that we deleted above should NOT get\nrestored (Check with `GET\n_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-${HIDDEN_spaceId}`\n)","sha":"97707afacb3d4abb4628a802b88efc60e242b0a3"}},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.21","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->