### PR TITLE
fix(fleet): widen agentless throughput index patterns for dynamic_dataset streams

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_throughput_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_throughput_helper.test.ts
@@ -10,7 +10,7 @@ import type { PackagePolicy } from '../types/models';
 import { getAgentlessThroughputIndexPatterns } from './agentless_throughput_helper';
 
 const makePolicy = (
-  streams: Array<{ enabled: boolean; type?: string; dataset: string }>
+  streams: Array<{ enabled: boolean; type?: string; dataset: string; dynamicDataset?: boolean }>
 ): Pick<PackagePolicy, 'inputs'> =>
   ({
     inputs: [
@@ -19,7 +19,13 @@ const makePolicy = (
         enabled: true,
         streams: streams.map((s) => ({
           enabled: s.enabled,
-          data_stream: { type: s.type ?? 'logs', dataset: s.dataset },
+          data_stream: {
+            type: s.type ?? 'logs',
+            dataset: s.dataset,
+            ...(s.dynamicDataset !== undefined
+              ? { elasticsearch: { dynamic_dataset: s.dynamicDataset } }
+              : {}),
+          },
         })),
       },
     ],
@@ -82,6 +88,47 @@ describe('getAgentlessThroughputIndexPatterns', () => {
     expect(getAgentlessThroughputIndexPatterns(policy)).toEqual([
       'logs-nginx.access-*',
       'metrics-nginx.status-*',
+    ]);
+  });
+
+  it('widens the pattern to the package namespace when dynamic_dataset is true', () => {
+    // Okta EA: dataset is entityanalytics_okta.entity but routing rules divert all
+    // documents to entityanalytics_okta.user and entityanalytics_okta.device.
+    const policy = makePolicy([
+      { enabled: true, dataset: 'entityanalytics_okta.entity', dynamicDataset: true },
+    ]);
+    expect(getAgentlessThroughputIndexPatterns(policy)).toEqual(['logs-entityanalytics_okta.*-*']);
+  });
+
+  it('uses the explicit type when dynamic_dataset is true', () => {
+    const policy = makePolicy([
+      { enabled: true, type: 'metrics', dataset: 'mypkg.entity', dynamicDataset: true },
+    ]);
+    expect(getAgentlessThroughputIndexPatterns(policy)).toEqual(['metrics-mypkg.*-*']);
+  });
+
+  it('deduplicates widened patterns from multiple dynamic_dataset streams in the same package', () => {
+    // Two different declared data-stream names under the same package both collapse to the same widened pattern.
+    const policy = makePolicy([
+      { enabled: true, dataset: 'entityanalytics_okta.entity', dynamicDataset: true },
+      { enabled: true, dataset: 'entityanalytics_okta.other', dynamicDataset: true },
+    ]);
+    expect(getAgentlessThroughputIndexPatterns(policy)).toEqual(['logs-entityanalytics_okta.*-*']);
+  });
+
+  it('treats dynamic_dataset: false the same as absent (uses the exact dataset pattern)', () => {
+    const policy = makePolicy([{ enabled: true, dataset: 'pkg.ds', dynamicDataset: false }]);
+    expect(getAgentlessThroughputIndexPatterns(policy)).toEqual(['logs-pkg.ds-*']);
+  });
+
+  it('mixes regular and dynamic_dataset streams correctly', () => {
+    const policy = makePolicy([
+      { enabled: true, dataset: 'nginx.access' },
+      { enabled: true, dataset: 'entityanalytics_okta.entity', dynamicDataset: true },
+    ]);
+    expect(getAgentlessThroughputIndexPatterns(policy)).toEqual([
+      'logs-nginx.access-*',
+      'logs-entityanalytics_okta.*-*',
     ]);
   });
 

--- a/x-pack/platform/plugins/shared/fleet/common/services/agentless_throughput_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/agentless_throughput_helper.ts
@@ -9,13 +9,7 @@ import { uniq } from 'lodash';
 
 import type { PackagePolicy } from '../types/models';
 
-/**
- * Derives the unique Elasticsearch index patterns for the enabled data streams
- * of an agentless package policy. Matches the index targeting used by the
- * throughput aggregation query in `server/services/agentless/throughput.ts`.
- *
- * Returns patterns of the form `${type}-${dataset}-*`.
- */
+/** Derives unique ES index patterns for an agentless policy's enabled streams, widening to `<type>-<pkg>.*-*` when `dynamic_dataset: true` to cover routing-rule targets. */
 export const getAgentlessThroughputIndexPatterns = (
   packagePolicy: Pick<PackagePolicy, 'inputs'>
 ): string[] =>
@@ -23,6 +17,14 @@ export const getAgentlessThroughputIndexPatterns = (
     packagePolicy.inputs.flatMap((input) =>
       input.streams
         .filter((stream) => stream.enabled)
-        .map((stream) => `${stream.data_stream.type ?? 'logs'}-${stream.data_stream.dataset}-*`)
+        .map((stream) => {
+          const type = stream.data_stream.type ?? 'logs';
+          const { dataset, elasticsearch } = stream.data_stream;
+          if (elasticsearch?.dynamic_dataset) {
+            const packageName = dataset.split('.')[0];
+            return `${type}-${packageName}.*-*`;
+          }
+          return `${type}-${dataset}-*`;
+        })
     )
   );


### PR DESCRIPTION
## Summary

Fixes `0.00/s` throughput display and broken Discover link for agentless Entity Analytics integrations (Okta, Active Directory, Microsoft Entra ID) in the Fleet UI integration policies table.

**Root cause:** `getAgentlessThroughputIndexPatterns` built ES index patterns directly from the policy-declared dataset name, without accounting for `dynamic_dataset: true`. These integrations declare a single stream with `dataset: entityanalytics_<pkg>.entity`, but a `routing_rules.yml` diverts every document to per-type data streams (e.g. `entityanalytics_okta.user-*`, `entityanalytics_okta.device-*`) at ingest time. The declared `entity` data stream is always empty, so the throughput aggregation returned 0 docs and the Discover ad-hoc data view linked to an empty index.

Data collection itself was working correctly — this was purely a Fleet UI display bug.

**Fix:** When `stream.data_stream.elasticsearch?.dynamic_dataset` is `true`, the index pattern is widened from `<type>-<dataset>-*` to `<type>-<packageName>.*-*`, covering all routing-rule targets. This matches the approach already used in `package_policy_to_agent_permissions.ts` for the same flag. Both the server-side throughput aggregation (`server/services/agentless/throughput.ts`) and the client-side Discover link (`agentless_table.tsx`) call the same helper, so both are fixed by this single change.

Introduced by elastic/integrations#20212 (agentless deployment mode for entity analytics integrations, merged 2026-08-07).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations. _(no breaking changes — query pattern is widened, not changed for unaffected integrations)_
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels. _(9.5 backport likely needed — `agentless_throughput_helper.ts` postdates the 9.4 branch cut so 9.4 is not affected)_

### Identify risks

- [ ] No data loss risk — this change only affects which indices are queried for the throughput UI metric and Discover link. It does not touch ingestion, routing, or stored data.
- [ ] The widened pattern `logs-entityanalytics_okta.*-*` could theoretically match unrelated indices if another integration shared the same package-name prefix, but Elastic integration naming conventions make this extremely unlikely. The server-side query also constrains documents by `agent.name: *${packagePolicy.id}*`, so over-matching indices return 0 relevant docs.

### Release Notes

```
**Fleet**: Fixed agentless integration policies (Okta Entity Analytics, Active Directory Entity Analytics, Microsoft Entra ID Entity Analytics) incorrectly showing `0.00/s` throughput and linking to an empty data stream in the Fleet UI. These integrations use routing rules that divert all documents away from the declared data stream; the throughput query and Discover link now correctly target the routed data streams.
```

---

- resolves elastic/sdh-beats#7504

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->