### PR TITLE
[Entity Analytics] Fix watchlist index template and rollback

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
@@ -80,7 +80,7 @@ describe('WatchlistConfigClient', () => {
       expect(result).toMatchObject({ id: SO_ID, name: 'Test Watchlist' });
     });
 
-    it('rolls back the saved object when index creation fails', async () => {
+    it('deletes the saved object when index creation fails', async () => {
       const indexError = new Error('Index creation failed');
       mockCreateOrUpdateIndex.mockRejectedValueOnce(indexError);
       soClientMock.delete.mockResolvedValue({});
@@ -92,7 +92,7 @@ describe('WatchlistConfigClient', () => {
       });
     });
 
-    it('rethrows the original error even if the SO rollback delete also fails', async () => {
+    it('rethrows the original error when the SO rollback delete fails', async () => {
       mockCreateOrUpdateIndex.mockRejectedValueOnce(new Error('Index creation failed'));
       soClientMock.delete.mockRejectedValueOnce(new Error('Delete also failed'));
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
@@ -91,7 +91,6 @@ describe('WatchlistConfigClient', () => {
         refresh: 'wait_for',
       });
     });
-
   });
 
   describe('getEntityCounts', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
@@ -59,7 +59,7 @@ describe('WatchlistConfigClient', () => {
 
   describe('create', () => {
     const SO_ID = 'new-watchlist-id';
-    const attrs = { name: 'Test Watchlist' };
+    const attrs = { name: 'Test Watchlist', riskModifier: 0 };
     const savedObjectResult = {
       id: SO_ID,
       type: 'watchlist-config',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
@@ -24,6 +24,11 @@ jest.mock('../entity_sources/entity_source_api_key', () => ({
   invalidateEntitySourceApiKey: (...args: unknown[]) => mockInvalidateEntitySourceApiKey(...args),
 }));
 
+const mockCreateOrUpdateIndex = jest.fn();
+jest.mock('../../utils/create_or_update_index', () => ({
+  createOrUpdateIndex: (...args: unknown[]) => mockCreateOrUpdateIndex(...args),
+}));
+
 describe('WatchlistConfigClient', () => {
   let soClientMock: ReturnType<typeof savedObjectsClientMock.create>;
   let esClientMock: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
@@ -50,6 +55,52 @@ describe('WatchlistConfigClient', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const SO_ID = 'new-watchlist-id';
+    const attrs = { name: 'Test Watchlist' };
+    const savedObjectResult = {
+      id: SO_ID,
+      type: 'watchlist-config',
+      references: [],
+      attributes: attrs,
+    };
+
+    beforeEach(() => {
+      soClientMock.create.mockResolvedValue(savedObjectResult);
+      mockCreateOrUpdateIndex.mockResolvedValue(undefined);
+    });
+
+    it('creates the saved object and index, then returns the watchlist', async () => {
+      const result = await client.create(attrs);
+
+      expect(soClientMock.create).toHaveBeenCalledTimes(1);
+      expect(mockCreateOrUpdateIndex).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({ id: SO_ID, name: 'Test Watchlist' });
+    });
+
+    it('rolls back the saved object when index creation fails', async () => {
+      const indexError = new Error('Index creation failed');
+      mockCreateOrUpdateIndex.mockRejectedValueOnce(indexError);
+      soClientMock.delete.mockResolvedValue({});
+
+      await expect(client.create(attrs)).rejects.toThrow('Index creation failed');
+
+      expect(soClientMock.delete).toHaveBeenCalledWith('watchlist-config', SO_ID, {
+        refresh: 'wait_for',
+      });
+    });
+
+    it('rethrows the original error even if the SO rollback delete also fails', async () => {
+      mockCreateOrUpdateIndex.mockRejectedValueOnce(new Error('Index creation failed'));
+      soClientMock.delete.mockRejectedValueOnce(new Error('Delete also failed'));
+
+      await expect(client.create(attrs)).rejects.toThrow('Index creation failed');
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.stringContaining(`Failed to roll back watchlist SO '${SO_ID}'`)
+      );
+    });
   });
 
   describe('getEntityCounts', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.test.ts
@@ -92,15 +92,6 @@ describe('WatchlistConfigClient', () => {
       });
     });
 
-    it('rethrows the original error when the SO rollback delete fails', async () => {
-      mockCreateOrUpdateIndex.mockRejectedValueOnce(new Error('Index creation failed'));
-      soClientMock.delete.mockRejectedValueOnce(new Error('Delete also failed'));
-
-      await expect(client.create(attrs)).rejects.toThrow('Index creation failed');
-      expect(loggerMock.error).toHaveBeenCalledWith(
-        expect.stringContaining(`Failed to roll back watchlist SO '${SO_ID}'`)
-      );
-    });
   });
 
   describe('getEntityCounts', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
@@ -134,7 +134,13 @@ export class WatchlistConfigClient {
         },
       });
     } catch (err) {
-      await this.deps.soClient.delete(watchlistConfigTypeName, so.id, { refresh: 'wait_for' });
+      await this.deps.soClient
+        .delete(watchlistConfigTypeName, so.id, { refresh: 'wait_for' })
+        .catch((deleteErr) =>
+          this.deps.logger.error(
+            `Failed to roll back watchlist saved object '${so.id}' after index creation failed: ${deleteErr.message}`
+          )
+        );
       throw err;
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
@@ -134,13 +134,7 @@ export class WatchlistConfigClient {
         },
       });
     } catch (err) {
-      try {
-        await this.deps.soClient.delete(watchlistConfigTypeName, so.id, { refresh: 'wait_for' });
-      } catch (deleteErr) {
-        this.deps.logger.error(
-          `Failed to roll back watchlist SO '${so.id}' after index creation failure: ${deleteErr.message}`
-        );
-      }
+      await this.deps.soClient.delete(watchlistConfigTypeName, so.id, { refresh: 'wait_for' });
       throw err;
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
@@ -123,15 +123,26 @@ export class WatchlistConfigClient {
       throw new Error('internalEsClient is required to create a watchlist index');
     }
 
-    await createOrUpdateIndex({
-      esClient: this.deps.internalEsClient,
-      logger: this.deps.logger,
-      options: {
-        index: getIndexForWatchlist(this.deps.namespace),
-        mappings: generateWatchlistEntityIndexMappings(),
-        settings: { hidden: true, auto_expand_replicas: '0-1' },
-      },
-    });
+    try {
+      await createOrUpdateIndex({
+        esClient: this.deps.internalEsClient,
+        logger: this.deps.logger,
+        options: {
+          index: getIndexForWatchlist(this.deps.namespace),
+          mappings: generateWatchlistEntityIndexMappings(),
+          settings: { hidden: true, auto_expand_replicas: '0-1' },
+        },
+      });
+    } catch (err) {
+      try {
+        await this.deps.soClient.delete(watchlistConfigTypeName, so.id, { refresh: 'wait_for' });
+      } catch (deleteErr) {
+        this.deps.logger.error(
+          `Failed to roll back watchlist SO '${so.id}' after index creation failure: ${deleteErr.message}`
+        );
+      }
+      throw err;
+    }
 
     return toWatchlistObject(so);
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.test.ts
@@ -393,30 +393,17 @@ describe('installPrebuiltWatchlists', function () {
     expect(new Set(names).size).toBe(names.length);
   });
 
-  describe('watchlist index template', () => {
-    beforeEach(() => {
-      mockSoClient.find.mockResolvedValue(buildEmptySpacesResponse());
-      mockWatchlistGet.mockRejectedValue(new Error('not found'));
-    });
+  it('registers an index template for .entity_analytics.watchlists.*', async () => {
+    mockSoClient.find.mockResolvedValue(buildEmptySpacesResponse());
+    mockWatchlistGet.mockRejectedValue(new Error('not found'));
 
-    it('registers an index template for .entity_analytics.watchlists.*', async () => {
-      await callInstall();
+    await callInstall();
 
-      expect(mockEsClient.indices.putIndexTemplate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'entity_analytics_watchlists',
-          index_patterns: ['.entity_analytics.watchlists.*'],
-        })
-      );
-    });
-
-    it('continues even if index template registration fails', async () => {
-      mockEsClient.indices.putIndexTemplate.mockRejectedValueOnce(new Error('ES error'));
-
-      await expect(callInstall()).resolves.not.toThrow();
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to install watchlist index template')
-      );
-    });
+    expect(mockEsClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'entity_analytics_watchlists',
+        index_patterns: ['.entity_analytics.watchlists.*'],
+      })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.test.ts
@@ -392,4 +392,31 @@ describe('installPrebuiltWatchlists', function () {
     const names = getPrebuiltWatchlists('default').map((w) => w.name);
     expect(new Set(names).size).toBe(names.length);
   });
+
+  describe('watchlist index template', () => {
+    beforeEach(() => {
+      mockSoClient.find.mockResolvedValue(buildEmptySpacesResponse());
+      mockWatchlistGet.mockRejectedValue(new Error('not found'));
+    });
+
+    it('registers an index template for .entity_analytics.watchlists.*', async () => {
+      await callInstall();
+
+      expect(mockEsClient.indices.putIndexTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'entity_analytics_watchlists',
+          index_patterns: ['.entity_analytics.watchlists.*'],
+        })
+      );
+    });
+
+    it('continues even if index template registration fails', async () => {
+      mockEsClient.indices.putIndexTemplate.mockRejectedValueOnce(new Error('ES error'));
+
+      await expect(callInstall()).resolves.not.toThrow();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to install watchlist index template')
+      );
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/migrations/install_prebuilt_watchlists.ts
@@ -28,9 +28,33 @@ import {
 } from '../entity_sources/infra';
 import { watchlistConfigTypeName } from '../management/saved_object/watchlist_config_type';
 import type { StartPlugins } from '../../../../plugin';
+import { generateWatchlistEntityIndexMappings } from '../entities/mappings';
+import { ENTITY_ANALYTICS_WATCHLISTS_PREFIX } from '../entities/utils';
 
 // Bump this when PREBUILT_WATCHLISTS definitions change
 export const PREBUILT_WATCHLISTS_VERSION = 2;
+
+const WATCHLIST_INDEX_TEMPLATE_NAME = 'entity_analytics_watchlists';
+
+export const installWatchlistIndexTemplate = async (
+  esClient: ElasticsearchClient,
+  logger: Logger
+): Promise<void> => {
+  try {
+    await esClient.indices.putIndexTemplate({
+      name: WATCHLIST_INDEX_TEMPLATE_NAME,
+      index_patterns: [`${ENTITY_ANALYTICS_WATCHLISTS_PREFIX}.*`],
+      template: {
+        mappings: generateWatchlistEntityIndexMappings(),
+        settings: { hidden: true, auto_expand_replicas: '0-1' },
+      },
+      priority: 500,
+    });
+    logger.debug(`Watchlist index template '${WATCHLIST_INDEX_TEMPLATE_NAME}' installed`);
+  } catch (err) {
+    logger.error(`Failed to install watchlist index template: ${err.message}`);
+  }
+};
 
 const OKTA_PRIVILEGED_ROLES = [
   'Super Administrator',
@@ -290,6 +314,8 @@ export const installPrebuiltWatchlists = async ({
 }: EntityAnalyticsMigrationsParams) => {
   const [coreStart] = await getStartServices();
   const esClient = coreStart.elasticsearch.client.asInternalUser;
+
+  await installWatchlistIndexTemplate(esClient, logger);
 
   let namespaces: Set<string>;
 


### PR DESCRIPTION
## Summary

fixes #281938
fixes #281939
 
two related bugs that together can corrupt the watchlist index mapping, breaking sync and delete.

**#281938 — Missing index template**

No ES index template exists for `.entity_analytics.watchlists.*`. If any write reaches the index before `watchlist_config.create()` runs, ES auto-creates it with dynamic mapping — `labels.source_ids` becomes `text` instead of `keyword`, breaking all `terms` aggregations with `Fielddata is disabled on [labels.source_ids]`.

Fix: register a composable index template at startup in `installPrebuiltWatchlists`.

**#281939 — Orphaned SO on index creation failure**

In `WatchlistConfigClient.create()`, the SO is persisted before `createOrUpdateIndex`. If index creation fails the SO remains, gets picked up by the sync maintainer, and triggers an auto-creation with wrong dynamic mapping — directly feeding #281938.

Fix: delete the SO before rethrowing on index creation failure. Mirrors the existing rollback pattern in `routes/create.ts:159–164`.

## Testing

- New `describe('create')` block in `watchlist_config.test.ts` covering the happy path and SO deletion on index failure.
- Single `it` in `install_prebuilt_watchlists.test.ts` asserting `putIndexTemplate` is called with the correct name and pattern.


## Manual Testing

**no mapping conflict on `labels.source_id`:**

```

DELETE .entity_analytics.watchlists.default // simulate no index

POST .entity_analytics.watchlists.default/_doc
{ "@timestamp": "2024-01-01", "labels": { "source_ids": "manual" } }

POST .entity_analytics.watchlists.default/_search
{ "size": 0, "aggs": { "x": { "terms": { "field": "labels.source_ids" } } } }
```

→ on `main` - `Fielddata is disabled on [labels.source_ids]`, this PR - passes


