### PR TITLE
[Security Solution][Alerts page] bring assignees to the same row as page filters to mimic attack page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/content.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { TestProviders } from '../../../common/mock';
 import { AlertsPageContent, SECURITY_SOLUTION_PAGE_WRAPPER_TEST_ID } from './content';
 import type { DataView } from '@kbn/data-views-plugin/common';
@@ -15,16 +16,44 @@ import { GO_TO_RULES_BUTTON_TEST_ID } from './header/header_section';
 import { FILTER_BY_ASSIGNEES_BUTTON } from '../../../common/components/filter_by_assignees_popover/test_ids';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { getUserPrivilegesMockDefaultValue } from '../../../common/components/user_privileges/__mocks__';
+import { useLicense } from '../../../common/hooks/use_license';
+import { useGetCurrentUserProfile } from '../../../common/components/user_profiles/use_get_current_user_profile';
+import { useSuggestUsers } from '../../../common/components/user_profiles/use_suggest_users';
 
 jest.mock('../../../common/components/user_privileges');
+jest.mock('../../../common/hooks/use_license');
+jest.mock('../../../common/components/user_profiles/use_get_current_user_profile');
+jest.mock('../../../common/components/user_profiles/use_suggest_users');
 
 const mockUseUserPrivileges = useUserPrivileges as jest.Mock;
+
+const currentUser: UserProfileWithAvatar = {
+  uid: 'uid1',
+  enabled: true,
+  user: {
+    username: 'current.user',
+    email: 'current.user@elastic.co',
+    full_name: 'Current User',
+  },
+  data: {},
+};
+const user: UserProfileWithAvatar = {
+  uid: 'uid2',
+  enabled: true,
+  user: {
+    username: 'jon.doe',
+    email: 'jon.do@elastic.co',
+    full_name: 'John Doe',
+  },
+  data: {},
+};
 
 const dataView: DataView = createStubDataView({ spec: {} });
 
 describe('AlertsPageContent', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (useLicense as jest.Mock).mockReturnValue({ isPlatinumPlus: () => true });
     mockUseUserPrivileges.mockReturnValue(
       getUserPrivilegesMockDefaultValue({
         rulesPrivileges: {
@@ -55,6 +84,38 @@ describe('AlertsPageContent', () => {
       expect(screen.getByTestId(FILTER_BY_ASSIGNEES_BUTTON)).toBeInTheDocument();
       expect(screen.getByTestId(GO_TO_RULES_BUTTON_TEST_ID)).toBeInTheDocument();
       expect(screen.getByTestId('chartPanels')).toBeInTheDocument();
+    });
+  });
+
+  it('should set the assignees when selecting a user', async () => {
+    (useGetCurrentUserProfile as jest.Mock).mockReturnValue({
+      data: user,
+    });
+    (useSuggestUsers as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: [currentUser, user],
+    });
+
+    render(
+      <TestProviders>
+        <AlertsPageContent dataView={dataView} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId(FILTER_BY_ASSIGNEES_BUTTON));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`userProfileSelectableOption-${user.user.username}`)
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId(`userProfileSelectableOption-${user.user.username}`));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`userProfileSelectableOption-${user.user.username}`)
+      ).toHaveAttribute('aria-checked', 'true');
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/content.tsx
@@ -5,8 +5,15 @@
  * 2.0.
  */
 
-import { EuiHorizontalRule, EuiSpacer, EuiWindowEvent } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiSpacer,
+  EuiWindowEvent,
+} from '@elastic/eui';
 import styled from '@emotion/styled';
+import { isEqual } from 'lodash';
 import { noop } from 'lodash/fp';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { isTab } from '@kbn/timelines-plugin/public';
@@ -20,6 +27,7 @@ import { HeaderPage } from '../../../common/components/header_page';
 import { KPIsSection } from './kpis/kpis_section';
 import { FiltersSection } from './filters/filters_section';
 import { HeaderSection } from './header/header_section';
+import { FilterByAssigneesPopover } from '../../../common/components/filter_by_assignees_popover/filter_by_assignees_popover';
 import { SearchBarSection } from './search_bar/search_bar_section';
 import { TableSection } from './table/table_section';
 import type { AssigneesIdsSelection } from '../../../common/components/assignees/types';
