### PR TITLE
Missing user-select CSS attribute on buttons in the Workflows err...

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import '@emotion/jest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { TestProvider } from '../../../shared/mocks/test_providers';
+import type { YamlValidationResult } from '../../../features/validate_workflow_yaml/model/types';
+import { WorkflowYamlValidationAccordion } from './workflow_yaml_validation_accordion';
+
+const validationErrors: YamlValidationResult[] = [
+  {
+    id: 'error-1',
+    startLineNumber: 1,
+    startColumn: 1,
+    endLineNumber: 1,
+    endColumn: 10,
+    hoverMessage: null,
+    severity: 'error',
+    message: 'Unexpected token',
+    owner: 'yaml',
+  },
+];
+
+describe('WorkflowYamlValidationAccordion', () => {
+  it('renders validation errors as user-selectable text', () => {
+    render(
+      <WorkflowYamlValidationAccordion
+        isMounted={true}
+        isLoading={false}
+        error={null}
+        validationErrors={validationErrors}
+      />,
+      { wrapper: TestProvider }
+    );
+
+    const errorButton = screen.getByText('Unexpected token').closest('button');
+    expect(errorButton).toHaveStyleRule('user-select', 'text');
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.tsx
@@ -343,6 +343,7 @@ const componentStyles = {
       flexDirection: 'row',
       alignItems: 'flex-start',
       gap: euiThemeContext.euiTheme.size.s,
+      userSelect: 'text',
       '&:hover': {
         textDecoration: 'underline',
       },


### PR DESCRIPTION
This is a small, targeted change to .../ui/workflow_yaml_validation_accordion.test.tsx, .../ui/workflow_yaml_validation_accordion.tsx that resolves the reported issue without touching anything unrelated. Fixes #281452.

My environment could not install everything, so I kept this tightly scoped; the changed-file checks pass and CI can cover the rest.
