### PR TITLE
[Fleet] Reuse Fleet's existing EPM cache session for bumpRevision's getPackageInfo fallback

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -56,6 +56,7 @@ import { createAgentPolicyWithPackages } from './agent_policy_create';
 import { reassignAgentsFromVersionSpecificPolicies } from './utils/version_specific_policies';
 import { agentlessAgentService } from './agents/agentless_agent';
 import { getPackageInfo } from './epm/packages';
+import { runWithCache, getPackageInfoCache, setPackageInfoCache } from './epm/packages/cache';
 import { ensureInstalledPackage } from './epm/packages/install';
 
 jest.mock('./spaces/helpers');
@@ -1088,6 +1089,72 @@ describe('Agent policy', () => {
           has_agent_version_conditions: false,
           min_agent_version: null,
           package_agent_version_conditions: null,
+        })
+      );
+    });
+
+    it('should open a cache session so the package-info fallback lookup is shared across package policies', async () => {
+      const soClient = getSavedObjectMock({ revision: 1, monitoring_enabled: [] });
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      // Three package policies sharing the same package+version (e.g. several monitor package
+      // policies on one shared agent policy), none with a persisted version condition yet.
+      mockedPackagePolicyService.findAllForAgentPolicy.mockResolvedValue([
+        { id: 'pp-1', package: { name: 'apache', title: 'Apache', version: '1.3.2' } } as any,
+        { id: 'pp-2', package: { name: 'apache', title: 'Apache', version: '1.3.2' } } as any,
+        { id: 'pp-3', package: { name: 'apache', title: 'Apache', version: '1.3.2' } } as any,
+      ]);
+      // getPackageInfo itself does the caching (via getPackageInfoCache/setPackageInfoCache) when
+      // called inside a runWithCache session; simulate that here since ./epm/packages is mocked.
+      let computeCount = 0;
+      jest.mocked(getPackageInfo).mockImplementation(async ({ pkgName, pkgVersion }) => {
+        const cached = getPackageInfoCache(pkgName, pkgVersion);
+        if (cached) {
+          return cached;
+        }
+        computeCount++;
+        const info = { conditions: { agent: { version: '>=9.0.0' } } } as any;
+        setPackageInfoCache(pkgName, pkgVersion, info);
+        return info;
+      });
+
+      await agentPolicyService.bumpRevision(soClient, esClient, 'agent-policy');
+
+      // bumpRevision must have opened its own runWithCache session (none was active) for
+      // getPackageInfo's cache to have anywhere to store the first lookup's result.
+      expect(getPackageInfo).toHaveBeenCalledTimes(3);
+      expect(computeCount).toBe(1);
+    });
+
+    it('should reuse an already-active cache session instead of shadowing it with a new one', async () => {
+      const soClient = getSavedObjectMock({ revision: 1, monitoring_enabled: [] });
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      mockedPackagePolicyService.findAllForAgentPolicy.mockResolvedValue([
+        { id: 'pp-1', package: { name: 'apache', title: 'Apache', version: '1.3.2' } } as any,
+      ]);
+      jest.mocked(getPackageInfo).mockImplementation(async ({ pkgName, pkgVersion }) => {
+        return (getPackageInfoCache(pkgName, pkgVersion) ?? {}) as any;
+      });
+
+      await runWithCache(async () => {
+        // Pre-populate the outer session's cache, as a bulk caller (e.g. bumpAgentPoliciesRevision)
+        // would after resolving an earlier package policy that shares this package+version.
+        setPackageInfoCache('apache', '1.3.2', {
+          conditions: { agent: { version: '>=9.0.0' } },
+        } as any);
+
+        await agentPolicyService.bumpRevision(soClient, esClient, 'agent-policy');
+      });
+
+      // If bumpRevision had started its own nested session, the pre-populated cache entry above
+      // would be invisible to it and this would fall back to `{}` (no conditions).
+      expect(soClient.update).toHaveBeenCalledWith(
+        expect.anything(),
+        'agent-policy',
+        expect.objectContaining({
+          has_agent_version_conditions: true,
+          min_agent_version: '9.0.0',
         })
       );
     });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -149,6 +149,7 @@ import {
 
 import { bulkInstallPackages, getPackageInfo } from './epm/packages';
 import { ensureInstalledPackage } from './epm/packages/install';
+import { runWithCache, isRunningWithCache } from './epm/packages/cache';
 import { unenrollForAgentPolicyId } from './agents';
 import { getAgentCountForAgentPolicies } from './agent_policies/agent_policy_agent_count';
 import {
@@ -1296,18 +1297,27 @@ class AgentPolicyService {
     }
   ): Promise<void> {
     return withSpan('bump_agent_policy_revision', async () => {
-      const { hasAgentVersionConditions, minAgentVersion, packageAgentVersionConditions } =
-        await this.computeMinAgentVersionData(soClient, id);
-      await this._update(soClient, esClient, id, {}, options?.user, {
-        bumpRevision: true,
-        removeProtection: options?.removeProtection ?? false,
-        skipValidation: options?.skipValidation ?? true,
-        returnUpdatedPolicy: false,
-        asyncDeploy: options?.asyncDeploy,
-        hasAgentVersionConditions,
-        minAgentVersion: minAgentVersion ?? null,
-        packageAgentVersionConditions: packageAgentVersionConditions ?? null,
-      });
+      const run = async () => {
+        const { hasAgentVersionConditions, minAgentVersion, packageAgentVersionConditions } =
+          await this.computeMinAgentVersionData(soClient, id);
+        await this._update(soClient, esClient, id, {}, options?.user, {
+          bumpRevision: true,
+          removeProtection: options?.removeProtection ?? false,
+          skipValidation: options?.skipValidation ?? true,
+          returnUpdatedPolicy: false,
+          asyncDeploy: options?.asyncDeploy,
+          hasAgentVersionConditions,
+          minAgentVersion: minAgentVersion ?? null,
+          packageAgentVersionConditions: packageAgentVersionConditions ?? null,
+        });
+      };
+
+      // Reuse an already-active cache session (e.g. a bulk caller wrapping many bumpRevision
+      // calls in one runWithCache) rather than starting a new, narrower one that would shadow it
+      // for this call's duration. When called standalone, open a session so the getPackageInfo
+      // fallback lookup in computeMinAgentVersionData is still cached across this policy's own
+      // package policies.
+      return isRunningWithCache() ? run() : runWithCache(run);
     });
   }
 
@@ -1326,7 +1336,10 @@ class AgentPolicyService {
       let versionCondition = pp.package_agent_version_condition;
 
       // For package policies created before this field was introduced, fall back
-      // to looking up the installed package info to get the version condition.
+      // to looking up the installed package info to get the version condition. getPackageInfo
+      // is itself cached per name+version for the lifetime of the enclosing runWithCache session
+      // (see bumpRevision below), so this stays cheap even when several package policies on the
+      // same agent policy share a package+version.
       if (!versionCondition && pp.package?.name && pp.package?.version) {
         try {
           const pkgInfo = await getPackageInfo({

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/cache.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/cache.ts
@@ -139,3 +139,13 @@ export async function runWithCache<T = any>(cb: () => Promise<T>): Promise<T> {
 
   return cacheStore.run(cache, cb);
 }
+
+/**
+ * Whether the current async context is already inside a `runWithCache` session. Callers that may
+ * run either standalone or nested inside a caller's own `runWithCache` (e.g. a bulk operation) can
+ * use this to avoid starting a new, narrower-scoped session that would shadow the caller's cache
+ * for its duration instead of sharing it.
+ */
+export function isRunningWithCache(): boolean {
+  return cacheStore.getStore() !== undefined;
+}


### PR DESCRIPTION
## 📝 Summary

Part 3 of 3 in a small series trimming redundant work out of `agentPolicyService.bumpRevision` (Fleet's hottest write path). See part 1: #286712, part 2: #286714. Independent of part 2 — applies cleanly on top of `main` either way.

`computeMinAgentVersionData` falls back to `getPackageInfo` for package policies created before `package_agent_version_condition` was persisted — once per package policy needing it, with no de-duplication. An agent policy with many package policies of the same integration (e.g. several Synthetics monitor package policies sharing one agent policy) repeats the identical lookup once per instance.

## 🔍 What I found (thanks to a review question — Fleet already has a cache for exactly this!)

`getPackageInfo` already checks/populates a request-scoped LRU cache keyed by `name:version` in [`services/epm/packages/cache.ts`](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/cache.ts):

```ts
export async function getPackageInfo({ ... }) {
  const cacheResult = getPackageInfoCache(pkgName, pkgVersion);
  if (cacheResult) return cacheResult;
  // ...compute...
  setPackageInfoCache(pkgName, pkgVersion, installable);
}
```

But that cache is backed by `AsyncLocalStorage` and is a **no-op unless the call happens inside a `runWithCache(...)` session**. Some `bumpRevision` callers already open one (`bumpAgentPoliciesRevision`), others don't (`preconfiguration.ts`, `copy()`) — so the fallback lookup was uncached on those paths.

My first pass at this PR added a bespoke `Map` cache local to `computeMinAgentVersionData`. That duplicated infrastructure Fleet already has, so I reworked it to plug into the existing mechanism instead.

## 🔧 Change

- `bumpRevision` now opens a `runWithCache` session itself **only when one isn't already active** (checked via a new `isRunningWithCache()` export), so the fallback lookup gets deduped via the cache Fleet already maintains.
- Deliberately **does not** unconditionally wrap in `runWithCache`: a bulk caller (e.g. `bumpAgentPoliciesRevision`) already wraps many `bumpRevision` calls in one shared session so lookups dedupe *across the whole batch* — always opening a new nested session per call would shadow that shared cache for each call's duration and silently narrow its scope back down to one agent policy at a time.

```diff
+ export function isRunningWithCache(): boolean {
+   return cacheStore.getStore() !== undefined;
+ }
```

```diff
-   const { hasAgentVersionConditions, ... } = await this.computeMinAgentVersionData(soClient, id);
-   await this._update(...);
+   const run = async () => {
+     const { hasAgentVersionConditions, ... } = await this.computeMinAgentVersionData(soClient, id);
+     await this._update(...);
+   };
+   return isRunningWithCache() ? run() : runWithCache(run);
```

## ✅ Testing

- New test: opens its own session and asserts `getPackageInfo`'s cache-population logic (simulated, since `./epm/packages` is mocked) only *computes* once across 3 package policies sharing a package+version.
- New test: pre-populates the cache inside an **outer** `runWithCache` before calling `bumpRevision`, asserting the outer cache entry is visible — this fails if `bumpRevision` unconditionally opens its own nested session (verified locally by temporarily reverting the `isRunningWithCache()` check and confirming this test catches it).
- `node scripts/jest x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts` — 126/126 passing.
- Also ran `cache.test.ts` and the neighboring suites that exercise `bumpRevision` (`preconfiguration`, `agentless_policies`, `spaces/agent_policy`, `rollback`, `change_privilege_level`, `version_specific_policy_assignment_task`, `package_policy`) — 417/417 passing.
- `node scripts/eslint --fix` on changed files.
- `node scripts/check.js --scope branch` — lint ✓, tsc ✓ (2 projects).