### PR TITLE
[Console] Fix Monaco overlays in dark mode

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/code_editor/theme.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/code_editor/theme.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { UseEuiTheme } from '@elastic/eui';
+import { createTheme } from './theme';
+
+const createMockTheme = (colorMode: UseEuiTheme['colorMode']): UseEuiTheme => ({
+  colorMode,
+  highContrastMode: false,
+  modifications: {},
+  euiTheme: {
+    colors: {
+      vis: {},
+    },
+  } as UseEuiTheme['euiTheme'],
+});
+
+describe('WHEN creating a code editor theme', () => {
+  it.each([
+    { colorMode: 'DARK' as const, expectedBase: 'vs-dark' as const },
+    { colorMode: 'LIGHT' as const, expectedBase: 'vs' as const },
+  ])('SHOULD use $expectedBase as the base in $colorMode mode', ({ colorMode, expectedBase }) => {
+    expect(createTheme(createMockTheme(colorMode)).base).toBe(expectedBase);
+  });
+});

--- a/src/platform/packages/shared/kbn-monaco/src/code_editor/theme.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/code_editor/theme.ts
@@ -11,11 +11,11 @@ import type { UseEuiTheme } from '@elastic/eui';
 import type { monaco } from '../..';
 
 export function createTheme(
-  { euiTheme }: UseEuiTheme,
+  { colorMode, euiTheme }: UseEuiTheme,
   backgroundColor?: string
 ): monaco.editor.IStandaloneThemeData {
   return {
-    base: 'vs',
+    base: colorMode === 'DARK' ? 'vs-dark' : 'vs',
     inherit: true,
     rules: [
       {


### PR DESCRIPTION
Closes #276397

## Summary

- Align shared Monaco overlays with Kibana’s active light or dark theme.

## Root Cause

- The shared theme always inherited Monaco’s light `vs` defaults, leaving unresolved overlay colors light or low-contrast in dark mode.

## Fix

- Select `vs-dark` for EUI dark mode and preserve `vs` for light mode.
- Add unit coverage for both modes.

## Test Plan

- `node scripts/jest src/platform/packages/shared/kbn-monaco` — 32 suites and 352 tests passed.
- `node scripts/type_check --project src/platform/packages/shared/kbn-monaco/tsconfig.json` — passed.
- `node scripts/eslint --fix src/platform/packages/shared/kbn-monaco/src/code_editor/theme.ts src/platform/packages/shared/kbn-monaco/src/code_editor/theme.test.ts` — passed.
- Reverting the dark base to `vs` failed the targeted test; restoring it passed 2 tests.
- Console dark-mode overlays had a minimum measured contrast of 6.87; light-mode overlays had 5.86.
- Index Management’s dark F1 palette had a minimum measured contrast of 6.87.

## Screenshots

**Before — Console context menu:**

<img width="1280" height="720" alt="Before - Console context menu" src="https://github.com/user-attachments/assets/12f12e79-2ac0-459b-8e71-dc73acb8db49" />

**After — Console context menu:**

<img width="1280" height="720" alt="After - Console context menu" src="https://github.com/user-attachments/assets/98f369af-b017-40cc-9ddd-3ff4c9e71bd8" />

**Before — Console command palette:**

<img width="1280" height="720" alt="Before - Console command palette" src="https://github.com/user-attachments/assets/828a35db-4c9b-4201-9244-2d06030506c5" />

**After — Console command palette:**

<img width="1280" height="720" alt="After - Console command palette" src="https://github.com/user-attachments/assets/bf6cb038-1702-4214-9cef-59cb7e0ad3f7" />

**Before — Index Management settings editor command palette:**

<img width="1280" height="720" alt="Before - Index Management settings editor command palette" src="https://github.com/user-attachments/assets/2a468617-f3e2-421a-84f0-abcfeb42ae66" />

**After — Index Management settings editor command palette:**

<img width="1280" height="720" alt="After - Index Management settings editor command palette" src="https://github.com/user-attachments/assets/e454adaf-c18f-4751-9aee-4fc9d1b19a36" />

Assisted with Cursor using GPT-5.6 Sol

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->