### PR TITLE
[Security Solution][Notes] Fix notes search bar crash on invalid query syntax

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.test.tsx
@@ -71,6 +71,21 @@ describe('SearchRow', () => {
     expect(mockDispatch).toHaveBeenCalled();
   });
 
+  it('should not dispatch when the search query contains invalid syntax', async () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <SearchRow />
+      </TestProviders>
+    );
+
+    const searchBox = getByTestId(SEARCH_BAR_TEST_ID);
+
+    await userEvent.type(searchBox, ';');
+    await userEvent.keyboard('{enter}');
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
   it('should call the correct action when select a value in the associated note dropdown', async () => {
     const { getByTestId } = render(
       <TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/search_row.tsx
@@ -12,7 +12,6 @@ import {
   EuiFlexItem,
   EuiSearchBar,
   EuiSelect,
-  Query,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux-v7';
@@ -54,7 +53,8 @@ export const SearchRow = React.memo(() => {
   const notesAssociatedFilter = useSelector(selectNotesTableAssociatedFilter);
 
   const onQueryChange = useCallback(
-    ({ queryText }: { queryText: string }) => {
+    ({ queryText, error }: { queryText: string; error: Error | null }) => {
+      if (error) return;
       dispatch(userSearchedNotes(queryText.trim()));
     },
     [dispatch]
@@ -70,7 +70,7 @@ export const SearchRow = React.memo(() => {
   return (
     <EuiFlexGroup gutterSize="m">
       <EuiFlexItem>
-        <EuiSearchBar box={searchBox} onChange={onQueryChange} query={Query.parse(notesSearch)} />
+        <EuiSearchBar box={searchBox} onChange={onQueryChange} defaultQuery={notesSearch} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <CreatedByFilterDropdown />


### PR DESCRIPTION
## Summary

### What
Fixes a regression introduced in #286574 where the Notes management page crashes when the search bar contains invalid EUI query syntax (e.g. an unbalanced quote, a stray `:`, or a semicolon).

### Why
PR #286574 changed `EuiSearchBar` from `defaultQuery=""` to `query={Query.parse(notesSearch)}` to restore the persisted search value. However, `EuiSearchBar` fires `onChange` even when the typed text fails to parse — passing `error` alongside the raw `queryText`. The previous `onQueryChange` ignored `error` and dispatched the raw text to Redux. On the next render `Query.parse(notesSearch)` would throw a `SyntaxError` on the stored invalid text, crashing the page.

Fixes regression introduced in #286574, which fixed #285563.

### Changes

- Switch `EuiSearchBar` from controlled `query={Query.parse(notesSearch)}` to uncontrolled `defaultQuery={notesSearch}` so parse errors are handled internally by EUI rather than crashing the component
- Guard `onQueryChange` to skip dispatch when EUI reports a parse error, preventing invalid text from ever being stored in Redux
- Remove the now-unused `Query` import from `@elastic/eui`
- Add unit test covering that invalid query syntax does not dispatch to Redux

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Regression (low):** Switching to `defaultQuery` means the stored search value is applied once on mount rather than on every render. This is the correct behaviour — EUI manages internal state from there. Users navigating back to the Notes page will see the last valid search term restored, unchanged from the intended fix in #286574.
- **No data loss, no API changes, no performance impact.**

### Release note

> Fixes a crash on the Notes management page when invalid query syntax (such as an unbalanced quote or semicolon) is entered in the search bar.

**Suggested label:** `release_note:fix`