### PR TITLE
Fix dynamic config allowlist for Alerting V2

### DIFF
--- a/src/core/server/integration_tests/config/check_dynamic_config.test.ts
+++ b/src/core/server/integration_tests/config/check_dynamic_config.test.ts
@@ -140,6 +140,8 @@ if (getFips() === 0) {
         // We need this for enriching our Perf tests with more valuable data regarding the steps of the test
         // Also helpful in Cloud & Serverless testing because we can't control the labels in those offerings
         'telemetry.labels',
+        // Allows Scout tests to switch ES|QL response formats without restarting Kibana
+        'xpack.alerting_v2.esql.responseFormat',
         // This allow to test fleet features flags while in devlopment
         'xpack.fleet.experimentalFeatures',
       ]);


### PR DESCRIPTION
## Summary

Add the Alerting V2 ES|QL response format setting to the expected dynamic configuration allowlist. This setting is intentionally dynamic so Scout tests can switch response formats without restarting Kibana.

## Testing

- `node scripts/jest_integration src/core/server/integration_tests/config/check_dynamic_config.test.ts`
- `node scripts/eslint src/core/server/integration_tests/config/check_dynamic_config.test.ts`