### PR TITLE
[Osquery] Unpin agent version, use latest for all environments

### DIFF
--- a/x-pack/solutions/security/test/osquery_cypress/agent.ts
+++ b/x-pack/solutions/security/test/osquery_cypress/agent.ts
@@ -13,17 +13,9 @@ import {
   waitForHostToEnroll,
 } from '@kbn/security-solution-plugin/scripts/endpoint/common/fleet_services';
 
-import { isServerlessKibanaFlavor } from '@kbn/security-solution-plugin/common/endpoint/utils/kibana_status';
 import chalk from 'chalk';
 import { Manager } from './resource_manager';
 import { generateRandomString, getLatestAvailableAgentVersion } from './utils';
-
-// Pin the stateful (ESS) enrolled agent to a fixed version to work around a
-// regression in the 9.5/9.6 Elastic Agent. Serverless keeps resolving the
-// latest available version. Keep this plain (no `-SNAPSHOT`) so the released
-// docker image tag resolves.
-// TODO: unpin once the 9.5/9.6 agent regression is resolved.
-const PINNED_STATEFUL_AGENT_VERSION = '9.4.3';
 
 export class AgentManager extends Manager {
   private readonly log: ToolingLog;
@@ -48,12 +40,10 @@ export class AgentManager extends Manager {
   public async setup() {
     this.log.info(chalk.bold('Setting up Agent'));
 
-    const isServerless = await isServerlessKibanaFlavor(this.kbnClient);
-    const agentVersion = isServerless
-      ? await getLatestAvailableAgentVersion(this.kbnClient, this.log)
-      : PINNED_STATEFUL_AGENT_VERSION;
-
-    const artifact = `docker.elastic.co/elastic-agent/elastic-agent:${agentVersion}`;
+    const artifact = `docker.elastic.co/elastic-agent/elastic-agent:${await getLatestAvailableAgentVersion(
+      this.kbnClient,
+      this.log
+    )}`;
     this.log.indent(4, () => this.log.info(`Image: ${artifact}`));
     const containerName = generateRandomString(12);
     const fleetServerUrl =


### PR DESCRIPTION
Reverts the stateful agent version pin from #278791. Both ESS and serverless now resolve the latest available agent version via getLatestAvailableAgentVersion.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->