@@ -35,6 +43,9 @@ import type { Status } from '../../../../common/api/detection_engine';
 
 export const CONTENT_TEST_ID = 'alerts-page-content';
 export const SECURITY_SOLUTION_PAGE_WRAPPER_TEST_ID = 'alerts-page-security-solution-page-wrapper';
+export const ALERTS_PAGE_ASSIGNEE_FILTER_TEST_ID = 'alerts-page-assignee-filter';
+export const ALERTS_PAGE_STANDARD_FILTERS_TEST_ID = 'alerts-page-standard-filters';
+const FILTERS_SECTION_MIN_WIDTH = 480;
 
 /**
  * Need a 100% height here to account for the graph/analyze tool, which sets no explicit height parameters, but fills the available space.
@@ -43,6 +54,11 @@ const StyledFullHeightContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+`;
+
+const VerticalDivider = styled(EuiFlexItem)`
+  align-self: stretch;
+  border-left: ${({ theme: { euiTheme } }) => euiTheme.border.thin};
 `;
 
 export interface AlertsPageContentProps {
@@ -68,6 +84,15 @@ export const AlertsPageContent = memo(({ dataView }: AlertsPageContentProps) => 
   const getTable = useMemo(() => dataTableSelectors.getTableByIdSelector(), []);
   const isTableLoading = useShallowEqualSelector(
     (state) => (getTable(state, TableId.alertsOnAlertsPage) ?? tableDefaults).isLoading
+  );
+
+  const onAssigneesSelectionChange = useCallback(
+    (newAssignees: AssigneesIdsSelection[]) => {
+      if (!isEqual(newAssignees, assignees)) {
+        setAssignees(newAssignees);
+      }
+    },
+    [assignees, setAssignees]
   );
 
   const onSkipFocusBeforeEventsTable = useCallback(() => {
@@ -113,18 +138,34 @@ export const AlertsPageContent = memo(({ dataView }: AlertsPageContentProps) => 
       >
         <Display show={!globalFullScreen}>
           <HeaderPage title={PAGE_TITLE}>
-            <HeaderSection assignees={assignees} setAssignees={setAssignees} />
+            <HeaderSection />
           </HeaderPage>
           <EuiHorizontalRule margin="none" />
           <EuiSpacer size="l" />
-          <FiltersSection
-            assignees={assignees}
-            dataView={dataView}
-            pageFilters={pageFilters}
-            setStatusFilter={setStatusFilter}
-            setPageFilters={setPageFilters}
-            setPageFilterHandler={setPageFilterHandler}
-          />
+          <EuiFlexGroup direction="row" responsive={false} wrap={true}>
+            <EuiFlexItem grow={false} data-test-subj={ALERTS_PAGE_ASSIGNEE_FILTER_TEST_ID}>
+              <FilterByAssigneesPopover
+                selectedUserIds={assignees}
+                onSelectionChange={onAssigneesSelectionChange}
+                compressed={true}
+              />
+            </EuiFlexItem>
+            <VerticalDivider grow={false} aria-hidden={true} />
+            <EuiFlexItem
+              grow={1}
+              style={{ minWidth: FILTERS_SECTION_MIN_WIDTH }}
+              data-test-subj={ALERTS_PAGE_STANDARD_FILTERS_TEST_ID}
+            >
+              <FiltersSection
+                assignees={assignees}
+                dataView={dataView}
+                pageFilters={pageFilters}
+                setStatusFilter={setStatusFilter}
+                setPageFilters={setPageFilters}
+                setPageFilterHandler={setPageFilterHandler}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
           <EuiSpacer size="l" />
           <KPIsSection assignees={assignees} pageFilters={pageFilters} dataView={dataView} />
           <EuiSpacer size="l" />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/header/header_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/header/header_section.test.tsx
@@ -6,47 +6,17 @@
  */
 
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import { GO_TO_RULES_BUTTON_TEST_ID, HeaderSection } from './header_section';
-import { FILTER_BY_ASSIGNEES_BUTTON } from '../../../../common/components/filter_by_assignees_popover/test_ids';
-import { useSuggestUsers } from '../../../../common/components/user_profiles/use_suggest_users';
-import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
-import { useLicense } from '../../../../common/hooks/use_license';
-import { useGetCurrentUserProfile } from '../../../../common/components/user_profiles/use_get_current_user_profile';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 
-jest.mock('../../../../common/hooks/use_license');
 jest.mock('../../../../common/components/user_privileges');
