### PR TITLE
[Agent Builder] Conversation sharing UI

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_ui_ebt.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/telemetry/agent_builder_ui_ebt.ts
@@ -162,6 +162,7 @@ const ebtAction = {
     DELETE: 'delete',
     RENAME_SAVE: 'rename_save',
     RENAME_CANCEL: 'rename_cancel',
+    OPEN_SHARE: 'open_share',
     OPEN_MORE_ACTIONS: 'open_more_actions',
     AGENT_DETAILS: 'agent_details',
     GENAI_SETTINGS: 'genai_settings',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
@@ -12,6 +12,7 @@ import { AGENT_BUILDER_UI_EBT } from '@kbn/agent-builder-common';
 import { getEbtProps } from '@kbn/ebt-click';
 import { useConversationContext } from '../../../context/conversation/conversation_context';
 import { MoreActionsButton } from './more_actions_button';
+import { ConversationShareButton } from './conversation_share_button';
 
 const labels = {
   container: i18n.translate('xpack.agentBuilder.conversationActions.container', {
@@ -37,6 +38,7 @@ export const ConversationRightActions: React.FC<ConversationRightActionsProps> =
       aria-label={labels.container}
       responsive={false}
     >
+      <ConversationShareButton />
       <MoreActionsButton onCloseSidebar={isEmbeddedContext ? onClose : undefined} />
       {isEmbeddedContext && (
         <EuiToolTip content={labels.close} disableScreenReaderOutput>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button.test.tsx
@@ -1,0 +1,245 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import {
+  ConversationAccessControlMode,
+  ConversationAccessControlRole,
+  type Conversation,
+} from '@kbn/agent-builder-common';
+import { useConversationId } from '../../../context/conversation/use_conversation_id';
+import {
+  useConversation,
+  useConversationPermissions,
+  useHasPersistedConversation,
+} from '../../../hooks/use_conversation';
+import { useSuggestUsers } from '../../../hooks/use_suggest_users';
+import {
+  useConversationAccessControlProfiles,
+  useUpdateConversationAccessControl,
+} from '../../../hooks/use_conversation_access_control';
+import { ConversationShareButton } from './conversation_share_button';
+
+jest.mock('../../../context/conversation/use_conversation_id', () => ({
+  useConversationId: jest.fn(),
+}));
+
+jest.mock('../../../hooks/use_conversation', () => ({
+  useConversation: jest.fn(),
+  useConversationPermissions: jest.fn(),
+  useHasPersistedConversation: jest.fn(),
+}));
+
+jest.mock('../../../hooks/use_suggest_users', () => ({
+  useSuggestUsers: jest.fn(),
+}));
+
+jest.mock('../../../hooks/use_conversation_access_control', () => ({
+  useConversationAccessControlProfiles: jest.fn(),
+  useUpdateConversationAccessControl: jest.fn(),
+}));
+
+const mockUseConversationId = jest.mocked(useConversationId);
+const mockUseConversation = jest.mocked(useConversation);
+const mockUseConversationPermissions = jest.mocked(useConversationPermissions);
+const mockUseHasPersistedConversation = jest.mocked(useHasPersistedConversation);
+const mockUseSuggestUsers = jest.mocked(useSuggestUsers);
+const mockUseConversationAccessControlProfiles = jest.mocked(useConversationAccessControlProfiles);
+const mockUseUpdateConversationAccessControl = jest.mocked(useUpdateConversationAccessControl);
+
+const mutate = jest.fn();
+let updateOptions: Parameters<typeof useUpdateConversationAccessControl>[0];
+
+const ownerProfile = {
+  uid: 'owner-1',
+  user: { username: 'ethan', full_name: 'Ethan Smith' },
+  data: {},
+  enabled: true,
+};
+
+const memberProfile = {
+  uid: 'member-1',
+  user: { username: 'alex', full_name: 'Alex Kim' },
+  data: {},
+  enabled: true,
+};
+
+const baseConversation = {
+  id: 'conversation-1',
+  agent_id: 'agent-1',
+  user: { id: 'owner-1', username: 'ethan' },
+  title: 'My conversation',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  rounds: [],
+  access_control: {
+    access_mode: ConversationAccessControlMode.Private,
+    entries: [],
+  },
+} as unknown as Conversation;
+
+const renderShareButton = ({
+  conversation = baseConversation,
+  canUpdateAccessControl = true,
+}: {
+  conversation?: Conversation;
+  canUpdateAccessControl?: boolean;
+} = {}) => {
+  mockUseConversationId.mockReturnValue(conversation?.id);
+  mockUseConversation.mockReturnValue({
+    conversation,
+    isLoading: false,
+    isFetching: false,
+    isFetched: true,
+    isError: false,
+    error: undefined,
+  });
+  mockUseHasPersistedConversation.mockReturnValue(Boolean(conversation));
+  mockUseConversationPermissions.mockReturnValue({
+    rename: false,
+    delete: false,
+    update_access_control: canUpdateAccessControl,
+  });
+  mockUseSuggestUsers.mockReturnValue({ data: [], isFetching: false } as never);
+  mockUseConversationAccessControlProfiles.mockReturnValue({
+    data: [ownerProfile, memberProfile],
+  } as never);
+  mockUseUpdateConversationAccessControl.mockImplementation((options) => {
+    updateOptions = options;
+    return { mutate, isLoading: false } as never;
+  });
+
+  render(
+    <IntlProvider locale="en">
+      <ConversationShareButton />
+    </IntlProvider>
+  );
+};
+
+const openPopover = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('agentBuilderConversationInviteButton'));
+  });
+};
+
+describe('ConversationShareButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render without access-control update permission', () => {
+    renderShareButton({ canUpdateAccessControl: false });
+
+    expect(screen.queryByTestId('agentBuilderConversationInviteButton')).not.toBeInTheDocument();
+  });
+
+  it('opens the sharing popover with owner and current members', async () => {
+    renderShareButton({
+      conversation: {
+        ...baseConversation,
+        access_control: {
+          access_mode: ConversationAccessControlMode.Private,
+          entries: [
+            {
+              type: 'user',
+              id: 'member-1',
+              role: ConversationAccessControlRole.Member,
+              added_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        },
+      },
+    });
+
+    await openPopover();
+
+    expect(screen.getByTestId('agentBuilderConversationSharingPopover')).toBeInTheDocument();
+    expect(screen.getByText('Ethan Smith')).toBeInTheDocument();
+    expect(screen.getByText('Alex Kim')).toBeInTheDocument();
+    expect(screen.getByText('Author')).toBeInTheDocument();
+    expect(screen.getByText('Member')).toBeInTheDocument();
+  });
+
+  it('saves public access with no ACL entries', async () => {
+    renderShareButton({
+      conversation: {
+        ...baseConversation,
+        access_control: {
+          access_mode: ConversationAccessControlMode.Private,
+          entries: [
+            {
+              type: 'user',
+              id: 'member-1',
+              role: ConversationAccessControlRole.Member,
+              added_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        },
+      },
+    });
+
+    await openPopover();
+    fireEvent.change(screen.getByTestId('agentBuilderConversationSharingAccessModeSelect'), {
+      target: { value: ConversationAccessControlMode.Public },
+    });
+
+    expect(mutate).toHaveBeenCalledWith({
+      access_mode: ConversationAccessControlMode.Public,
+      entries: [],
+    });
+  });
+
+  it('removes an individual member from restricted access', async () => {
+    renderShareButton({
+      conversation: {
+        ...baseConversation,
+        access_control: {
+          access_mode: ConversationAccessControlMode.Private,
+          entries: [
+            {
+              type: 'user',
+              id: 'member-1',
+              role: ConversationAccessControlRole.Member,
+              added_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        },
+      },
+    });
+
+    await openPopover();
+    fireEvent.click(screen.getByTestId('agentBuilderConversationShareRemoveMember'));
+
+    expect(mutate).toHaveBeenCalledWith({
+      access_mode: ConversationAccessControlMode.Private,
+      entries: [],
+    });
+  });
+
+  it('enables user suggestions only while the restricted sharing popover is open', async () => {
+    renderShareButton();
+
+    expect(mockUseSuggestUsers).toHaveBeenLastCalledWith('', { enabled: false });
+
+    await openPopover();
+
+    expect(mockUseSuggestUsers).toHaveBeenLastCalledWith('', { enabled: true });
+  });
+
+  it('shows save errors inside the popover', async () => {
+    renderShareButton();
+    await openPopover();
+
+    act(() => {
+      updateOptions.onError?.(new Error('nope'));
+    });
+
+    expect(screen.getByText('Failed to update sharing settings')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button.tsx
@@ -1,0 +1,486 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonIcon,
+  EuiCallOut,
+  EuiComboBox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiHorizontalRule,
+  EuiPopover,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  EuiToolTip,
+  useEuiTheme,
+  type EuiComboBoxOptionOption,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useDebouncedValue } from '@kbn/react-hooks';
+import {
+  AGENT_BUILDER_UI_EBT,
+  ConversationAccessControlMode,
+  ConversationAccessControlRole,
+  normalizeConversationAccessControl,
+} from '@kbn/agent-builder-common';
+import {
+  getUserDisplayName,
+  UserAvatar,
+  type UserProfileWithAvatar,
+} from '@kbn/user-profile-components';
+import { getEbtProps } from '@kbn/ebt-click';
+import {
+  useConversation,
+  useConversationPermissions,
+  useHasPersistedConversation,
+} from '../../../hooks/use_conversation';
+import { useConversationId } from '../../../context/conversation/use_conversation_id';
+import { useSuggestUsers } from '../../../hooks/use_suggest_users';
+import {
+  useConversationAccessControlProfiles,
+  useUpdateConversationAccessControl,
+} from '../../../hooks/use_conversation_access_control';
+
+interface UserOption extends EuiComboBoxOptionOption<string> {
+  profile: UserProfileWithAvatar;
+}
+
+const SEARCH_DEBOUNCE_MS = 200;
+
+const labels = {
+  invite: i18n.translate('xpack.agentBuilder.conversationSharing.invite', {
+    defaultMessage: 'Invite',
+  }),
+  sharing: i18n.translate('xpack.agentBuilder.conversationSharing.title', {
+    defaultMessage: 'Sharing',
+  }),
+  close: i18n.translate('xpack.agentBuilder.conversationSharing.close', {
+    defaultMessage: 'Close sharing',
+  }),
+  generalAccess: i18n.translate('xpack.agentBuilder.conversationSharing.generalAccess', {
+    defaultMessage: 'General access',
+  }),
+  restricted: i18n.translate('xpack.agentBuilder.conversationSharing.restricted', {
+    defaultMessage: 'Restricted',
+  }),
+  public: i18n.translate('xpack.agentBuilder.conversationSharing.public', {
+    defaultMessage: 'Public',
+  }),
+  restrictedHelp: i18n.translate('xpack.agentBuilder.conversationSharing.restrictedHelp', {
+    defaultMessage: 'Only manually added members can see this chat',
+  }),
+  publicHelp: i18n.translate('xpack.agentBuilder.conversationSharing.publicHelp', {
+    defaultMessage: "Anyone with access to this chat's agent can see this chat",
+  }),
+  currentMembers: i18n.translate('xpack.agentBuilder.conversationSharing.currentMembers', {
+    defaultMessage: 'Current members',
+  }),
+  searchUsers: i18n.translate('xpack.agentBuilder.conversationSharing.searchUsers', {
+    defaultMessage: 'Search for users to add',
+  }),
+  author: i18n.translate('xpack.agentBuilder.conversationSharing.author', {
+    defaultMessage: 'Author',
+  }),
+  member: i18n.translate('xpack.agentBuilder.conversationSharing.member', {
+    defaultMessage: 'Member',
+  }),
+  removeMember: i18n.translate('xpack.agentBuilder.conversationSharing.removeMember', {
+    defaultMessage: 'Remove member',
+  }),
+  saveError: i18n.translate('xpack.agentBuilder.conversationSharing.saveError', {
+    defaultMessage: 'Failed to update sharing settings',
+  }),
+  publicSearchHelp: i18n.translate('xpack.agentBuilder.conversationSharing.publicSearchHelp', {
+    defaultMessage: 'Switch to restricted access to add individual members.',
+  }),
+};
+
+const accessModeOptions = [
+  {
+    value: ConversationAccessControlMode.Private,
+    text: labels.restricted,
+  },
+  {
+    value: ConversationAccessControlMode.Public,
+    text: labels.public,
+  },
+];
+
+const getProfileDisplayName = (profile: UserProfileWithAvatar | undefined, fallback: string) =>
+  profile ? getUserDisplayName(profile.user) : fallback;
+
+const profileToOption = (profile: UserProfileWithAvatar): UserOption => ({
+  label: getUserDisplayName(profile.user),
+  value: profile.uid,
+  key: profile.uid,
+  profile,
+});
+
+const MemberRow: React.FC<{
+  name: string;
+  profile?: UserProfileWithAvatar;
+  badge: string;
+  onRemove?: () => void;
+  isDisabled?: boolean;
+}> = ({ name, profile, badge, onRemove, isDisabled }) => (
+  <EuiFlexGroup
+    alignItems="center"
+    justifyContent="spaceBetween"
+    gutterSize="s"
+    responsive={false}
+    data-test-subj="agentBuilderConversationShareMemberRow"
+  >
+    <EuiFlexItem>
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <UserAvatar
+            user={profile?.user ?? { username: name }}
+            avatar={profile?.data?.avatar}
+            size="s"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow>
+          <EuiText size="s">{name}</EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiBadge>{badge}</EuiBadge>
+        </EuiFlexItem>
+        {onRemove ? (
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content={labels.removeMember} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="cross"
+                color="text"
+                size="s"
+                aria-label={labels.removeMember}
+                onClick={onRemove}
+                isDisabled={isDisabled}
+                data-test-subj="agentBuilderConversationShareRemoveMember"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        ) : null}
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);
+
+export const ConversationShareButton: React.FC = () => {
+  const { euiTheme } = useEuiTheme();
+  const conversationId = useConversationId();
+  const hasPersistedConversation = useHasPersistedConversation();
+  const { update_access_control: canUpdateAccessControl } = useConversationPermissions();
+  const { conversation } = useConversation();
+
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [accessMode, setAccessMode] = useState(ConversationAccessControlMode.Private);
+  const [memberIds, setMemberIds] = useState<string[]>([]);
+  const [searchValue, setSearchValue] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  const accessControl = useMemo(
+    () => normalizeConversationAccessControl(conversation?.access_control),
+    [conversation?.access_control]
+  );
+  const accessControlMemberIds = useMemo(
+    () => accessControl.entries.map((entry) => entry.id),
+    [accessControl]
+  );
+
+  useEffect(() => {
+    setAccessMode(accessControl.access_mode);
+    setMemberIds(accessControlMemberIds);
+  }, [accessControl.access_mode, accessControlMemberIds]);
+
+  const ownerId = conversation?.user.id;
+  const ownerFallbackName = conversation?.user.username ?? '';
+  const profileUids = useMemo(
+    () => [ownerId, ...memberIds].filter((uid): uid is string => Boolean(uid)),
+    [memberIds, ownerId]
+  );
+  const { data: profiles = [] } = useConversationAccessControlProfiles({
+    uids: profileUids,
+    enabled: isPopoverOpen,
+  });
+  const profileByUid = useMemo(
+    () => new Map(profiles.map((profile) => [profile.uid, profile])),
+    [profiles]
+  );
+
+  const debouncedSearch = useDebouncedValue(searchValue, SEARCH_DEBOUNCE_MS);
+  const { data: suggestedProfiles = [], isFetching: isSearchingUsers } = useSuggestUsers(
+    debouncedSearch,
+    {
+      enabled:
+        isPopoverOpen &&
+        canUpdateAccessControl &&
+        accessMode === ConversationAccessControlMode.Private,
+    }
+  );
+
+  const excludedIds = useMemo(
+    () => new Set([ownerId, ...memberIds].filter(Boolean)),
+    [memberIds, ownerId]
+  );
+  const userOptions = useMemo<UserOption[]>(
+    () =>
+      suggestedProfiles
+        .filter((profile) => !excludedIds.has(profile.uid))
+        .map((profile) => profileToOption(profile)),
+    [excludedIds, suggestedProfiles]
+  );
+
+  const { mutate: updateAccessControl, isLoading: isSaving } = useUpdateConversationAccessControl({
+    conversationId: conversationId ?? '',
+    agentId: conversation?.agent_id,
+    onSuccess: () => {
+      setErrorMessage(undefined);
+    },
+    onError: () => {
+      setErrorMessage(labels.saveError);
+      setAccessMode(accessControl.access_mode);
+      setMemberIds(accessControlMemberIds);
+    },
+  });
+
+  const saveAccessControl = useCallback(
+    (nextAccessMode: ConversationAccessControlMode, nextMemberIds: string[]) => {
+      if (!conversationId) {
+        return;
+      }
+
+      updateAccessControl({
+        access_mode: nextAccessMode,
+        entries:
+          nextAccessMode === ConversationAccessControlMode.Public
+            ? []
+            : nextMemberIds.map((id) => ({
+                type: 'user',
+                id,
+                role: ConversationAccessControlRole.Member,
+              })),
+      });
+    },
+    [conversationId, updateAccessControl]
+  );
+
+  const onAccessModeChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const nextAccessMode = event.target.value as ConversationAccessControlMode;
+      const nextMemberIds =
+        nextAccessMode === ConversationAccessControlMode.Public ? [] : memberIds;
+
+      setAccessMode(nextAccessMode);
+      setMemberIds(nextMemberIds);
+      saveAccessControl(nextAccessMode, nextMemberIds);
+    },
+    [memberIds, saveAccessControl]
+  );
+
+  const onAddUser = useCallback(
+    (selectedOptions: Array<EuiComboBoxOptionOption<string>>) => {
+      const selected = selectedOptions[0] as UserOption | undefined;
+      const nextId = selected?.value;
+      if (!nextId || memberIds.includes(nextId)) {
+        return;
+      }
+
+      const nextMemberIds = [...memberIds, nextId];
+      setMemberIds(nextMemberIds);
+      setSearchValue('');
+      saveAccessControl(accessMode, nextMemberIds);
+    },
+    [accessMode, memberIds, saveAccessControl]
+  );
+
+  const onRemoveUser = useCallback(
+    (id: string) => {
+      const nextMemberIds = memberIds.filter((memberId) => memberId !== id);
+      setMemberIds(nextMemberIds);
+      saveAccessControl(accessMode, nextMemberIds);
+    },
+    [accessMode, memberIds, saveAccessControl]
+  );
+
+  const renderOption = useCallback((option: EuiComboBoxOptionOption<string>) => {
+    const { profile } = option as UserOption;
+    const displayName = getUserDisplayName(profile.user);
+    const secondary = profile.user.email ?? profile.user.username;
+    const showSecondary = secondary && secondary !== displayName;
+
+    return (
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <UserAvatar user={profile.user} avatar={profile.data?.avatar} size="s" />
+        </EuiFlexItem>
+        <EuiFlexItem grow>
+          <EuiText size="s">{displayName}</EuiText>
+          {showSecondary ? (
+            <EuiText size="xs" color="subdued">
+              {secondary}
+            </EuiText>
+          ) : null}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }, []);
+
+  if (!conversation || !conversationId || !hasPersistedConversation || !canUpdateAccessControl) {
+    return null;
+  }
+
+  const ownerProfile = ownerId ? profileByUid.get(ownerId) : undefined;
+  const ownerName = getProfileDisplayName(ownerProfile, ownerFallbackName);
+  const isPublic = accessMode === ConversationAccessControlMode.Public;
+
+  return (
+    <EuiPopover
+      button={
+        <EuiButton
+          size="s"
+          color="text"
+          iconType="users"
+          minWidth={false}
+          onClick={() => setIsPopoverOpen((isOpen) => !isOpen)}
+          data-test-subj="agentBuilderConversationInviteButton"
+          {...getEbtProps({
+            element: AGENT_BUILDER_UI_EBT.element.pageContent,
+            action: AGENT_BUILDER_UI_EBT.action.conversation.OPEN_SHARE,
+            detail: 'conversation',
+          })}
+        >
+          {labels.invite}
+        </EuiButton>
+      }
+      isOpen={isPopoverOpen}
+      closePopover={() => setIsPopoverOpen(false)}
+      panelPaddingSize="none"
+      anchorPosition="downRight"
+      aria-label={labels.sharing}
+    >
+      <div
+        css={css`
+          width: 467px;
+          max-width: calc(100vw - ${euiTheme.size.xl});
+        `}
+        data-test-subj="agentBuilderConversationSharingPopover"
+      >
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="spaceBetween"
+          gutterSize="s"
+          responsive={false}
+          css={css`
+            padding: ${euiTheme.size.m};
+          `}
+        >
+          <EuiFlexItem>
+            <EuiTitle size="xxxs">
+              <h2>{labels.sharing}</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content={labels.close} disableScreenReaderOutput>
+              <EuiButtonIcon
+                iconType="cross"
+                size="s"
+                color="text"
+                aria-label={labels.close}
+                onClick={() => setIsPopoverOpen(false)}
+                data-test-subj="agentBuilderConversationSharingCloseButton"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiHorizontalRule margin="none" />
+        <div
+          css={css`
+            padding: ${euiTheme.size.m};
+          `}
+        >
+          {errorMessage ? (
+            <>
+              <EuiCallOut announceOnMount color="danger" size="s" title={errorMessage} />
+              <EuiSpacer size="m" />
+            </>
+          ) : null}
+          <EuiFormRow label={labels.generalAccess} fullWidth>
+            <EuiSelect
+              compressed
+              fullWidth
+              value={accessMode}
+              options={accessModeOptions}
+              onChange={onAccessModeChange}
+              disabled={isSaving}
+              data-test-subj="agentBuilderConversationSharingAccessModeSelect"
+            />
+          </EuiFormRow>
+          <EuiText size="xs" color="subdued">
+            {isPublic ? labels.publicHelp : labels.restrictedHelp}
+          </EuiText>
+          <EuiSpacer size="l" />
+          <EuiFormRow
+            label={labels.currentMembers}
+            fullWidth
+            helpText={isPublic ? labels.publicSearchHelp : undefined}
+          >
+            <EuiComboBox<string>
+              compressed
+              fullWidth
+              async
+              placeholder={labels.searchUsers}
+              aria-label={labels.searchUsers}
+              options={userOptions}
+              selectedOptions={[]}
+              onChange={onAddUser}
+              onSearchChange={setSearchValue}
+              isLoading={isSearchingUsers}
+              isDisabled={isSaving || isPublic}
+              isClearable={false}
+              singleSelection={{ asPlainText: true }}
+              renderOption={renderOption}
+              rowHeight={48}
+              data-test-subj="agentBuilderConversationSharingUserSearch"
+            />
+          </EuiFormRow>
+          <EuiSpacer size="s" />
+          <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
+            <EuiFlexItem>
+              <MemberRow name={ownerName} profile={ownerProfile} badge={labels.author} />
+            </EuiFlexItem>
+            {memberIds.map((memberId) => {
+              const memberProfile = profileByUid.get(memberId);
+              const memberName = getProfileDisplayName(memberProfile, memberId);
+              return (
+                <EuiFlexItem key={memberId}>
+                  <MemberRow
+                    name={memberName}
+                    profile={memberProfile}
+                    badge={labels.member}
+                    isDisabled={isSaving}
+                    onRemove={() => onRemoveUser(memberId)}
+                  />
+                </EuiFlexItem>
+              );
+            })}
+          </EuiFlexGroup>
+        </div>
+      </div>
+    </EuiPopover>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button/conversation_participants_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button/conversation_participants_list.tsx
@@ -24,6 +24,8 @@ import {
 import { useConversationPermissions } from '../../../../hooks/use_conversation';
 import { authorLabel, removeMemberLabel } from './conversation_share_i18n';
 
+const MEMBER_ROW_MIN_HEIGHT = 50;
+
 interface UserAccessRowProps {
   profile: UserProfileWithAvatar;
   badge?: string;
@@ -48,7 +50,7 @@ const UserAccessRow: React.FC<UserAccessRowProps> = ({
       gutterSize="s"
       responsive={false}
       css={css`
-        min-height: 49px;
+        min-height: ${MEMBER_ROW_MIN_HEIGHT}px;
         padding: ${euiTheme.size.s} 0;
         border-bottom: ${hasBottomBorder ? euiTheme.border.thin : 'none'};
       `}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button/conversation_share_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button/conversation_share_button.tsx
@@ -49,6 +49,8 @@ import {
 import { ConversationSharePopoverButton } from './conversation_share_popover_button';
 
 const SEARCH_DEBOUNCE_MS = 200;
+const POPOVER_WIDTH = 470;
+const POPOVER_HEADER_MIN_HEIGHT = 48;
 
 export const ConversationShareButton: React.FC = () => {
   const isExperimentalFeaturesEnabled = useExperimentalFeatures();
@@ -207,7 +209,7 @@ const ConversationSharePopover: React.FC<ConversationSharePopoverProps> = ({ con
     >
       <div
         css={css`
-          width: 467px;
+          width: ${POPOVER_WIDTH}px;
           max-width: calc(100vw - ${euiTheme.size.xl});
         `}
         data-test-subj="agentBuilderConversationSharingPopover"
@@ -218,7 +220,7 @@ const ConversationSharePopover: React.FC<ConversationSharePopoverProps> = ({ con
           gutterSize="s"
           responsive={false}
           css={css`
-            min-height: 48px;
+            min-height: ${POPOVER_HEADER_MIN_HEIGHT}px;
             padding: 0 ${euiTheme.size.m};
           `}
         >

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button/conversation_share_editable_content.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button/conversation_share_editable_content.tsx
@@ -27,6 +27,8 @@ import { ConversationAccessModeSelect } from './conversation_access_mode_select'
 import { ConversationParticipantsList } from './conversation_participants_list';
 import { currentMembersLabel, searchUsersLabel } from './conversation_share_i18n';
 
+const USER_SEARCH_OPTION_ROW_HEIGHT = 48;
+
 interface UserSearchOptionProps {
   profile: UserProfileWithAvatar;
 }
@@ -157,7 +159,7 @@ export const ConversationShareEditableContent: React.FC<ConversationShareEditabl
 
             return <UserSearchOption key={option.key ?? option.value} profile={profile} />;
           }}
-          rowHeight={48}
+          rowHeight={USER_SEARCH_OPTION_ROW_HEIGHT}
           data-test-subj="agentBuilderConversationSharingUserSearch"
         />
       </EuiFormRow>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button/conversation_share_popover_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_share_button/conversation_share_popover_button.tsx
@@ -22,6 +22,8 @@ import { useConversationPermissions } from '../../../../hooks/use_conversation';
 import { useInviteMembersSummary } from '../../../../hooks/use_conversation_access_control';
 import { extraMembersLabel, inviteLabel, sharingLabel } from './conversation_share_i18n';
 
+const EXTRA_COUNT_AVATAR_OVERLAP_OFFSET = 1;
+
 interface ConversationShareTriggerButtonProps {
   ariaLabel: string;
   children: React.ReactNode;
@@ -127,7 +129,7 @@ const InviteMembersSummaryButton: React.FC<InviteMembersSummaryButtonProps> = ({
           <EuiFlexItem
             grow={false}
             css={css`
-              margin-inline-start: calc(-${avatarOverlap} + 1px);
+              margin-inline-start: calc(-${avatarOverlap} + ${EXTRA_COUNT_AVATAR_OVERLAP_OFFSET}px);
             `}
           >
             <EuiAvatar

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_conversation_access_control.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_conversation_access_control.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@kbn/react-query';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import type { Conversation } from '@kbn/agent-builder-common';
+import {
+  normalizeConversationAccessControl,
+  type ConversationAccessControl,
+} from '@kbn/agent-builder-common';
+import type { UpdateConversationAccessControlRequestBody } from '../../../common/http_api/conversations';
+import { queryKeys } from '../query_keys';
+import { mutationKeys } from '../mutation_keys';
+import { useKibana } from './use_kibana';
+import { useAgentBuilderServices } from './use_agent_builder_service';
+
+const AVATAR_DATA_PATH = 'avatar';
+
+export const useConversationAccessControlProfiles = ({
+  uids,
+  enabled = true,
+}: {
+  uids: string[];
+  enabled?: boolean;
+}) => {
+  const {
+    services: { userProfile },
+  } = useKibana();
+
+  const dedupedUids = useMemo(() => Array.from(new Set(uids)).sort(), [uids]);
+
+  return useQuery({
+    queryKey: queryKeys.security.ownerProfiles(dedupedUids),
+    enabled: enabled && dedupedUids.length > 0 && Boolean(userProfile),
+    queryFn: async (): Promise<UserProfileWithAvatar[]> => {
+      if (!userProfile) {
+        return [];
+      }
+
+      return await userProfile.bulkGet<UserProfileWithAvatar['data']>({
+        uids: new Set(dedupedUids),
+        dataPath: AVATAR_DATA_PATH,
+      });
+    },
+  });
+};
+
+export const useUpdateConversationAccessControl = ({
+  conversationId,
+  agentId,
+  onSuccess,
+  onError,
+}: {
+  conversationId: string;
+  agentId?: string;
+  onSuccess?: (accessControl: ConversationAccessControl) => void;
+  onError?: (error: Error) => void;
+}) => {
+  const { conversationsService } = useAgentBuilderServices();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: mutationKeys.updateConversationAccessControl(conversationId),
+    mutationFn: (accessControl: UpdateConversationAccessControlRequestBody) =>
+      conversationsService.updateAccessControl({ conversationId, accessControl }),
+    onSuccess: (accessControl) => {
+      const normalizedAccessControl = normalizeConversationAccessControl(accessControl);
+
+      queryClient.setQueryData<Conversation>(
+        queryKeys.conversations.byId(conversationId),
+        (current) =>
+          current
+            ? {
+                ...current,
+                access_control: normalizedAccessControl,
+              }
+            : current
+      );
+      queryClient.invalidateQueries({ queryKey: queryKeys.conversations.all });
+      if (agentId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.conversations.byAgent(agentId) });
+      }
+
+      onSuccess?.(normalizedAccessControl);
+    },
+    onError,
+  });
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/mutation_keys.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/mutation_keys.ts
@@ -13,4 +13,6 @@ export const mutationKeys = {
   resumeRound: ['resumeRound'] as const,
   updateAgentAccessControl: (agentId: string) =>
     ['agentProfiles', agentId, 'accessControl', 'update'] as const,
+  updateConversationAccessControl: (conversationId: string) =>
+    ['conversations', conversationId, 'accessControl', 'update'] as const,
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/conversations/conversations_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/conversations/conversations_service.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ConversationAccessControlMode,
+  ConversationAccessControlRole,
+} from '@kbn/agent-builder-common';
+import { publicApiPath } from '../../../common/constants';
+import { ConversationsService } from './conversations_service';
+
+describe('ConversationsService', () => {
+  it('updates conversation access control', async () => {
+    const put = jest.fn().mockResolvedValue({
+      access_mode: ConversationAccessControlMode.Private,
+      entries: [],
+    });
+    const service = new ConversationsService({ http: { put } as never });
+    const accessControl = {
+      access_mode: ConversationAccessControlMode.Private,
+      entries: [
+        {
+          type: 'user' as const,
+          id: 'u_123',
+          role: ConversationAccessControlRole.Member,
+        },
+      ],
+    };
+
+    await service.updateAccessControl({ conversationId: 'conversation-1', accessControl });
+
+    expect(put).toHaveBeenCalledWith(
+      `${publicApiPath}/conversations/conversation-1/access_control`,
+      {
+        body: JSON.stringify(accessControl),
+      }
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/conversations/conversations_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/conversations/conversations_service.ts
@@ -14,6 +14,8 @@ import type {
   MarkPinnedConversationResponse,
   MarkReadConversationResponse,
   RenameConversationResponse,
+  UpdateConversationAccessControlRequestBody,
+  UpdateConversationAccessControlResponse,
 } from '../../../common/http_api/conversations';
 import type { ReadWorkspaceFileResponse } from '../../../common/http_api/workspace_files';
 import type {
@@ -86,6 +88,21 @@ export class ConversationsService {
     return await this.http.post<MarkPinnedConversationResponse>(
       `${internalApiPath}/conversations/${conversationId}/_set_pinned`,
       { body: JSON.stringify({ pinned }) }
+    );
+  }
+
+  async updateAccessControl({
+    conversationId,
+    accessControl,
+  }: {
+    conversationId: string;
+    accessControl: UpdateConversationAccessControlRequestBody;
+  }): Promise<UpdateConversationAccessControlResponse> {
+    return await this.http.put<UpdateConversationAccessControlResponse>(
+      `${publicApiPath}/conversations/${conversationId}/access_control`,
+      {
+        body: JSON.stringify(accessControl),
+      }
     );
   }
 


### PR DESCRIPTION
Closes elastic/search-team#15814

## Summary
- Adds the Agent Builder conversation sharing entrypoint and popover for managing private/public conversation access.
- Wires conversation ACL updates through the access-control API with user search, member removal, sorted member lists, and shared-member avatar summaries.
- Supports a read-only participants popover for shared users who can view conversation members but cannot invite, remove members, or change access mode.
- Adds focused unit coverage for editable sharing, read-only participants, member ordering, and invite summary behavior.

## Demo



https://github.com/user-attachments/assets/fb997e09-68f7-47ed-b504-f24f58a4f6ea