### PR TITLE
[ResponseOps] Fixes failing test by adding xpack.alerting_v2.esql.responseFormat

### DIFF
--- a/src/core/server/integration_tests/config/check_dynamic_config.test.ts
+++ b/src/core/server/integration_tests/config/check_dynamic_config.test.ts
@@ -140,6 +140,8 @@ if (getFips() === 0) {
         // We need this for enriching our Perf tests with more valuable data regarding the steps of the test
         // Also helpful in Cloud & Serverless testing because we can't control the labels in those offerings
         'telemetry.labels',
+        // Lets Scout tests flip the ES|QL response format at runtime
+        'xpack.alerting_v2.esql.responseFormat',
         // This allow to test fleet features flags while in devlopment
         'xpack.fleet.experimentalFeatures',
       ]);


### PR DESCRIPTION
## Summary

Fixes failing test from this PR, https://github.com/elastic/kibana/pull/285023



