### PR TITLE
[Entity Graph] Show default graph filter; fix grouped node label; fix filter forwarding to timeline

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/filters/search_filters.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/filters/search_filters.ts
@@ -22,6 +22,7 @@ import type {
 } from '@kbn/es-query/src/filters/build_filters';
 
 export const CONTROLLED_BY_GRAPH_INVESTIGATION_FILTER = 'graph-investigation';
+export const CONTROLLED_BY_GRAPH_INVESTIGATION_DEFAULT_FILTER = 'graph-investigation-default';
 
 const buildSinglePhraseFilter = (
   field: string,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
@@ -10,7 +10,7 @@ import { SearchBar } from '@kbn/unified-search-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { i18n } from '@kbn/i18n';
 import type { DataView } from '@kbn/data-views-plugin/public';
-import { buildEsQuery, isCombinedFilter } from '@kbn/es-query';
+import { buildEsQuery, isCombinedFilter, FilterStateStore } from '@kbn/es-query';
 import type { Filter, Query, TimeRange } from '@kbn/es-query';
 import type { ProjectRouting } from '@kbn/cloud-security-posture-common/schema/graph/v1';
 import { css } from '@emotion/react';
@@ -29,7 +29,11 @@ import { analyzeDocuments } from '../node/label_node/analyze_documents';
 import { EVENT_ID, GRAPH_NODES_LIMIT, TOGGLE_SEARCH_BAR_STORAGE_KEY } from '../../common/constants';
 import { Actions } from '../controls/actions';
 import { AnimatedSearchBarContainer, useBorder } from './styles';
-import { CONTROLLED_BY_GRAPH_INVESTIGATION_FILTER, addFilter } from '../filters/search_filters';
+import {
+  CONTROLLED_BY_GRAPH_INVESTIGATION_FILTER,
+  CONTROLLED_BY_GRAPH_INVESTIGATION_DEFAULT_FILTER,
+  addFilter,
+} from '../filters/search_filters';
 import { useEntityNodeExpandPopover } from '../popovers/node_expand/use_entity_node_expand_popover';
 import { useLabelNodeExpandPopover } from '../popovers/node_expand/use_label_node_expand_popover';
 import type { NodeViewModel } from '../types';
@@ -259,6 +263,47 @@ export const GraphInvestigation = memo<GraphInvestigationProps>(
       entityIds ?? emptyEntityIds,
       dataView?.id ?? ''
     );
+    const defaultFilters = useMemo<Filter[]>(() => {
+      if (!originEventIds || originEventIds.length === 0 || !dataView?.id) return [];
+      const eventIds = originEventIds.map(({ id }) => id);
+
+      if (eventIds.length === 1) {
+        return [
+          {
+            $state: { store: FilterStateStore.APP_STATE },
+            meta: {
+              key: EVENT_ID,
+              index: dataView.id,
+              negate: false,
+              disabled: false,
+              type: 'phrase' as const,
+              field: EVENT_ID,
+              controlledBy: CONTROLLED_BY_GRAPH_INVESTIGATION_DEFAULT_FILTER,
+              params: { query: eventIds[0] },
+            },
+            query: { match_phrase: { [EVENT_ID]: eventIds[0] } },
+          },
+        ];
+      }
+
+      return [
+        {
+          $state: { store: FilterStateStore.APP_STATE },
+          meta: {
+            key: EVENT_ID,
+            index: dataView.id,
+            negate: false,
+            disabled: false,
+            type: 'phrases' as const,
+            field: EVENT_ID,
+            controlledBy: CONTROLLED_BY_GRAPH_INVESTIGATION_DEFAULT_FILTER,
+            params: eventIds,
+          },
+          query: { terms: { [EVENT_ID]: eventIds } },
+        },
+      ];
+    }, [originEventIds, dataView?.id]);
+
     const [timeRange, setTimeRange] = useState<TimeRange>(initialTimeRange);
     const [searchToggled, setSearchToggled] = useSessionStorage(
       TOGGLE_SEARCH_BAR_STORAGE_KEY,
@@ -575,10 +620,15 @@ export const GraphInvestigation = memo<GraphInvestigationProps>(
                   dateRangeTo={timeRange.to}
                   query={kquery}
                   indexPatterns={[dataView]}
-                  filters={searchFilters}
+                  filters={[...defaultFilters, ...searchFilters]}
                   submitButtonStyle={'iconOnly'}
                   onFiltersUpdated={(newFilters) => {
-                    setSearchFilters(newFilters);
+                    setSearchFilters(
+                      newFilters.filter(
+                        (f) =>
+                          f.meta.controlledBy !== CONTROLLED_BY_GRAPH_INVESTIGATION_DEFAULT_FILTER
+                      )
+                    );
                   }}
                   onQuerySubmit={(payload, isUpdate) => {
                     if (isUpdate) {

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/node_expand/get_entity_expand_items.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/node_expand/get_entity_expand_items.ts
@@ -111,6 +111,8 @@ export interface GetEntityExpandItemsOptions {
   shouldRender: EntityExpandShouldRender;
   /** Whether entity details should be disabled (shown but not clickable). Defaults to false. */
   showEntityDetailsDisabled?: boolean;
+  /** Whether the node is a grouped entities node. Changes the entity details label. Defaults to false. */
+  isGrouped?: boolean;
   /** Whether entity relationships is currently expanded (controls show/hide label) */
   isEntityRelationshipsExpanded?: boolean;
   /** Whether the entity is part of the initial set of entities (e.g., from the original graph request) */
@@ -145,6 +147,7 @@ export const getEntityExpandItems = (
     isInitialEntity = false,
     toggleEntityRelationships,
     showEntityRelationshipsDisabled = false,
+    isGrouped = false,
   } = options;
 
   const items: Array<ItemExpandPopoverListItemProps | SeparatorExpandPopoverListItemProps> = [];
@@ -273,10 +276,15 @@ export const getEntityExpandItems = (
       type: 'item',
       iconType: 'maximize',
       testSubject: GRAPH_NODE_POPOVER_SHOW_ENTITY_DETAILS_ITEM_ID,
-      label: i18n.translate(
-        'securitySolutionPackages.csp.graph.graphNodeExpandPopover.showEntityDetails',
-        { defaultMessage: 'Show entity details' }
-      ),
+      label: isGrouped
+        ? i18n.translate(
+            'securitySolutionPackages.csp.graph.graphNodeExpandPopover.showGroupedEntities',
+            { defaultMessage: 'Show grouped entities' }
+          )
+        : i18n.translate(
+            'securitySolutionPackages.csp.graph.graphNodeExpandPopover.showEntityDetails',
+            { defaultMessage: 'Show entity details' }
+          ),
       disabled: showEntityDetailsDisabled,
       onClick: handleEntityDetailsClick,
       showToolTip: showEntityDetailsDisabled,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/node_expand/use_entity_node_expand_popover.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/node_expand/use_entity_node_expand_popover.test.tsx
@@ -219,6 +219,7 @@ describe('useEntityNodeExpandPopover', () => {
       expect(items[5]).toMatchObject({
         type: 'item',
         testSubject: GRAPH_NODE_POPOVER_SHOW_ENTITY_DETAILS_ITEM_ID,
+        label: 'Show entity details',
         disabled: false,
       });
     });
@@ -260,6 +261,7 @@ describe('useEntityNodeExpandPopover', () => {
       expect(items[0]).toMatchObject({
         type: 'item',
         testSubject: GRAPH_NODE_POPOVER_SHOW_ENTITY_DETAILS_ITEM_ID,
+        label: 'Show grouped entities',
         disabled: false,
       });
     });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/node_expand/use_entity_node_expand_popover.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/popovers/node_expand/use_entity_node_expand_popover.ts
@@ -155,6 +155,7 @@ export const useEntityNodeExpandPopover = (
           showEntityDetails:
             (isSingleEntity || isGroupedEntities) && onOpenEventPreview !== undefined,
         },
+        isGrouped: isGroupedEntities,
         isEntityRelationshipsExpanded: isEntityRelationshipExpandedForScope(scopeId, node.id),
         isInitialEntity,
         toggleEntityRelationships: (action) => {


### PR DESCRIPTION
<img width="973" height="1093" alt="Entity Graph filter bar" src="https://github.com/user-attachments/assets/4b8d972d-2428-47d3-8cf3-3e2190fe6c92" />

## Summary

Fixes Entity Graph filter visibility and entity navigation behavior:

- **Closes #264435** — Shows origin event IDs as visible, non-removable filter pills. These constraints were previously applied only on the server, so users could not see why the origin event and its connected nodes remained in the graph.
- **Closes #285368** — Renames the grouped-node context action from “Show entity details” to “Show grouped entities”.
- Preserves the Entity Graph origin entity filter when opening Timeline. Entity IDs are Entity Store EUIDs, not event fields, so the graph uses the existing EUID helpers to build Timeline filters from the entity’s event identity fields.
- For entity records that do not retain the namespace source fields, uses the available EUID identity building block rather than generating strict guards that exclude matching events.
- Makes the default graph filter pill presentation local to the graph: it has no hover tooltip, and an **OR** separator appears before additional user filters to make the query relationship clear.

## Changes

- Display origin event and entity default filters in the graph filter bar without allowing them to change the server-side origin constraints.
- Transfer entity-origin filters to Timeline for both actor and target event roles.
- Use Entity Store EUID helpers for entity identity and namespace source-field handling; no EUID parsing or duplicated conversion logic is introduced.
- Render the default filter pill and OR separator in the graph component, without changing the shared search/filter component.
- Update the grouped entity-node action label.

## Test plan

- [ ] Open Entity Graph from an event or alert flyout and verify origin event ID pills are visible and non-removable.
- [ ] Open Entity Graph from an entity flyout and select **Investigate in Timeline**. Verify the entity’s event identity filter is transferred to Timeline.
- [ ] Verify an entity whose graph record has only `user.id` does not transfer an exclusion for `user.email`.
- [ ] Add a graph filter after the default filter and verify **OR** appears between them.
- [ ] Hover the default filter pill and verify it has no tooltip.
- [ ] Open a grouped entity node and verify the action reads “Show grouped entities”; verify a single node still reads “Show entity details”.
- [x] Run focused graph unit/story tests.
- [x] Run the graph package type check and ESLint.
