### PR TITLE
[CI] Skip FTR for dependency ownership changes

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts
@@ -122,6 +122,15 @@ describe('shouldSkipFtrTests', () => {
     ).toBe(true);
   });
 
+  it('returns true for dependency ownership and Renovate changes', () => {
+    expect(
+      shouldSkipFtrTests(new Set(['@kbn/dependency-ownership']), [
+        'packages/kbn-dependency-ownership/src/rule.ts',
+        'renovate.json',
+      ])
+    ).toBe(true);
+  });
+
   it('returns false when any affected module is not excluded', () => {
     expect(
       shouldSkipFtrTests(new Set(['@kbn/scout', '@kbn/dashboard-plugin']), [

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.ts
@@ -41,6 +41,7 @@ export const FTR_EXCLUDED_MODULES: ReadonlySet<string> = new Set([
   '@kbn/evals',
   '@kbn/evals-extensions',
   '@kbn/performance-testing-dataset-extractor',
+  '@kbn/dependency-ownership',
 
   // Lint
   '@kbn/eslint-config',


### PR DESCRIPTION
## Summary

- exclude the dev-only `@kbn/dependency-ownership` package from FTR selection
- cover dependency ownership changes mixed with `renovate.json` in the selective FTR test

## Validation

- `npm test -- --runInBand pipeline-utils/ci-stats/pick_test_group_run_order/selective_ftr.test.ts` from `.buildkite`
- `npm run typecheck` from `.buildkite`

Release note: skip