### PR TITLE
[Console] Fix autocomplete after triple-quoted values

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts
@@ -166,6 +166,38 @@ describe('console parser', () => {
     expect(requests).toEqual([{ startOffset: 0, endOffset: 30 }]);
   });
 
+  it('leaves the request end unset after an inline triple quote and later syntax error', () => {
+    const input = 'POST _query\n{\n  "query": """ FROM my-index | """,\n\n}';
+    const { requests } = parser(input)!;
+
+    expect(requests).toEqual([{ startOffset: 0 }]);
+  });
+
+  it('leaves the request end unset after a multiline triple quote and later syntax error', () => {
+    const input = 'POST _query\n{\n  "script": """\n  some content\n  """,\n  "\n}';
+    const { requests } = parser(input)!;
+
+    expect(requests).toEqual([{ startOffset: 0 }]);
+  });
+
+  it('leaves the request end unset for an unterminated triple-quoted value', () => {
+    const input = 'POST _query\n{\n  "script": """\n  some content';
+    const { requests } = parser(input)!;
+
+    expect(requests).toEqual([{ startOffset: 0 }]);
+  });
+
+  it('recovers the next request after a syntax error following a triple-quoted value', () => {
+    const input = 'POST _query\n{\n  "script": """foo""",\n}\n\nGET _search';
+    const { requests, errors } = parser(input)!;
+
+    expect(errors).toEqual([{ text: 'Bad string', offset: 38 }]);
+    expect(requests).toEqual([
+      { startOffset: 0, endOffset: 37 },
+      { startOffset: 40, endOffset: 51 },
+    ]);
+  });
+
   it('emits duplicate-key error and continues parsing next request', () => {
     const input = 'GET _search\n{ "a": 1, "a": 2 }\n\nPOST _test';
     const { requests, errors } = parser(input)!;

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.ts
@@ -101,7 +101,13 @@ export const createParser = (): ConsoleParser => {
     if (i < 0) {
       error(errorMessage || "Expected '" + upTo + "'");
     }
-    reset(i + upTo.length);
+    // Example: `"query": """...""",` can be followed by more fields in the same body.
+    // If the closing `"""` is stored as the request end, autocomplete below it shows request
+    // methods or no suggestions instead of body fields.
+    const afterClosingDelimiter = i + upTo.length;
+    ch = text.charAt(afterClosingDelimiter);
+    at = afterClosingDelimiter + 1;
+
     return text.substring(currentAt, i);
   };
   const peek = function (offset: number) {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts
@@ -1736,6 +1736,43 @@ describe('Editor actions provider', () => {
     } as unknown as jest.Mocked<monaco.editor.ITextModel>;
     const mockPosition = { lineNumber: 1, column: 1 } as jest.Mocked<monaco.Position>;
     const mockContext = {} as jest.Mocked<monaco.languages.CompletionContext>;
+    const setupParserBackedBodyCompletion = (lines: string[]) => {
+      const parserResult = createParser()(lines.join('\n'));
+      if (!parserResult) {
+        throw new Error('Expected Console parser result');
+      }
+      mockGetParsedRequests.mockResolvedValue(parserResult.requests);
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = [{ name: 'columnar' }];
+      });
+      return createModel(lines);
+    };
+
+    it('uses body completion below an inline triple-quoted value', async () => {
+      const lines = ['POST _query', '{', '  "query": """ FROM my-index | """,', '', '}'];
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        setupParserBackedBodyCompletion(lines),
+        { lineNumber: 4, column: 1 } as monaco.Position,
+        mockContext
+      );
+
+      expect(mockPopulateContext).toHaveBeenCalled();
+      expect(completionItems.suggestions.map(({ label }) => label)).toEqual(['columnar']);
+    });
+
+    it('uses body completion inside an unfinished key after a multiline triple-quoted value', async () => {
+      const lines = ['POST _query', '{', '  "script": """', '  some content', '  """,', '  "', '}'];
+      const completionItems = await editorActionsProvider.provideCompletionItems(
+        setupParserBackedBodyCompletion(lines),
+        { lineNumber: 6, column: 4 } as monaco.Position,
+        mockContext
+      );
+
+      expect(mockPopulateContext).toHaveBeenCalled();
+      expect(completionItems.suggestions.map(({ label }) => label)).toEqual(['columnar']);
+    });
+
     it('returns completion items for method if no requests', async () => {
       mockGetParsedRequests.mockResolvedValue([]);
       const completionItems = await editorActionsProvider.provideCompletionItems(


### PR DESCRIPTION
Closes #284395

## Summary

- Keep incomplete Console requests open after parsing closed triple-quoted values, so body autocomplete remains scoped to the current request.
- Add parser and completion-provider regressions for inline and multiline triple-quoted values, plus next-request recovery.

## Root Cause

`nextUpTo()` advanced past triple-quoted values by calling `reset()`. Since #215568, `reset()` also finalizes the current request's `endOffset`, so a later syntax error preserved a stale boundary.

## Fix

Advance the parser cursor directly in `nextUpTo()` without running request-boundary reset logic.

## Test Plan

1. Enter both reproductions from #284395 in Dev Tools Console and trigger autocomplete at the indicated cursor positions.
2. Verify body fields such as `columnar`, `filter`, and `query` appear instead of request methods or an empty result.
3. `node scripts/jest 'src/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts'` — 42/42 passed.
4. `node scripts/jest 'src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.test.ts'` — 160/160 passed.
5. Scoped type checks, ESLint, `git diff --check`, and the parser state-machine verification passed.
6. Live local Kibana verification showed 11 body suggestions for both reproductions.

## Videos

**Reproduction 1 — body autocomplete below an inline triple-quoted value**

Before: Console shows request method suggestions on the next body line.

https://github.com/user-attachments/assets/3af19924-d9e1-4474-8124-b6f89e14cef2

After: Console shows body field suggestions on the next body line.

https://github.com/user-attachments/assets/786bc6f5-b5a3-414e-beb8-2f77938cb767

**Reproduction 2 — body autocomplete inside an unfinished key after a multiline triple-quoted value**

Before: Console shows no suggestions inside the `"` key prefix.

https://github.com/user-attachments/assets/f3a070ed-4d85-4b16-bf0f-2a6a0e674828

After: Console shows body field suggestions inside the `"` key prefix.

https://github.com/user-attachments/assets/60b1879f-68b9-4e7c-9380-d7dff53f4b72

## Release Note

Fixed Dev Tools Console body autocomplete after closed triple-quoted string values.

Assisted with Cursor using GPT-5.6 Sol

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->