### PR TITLE
[Console] Preserve primitive autocomplete values

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -766,6 +766,32 @@ describe('autocomplete_utils', () => {
         expect(acceptSuggestion(editorLines, stringTerm!)).toBe('  "mode": "foo.bar"');
       });
 
+      it('SHOULD replace the whole quoted punctuated value for non-dotted string terms', async () => {
+        mockPopulateContext.mockImplementation((...args) => {
+          const context = args[0][1];
+          context.autoCompleteSet = [{ name: 'foo-bar' }];
+        });
+        const editorLines = ['GET _search', '{', '  "mode": "foo-b"'];
+        // Cursor after `b`, before the auto-closed closing quote; Monaco's word starts after `-`.
+        const position = { lineNumber: 3, column: 17 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 16, word: 'b' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const stringTerm = items.find((item) => item.label === 'foo-bar');
+        expect(stringTerm?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 12,
+          endLineNumber: 3,
+          endColumn: 18,
+        });
+        expect(acceptSuggestion(editorLines, stringTerm!)).toBe('  "mode": "foo-bar"');
+      });
+
       it('SHOULD NOT suggest primitive terms inside a triple-quoted value', async () => {
         const editorLines = ['GET _search', '{', '  "value": """-1"""'];
         // Cursor after `-1`, before the closing triple quote.
@@ -934,6 +960,29 @@ describe('autocomplete_utils', () => {
 
         const items = await getBodyCompletionItems(
           buildModel(editorLines, { startColumn: 14, word: '' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find((item) => item.label === '0.5' && item.insertText === '0.5');
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 12,
+          endLineNumber: 3,
+          endColumn: 14,
+        });
+        const acc = acceptSuggestion(editorLines, primitive!);
+        expect(JSON.parse(`{${acc}}`)).toEqual({ value: 0.5 });
+        expect(acc).toBe('  "value": 0.5');
+      });
+
+      it('SHOULD repair a bare leading-dot decimal prefix for numeric primitive terms', async () => {
+        const editorLines = ['GET _search', '{', '  "value": .5'];
+        const position = { lineNumber: 3, column: 14 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 13, word: '5' }),
           position,
           1,
           mockEditor

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -822,6 +822,24 @@ describe('autocomplete_utils', () => {
         expect(items.find((item) => item.label === 'some_string_value')).toBeDefined();
       });
 
+      it('SHOULD NOT suggest primitive terms inside a multiline quoted value', async () => {
+        const editorLines = ['GET _search', '{', '  "value": "abc', 'def -'];
+        // Cursor after `-` on the continuation line of a quoted value whose
+        // opening quote lives on the previous line.
+        const position = { lineNumber: 4, column: 6 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 6, word: '' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        expect(items.find((item) => item.label === '-1')).toBeUndefined();
+        expect(items.find((item) => item.label === '0.5')).toBeUndefined();
+        expect(items.find((item) => item.label === 'some_string_value')).toBeDefined();
+      });
+
       it('SHOULD cover both quotes when accepted straight from the trigger quote', async () => {
         const editorLines = ['GET _search', '{', '  "refresh": ""'];
         // Cursor between the auto-closed quotes, before typing anything.

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -622,6 +622,8 @@ describe('autocomplete_utils', () => {
             { name: false },
             { name: -1 },
             { name: 0.5 },
+            { name: 1e-7 },
+            { name: 1e21 },
             { name: 'false' },
             { name: 'some_string_value' },
           ] as unknown as AutoCompleteContext['autoCompleteSet'];
@@ -923,6 +925,54 @@ describe('autocomplete_utils', () => {
         const acc = acceptSuggestion(editorLines, primitive!);
         expect(JSON.parse(`{${acc}}`)).toEqual({ value: 0.5 });
         expect(acc).toBe('  "value": 0.5');
+      });
+
+      it('SHOULD replace a bare negative exponent prefix for numeric primitive terms', async () => {
+        const editorLines = ['GET _search', '{', '  "value": 1e-'];
+        const position = { lineNumber: 3, column: 15 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 15, word: '' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find((item) => item.label === '1e-7' && item.insertText === '1e-7');
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 12,
+          endLineNumber: 3,
+          endColumn: 15,
+        });
+        const acc = acceptSuggestion(editorLines, primitive!);
+        expect(JSON.parse(`{${acc}}`)).toEqual({ value: 1e-7 });
+        expect(acc).toBe('  "value": 1e-7');
+      });
+
+      it('SHOULD replace a bare positive exponent prefix for numeric primitive terms', async () => {
+        const editorLines = ['GET _search', '{', '  "value": 1e+'];
+        const position = { lineNumber: 3, column: 15 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 15, word: '' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find(
+          (item) => item.label === '1e+21' && item.insertText === '1e+21'
+        );
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 12,
+          endLineNumber: 3,
+          endColumn: 15,
+        });
+        const acc = acceptSuggestion(editorLines, primitive!);
+        expect(JSON.parse(`{${acc}}`)).toEqual({ value: 1e21 });
+        expect(acc).toBe('  "value": 1e+21');
       });
     });
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -878,6 +878,52 @@ describe('autocomplete_utils', () => {
         expect(primitive?.filterText).toBeUndefined();
         expect(acceptSuggestion(editorLines, primitive!)).toBe('  "refresh": false');
       });
+
+      it('SHOULD replace a bare minus prefix for negative primitive terms', async () => {
+        const editorLines = ['GET _search', '{', '  "value": -'];
+        const position = { lineNumber: 3, column: 13 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 13, word: '' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find((item) => item.label === '-1' && item.insertText === '-1');
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 12,
+          endLineNumber: 3,
+          endColumn: 13,
+        });
+        const acc = acceptSuggestion(editorLines, primitive!);
+        expect(JSON.parse(`{${acc}}`)).toEqual({ value: -1 });
+        expect(acc).toBe('  "value": -1');
+      });
+
+      it('SHOULD replace a bare decimal prefix for numeric primitive terms', async () => {
+        const editorLines = ['GET _search', '{', '  "value": 0.'];
+        const position = { lineNumber: 3, column: 14 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 14, word: '' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find((item) => item.label === '0.5' && item.insertText === '0.5');
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 12,
+          endLineNumber: 3,
+          endColumn: 14,
+        });
+        const acc = acceptSuggestion(editorLines, primitive!);
+        expect(JSON.parse(`{${acc}}`)).toEqual({ value: 0.5 });
+        expect(acc).toBe('  "value": 0.5');
+      });
     });
 
     it('ignores quotes inside comments when completing in the middle of a quoted field', async () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -650,6 +650,7 @@ describe('autocomplete_utils', () => {
           endLineNumber: 3,
           endColumn: 17, // includes the auto-closed closing quote
         });
+        expect(primitive?.filterText).toBe('"false');
         expect(stringTerm?.range).toEqual({
           startLineNumber: 3,
           startColumn: 15, // string terms re-insert the quotes themselves
@@ -681,6 +682,7 @@ describe('autocomplete_utils', () => {
           endLineNumber: 3,
           endColumn: 16,
         });
+        expect(primitive?.filterText).toBe('"-1');
         const acc = acceptSuggestion(editorLines, primitive!);
         expect(JSON.parse(`{${acc}}`)).toEqual({ value: -1 });
         expect(acc).toBe('  "value": -1');
@@ -705,6 +707,7 @@ describe('autocomplete_utils', () => {
           endLineNumber: 3,
           endColumn: 16,
         });
+        expect(primitive?.filterText).toBe('"0.5');
         const acc = acceptSuggestion(editorLines, primitive!);
         expect(JSON.parse(`{${acc}}`)).toEqual({ value: 0.5 });
         expect(acc).toBe('  "value": 0.5');
@@ -729,6 +732,7 @@ describe('autocomplete_utils', () => {
           endLineNumber: 3,
           endColumn: 18,
         });
+        expect(primitive?.filterText).toBe('"0.5');
         const acc = acceptSuggestion(editorLines, primitive!);
         expect(JSON.parse(`{${acc}}`)).toEqual({ values: [0.5] });
         expect(acc).toBe('  "values": [0.5]');
@@ -838,6 +842,7 @@ describe('autocomplete_utils', () => {
           endLineNumber: 3,
           endColumn: 16, // includes the auto-closed closing quote
         });
+        expect(primitive?.filterText).toBe('"false');
         expect(stringTerm?.range).toEqual({
           startLineNumber: 3,
           startColumn: 15,
@@ -870,6 +875,7 @@ describe('autocomplete_utils', () => {
           endLineNumber: 3,
           endColumn: 15,
         });
+        expect(primitive?.filterText).toBeUndefined();
         expect(acceptSuggestion(editorLines, primitive!)).toBe('  "refresh": false');
       });
     });

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -1038,6 +1038,37 @@ ${lineContentBeforePosition}`;
       expect(getInsertText({ name: 'field', template: null }, '', context)).toBe('"field"');
     });
 
+    it.each([
+      { conditionalTemplate: false, expected: '"enabled": false' },
+      { conditionalTemplate: 0, expected: '"enabled": 0' },
+      { conditionalTemplate: '', expected: '"enabled"' },
+      { conditionalTemplate: null, expected: '"enabled"' },
+    ])(
+      'SHOULD use matching conditional template $conditionalTemplate instead of the default',
+      ({ conditionalTemplate, expected }) => {
+        const context: AutoCompleteContext = {
+          ...mockContext,
+          addTemplate: true,
+          endpoint: {
+            paramsAutocomplete: {
+              getTopLevelComponents: () => [],
+            },
+            bodyAutocompleteRootComponents: [],
+            data_autocomplete_rules: {
+              enabled: {
+                __one_of: [
+                  { __template: true },
+                  { __condition: { lines_regex: 'mode' }, __template: conditionalTemplate },
+                ],
+              },
+            },
+          },
+        };
+
+        expect(getInsertText({ name: 'enabled', template: true }, 'mode', context)).toBe(expected);
+      }
+    );
+
     it('does not add quotes around braces and brackets', () => {
       expect(
         getInsertText(

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -710,6 +710,40 @@ describe('autocomplete_utils', () => {
         expect(acc).toBe('  "value": 0.5');
       });
 
+      it('SHOULD NOT suggest primitive terms inside a triple-quoted value', async () => {
+        const editorLines = ['GET _search', '{', '  "value": """-1"""'];
+        // Cursor after `-1`, before the closing triple quote.
+        const position = { lineNumber: 3, column: 17 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 16, word: '1' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        expect(items.find((item) => item.label === '-1')).toBeUndefined();
+        expect(items.find((item) => item.label === '0.5')).toBeUndefined();
+        expect(items.find((item) => item.label === 'some_string_value')).toBeDefined();
+      });
+
+      it('SHOULD NOT suggest primitive terms inside a multiline triple-quoted value', async () => {
+        const editorLines = ['GET _search', '{', '  "value": """', '-1', '"""'];
+        // Cursor after `-1` in the multiline triple-quoted value.
+        const position = { lineNumber: 4, column: 3 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 2, word: '1' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        expect(items.find((item) => item.label === '-1')).toBeUndefined();
+        expect(items.find((item) => item.label === '0.5')).toBeUndefined();
+        expect(items.find((item) => item.label === 'some_string_value')).toBeDefined();
+      });
+
       it('SHOULD cover both quotes when accepted straight from the trigger quote', async () => {
         const editorLines = ['GET _search', '{', '  "refresh": ""'];
         // Cursor between the auto-closed quotes, before typing anything.

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -1013,6 +1013,31 @@ ${lineContentBeforePosition}`;
       expect(getInsertText({ name: undefined } as ResultTerm, '', mockContext)).toBe('');
     });
 