-jest.mock('../../../../common/components/user_profiles/use_get_current_user_profile');
-jest.mock('../../../../common/components/user_profiles/use_suggest_users');
 
 const mockUseUserPrivileges = useUserPrivileges as jest.Mock;
 
-const currentUser: UserProfileWithAvatar = {
-  uid: 'uid1',
-  enabled: true,
-  user: {
-    username: 'current.user',
-    email: 'current.user@elastic.co',
-    full_name: 'Current User',
-  },
-  data: {},
-};
-const user: UserProfileWithAvatar = {
-  uid: 'uid2',
-  enabled: true,
-  user: {
-    username: 'jon.doe',
-    email: 'jon.do@elastic.co',
-    full_name: 'John Doe',
-  },
-  data: {},
-};
-
 describe('HeaderSection', () => {
   beforeEach(() => {
-    (useLicense as jest.Mock).mockReturnValue({ isPlatinumPlus: () => true });
     mockUseUserPrivileges.mockReturnValue({
       rulesPrivileges: {
         rules: {
@@ -56,18 +26,17 @@ describe('HeaderSection', () => {
     });
   });
 
-  it('should render correctly with manage rules button', () => {
+  it('should render the manage rules button', () => {
     const { getByTestId } = render(
       <TestProviders>
-        <HeaderSection assignees={[]} setAssignees={jest.fn()} />
+        <HeaderSection />
       </TestProviders>
     );
 
-    expect(getByTestId(FILTER_BY_ASSIGNEES_BUTTON)).toBeInTheDocument();
     expect(getByTestId(GO_TO_RULES_BUTTON_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should not render manage rules button when showManageRulesButton is false', () => {
+  it('should not render the manage rules button when the user cannot read rules', () => {
     mockUseUserPrivileges.mockReturnValueOnce({
       rulesPrivileges: {
         rules: {
@@ -75,73 +44,12 @@ describe('HeaderSection', () => {
         },
       },
     });
-    const { getByTestId, queryByTestId } = render(
+    const { queryByTestId } = render(
       <TestProviders>
-        <HeaderSection assignees={[]} setAssignees={jest.fn()} />
+        <HeaderSection />
       </TestProviders>
     );
 
-    expect(getByTestId(FILTER_BY_ASSIGNEES_BUTTON)).toBeInTheDocument();
     expect(queryByTestId(GO_TO_RULES_BUTTON_TEST_ID)).not.toBeInTheDocument();
-  });
-
-  it('should set assignee', async () => {
-    const setAssignees = jest.fn();
-
-    (useGetCurrentUserProfile as jest.Mock).mockReturnValue({
-      data: user,
-    });
-    (useSuggestUsers as jest.Mock).mockReturnValue({
-      isLoading: false,
-      data: [currentUser, user],
-    });
-
-    const { getByTestId } = render(
-      <TestProviders>
-        <HeaderSection assignees={[]} setAssignees={setAssignees} />
-      </TestProviders>
-    );
-
-    fireEvent.click(getByTestId(FILTER_BY_ASSIGNEES_BUTTON));
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId(`userProfileSelectableOption-${user.user.username}`)
-      ).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByTestId(`userProfileSelectableOption-${user.user.username}`));
-
-    expect(setAssignees).toHaveBeenCalledWith([user.uid]);
-  });
-
-  it('should not set assignee if user is already assigned', async () => {
-    const setAssignees = jest.fn();
-
-    (useGetCurrentUserProfile as jest.Mock).mockReturnValue({
-      data: user,
-    });
-    (useSuggestUsers as jest.Mock).mockReturnValue({
-      isLoading: false,
-      data: [currentUser, user],
-    });
-
-    const { getByTestId } = render(
-      <TestProviders>
-        <HeaderSection assignees={[user.uid]} setAssignees={setAssignees} />
-      </TestProviders>
-    );
-
-    fireEvent.click(getByTestId(FILTER_BY_ASSIGNEES_BUTTON));
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId(`userProfileSelectableOption-${user.user.username}`)
-      ).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByTestId(`userProfileSelectableOption-${user.user.username}`));
-
-    expect(setAssignees).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/header/header_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/header/header_section.tsx
@@ -5,13 +5,8 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import type { Dispatch, SetStateAction } from 'react';
-import React, { memo, useCallback } from 'react';
-import { isEqual } from 'lodash';
+import React, { memo } from 'react';
 import { i18n } from '@kbn/i18n';
-import { FilterByAssigneesPopover } from '../../../../common/components/filter_by_assignees_popover/filter_by_assignees_popover';
-import type { AssigneesIdsSelection } from '../../../../common/components/assignees/types';
 import { SecurityPageName } from '../../../../app/types';
 import { SecuritySolutionLinkButton } from '../../../../common/components/links';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
@@ -22,51 +17,24 @@ const BUTTON_MANAGE_RULES = i18n.translate('xpack.securitySolution.alertsPage.bu
 
 export const GO_TO_RULES_BUTTON_TEST_ID = 'alerts-page-manage-alert-detection-rules';
 
-export interface HeaderSectionProps {
-  /**
-   * List of assignees retrieved from the assignees button on the alert page
-   */
-  assignees: AssigneesIdsSelection[];
-  /**
-   * Callback to set the assignees for the alerts page as they're also used in the FilterSection component
-   */
-  setAssignees: Dispatch<SetStateAction<AssigneesIdsSelection[]>>;
-}
-
 /**
- * UI section of the alerts page that renders the assignees button and a button to navigate to the rules page.
+ * UI section of the alerts page that renders a button to navigate to the rules page.
  */
-export const HeaderSection = memo(({ assignees, setAssignees }: HeaderSectionProps) => {
+export const HeaderSection = memo(() => {
   const canReadRules = useUserPrivileges().rulesPrivileges.rules.read;
-  const handleSelectedAssignees = useCallback(
-    (newAssignees: AssigneesIdsSelection[]) => {
-      if (!isEqual(newAssignees, assignees)) {
-        setAssignees(newAssignees);
-      }
-    },
-    [assignees, setAssignees]
-  );
+
+  if (!canReadRules) {
+    return null;
+  }
 
   return (
-    <EuiFlexGroup gutterSize="m">
-      <EuiFlexItem>
-        <FilterByAssigneesPopover
-          selectedUserIds={assignees}
-          onSelectionChange={handleSelectedAssignees}
-        />
-      </EuiFlexItem>
-      {canReadRules ? (
-        <EuiFlexItem>
-          <SecuritySolutionLinkButton
-            deepLinkId={SecurityPageName.rules}
-            data-test-subj={GO_TO_RULES_BUTTON_TEST_ID}
-            fill
-          >
-            {BUTTON_MANAGE_RULES}
-          </SecuritySolutionLinkButton>
-        </EuiFlexItem>
-      ) : null}
-    </EuiFlexGroup>
+    <SecuritySolutionLinkButton
+      deepLinkId={SecurityPageName.rules}
+      data-test-subj={GO_TO_RULES_BUTTON_TEST_ID}
+      fill
+    >
+      {BUTTON_MANAGE_RULES}
+    </SecuritySolutionLinkButton>
   );
 });
 


### PR DESCRIPTION
## Summary

This PR makes a small change to the Alerts page. Following what was done in this previous [PR](https://github.com/elastic/kibana/pull/256760), this current PR moves the `Assignees` button from the top of the page, to the left of the page filters. It also mimics the UI of the rest of the page filters buttons.

#### `main` branch
<img width="1562" height="857" alt="Screenshot 2026-08-21 at 6 58 06 PM" src="https://github.com/user-attachments/assets/c86fa17d-5195-4501-b8ad-07f2c430747b" />

#### This branch

https://github.com/user-attachments/assets/79af7757-5480-4e1c-a053-e46797b7c9df

> [!NOTE]
> No actual behavior is changed, the button is just moved and skinned slightly differently

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/286623