### PR TITLE
[8.19] [Security Solution][Notes] Fix notes page not restoring filter UI state on return (#286574)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.test.tsx
@@ -7,6 +7,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { useSelector } from 'react-redux-v7';
 import { CreatedByFilterDropdown } from './created_by_filter_dropdown';
 import { CREATED_BY_SELECT_TEST_ID } from './test_ids';
 import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
@@ -24,6 +25,7 @@ jest.mock('react-redux', () => {
   return {
     ...original,
     useDispatch: () => mockDispatch,
+    useSelector: jest.fn(),
   };
 });
 
@@ -45,6 +47,7 @@ describe('UserFilterDropdown', () => {
     });
     (useLicense as jest.Mock).mockReturnValue({ isPlatinumPlus: () => true });
     (useUpsellingMessage as jest.Mock).mockReturnValue('upsellingMessage');
+    (useSelector as jest.Mock).mockReturnValue(''); // no stored filter by default
   });
 
   it('should render the component enabled', () => {
@@ -74,5 +77,21 @@ describe('UserFilterDropdown', () => {
     fireEvent.click(option);
 
     expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should restore the previously selected user from the store on mount', () => {
+    (useSelector as jest.Mock).mockReturnValue('1'); // uid matching 'test' user
+
+    render(<CreatedByFilterDropdown />);
+
+    expect(screen.getByDisplayValue('test')).toBeInTheDocument();
+  });
+
+  it('should show no selection when the stored filter is cleared', () => {
+    (useSelector as jest.Mock).mockReturnValue('');
+
+    const { getByTestId } = render(<CreatedByFilterDropdown />);
+
+    expect(getByTestId('comboBoxSearchInput')).toHaveValue('');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.test.tsx
@@ -7,7 +7,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { useSelector } from 'react-redux-v7';
+import { useSelector } from 'react-redux';
 import { CreatedByFilterDropdown } from './created_by_filter_dropdown';
 import { CREATED_BY_SELECT_TEST_ID } from './test_ids';
 import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { EuiComboBox, EuiToolTip } from '@elastic/eui';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux-v7';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { i18n } from '@kbn/i18n';
 import type { EuiComboBoxOptionOption } from '@elastic/eui/src/components/combo_box/types';
@@ -15,7 +15,7 @@ import { useLicense } from '../../common/hooks/use_license';
 import { useUpsellingMessage } from '../../common/hooks/use_upselling';
 import { CREATED_BY_SELECT_TEST_ID } from './test_ids';
 import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
-import { userFilterCreatedBy } from '..';
+import { userFilterCreatedBy, selectNotesTableCreatedByFilter } from '..';
 
 export const CREATED_BY = i18n.translate('xpack.securitySolution.notes.createdByDropdownLabel', {
   defaultMessage: 'Created by',
@@ -51,10 +51,16 @@ export const CreatedByFilterDropdown = React.memo(() => {
     [data]
   );
 
-  const [selectedUser, setSelectedUser] = useState<Array<EuiComboBoxOptionOption<User>>>();
+  const createdByFilter = useSelector(selectNotesTableCreatedByFilter);
+
+  const selectedUser = useMemo<Array<EuiComboBoxOptionOption<User>>>(() => {
+    if (!createdByFilter || !users.length) return [];
+    const match = users.find((u) => u.id === createdByFilter);
+    return match ? [match] : [];
+  }, [createdByFilter, users]);
+
   const onChange = useCallback(
     (user: Array<EuiComboBoxOptionOption<User>>) => {
-      setSelectedUser(user);
       dispatch(userFilterCreatedBy(user.length > 0 ? (user[0].id as string) : ''));
     },
     [dispatch]

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/created_by_filter_dropdown.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo, useCallback } from 'react';
 import { EuiComboBox, EuiToolTip } from '@elastic/eui';
-import { useDispatch, useSelector } from 'react-redux-v7';
+import { useDispatch, useSelector } from 'react-redux';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { i18n } from '@kbn/i18n';
 import type { EuiComboBoxOptionOption } from '@elastic/eui/src/components/combo_box/types';

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
@@ -8,6 +8,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { useSelector } from 'react-redux-v7';
 import { SearchRow } from './search_row';
 import {
   ASSOCIATED_NOT_SELECT_TEST_ID,
@@ -17,6 +18,7 @@ import {
 import { AssociatedFilter } from '../../../common/notes/constants';
 import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
 import { TestProviders } from '../../common/mock';
+import { selectNotesTableSearch, selectNotesTableAssociatedFilter } from '..';
 
 jest.mock('../../common/components/user_profiles/use_suggest_users');
 
@@ -27,6 +29,7 @@ jest.mock('react-redux', () => {
   return {
     ...original,
     useDispatch: () => mockDispatch,
+    useSelector: jest.fn(),
   };
 });
 
@@ -37,6 +40,8 @@ describe('SearchRow', () => {
       isLoading: false,
       data: [{ user: { username: 'test' } }, { user: { username: 'elastic' } }],
     });
+    // default: no stored filters
+    (useSelector as jest.Mock).mockReturnValue('');
   });
 
   it('should render the component', () => {
@@ -77,5 +82,33 @@ describe('SearchRow', () => {
     await userEvent.selectOptions(associatedNoteSelect, [AssociatedFilter.documentOnly]);
 
     expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should restore a previously applied search value from the store on mount', () => {
+    (useSelector as jest.Mock).mockImplementation((selector: unknown) =>
+      selector === selectNotesTableSearch ? 'previous search' : AssociatedFilter.all
+    );
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <SearchRow />
+      </TestProviders>
+    );
+
+    expect(getByTestId(SEARCH_BAR_TEST_ID)).toHaveValue('previous search');
+  });
+
+  it('should restore a previously applied associated filter from the store on mount', () => {
+    (useSelector as jest.Mock).mockImplementation((selector: unknown) =>
+      selector === selectNotesTableAssociatedFilter ? AssociatedFilter.documentOnly : ''
+    );
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <SearchRow />
+      </TestProviders>
+    );
+
+    expect(getByTestId(ASSOCIATED_NOT_SELECT_TEST_ID)).toHaveValue(AssociatedFilter.documentOnly);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
@@ -8,7 +8,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { useSelector } from 'react-redux-v7';
+import { useSelector } from 'react-redux';
 import { SearchRow } from './search_row';
 import {
   ASSOCIATED_NOT_SELECT_TEST_ID,
@@ -69,6 +69,21 @@ describe('SearchRow', () => {
     await userEvent.keyboard('{enter}');
 
     expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should not dispatch when the search query contains invalid syntax', async () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <SearchRow />
+      </TestProviders>
+    );
+
+    const searchBox = getByTestId(SEARCH_BAR_TEST_ID);
+
+    await userEvent.type(searchBox, ';');
+    await userEvent.keyboard('{enter}');
+
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('should call the correct action when select a value in the associated note dropdown', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
@@ -15,7 +15,7 @@ import {
   Query,
   useGeneratedHtmlId,
 } from '@elastic/eui';
-import { useDispatch, useSelector } from 'react-redux-v7';
+import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@kbn/i18n';
 import { CreatedByFilterDropdown } from './created_by_filter_dropdown';
 import { ASSOCIATED_NOT_SELECT_TEST_ID, SEARCH_BAR_TEST_ID } from './test_ids';
@@ -54,7 +54,8 @@ export const SearchRow = React.memo(() => {
   const notesAssociatedFilter = useSelector(selectNotesTableAssociatedFilter);
 
   const onQueryChange = useCallback(
-    ({ queryText }: { queryText: string }) => {
+    ({ queryText, error }: { queryText: string; error: Error | null }) => {
+      if (error) return;
       dispatch(userSearchedNotes(queryText.trim()));
     },
     [dispatch]

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
@@ -12,13 +12,19 @@ import {
   EuiFlexItem,
   EuiSearchBar,
   EuiSelect,
+  Query,
   useGeneratedHtmlId,
 } from '@elastic/eui';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux-v7';
 import { i18n } from '@kbn/i18n';
 import { CreatedByFilterDropdown } from './created_by_filter_dropdown';
 import { ASSOCIATED_NOT_SELECT_TEST_ID, SEARCH_BAR_TEST_ID } from './test_ids';
-import { userFilterAssociatedNotes, userSearchedNotes } from '..';
+import {
+  userFilterAssociatedNotes,
+  userSearchedNotes,
+  selectNotesTableSearch,
+  selectNotesTableAssociatedFilter,
+} from '..';
 import { AssociatedFilter } from '../../../common/notes/constants';
 
 const ATTACH_FILTER = i18n.translate('xpack.securitySolution.notes.management.attachFilter', {
@@ -44,6 +50,8 @@ const associatedNoteSelectOptions: EuiSelectOption[] = [
 export const SearchRow = React.memo(() => {
   const dispatch = useDispatch();
   const associatedSelectId = useGeneratedHtmlId({ prefix: 'associatedSelectId' });
+  const notesSearch = useSelector(selectNotesTableSearch);
+  const notesAssociatedFilter = useSelector(selectNotesTableAssociatedFilter);
 
   const onQueryChange = useCallback(
     ({ queryText }: { queryText: string }) => {
@@ -62,7 +70,7 @@ export const SearchRow = React.memo(() => {
   return (
     <EuiFlexGroup gutterSize="m">
       <EuiFlexItem>
-        <EuiSearchBar box={searchBox} onChange={onQueryChange} defaultQuery="" />
+        <EuiSearchBar box={searchBox} onChange={onQueryChange} query={Query.parse(notesSearch)} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <CreatedByFilterDropdown />
@@ -71,6 +79,7 @@ export const SearchRow = React.memo(() => {
         <EuiSelect
           id={associatedSelectId}
           options={associatedNoteSelectOptions}
+          value={notesAssociatedFilter}
           onChange={onAssociatedNoteSelectChange}
           prepend={ATTACH_FILTER}
           aria-label={ATTACH_FILTER}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution][Notes] Fix notes page not restoring filter UI state on return (#286574)](https://github.com/elastic/kibana/pull/286574)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon Wålstedt","email":"jon.walstedt@elastic.co"},"sourceCommit":{"committedDate":"2026-08-21T16:27:41Z","message":"[Security Solution][Notes] Fix notes page not restoring filter UI state on return (#286574)\n\n## Summary\n\n## What\nFixes a bug where previously applied filters on the Notes management\npage (search text, \"Attached to\" dropdown, \"Created by\" dropdown)\nremained active after navigating away and back, but were not reflected\nin the filter controls — making the list appear filtered with no visible\nreason.\n\n## Why\nFilter state is persisted in Redux, but all three filter controls\ninitialised from hardcoded defaults (`defaultQuery=\"\"`, no `value` prop,\nlocal `useState` with no initialisation) instead of reading from the\nstore on mount. Because the page component fully unmounts on navigation,\nreturning to the page always showed empty controls even though the\nstored filter was still applied to the data fetch.\n\nResolves issue #285563\n\nBefore fix: see video in issue  #285563\n\nAfter fix (using browser back button off screen): \n\n\nhttps://github.com/user-attachments/assets/daa7c2b2-7830-4018-abd1-59f106e26824\n\n\n## Changes\n\n- `search_row.tsx` — `EuiSearchBar` now uses\n`defaultQuery={notesSearch}` from Redux; `EuiSelect` (associated filter)\ngets `value={notesAssociatedFilter}` making it a controlled component\n- `created_by_filter_dropdown.tsx` — adds a `useEffect` that restores\nthe selected user option from `createdByFilter` in Redux once the user\nprofiles list has loaded\n- `search_row.test.tsx` — adds `useSelector` to the mock; adds tests\nasserting search and associated-filter values are restored on mount\n- `created_by_filter_dropdown.test.tsx` — adds `useSelector` to the mock\n(required now that the component calls it); adds a test asserting the\npreviously selected user is restored on mount\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Regressions (low):** `EuiSearchBar` with a non-empty `defaultQuery`\ncould theoretically fire `onChange` on mount and dispatch back to Redux,\nbut since the value would be identical to the stored value, Redux will\nnot update and no re-render loop occurs. Verified in testing.\n- No data loss, API, or performance risks.\n\n### Release note\n\n> Fixes an issue where previously applied filters on the Notes\nmanagement page were not shown in the filter controls after navigating\naway and returning, even though the filters were still active.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"4dea624716c9bdb51381e1d4458807b8cd6cf51b","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting","backport:all-open","v9.6.0"],"title":"[Security Solution][Notes] Fix notes page not restoring filter UI state on return","number":286574,"url":"https://github.com/elastic/kibana/pull/286574","mergeCommit":{"message":"[Security Solution][Notes] Fix notes page not restoring filter UI state on return (#286574)\n\n## Summary\n\n## What\nFixes a bug where previously applied filters on the Notes management\npage (search text, \"Attached to\" dropdown, \"Created by\" dropdown)\nremained active after navigating away and back, but were not reflected\nin the filter controls — making the list appear filtered with no visible\nreason.\n\n## Why\nFilter state is persisted in Redux, but all three filter controls\ninitialised from hardcoded defaults (`defaultQuery=\"\"`, no `value` prop,\nlocal `useState` with no initialisation) instead of reading from the\nstore on mount. Because the page component fully unmounts on navigation,\nreturning to the page always showed empty controls even though the\nstored filter was still applied to the data fetch.\n\nResolves issue #285563\n\nBefore fix: see video in issue  #285563\n\nAfter fix (using browser back button off screen): \n\n\nhttps://github.com/user-attachments/assets/daa7c2b2-7830-4018-abd1-59f106e26824\n\n\n## Changes\n\n- `search_row.tsx` — `EuiSearchBar` now uses\n`defaultQuery={notesSearch}` from Redux; `EuiSelect` (associated filter)\ngets `value={notesAssociatedFilter}` making it a controlled component\n- `created_by_filter_dropdown.tsx` — adds a `useEffect` that restores\nthe selected user option from `createdByFilter` in Redux once the user\nprofiles list has loaded\n- `search_row.test.tsx` — adds `useSelector` to the mock; adds tests\nasserting search and associated-filter values are restored on mount\n- `created_by_filter_dropdown.test.tsx` — adds `useSelector` to the mock\n(required now that the component calls it); adds a test asserting the\npreviously selected user is restored on mount\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Regressions (low):** `EuiSearchBar` with a non-empty `defaultQuery`\ncould theoretically fire `onChange` on mount and dispatch back to Redux,\nbut since the value would be identical to the stored value, Redux will\nnot update and no re-render loop occurs. Verified in testing.\n- No data loss, API, or performance risks.\n\n### Release note\n\n> Fixes an issue where previously applied filters on the Notes\nmanagement page were not shown in the filter controls after navigating\naway and returning, even though the filters were still active.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"4dea624716c9bdb51381e1d4458807b8cd6cf51b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/286574","number":286574,"mergeCommit":{"message":"[Security Solution][Notes] Fix notes page not restoring filter UI state on return (#286574)\n\n## Summary\n\n## What\nFixes a bug where previously applied filters on the Notes management\npage (search text, \"Attached to\" dropdown, \"Created by\" dropdown)\nremained active after navigating away and back, but were not reflected\nin the filter controls — making the list appear filtered with no visible\nreason.\n\n## Why\nFilter state is persisted in Redux, but all three filter controls\ninitialised from hardcoded defaults (`defaultQuery=\"\"`, no `value` prop,\nlocal `useState` with no initialisation) instead of reading from the\nstore on mount. Because the page component fully unmounts on navigation,\nreturning to the page always showed empty controls even though the\nstored filter was still applied to the data fetch.\n\nResolves issue #285563\n\nBefore fix: see video in issue  #285563\n\nAfter fix (using browser back button off screen): \n\n\nhttps://github.com/user-attachments/assets/daa7c2b2-7830-4018-abd1-59f106e26824\n\n\n## Changes\n\n- `search_row.tsx` — `EuiSearchBar` now uses\n`defaultQuery={notesSearch}` from Redux; `EuiSelect` (associated filter)\ngets `value={notesAssociatedFilter}` making it a controlled component\n- `created_by_filter_dropdown.tsx` — adds a `useEffect` that restores\nthe selected user option from `createdByFilter` in Redux once the user\nprofiles list has loaded\n- `search_row.test.tsx` — adds `useSelector` to the mock; adds tests\nasserting search and associated-filter values are restored on mount\n- `created_by_filter_dropdown.test.tsx` — adds `useSelector` to the mock\n(required now that the component calls it); adds a test asserting the\npreviously selected user is restored on mount\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- **Regressions (low):** `EuiSearchBar` with a non-empty `defaultQuery`\ncould theoretically fire `onChange` on mount and dispatch back to Redux,\nbut since the value would be identical to the stored value, Redux will\nnot update and no re-render loop occurs. Verified in testing.\n- No data loss, API, or performance risks.\n\n### Release note\n\n> Fixes an issue where previously applied filters on the Notes\nmanagement page were not shown in the filter controls after navigating\naway and returning, even though the filters were still active.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>","sha":"4dea624716c9bdb51381e1d4458807b8cd6cf51b"}}]}] BACKPORT-->