+    it('SHOULD insert boolean and number names as JSON primitives', () => {
+      expect(getInsertText({ name: true }, '', mockContext)).toBe('true');
+      expect(getInsertText({ name: false }, '', mockContext)).toBe('false');
+      expect(getInsertText({ name: 0 }, '', mockContext)).toBe('0');
+      expect(getInsertText({ name: 42 }, '', mockContext)).toBe('42');
+      expect(getInsertText({ name: 'false' }, '', mockContext)).toBe('"false"');
+      expect(getInsertText({ name: '42' }, '', mockContext)).toBe('"42"');
+    });
+
+    it('SHOULD insert false and zero templates when addTemplate is true', () => {
+      const context = { ...mockContext, addTemplate: true };
+
+      expect(getInsertText({ name: 'disabled', template: false }, '', context)).toBe(
+        '"disabled": false'
+      );
+      expect(getInsertText({ name: 'retries', template: 0 }, '', context)).toBe('"retries": 0');
+    });
+
+    it('SHOULD preserve key-only insertion for empty and null templates', () => {
+      const context = { ...mockContext, addTemplate: true };
+
+      expect(getInsertText({ name: '_source', template: '' }, '', context)).toBe('"_source"');
+      expect(getInsertText({ name: 'field', template: null }, '', context)).toBe('"field"');
+    });
+
     it('does not add quotes around braces and brackets', () => {
       expect(
         getInsertText(

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -992,6 +992,33 @@ describe('autocomplete_utils', () => {
         expect(JSON.parse(`{${acc}}`)).toEqual({ value: 1e21 });
         expect(acc).toBe('  "value": 1e+21');
       });
+
+      it.each(['1e-7', '1e+21'])(
+        'SHOULD complete sibling fields after an exponent primitive value %s',
+        async (exponentValue) => {
+          mockPopulateContext.mockImplementation((...args) => {
+            const [bodyTokens, context] = args[0];
+            context.autoCompleteSet =
+              bodyTokens.at(-1) === '{'
+                ? ([{ name: 'next_field' }] as unknown as AutoCompleteContext['autoCompleteSet'])
+                : [];
+          });
+          const editorLines = ['GET _search', '{', `  "value": ${exponentValue}, "`];
+          const position = {
+            lineNumber: 3,
+            column: editorLines[2].length + 1,
+          } as monaco.Position;
+
+          const items = await getBodyCompletionItems(
+            buildModel(editorLines, { startColumn: editorLines[2].length, word: '' }),
+            position,
+            1,
+            mockEditor
+          );
+
+          expect(items.map((item) => item.label)).toContain('next_field');
+        }
+      );
     });
 
     it('ignores quotes inside comments when completing in the middle of a quoted field', async () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -579,6 +579,145 @@ describe('autocomplete_utils', () => {
       });
     });
 
+    describe('WHEN completing a primitive value inside an auto-closed string', () => {
+      const buildModel = (
+        editorLines: string[],
+        wordUntilPosition: { startColumn: number; word: string }
+      ) =>
+        ({
+          getLineContent: (lineNumber: number) => editorLines[lineNumber - 1],
+          getValueInRange: jest.fn(
+            ({ startLineNumber, startColumn, endLineNumber, endColumn }: monaco.IRange) => {
+              if (startLineNumber === endLineNumber) {
+                return editorLines[startLineNumber - 1].slice(startColumn - 1, endColumn - 1);
+              }
+              const selectedLines = editorLines.slice(startLineNumber - 1, endLineNumber);
+              selectedLines[0] = selectedLines[0].slice(startColumn - 1);
+              selectedLines[selectedLines.length - 1] = selectedLines[
+                selectedLines.length - 1
+              ].slice(0, endColumn - 1);
+              return selectedLines.join('\n');
+            }
+          ),
+          getWordUntilPosition: () => wordUntilPosition,
+          getLineMaxColumn: (lineNumber: number) => editorLines[lineNumber - 1].length + 1,
+        } as unknown as monaco.editor.ITextModel);
+
+      // Simulates Monaco applying a completion item over its single-range form.
+      const acceptSuggestion = (editorLines: string[], item: monaco.languages.CompletionItem) => {
+        if (!item.range || !('startLineNumber' in item.range)) {
+          throw new Error('completion item must use the single-range form');
+        }
+        const { range } = item;
+        const line = editorLines[range.startLineNumber - 1];
+        return (
+          line.slice(0, range.startColumn - 1) + item.insertText + line.slice(range.endColumn - 1)
+        );
+      };
+
+      beforeEach(() => {
+        mockPopulateContext.mockImplementation((...args) => {
+          const context = args[0][1];
+          context.autoCompleteSet = [
+            { name: false },
+            { name: 'false' },
+            { name: 'some_string_value' },
+          ] as unknown as AutoCompleteContext['autoCompleteSet'];
+        });
+      });
+
+      it('SHOULD cover the opening quote for primitive terms when completing mid-word', async () => {
+        const editorLines = ['GET _search', '{', '  "refresh": "f"'];
+        // Cursor after `f`, before the auto-closed closing quote.
+        const position = { lineNumber: 3, column: 16 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 15, word: 'f' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find(
+          (item) => item.label === 'false' && item.insertText === 'false'
+        );
+        const stringTerm = items.find((item) => item.label === 'some_string_value');
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 14, // includes the opening quote
+          endLineNumber: 3,
+          endColumn: 17, // includes the auto-closed closing quote
+        });
+        expect(stringTerm?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 15, // string terms re-insert the quotes themselves
+          endLineNumber: 3,
+          endColumn: 17,
+        });
+        const acc = acceptSuggestion(editorLines, primitive!);
+        expect(JSON.parse(`{${acc}}`)).toEqual({ refresh: false });
+        expect(acc).toBe('  "refresh": false');
+        expect(acceptSuggestion(editorLines, stringTerm!)).toBe('  "refresh": "some_string_value"');
+      });
+
+      it('SHOULD cover both quotes when accepted straight from the trigger quote', async () => {
+        const editorLines = ['GET _search', '{', '  "refresh": ""'];
+        // Cursor between the auto-closed quotes, before typing anything.
+        const position = { lineNumber: 3, column: 15 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 15, word: '' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find(
+          (item) => item.label === 'false' && item.insertText === 'false'
+        );
+        const stringTerm = items.find((item) => item.label === 'some_string_value');
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 14, // includes the opening quote
+          endLineNumber: 3,
+          endColumn: 16, // includes the auto-closed closing quote
+        });
+        expect(stringTerm?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 15,
+          endLineNumber: 3,
+          endColumn: 16,
+        });
+        expect(JSON.parse(`{${acceptSuggestion(editorLines, primitive!)}}`)).toEqual({
+          refresh: false,
+        });
+        expect(acceptSuggestion(editorLines, stringTerm!)).toBe('  "refresh": "some_string_value"');
+      });
+
+      it('SHOULD NOT shift the range when typing an unquoted value', async () => {
+        const editorLines = ['GET _search', '{', '  "refresh": f'];
+        const position = { lineNumber: 3, column: 15 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 14, word: 'f' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find(
+          (item) => item.label === 'false' && item.insertText === 'false'
+        );
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 14, // starts at the word: there is no quote to replace
+          endLineNumber: 3,
+          endColumn: 15,
+        });
+        expect(acceptSuggestion(editorLines, primitive!)).toBe('  "refresh": false');
+      });
+    });
+
     it('ignores quotes inside comments when completing in the middle of a quoted field', async () => {
       mockPopulateContext.mockImplementation((...args) => {
         const context = args[0][1];

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -710,6 +710,56 @@ describe('autocomplete_utils', () => {
         expect(acc).toBe('  "value": 0.5');
       });
 
+      it('SHOULD suggest decimal primitive terms inside an array value', async () => {
+        const editorLines = ['GET _search', '{', '  "values": ["0."]'];
+        // Cursor after `0.`, before the auto-closed closing quote; Monaco has no word at `.`.
+        const position = { lineNumber: 3, column: 17 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 17, word: '' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find((item) => item.label === '0.5' && item.insertText === '0.5');
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 14, // includes the opening quote and typed decimal prefix
+          endLineNumber: 3,
+          endColumn: 18,
+        });
+        const acc = acceptSuggestion(editorLines, primitive!);
+        expect(JSON.parse(`{${acc}}`)).toEqual({ values: [0.5] });
+        expect(acc).toBe('  "values": [0.5]');
+      });
+
+      it('SHOULD replace the whole quoted dotted value for string terms', async () => {
+        mockPopulateContext.mockImplementation((...args) => {
+          const context = args[0][1];
+          context.autoCompleteSet = [{ name: 'foo.bar' }];
+        });
+        const editorLines = ['GET _search', '{', '  "mode": "foo.b"'];
+        // Cursor after `b`, before the auto-closed closing quote.
+        const position = { lineNumber: 3, column: 17 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 16, word: 'b' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const stringTerm = items.find((item) => item.label === 'foo.bar');
+        expect(stringTerm?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 12, // preserves the opening quote but replaces the full value prefix
+          endLineNumber: 3,
+          endColumn: 18,
+        });
+        expect(acceptSuggestion(editorLines, stringTerm!)).toBe('  "mode": "foo.bar"');
+      });
+
       it('SHOULD NOT suggest primitive terms inside a triple-quoted value', async () => {
         const editorLines = ['GET _search', '{', '  "value": """-1"""'];
         // Cursor after `-1`, before the closing triple quote.
@@ -717,6 +767,28 @@ describe('autocomplete_utils', () => {
 
         const items = await getBodyCompletionItems(
           buildModel(editorLines, { startColumn: 16, word: '1' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        expect(items.find((item) => item.label === '-1')).toBeUndefined();
+        expect(items.find((item) => item.label === '0.5')).toBeUndefined();
+        expect(items.find((item) => item.label === 'some_string_value')).toBeDefined();
+      });
+
+      it('SHOULD NOT suggest primitive terms inside an oversized triple-quoted value', async () => {
+        const pad = 'x'.repeat(100_001);
+        const lineContentBeforePosition = `  "pad": "${pad}", "value": """-1`;
+        const editorLines = ['GET _search', '{', `${lineContentBeforePosition}"""`];
+        // Cursor after `-1`, before the closing triple quote.
+        const position = {
+          lineNumber: 3,
+          column: lineContentBeforePosition.length + 1,
+        } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: lineContentBeforePosition.length, word: '1' }),
           position,
           1,
           mockEditor

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -620,6 +620,8 @@ describe('autocomplete_utils', () => {
           const context = args[0][1];
           context.autoCompleteSet = [
             { name: false },
+            { name: -1 },
+            { name: 0.5 },
             { name: 'false' },
             { name: 'some_string_value' },
           ] as unknown as AutoCompleteContext['autoCompleteSet'];
@@ -658,6 +660,54 @@ describe('autocomplete_utils', () => {
         expect(JSON.parse(`{${acc}}`)).toEqual({ refresh: false });
         expect(acc).toBe('  "refresh": false');
         expect(acceptSuggestion(editorLines, stringTerm!)).toBe('  "refresh": "some_string_value"');
+      });
+
+      it('SHOULD cover the opening quote and typed minus for negative primitive terms', async () => {
+        const editorLines = ['GET _search', '{', '  "value": "-1"'];
+        // Monaco's word starts at `1`, after the JSON minus.
+        const position = { lineNumber: 3, column: 15 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 14, word: '1' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find((item) => item.label === '-1' && item.insertText === '-1');
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 12, // includes the opening quote and typed minus
+          endLineNumber: 3,
+          endColumn: 16,
+        });
+        const acc = acceptSuggestion(editorLines, primitive!);
+        expect(JSON.parse(`{${acc}}`)).toEqual({ value: -1 });
+        expect(acc).toBe('  "value": -1');
+      });
+
+      it('SHOULD cover the opening quote and typed decimal prefix for numeric primitive terms', async () => {
+        const editorLines = ['GET _search', '{', '  "value": "0."'];
+        // Cursor after `0.`, before the auto-closed closing quote; Monaco has no word at `.`.
+        const position = { lineNumber: 3, column: 15 } as monaco.Position;
+
+        const items = await getBodyCompletionItems(
+          buildModel(editorLines, { startColumn: 15, word: '' }),
+          position,
+          1,
+          mockEditor
+        );
+
+        const primitive = items.find((item) => item.label === '0.5' && item.insertText === '0.5');
+        expect(primitive?.range).toEqual({
+          startLineNumber: 3,
+          startColumn: 12, // includes the opening quote and typed decimal prefix
+          endLineNumber: 3,
+          endColumn: 16,
+        });
+        const acc = acceptSuggestion(editorLines, primitive!);
+        expect(JSON.parse(`{${acc}}`)).toEqual({ value: 0.5 });
+        expect(acc).toBe('  "value": 0.5');
       });
 
       it('SHOULD cover both quotes when accepted straight from the trigger quote', async () => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -506,6 +506,10 @@ const getSuggestions = (
     openingQuoteStartColumn !== false && openingQuoteStartColumn !== undefined
       ? { ...range, startColumn: openingQuoteStartColumn }
       : range;
+  const primitiveTermFilterText =
+    openingQuoteStartColumn !== false && openingQuoteStartColumn !== undefined
+      ? (name: ResultTerm['name']) => `"${String(name)}`
+      : undefined;
   const quotedValueRange =
     openingQuoteStartColumn !== false &&
     openingQuoteStartColumn !== undefined &&
@@ -545,6 +549,9 @@ const getSuggestions = (
           // the kind is only used to configure the icon
           kind: monaco.languages.CompletionItemKind.Constant,
           range: typeof item.name !== 'string' ? primitiveTermRange : quotedValueRange,
+          ...(typeof item.name !== 'string' && primitiveTermFilterText
+            ? { filterText: primitiveTermFilterText(item.name) }
+            : {}),
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           ...(endsInsideEmptyContainer
             ? { command: { id: 'editor.action.triggerSuggest', title: '' } }

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -370,6 +370,18 @@ const findOpeningQuoteStartColumn = (lineContentBeforePosition: string): number 
   }
 };
 
+const findUnquotedPrimitiveValueStartColumn = (
+  lineContentBeforePosition: string
+): number | undefined => {
+  const primitivePrefixMatch = lineContentBeforePosition.match(
+    /(?:^|[\s:[,])(-?(?:\d+(?:\.\d*)?|\.\d*)|-)$/
+  );
+  const primitivePrefix = primitivePrefixMatch?.[1];
+  return primitivePrefix
+    ? lineContentBeforePosition.length - primitivePrefix.length + 1
+    : undefined;
+};
+
 const isCompletingObjectKey = (bodyTokens: string[]): boolean => bodyTokens.at(-1) === '{';
 
 // If there is a closing `"` after the cursor, include it in the replacement range so accepting
@@ -498,13 +510,17 @@ const getSuggestions = (
     endColumn,
   };
 
-  // Primitive terms insert bare JSON literals (`true`, `0`), so when the cursor is inside a
-  // quoted string the replacement range must also cover the opening quote. Monaco can start the
-  // current word after JSON punctuation (`-`, `.`), so scan back to the string boundary instead
-  // of shifting by one column.
+  // Primitive terms insert bare JSON literals (`true`, `0`), so their replacement range must
+  // cover any quote or numeric punctuation that Monaco leaves outside the current word.
+  const unquotedPrimitiveValueStartColumn =
+    openingQuoteStartColumn === false || openingQuoteStartColumn === undefined
+      ? findUnquotedPrimitiveValueStartColumn(lineContentBeforePosition)
+      : undefined;
   const primitiveTermRange =
     openingQuoteStartColumn !== false && openingQuoteStartColumn !== undefined
       ? { ...range, startColumn: openingQuoteStartColumn }
+      : unquotedPrimitiveValueStartColumn !== undefined
+      ? { ...range, startColumn: unquotedPrimitiveValueStartColumn }
       : range;
   const primitiveTermFilterText =
     openingQuoteStartColumn !== false && openingQuoteStartColumn !== undefined

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -374,7 +374,7 @@ const findUnquotedPrimitiveValueStartColumn = (
   lineContentBeforePosition: string
 ): number | undefined => {
   const primitivePrefixMatch = lineContentBeforePosition.match(
-    /(?:^|[\s:[,])(-?(?:\d+(?:\.\d*)?|\.\d*)|-)$/
+    /(?:^|[\s:[,])(-?(?:(?:\d+(?:\.\d*)?|\.\d*)(?:[eE][+-]?\d*)?)|-)$/
   );
   const primitivePrefix = primitivePrefixMatch?.[1];
   return primitivePrefix

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -360,6 +360,14 @@ const findUnescapedQuoteIndex = (
   return -1;
 };
 
+const findOpeningQuoteStartColumn = (lineContentBeforePosition: string): number | undefined => {
+  for (let index = lineContentBeforePosition.length - 1; index >= 0; index--) {
+    if (lineContentBeforePosition[index] === '"' && !isEscaped(lineContentBeforePosition, index)) {
+      return index + 1;
+    }
+  }
+};
+
 // If there is a closing `"` after the cursor, include it in the replacement range so accepting
 // a suggestion replaces the rest of the token instead of duplicating the quote.
 const getCompletionEndColumn = (
@@ -435,7 +443,9 @@ const getSuggestions = (
   // Check if we're typing a field name with a trailing dot
   // Check if we're typing a nested field name (contains a dot)
   // This handles both "category." (trailing dot) and "category.keywor" (partial field after dot)
-  const quotedFieldWithDotMatch = lineContentBeforePosition.match(/"([^"]*\.[^"]*)$/);
+  const quotedFieldWithDotMatch = /:\s*"[^"]*$/.test(lineContentBeforePosition)
+    ? null
+    : lineContentBeforePosition.match(/"([^"]*\.[^"]*)$/);
   // Also check for unquoted fields with dots (e.g., index.mode without quotes)
   const unquotedFieldWithDotMatch = lineContentBeforePosition.match(
     /(?:^|[\s{:,\[])([a-zA-Z_][\w]*(?:\.[\w]+)+)$/
@@ -473,12 +483,15 @@ const getSuggestions = (
   };
 
   // Primitive terms insert bare JSON literals (`true`, `0`), so when the cursor is inside a
-  // quoted string the replacement range must also cover the opening quote, otherwise accepting
-  // leaves it behind (`"refresh": "false`). String terms don't need this: they re-insert the
-  // closing quote themselves without the opening one.
-  const startsInsideQuotedString =
-    isInsideQuotedString && lineContentBeforePosition.charAt(startColumn - 2) === '"';
-  const primitiveTermRange = { ...range, startColumn: startColumn - 1 };
+  // quoted string the replacement range must also cover the opening quote. Monaco can start the
+  // current word after JSON punctuation (`-`, `.`), so scan back to the string boundary instead
+  // of shifting by one column.
+  const primitiveTermRangeStartColumn =
+    isInsideQuotedString && findOpeningQuoteStartColumn(lineContentBeforePosition);
+  const primitiveTermRange =
+    primitiveTermRangeStartColumn !== false && primitiveTermRangeStartColumn !== undefined
+      ? { ...range, startColumn: primitiveTermRangeStartColumn }
+      : range;
 
   return (
     filterTermsWithoutName(autocompleteSet)
@@ -507,8 +520,7 @@ const getSuggestions = (
           detail: i18nTexts.api,
           // the kind is only used to configure the icon
           kind: monaco.languages.CompletionItemKind.Constant,
-          range:
-            typeof item.name !== 'string' && startsInsideQuotedString ? primitiveTermRange : range,
+          range: typeof item.name !== 'string' ? primitiveTermRange : range,
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           ...(endsInsideEmptyContainer
             ? { command: { id: 'editor.action.triggerSuggest', title: '' } }

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -542,7 +542,7 @@ export const getInsertText = (
 
   // check if there is template to add
   const conditionalTemplate = getConditionalTemplate(name, bodyContent, context.endpoint);
-  if (conditionalTemplate) {
+  if (conditionalTemplate !== undefined) {
     template = conditionalTemplate;
   }
 
@@ -599,7 +599,7 @@ const getConditionalTemplate = (
     return false;
   });
   // use the template from the matched rule
-  if (matchedRule && matchedRule.__template) {
+  if (matchedRule && matchedRule.__template !== undefined) {
     return matchedRule.__template;
   }
 };

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -546,7 +546,7 @@ export const getInsertText = (
     template = conditionalTemplate;
   }
 
-  if (template && context.addTemplate) {
+  if (template !== undefined && template !== null && template !== '' && context.addTemplate) {
     let templateLines;
     const templateRecord = isRecord(template) ? template : {};
     const raw = templateRecord.__raw;
@@ -575,7 +575,7 @@ export const getInsertText = (
 };
 
 const getConditionalTemplate = (
-  name: string | boolean,
+  name: string | number | boolean,
   bodyContent: string,
   endpoint: AutoCompleteContext['endpoint']
 ) => {

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -466,8 +466,12 @@ const getSuggestions = (
   } = getCompletionLineState(model, position, bodyContentBeforePosition);
   context.addTemplate = canInsertTemplate;
   const completingObjectKey = isCompletingObjectKey(bodyTokens);
-  const openingQuoteStartColumn =
-    isInsideQuotedString && findOpeningQuoteStartColumn(lineContentBeforePosition);
+  // `false`: not inside a quoted string. A number: the column right after the string's opening
+  // quote on this line. `undefined`: inside a quoted string whose opening quote sits on an
+  // earlier line (multi-line continuation).
+  const openingQuoteStartColumn = isInsideQuotedString
+    ? findOpeningQuoteStartColumn(lineContentBeforePosition)
+    : false;
   // Check if we're typing a field name with a trailing dot
   // Check if we're typing a nested field name (contains a dot)
   // This handles both "category." (trailing dot) and "category.keywor" (partial field after dot)
@@ -512,24 +516,21 @@ const getSuggestions = (
 
   // Primitive terms insert bare JSON literals (`true`, `0`), so their replacement range must
   // cover any quote or numeric punctuation that Monaco leaves outside the current word.
+  const hasOpeningQuoteOnLine = typeof openingQuoteStartColumn === 'number';
   const unquotedPrimitiveValueStartColumn =
-    openingQuoteStartColumn === false || openingQuoteStartColumn === undefined
+    openingQuoteStartColumn === false
       ? findUnquotedPrimitiveValueStartColumn(lineContentBeforePosition)
       : undefined;
-  const primitiveTermRange =
-    openingQuoteStartColumn !== false && openingQuoteStartColumn !== undefined
-      ? { ...range, startColumn: openingQuoteStartColumn }
-      : unquotedPrimitiveValueStartColumn !== undefined
-      ? { ...range, startColumn: unquotedPrimitiveValueStartColumn }
-      : range;
-  const primitiveTermFilterText =
-    openingQuoteStartColumn !== false && openingQuoteStartColumn !== undefined
-      ? (name: ResultTerm['name']) => `"${String(name)}`
-      : undefined;
+  const primitiveTermRange = hasOpeningQuoteOnLine
+    ? { ...range, startColumn: openingQuoteStartColumn }
+    : unquotedPrimitiveValueStartColumn !== undefined
+    ? { ...range, startColumn: unquotedPrimitiveValueStartColumn }
+    : range;
+  const primitiveTermFilterText = hasOpeningQuoteOnLine
+    ? (name: ResultTerm['name']) => `"${String(name)}`
+    : undefined;
   const quotedValueRange =
-    openingQuoteStartColumn !== false &&
-    openingQuoteStartColumn !== undefined &&
-    !completingObjectKey
+    hasOpeningQuoteOnLine && !completingObjectKey
       ? { ...range, startColumn: openingQuoteStartColumn + 1 }
       : range;
 
@@ -541,7 +542,12 @@ const getSuggestions = (
           return false;
         }
 
-        if (isInsideTripleQuotedString && typeof item.name !== 'string') {
+        // Bare JSON literals are meaningless inside a triple-quoted ESQL query or a multi-line
+        // string continuation whose opening quote is not on this line.
+        if (
+          (isInsideTripleQuotedString || openingQuoteStartColumn === undefined) &&
+          typeof item.name !== 'string'
+        ) {
           return false;
         }
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -472,6 +472,14 @@ const getSuggestions = (
     endColumn,
   };
 
+  // Primitive terms insert bare JSON literals (`true`, `0`), so when the cursor is inside a
+  // quoted string the replacement range must also cover the opening quote, otherwise accepting
+  // leaves it behind (`"refresh": "false`). String terms don't need this: they re-insert the
+  // closing quote themselves without the opening one.
+  const startsInsideQuotedString =
+    isInsideQuotedString && lineContentBeforePosition.charAt(startColumn - 2) === '"';
+  const primitiveTermRange = { ...range, startColumn: startColumn - 1 };
+
   return (
     filterTermsWithoutName(autocompleteSet)
       // Filter suggestions to only show nested fields when there's a field being typed with a dot
@@ -499,7 +507,8 @@ const getSuggestions = (
           detail: i18nTexts.api,
           // the kind is only used to configure the icon
           kind: monaco.languages.CompletionItemKind.Constant,
-          range,
+          range:
+            typeof item.name !== 'string' && startsInsideQuotedString ? primitiveTermRange : range,
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           ...(endsInsideEmptyContainer
             ? { command: { id: 'editor.action.triggerSuggest', title: '' } }

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -9,10 +9,10 @@
 
 import { monaco } from '@kbn/monaco';
 import {
+  checkForTripleQuotesAndEsqlQuery,
   getLineRemainderWithoutConsoleComments,
   isEscaped,
   isInsideConsoleString,
-  isInsideTripleQuotedJsonValue,
 } from '@kbn/monaco/src/languages/console/utils';
 import type { MonacoEditorActionsProvider } from '../monaco_editor_actions_provider';
 import {
@@ -323,14 +323,15 @@ export const getBodyCompletionItems = async (
   // loading async suggestions
   if (context.asyncResultsState?.isLoading && context.asyncResultsState) {
     const results = await context.asyncResultsState.results;
-    return getSuggestions(model, position, results, context, bodyContentBeforePosition);
+    return getSuggestions(model, position, results, context, bodyContentBeforePosition, bodyTokens);
   }
   return getSuggestions(
     model,
     position,
     context.autoCompleteSet ?? [],
     context,
-    bodyContentBeforePosition
+    bodyContentBeforePosition,
+    bodyTokens
   );
 };
 
@@ -368,6 +369,8 @@ const findOpeningQuoteStartColumn = (lineContentBeforePosition: string): number 
     }
   }
 };
+
+const isCompletingObjectKey = (bodyTokens: string[]): boolean => bodyTokens.at(-1) === '{';
 
 // If there is a closing `"` after the cursor, include it in the replacement range so accepting
 // a suggestion replaces the rest of the token instead of duplicating the quote.
@@ -414,7 +417,8 @@ const getCompletionLineState = (
     getLineRemainderWithoutConsoleComments(bodyContentBeforePosition, lineContentAfterPosition)
   );
   const isInsideQuotedString = isInsideConsoleString(bodyContentBeforePosition);
-  const isInsideTripleQuotedString = isInsideTripleQuotedJsonValue(bodyContentBeforePosition);
+  const { insideTripleQuotes: isInsideTripleQuotedString } =
+    checkForTripleQuotesAndEsqlQuery(bodyContentBeforePosition);
 
   return {
     canInsertTemplate,
@@ -436,7 +440,8 @@ const getSuggestions = (
   position: monaco.Position,
   autocompleteSet: ResultTerm[],
   context: AutoCompleteContext,
-  bodyContentBeforePosition: string
+  bodyContentBeforePosition: string,
+  bodyTokens: string[]
 ) => {
   // get the word before suggestions to replace when selecting a suggestion from the list
   const wordUntilPosition = model.getWordUntilPosition(position);
@@ -448,12 +453,15 @@ const getSuggestions = (
     lineContentBeforePosition,
   } = getCompletionLineState(model, position, bodyContentBeforePosition);
   context.addTemplate = canInsertTemplate;
+  const completingObjectKey = isCompletingObjectKey(bodyTokens);
+  const openingQuoteStartColumn =
+    isInsideQuotedString && findOpeningQuoteStartColumn(lineContentBeforePosition);
   // Check if we're typing a field name with a trailing dot
   // Check if we're typing a nested field name (contains a dot)
   // This handles both "category." (trailing dot) and "category.keywor" (partial field after dot)
-  const quotedFieldWithDotMatch = /:\s*"[^"]*$/.test(lineContentBeforePosition)
-    ? null
-    : lineContentBeforePosition.match(/"([^"]*\.[^"]*)$/);
+  const quotedFieldWithDotMatch = completingObjectKey
+    ? lineContentBeforePosition.match(/"([^"]*\.[^"]*)$/)
+    : null;
   // Also check for unquoted fields with dots (e.g., index.mode without quotes)
   const unquotedFieldWithDotMatch = lineContentBeforePosition.match(
     /(?:^|[\s{:,\[])([a-zA-Z_][\w]*(?:\.[\w]+)+)$/
@@ -494,11 +502,15 @@ const getSuggestions = (
   // quoted string the replacement range must also cover the opening quote. Monaco can start the
   // current word after JSON punctuation (`-`, `.`), so scan back to the string boundary instead
   // of shifting by one column.
-  const primitiveTermRangeStartColumn =
-    isInsideQuotedString && findOpeningQuoteStartColumn(lineContentBeforePosition);
   const primitiveTermRange =
-    primitiveTermRangeStartColumn !== false && primitiveTermRangeStartColumn !== undefined
-      ? { ...range, startColumn: primitiveTermRangeStartColumn }
+    openingQuoteStartColumn !== false && openingQuoteStartColumn !== undefined
+      ? { ...range, startColumn: openingQuoteStartColumn }
+      : range;
+  const quotedValueRange =
+    openingQuoteStartColumn !== false &&
+    openingQuoteStartColumn !== undefined &&
+    !completingObjectKey
+      ? { ...range, startColumn: openingQuoteStartColumn + 1 }
       : range;
 
   return (
@@ -532,7 +544,7 @@ const getSuggestions = (
           detail: i18nTexts.api,
           // the kind is only used to configure the icon
           kind: monaco.languages.CompletionItemKind.Constant,
-          range: typeof item.name !== 'string' ? primitiveTermRange : range,
+          range: typeof item.name !== 'string' ? primitiveTermRange : quotedValueRange,
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           ...(endsInsideEmptyContainer
             ? { command: { id: 'editor.action.triggerSuggest', title: '' } }

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -12,6 +12,7 @@ import {
   getLineRemainderWithoutConsoleComments,
   isEscaped,
   isInsideConsoleString,
+  isInsideTripleQuotedJsonValue,
 } from '@kbn/monaco/src/languages/console/utils';
 import type { MonacoEditorActionsProvider } from '../monaco_editor_actions_provider';
 import {
@@ -413,10 +414,12 @@ const getCompletionLineState = (
     getLineRemainderWithoutConsoleComments(bodyContentBeforePosition, lineContentAfterPosition)
   );
   const isInsideQuotedString = isInsideConsoleString(bodyContentBeforePosition);
+  const isInsideTripleQuotedString = isInsideTripleQuotedJsonValue(bodyContentBeforePosition);
 
   return {
     canInsertTemplate,
     isInsideQuotedString,
+    isInsideTripleQuotedString,
     lineContentBeforePosition,
     endColumn: getCompletionEndColumn(
       position.column,
@@ -437,8 +440,13 @@ const getSuggestions = (
 ) => {
   // get the word before suggestions to replace when selecting a suggestion from the list
   const wordUntilPosition = model.getWordUntilPosition(position);
-  const { canInsertTemplate, endColumn, isInsideQuotedString, lineContentBeforePosition } =
-    getCompletionLineState(model, position, bodyContentBeforePosition);
+  const {
+    canInsertTemplate,
+    endColumn,
+    isInsideQuotedString,
+    isInsideTripleQuotedString,
+    lineContentBeforePosition,
+  } = getCompletionLineState(model, position, bodyContentBeforePosition);
   context.addTemplate = canInsertTemplate;
   // Check if we're typing a field name with a trailing dot
   // Check if we're typing a nested field name (contains a dot)
@@ -498,6 +506,10 @@ const getSuggestions = (
       // Filter suggestions to only show nested fields when there's a field being typed with a dot
       .filter((item) => {
         if ((isInsideQuotedString || !context.addTemplate) && usesStructuralSnippet(item)) {
+          return false;
+        }
+
+        if (isInsideTripleQuotedString && typeof item.name !== 'string') {
           return false;
         }
 

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.test.ts
@@ -212,6 +212,14 @@ describe('tokens_utils', () => {
         tokens: ['{'],
       },
       {
+        value: '{"test":1e-7,',
+        tokens: ['{'],
+      },
+      {
+        value: '{"test":1e+21,',
+        tokens: ['{'],
+      },
+      {
         value: '{"test":{},',
         tokens: ['{'],
       },

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.ts
@@ -203,6 +203,9 @@ export const parseBody = (value: string): string[] => {
     // optionally there is E notation
     if (isENotation(char)) {
       next();
+      if (isPlusSign(char) || isMinusSign(char)) {
+        next();
+      }
       // needs at least 1 digit after e or E
       if (!isDigit(char)) {
         throw new Error('Missing digits after E notation');
@@ -544,6 +547,9 @@ const isNumberStartChar = (char: string): boolean => {
 };
 const isMinusSign = (char: string): boolean => {
   return char === '-';
+};
+const isPlusSign = (char: string): boolean => {
+  return char === '+';
 };
 const isDigit = (char: string): boolean => {
   return digitRegex.test(char);

--- a/src/platform/plugins/shared/console/public/lib/autocomplete/body_completer.ts
+++ b/src/platform/plugins/shared/console/public/lib/autocomplete/body_completer.ts
@@ -265,7 +265,15 @@ function compileDescription(
     return [compileParametrizedValue(description, compilingContext)];
   }
 
-  return [new ConstantComponent(_.isString(description) ? description : String(description))];
+  if (typeof description === 'boolean' || typeof description === 'number') {
+    return [
+      new ConstantComponent(String(description), undefined, {
+        name: description,
+      }),
+    ];
+  }
+
+  return [new ConstantComponent(String(description))];
 }
 
 function compileParametrizedValue(

--- a/src/platform/plugins/shared/console/public/lib/autocomplete/types.ts
+++ b/src/platform/plugins/shared/console/public/lib/autocomplete/types.ts
@@ -15,7 +15,7 @@ export interface ResultTerm {
   meta?: string;
   context?: AutoCompleteContext;
   insertValue?: string;
-  name?: string | boolean;
+  name?: string | number | boolean;
   value?: string;
   score?: number;
   /**

--- a/src/platform/plugins/shared/console/public/lib/autocomplete/types.ts
+++ b/src/platform/plugins/shared/console/public/lib/autocomplete/types.ts
@@ -47,7 +47,7 @@ export interface DataAutoCompleteRulesOneOf {
   __condition?: {
     lines_regex: string;
   };
-  __template: Record<string, unknown>;
+  __template?: unknown;
   [key: string]: unknown;
 }
 

--- a/src/platform/plugins/shared/console/public/lib/kb/kb.test.ts
+++ b/src/platform/plugins/shared/console/public/lib/kb/kb.test.ts
@@ -206,4 +206,52 @@ describe('Knowledge base', () => {
       );
     });
   });
+
+  describe('WHEN body rules contain primitive suggestions', () => {
+    it('SHOULD preserve boolean, number, and string term types', () => {
+      const api = kb._test.loadApisFromJson({
+        es: {
+          endpoints: {
+            endpoint: {
+              data_autocomplete_rules: {
+                value: {
+                  __one_of: [true, false, 0, 42, 'false', '42'],
+                },
+              },
+            },
+          },
+        },
+      });
+      kb._test.setActiveApi(api);
+      const context = {
+        otherTokenValues: [],
+        endpointComponentResolver: kb.getEndpointBodyCompleteComponents,
+        globalComponentResolver: kb.getGlobalAutocompleteComponents,
+      } as AutoCompleteContext & {
+        endpointComponentResolver: typeof kb.getEndpointBodyCompleteComponents;
+        globalComponentResolver: typeof kb.getGlobalAutocompleteComponents;
+      };
+
+      populateContext(
+        ['{', 'value'],
+        context,
+        null,
+        true,
+        kb.getEndpointBodyCompleteComponents('endpoint')
+      );
+
+      expect(
+        context.autoCompleteSet
+          ?.map(({ name }) => `${typeof name}:${String(name)}`)
+          .sort((left, right) => left.localeCompare(right))
+      ).toEqual([
+        'boolean:false',
+        'boolean:true',
+        'number:0',
+        'number:42',
+        'string:42',
+        'string:false',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Closes #279853

## Summary

Console now preserves boolean and numeric autocomplete terms as JSON primitives. Property templates equal to `false` or `0` are also inserted instead of being dropped.

## Root Cause

- Autocomplete compilation converted non-string constants to strings, so insertion quoted them.
- Conditional template selection and insertion used truthiness checks, excluding `false` and `0`.
- Shared replacement ranges and number parsing assumed string or plain-number inputs.

## Fix

- Preserve boolean and number term types while keeping string lookalikes distinct.
- Insert `false` and `0` templates; empty-string and `null` templates remain key-only.
- Harden shared completion ranges and parser state for quoted, punctuated, multiline, and signed-exponent inputs.

## Before/After Video

**Boolean value suggestion inserts a JSON primitive**

Before:

https://github.com/user-attachments/assets/355b67c9-7ef4-43c7-ab0a-e99cc589cb4a

After:

https://github.com/user-attachments/assets/4c69c5d6-1ad3-4ca9-a527-684aafd47842

**Zero property template**

Before:

https://github.com/user-attachments/assets/e3788689-d190-4b06-bb47-a8563108169d

After:

https://github.com/user-attachments/assets/2405db7c-eacb-4d30-96a9-964c5ff4d5fe

**False property template**

Before:

https://github.com/user-attachments/assets/db54c0f3-ed32-47ce-b5d8-384cc09a2e8a

After:

https://github.com/user-attachments/assets/7ed3a01b-7105-4a6f-9ed6-57b4f497936a

**Primitive suggestion accepted from an auto-closed quoted prefix**

Before:

https://github.com/user-attachments/assets/ecd81ebd-3b08-4e42-9cad-8a0b629a48d8

After:

https://github.com/user-attachments/assets/4ed2245f-6080-4944-b4ca-779180048d5d

## Test Plan

Manual:

1. In a local Kibana, open Dev Tools Console and enter the reproduction request from #279853.
2. Trigger autocomplete after `"keyed": ` and accept `false`.
3. Confirm the editor contains `"keyed": false`.
4. Accept `priority` after entering `"p` in a `PUT _index_template/<name>` body; confirm `"priority": 0`.
5. Accept `explain` after entering `"e` in a `GET _search/template` body; confirm `"explain": false`.

Automated:

- `node scripts/jest src/platform/plugins/shared/console/public/lib/kb/kb.test.ts src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts src/platform/plugins/shared/console/public/application/containers/editor/utils/tokens_utils.test.ts --runInBand` — 3 suites and 168 tests passed on the final PR head.
- `node scripts/type_check --project src/platform/plugins/shared/console/tsconfig.json` — passed on the final PR head.
- Provider-level regressions cover numeric and quoted prefixes, signed-exponent sibling context, dotted and array values, and multiline/triple-quoted suppression. Current shipped body rules do not expose stable live triggers for every generic numeric term shape, so those cases are automated rather than video evidence.

## Release Note

Console autocomplete now inserts boolean and numeric suggestions as JSON primitives instead of quoted strings.

Assisted with Cursor using GPT-5.6 Sol


<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->