### PR TITLE
[Synthetics] Show assigned agent and real per-agent share for scalable private locations

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -46,6 +46,7 @@ export enum SYNTHETICS_API_URLS {
   AGENT_POLICIES = `/internal/synthetics/agent_policies`,
   PRIVATE_LOCATIONS_MONITORS = `/internal/synthetics/private_locations/monitors`,
   PRIVATE_LOCATION_AGENT_STATS = `/internal/synthetics/private_locations/agent_stats`,
+  MONITOR_AGENT_ASSIGNMENT = `/internal/synthetics/monitors/{monitorId}/agent_assignment`,
   ENABLE_DEFAULT_ALERTING = `/internal/synthetics/enable_default_alerting`,
   GET_ACTIONS_CONNECTORS = `/internal/synthetics/get_actions_connectors`,
   GET_CONNECTOR_TYPES = `/internal/synthetics/get_connector_types`,

--- a/x-pack/solutions/observability/plugins/synthetics/common/types/agent_stats.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/types/agent_stats.ts
@@ -41,6 +41,12 @@ export interface AgentStat {
   lastCheckinMessage: string | null;
   platform: string | null;
   tags: string[];
+  /**
+   * Monitors pinned to this agent via a stamped `${agent.id}` condition.
+   * Null on classic (non-sharded) locations — every enrolled agent runs all
+   * of the location's monitors.
+   */
+  monitorsAssigned: number | null;
 }
 
 export interface LocationAgentStats {
@@ -49,5 +55,7 @@ export interface LocationAgentStats {
   agentPolicyId: string;
   /** Agent policy display name, or the id when the policy can't be resolved. */
   agentPolicyName: string;
+  /** Whether this location opts into condition-based monitor distribution. */
+  isAgentSharding: boolean;
   agents: AgentStat[];
 }

--- a/x-pack/solutions/observability/plugins/synthetics/common/types/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/types/index.ts
@@ -10,6 +10,7 @@ export type * from './monitor_validation';
 export type * from './default_alerts';
 export type * from './overview';
 export type * from './agent_stats';
+export type * from './monitor_agent_assignment';
 
 // Re-export schema-derived types from server for use in common and public
 export type {

--- a/x-pack/solutions/observability/plugins/synthetics/common/types/monitor_agent_assignment.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/types/monitor_agent_assignment.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Fields the monitor-details "Assigned agent" UI consumes. Intentionally slim —
+ * no capacity/CPU/tags (those live on agent_stats).
+ */
+export interface MonitorAssignedAgent {
+  agentId: string;
+  host: string;
+  healthy: boolean;
+  agentVersion: string | null;
+}
+
+export interface MonitorLocationAssignment {
+  locationId: string;
+  locationLabel: string;
+  isAgentSharding: boolean;
+  agentPolicyId: string;
+  agentPolicyName: string;
+  /**
+   * Agents that run this monitor at this location.
+   * Sharded: 0–1 assigned agent. Classic: every enrolled agent.
+   */
+  agents: MonitorAssignedAgent[];
+}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_assigned_agents.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_assigned_agents.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MonitorAssignedAgents } from './monitor_assigned_agents';
+import { useMonitorAgentAssignments } from '../../settings/private_locations/hooks/use_monitor_agent_assignments';
+import type { MonitorLocationAssignment } from '../../../../../../common/types';
+
+jest.mock('../../../contexts', () => ({
+  useSyntheticsSettingsContext: () => ({ basePath: '' }),
+}));
+
+jest.mock('../../../hooks', () => ({
+  useFleetPermissions: () => ({ canReadAgents: true, canReadAgentPolicies: true }),
+}));
+
+jest.mock('../../settings/private_locations/hooks/use_monitor_agent_assignments', () => ({
+  useMonitorAgentAssignments: jest.fn(),
+}));
+
+const mockUseAssignments = useMonitorAgentAssignments as jest.MockedFunction<
+  typeof useMonitorAgentAssignments
+>;
+
+const assignment = (
+  overrides: Partial<MonitorLocationAssignment> = {}
+): MonitorLocationAssignment => ({
+  locationId: 'loc-1',
+  locationLabel: 'Local Docker PL',
+  isAgentSharding: false,
+  agentPolicyId: 'policy-1',
+  agentPolicyName: 'Policy One',
+  agents: [
+    { agentId: 'agent-1', host: 'host-a', healthy: true, agentVersion: '9.6.0' },
+    { agentId: 'agent-2', host: 'host-b', healthy: false, agentVersion: '9.5.0' },
+  ],
+  ...overrides,
+});
+
+describe('MonitorAssignedAgents', () => {
+  beforeEach(() => {
+    mockUseAssignments.mockReturnValue({ assignments: [], loading: false });
+  });
+
+  it('renders nothing when the monitor has no private-location assignments', () => {
+    const { container } = render(
+      <MonitorAssignedAgents
+        configId="mon-1"
+        monitorLocations={[{ id: 'us-east', label: 'US East', isServiceManaged: true }]}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockUseAssignments).toHaveBeenCalledWith(undefined);
+  });
+
+  it('lists every enrolled agent on a classic location', () => {
+    mockUseAssignments.mockReturnValue({
+      assignments: [assignment()],
+      loading: false,
+    });
+
+    render(
+      <MonitorAssignedAgents
+        configId="mon-1"
+        monitorLocations={[{ id: 'loc-1', label: 'Local Docker PL', isServiceManaged: false }]}
+      />
+    );
+
+    expect(screen.getByText('Location agents')).toBeInTheDocument();
+    expect(screen.getByText('host-a')).toBeInTheDocument();
+    expect(screen.getByText('host-b')).toBeInTheDocument();
+    expect(screen.getByText(/Agent policy: Policy One/)).toBeInTheDocument();
+  });
+
+  it('lists only the assigned agent on a sharded location', () => {
+    mockUseAssignments.mockReturnValue({
+      assignments: [
+        assignment({
+          isAgentSharding: true,
+          agents: [{ agentId: 'agent-2', host: 'host-b', healthy: true, agentVersion: '9.5.0' }],
+        }),
+      ],
+      loading: false,
+    });
+
+    render(
+      <MonitorAssignedAgents
+        configId="mon-1"
+        monitorLocations={[{ id: 'loc-1', label: 'Local Docker PL', isServiceManaged: false }]}
+      />
+    );
+
+    expect(screen.getByText('Assigned agent')).toBeInTheDocument();
+    expect(screen.getByText('host-b')).toBeInTheDocument();
+    expect(screen.queryByText('host-a')).not.toBeInTheDocument();
+  });
+
+  it('shows an unassigned state when a sharded location has no pinned agent yet', () => {
+    mockUseAssignments.mockReturnValue({
+      assignments: [assignment({ isAgentSharding: true, agents: [] })],
+      loading: false,
+    });
+
+    render(
+      <MonitorAssignedAgents
+        configId="mon-1"
+        monitorLocations={[{ id: 'loc-1', label: 'Local Docker PL', isServiceManaged: false }]}
+      />
+    );
+
+    expect(screen.getByText('Assigned agent')).toBeInTheDocument();
+    expect(screen.getByText(/not yet assigned/i)).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_assigned_agents.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_assigned_agents.test.tsx
@@ -44,7 +44,7 @@ const assignment = (
 
 describe('MonitorAssignedAgents', () => {
   beforeEach(() => {
-    mockUseAssignments.mockReturnValue({ assignments: [], loading: false });
+    mockUseAssignments.mockReturnValue({ assignments: [], loading: false, error: false });
   });
 
   it('renders nothing when the monitor has no private-location assignments', () => {
@@ -59,10 +59,57 @@ describe('MonitorAssignedAgents', () => {
     expect(mockUseAssignments).toHaveBeenCalledWith(undefined);
   });
 
+  it('keeps the block visible while assignments are loading', () => {
+    mockUseAssignments.mockReturnValue({
+      assignments: [],
+      loading: true,
+      error: false,
+    });
+
+    render(
+      <MonitorAssignedAgents
+        configId="mon-1"
+        monitorLocations={[
+          {
+            id: 'loc-1',
+            label: 'Local Docker PL',
+            isServiceManaged: false,
+            agentPolicyId: 'policy-1',
+            isAgentSharding: true,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Assigned agent')).toBeInTheDocument();
+    expect(screen.getByTestId('monitorAssignedAgentsLoading')).toBeInTheDocument();
+  });
+
+  it('shows an error when assignment fetch failed', () => {
+    mockUseAssignments.mockReturnValue({
+      assignments: [],
+      loading: false,
+      error: true,
+    });
+
+    render(
+      <MonitorAssignedAgents
+        configId="mon-1"
+        monitorLocations={[{ id: 'loc-1', label: 'Local Docker PL', isServiceManaged: false }]}
+      />
+    );
+
+    expect(screen.getByText('Location agents')).toBeInTheDocument();
+    expect(screen.getByTestId('monitorAssignedAgentsError')).toHaveTextContent(
+      'Unable to load assigned agents.'
+    );
+  });
+
   it('lists every enrolled agent on a classic location', () => {
     mockUseAssignments.mockReturnValue({
       assignments: [assignment()],
       loading: false,
+      error: false,
     });
 
     render(
@@ -87,6 +134,7 @@ describe('MonitorAssignedAgents', () => {
         }),
       ],
       loading: false,
+      error: false,
     });
 
     render(
@@ -105,6 +153,7 @@ describe('MonitorAssignedAgents', () => {
     mockUseAssignments.mockReturnValue({
       assignments: [assignment({ isAgentSharding: true, agents: [] })],
       loading: false,
+      error: false,
     });
 
     render(

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_assigned_agents.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_assigned_agents.tsx
@@ -17,123 +17,155 @@ import {
 import { i18n } from '@kbn/i18n';
 import { useSyntheticsSettingsContext } from '../../../contexts';
 import { useFleetPermissions } from '../../../hooks';
-import { useAgentStats } from '../../settings/private_locations/hooks/use_agent_stats';
+import { useMonitorAgentAssignments } from '../../settings/private_locations/hooks/use_monitor_agent_assignments';
 import {
   isAgentVersionMwCompatible,
   MIN_MW_SUPPORTED_AGENT_VERSION,
 } from '../../../../../../common/utils/agent_mw_support';
 import type { EncryptedSyntheticsSavedMonitor } from '../../../../../../common/runtime_types';
+import type { MonitorLocationAssignment } from '../../../../../../common/types';
 
 /**
- * "Location agents" rows for the monitor details panel: for each private
- * location the monitor runs at, the location's agent policy and the enrolled
- * agent hosts that run it (every enrolled agent runs the monitor today).
- * Renders nothing when the monitor uses no private location, so it's safe to
- * always mount.
+ * Agents that run this monitor at each private location. Classic locations
+ * list every enrolled host; scalable locations list the assigned agent.
  */
 export const MonitorAssignedAgents = ({
+  configId,
   monitorLocations,
   hasMaintenanceWindows = false,
 }: {
+  configId: string;
   monitorLocations?: EncryptedSyntheticsSavedMonitor['locations'];
   /** Whether the monitor has a maintenance window assigned, to gate the agent-version warning below. */
   hasMaintenanceWindows?: boolean;
 }) => {
-  const { byLocation } = useAgentStats();
+  const privateLocations = (monitorLocations ?? []).filter((loc) => !loc.isServiceManaged);
+  const { assignments } = useMonitorAgentAssignments(
+    privateLocations.length > 0 ? configId : undefined
+  );
   const { basePath } = useSyntheticsSettingsContext();
   const { canReadAgents, canReadAgentPolicies } = useFleetPermissions();
 
-  const privateLocations = (monitorLocations ?? []).filter((loc) => !loc.isServiceManaged);
-  const entries = privateLocations
-    .map((loc) => byLocation.get(loc.id))
-    .filter(
-      (stats): stats is NonNullable<typeof stats> => stats != null && stats.agents.length > 0
-    );
+  const privateLocationIds = new Set(privateLocations.map((loc) => loc.id));
+  const entries = assignments.filter(
+    (entry) =>
+      privateLocationIds.has(entry.locationId) && (entry.isAgentSharding || entry.agents.length > 0)
+  );
 
   if (entries.length === 0) {
     return null;
   }
 
+  const allSharded = entries.every((entry) => entry.isAgentSharding);
   const showLocationLabel = entries.length > 1;
 
   return (
     <>
       <EuiDescriptionListTitle>
-        {LOCATION_AGENTS_LABEL}{' '}
-        <EuiIconTip content={LOCATION_AGENTS_HELP} position="right" type="question" />
+        {allSharded ? ASSIGNED_AGENT_LABEL : LOCATION_AGENTS_LABEL}{' '}
+        <EuiIconTip
+          content={allSharded ? ASSIGNED_AGENT_HELP : LOCATION_AGENTS_HELP}
+          position="right"
+          type="question"
+        />
       </EuiDescriptionListTitle>
       <EuiDescriptionListDescription>
-        {entries.map((stats) => {
-          const policyName = stats.agentPolicyName;
-          const policyHref = `${basePath}/app/fleet/policies/${stats.agentPolicyId}`;
-          return (
-            <div key={stats.locationId} css={{ marginBottom: 8 }}>
-              {showLocationLabel && (
-                <EuiText size="xs" color="subdued">
-                  {stats.locationLabel}
-                </EuiText>
-              )}
-              {stats.agents.map((agent) => {
-                const hostHref = agent.agentId
-                  ? `${basePath}/app/fleet/agents/${encodeURIComponent(agent.agentId)}`
-                  : `${basePath}/app/fleet/agents?kuery=${encodeURIComponent(
-                      `policy_id:"${stats.agentPolicyId}"`
-                    )}`;
-                const label = agent.host || agent.agentId || '—';
-                return (
-                  <EuiHealth
-                    key={agent.agentId ?? agent.host}
-                    color={agent.healthy ? 'success' : 'danger'}
-                  >
-                    {canReadAgents ? (
-                      <EuiLink
-                        data-test-subj="syntheticsAssignedAgentLink"
-                        href={hostHref}
-                        target="_blank"
-                        external
-                        title={agent.agentId ?? label}
-                      >
-                        {label}
-                      </EuiLink>
-                    ) : (
-                      label
-                    )}
-                    {agent.host && agent.agentId && (
-                      <EuiText size="xs" color="subdued" component="span">
-                        {' '}
-                        ({agent.agentId})
-                      </EuiText>
-                    )}
-                    {hasMaintenanceWindows && !isAgentVersionMwCompatible(agent.agentVersion) && (
-                      <EuiIconTip
-                        type="warning"
-                        color="warning"
-                        content={MW_UNSUPPORTED_AGENT_TOOLTIP(agent.agentVersion)}
-                        data-test-subj="syntheticsAssignedAgentMwWarning"
-                      />
-                    )}
-                  </EuiHealth>
-                );
-              })}
-              <EuiText size="xs" color="subdued">
-                {canReadAgentPolicies ? (
-                  <EuiLink
-                    data-test-subj="syntheticsAssignedAgentPolicyLink"
-                    href={policyHref}
-                    target="_blank"
-                    external
-                  >
-                    {POLICY_CAPTION(policyName)}
-                  </EuiLink>
-                ) : (
-                  POLICY_CAPTION(policyName)
-                )}
-              </EuiText>
-            </div>
-          );
-        })}
+        {entries.map((stats) => (
+          <AssignmentEntry
+            key={stats.locationId}
+            stats={stats}
+            showLocationLabel={showLocationLabel}
+            basePath={basePath}
+            canReadAgents={canReadAgents}
+            canReadAgentPolicies={canReadAgentPolicies}
+            hasMaintenanceWindows={hasMaintenanceWindows}
+          />
+        ))}
       </EuiDescriptionListDescription>
     </>
+  );
+};
+
+const AssignmentEntry = ({
+  stats,
+  showLocationLabel,
+  basePath,
+  canReadAgents,
+  canReadAgentPolicies,
+  hasMaintenanceWindows,
+}: {
+  stats: MonitorLocationAssignment;
+  showLocationLabel: boolean;
+  basePath: string;
+  canReadAgents: boolean;
+  canReadAgentPolicies: boolean;
+  hasMaintenanceWindows: boolean;
+}) => {
+  const policyHref = `${basePath}/app/fleet/policies/${stats.agentPolicyId}`;
+
+  return (
+    <div key={stats.locationId} css={{ marginBottom: 8 }}>
+      {showLocationLabel && (
+        <EuiText size="xs" color="subdued">
+          {stats.locationLabel}
+        </EuiText>
+      )}
+      {stats.agents.length === 0 ? (
+        <EuiText size="s" color="subdued">
+          {UNASSIGNED_LABEL}
+        </EuiText>
+      ) : (
+        stats.agents.map((agent) => {
+          const hostHref = `${basePath}/app/fleet/agents/${encodeURIComponent(agent.agentId)}`;
+          const label = agent.host || agent.agentId;
+          return (
+            <EuiHealth key={agent.agentId} color={agent.healthy ? 'success' : 'danger'}>
+              {canReadAgents ? (
+                <EuiLink
+                  data-test-subj="syntheticsAssignedAgentLink"
+                  href={hostHref}
+                  target="_blank"
+                  external
+                  title={agent.agentId}
+                >
+                  {label}
+                </EuiLink>
+              ) : (
+                label
+              )}
+              {agent.host && (
+                <EuiText size="xs" color="subdued" component="span">
+                  {' '}
+                  ({agent.agentId})
+                </EuiText>
+              )}
+              {hasMaintenanceWindows && !isAgentVersionMwCompatible(agent.agentVersion) && (
+                <EuiIconTip
+                  type="warning"
+                  color="warning"
+                  content={MW_UNSUPPORTED_AGENT_TOOLTIP(agent.agentVersion)}
+                  data-test-subj="syntheticsAssignedAgentMwWarning"
+                />
+              )}
+            </EuiHealth>
+          );
+        })
+      )}
+      <EuiText size="xs" color="subdued">
+        {canReadAgentPolicies ? (
+          <EuiLink
+            data-test-subj="syntheticsAssignedAgentPolicyLink"
+            href={policyHref}
+            target="_blank"
+            external
+          >
+            {POLICY_CAPTION(stats.agentPolicyName)}
+          </EuiLink>
+        ) : (
+          POLICY_CAPTION(stats.agentPolicyName)
+        )}
+      </EuiText>
+    </div>
   );
 };
 
@@ -141,10 +173,29 @@ const LOCATION_AGENTS_LABEL = i18n.translate('xpack.synthetics.monitorDetails.lo
   defaultMessage: 'Location agents',
 });
 
+const ASSIGNED_AGENT_LABEL = i18n.translate('xpack.synthetics.monitorDetails.assignedAgentLabel', {
+  defaultMessage: 'Assigned agent',
+});
+
 const LOCATION_AGENTS_HELP = i18n.translate('xpack.synthetics.monitorDetails.locationAgentsHelp', {
   defaultMessage:
     "On a private location this monitor runs on every enrolled agent of the location's agent policy.",
 });
+
+const ASSIGNED_AGENT_HELP = i18n.translate(
+  'xpack.synthetics.monitorDetails.assignedAgentHelpDescription',
+  {
+    defaultMessage:
+      'On a scalable private location this monitor runs on exactly one assigned agent.',
+  }
+);
+
+const UNASSIGNED_LABEL = i18n.translate(
+  'xpack.synthetics.monitorDetails.assignedAgentUnassignedLabel',
+  {
+    defaultMessage: 'Not yet assigned',
+  }
+);
 
 const MW_UNSUPPORTED_AGENT_TOOLTIP = (agentVersion: string | null) =>
   i18n.translate('xpack.synthetics.monitorDetails.locationAgents.mwUnsupportedTooltip', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_assigned_agents.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_assigned_agents.tsx
@@ -12,6 +12,7 @@ import {
   EuiHealth,
   EuiIconTip,
   EuiLink,
+  EuiSkeletonText,
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -40,11 +41,15 @@ export const MonitorAssignedAgents = ({
   hasMaintenanceWindows?: boolean;
 }) => {
   const privateLocations = (monitorLocations ?? []).filter((loc) => !loc.isServiceManaged);
-  const { assignments } = useMonitorAgentAssignments(
+  const { assignments, loading, error } = useMonitorAgentAssignments(
     privateLocations.length > 0 ? configId : undefined
   );
   const { basePath } = useSyntheticsSettingsContext();
   const { canReadAgents, canReadAgentPolicies } = useFleetPermissions();
+
+  if (privateLocations.length === 0) {
+    return null;
+  }
 
   const privateLocationIds = new Set(privateLocations.map((loc) => loc.id));
   const entries = assignments.filter(
@@ -52,23 +57,55 @@ export const MonitorAssignedAgents = ({
       privateLocationIds.has(entry.locationId) && (entry.isAgentSharding || entry.agents.length > 0)
   );
 
+  const allSharded =
+    entries.length > 0
+      ? entries.every((entry) => entry.isAgentSharding)
+      : privateLocations.every(
+          (location) => 'isAgentSharding' in location && location.isAgentSharding === true
+        );
+
+  const title = (
+    <EuiDescriptionListTitle>
+      {allSharded ? ASSIGNED_AGENT_LABEL : LOCATION_AGENTS_LABEL}{' '}
+      <EuiIconTip
+        content={allSharded ? ASSIGNED_AGENT_HELP : LOCATION_AGENTS_HELP}
+        position="right"
+        type="question"
+      />
+    </EuiDescriptionListTitle>
+  );
+
+  if (loading && entries.length === 0) {
+    return (
+      <>
+        {title}
+        <EuiDescriptionListDescription data-test-subj="monitorAssignedAgentsLoading">
+          <EuiSkeletonText lines={2} size="s" />
+        </EuiDescriptionListDescription>
+      </>
+    );
+  }
+
+  if (error && entries.length === 0) {
+    return (
+      <>
+        {title}
+        <EuiDescriptionListDescription data-test-subj="monitorAssignedAgentsError">
+          {ASSIGNED_AGENTS_ERROR_LABEL}
+        </EuiDescriptionListDescription>
+      </>
+    );
+  }
+
   if (entries.length === 0) {
     return null;
   }
 
-  const allSharded = entries.every((entry) => entry.isAgentSharding);
   const showLocationLabel = entries.length > 1;
 
   return (
     <>
-      <EuiDescriptionListTitle>
-        {allSharded ? ASSIGNED_AGENT_LABEL : LOCATION_AGENTS_LABEL}{' '}
-        <EuiIconTip
-          content={allSharded ? ASSIGNED_AGENT_HELP : LOCATION_AGENTS_HELP}
-          position="right"
-          type="question"
-        />
-      </EuiDescriptionListTitle>
+      {title}
       <EuiDescriptionListDescription>
         {entries.map((stats) => (
           <AssignmentEntry
@@ -194,6 +231,13 @@ const UNASSIGNED_LABEL = i18n.translate(
   'xpack.synthetics.monitorDetails.assignedAgentUnassignedLabel',
   {
     defaultMessage: 'Not yet assigned',
+  }
+);
+
+const ASSIGNED_AGENTS_ERROR_LABEL = i18n.translate(
+  'xpack.synthetics.monitorDetails.assignedAgentsError',
+  {
+    defaultMessage: 'Unable to load assigned agents.',
   }
 );
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
@@ -185,6 +185,7 @@ export const MonitorDetailsPanel = ({
 
         {!hideLocations && (
           <MonitorAssignedAgents
+            key={configId}
             configId={configId}
             monitorLocations={monitor.locations}
             hasMaintenanceWindows={!isEmpty(maintenanceWindows)}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
@@ -185,6 +185,7 @@ export const MonitorDetailsPanel = ({
 
         {!hideLocations && (
           <MonitorAssignedAgents
+            configId={configId}
             monitorLocations={monitor.locations}
             hasMaintenanceWindows={!isEmpty(maintenanceWindows)}
           />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/mws_callout/use_outdated_mw_agent_locations.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/mws_callout/use_outdated_mw_agent_locations.test.ts
@@ -29,6 +29,7 @@ const mockAgent = (overrides: Partial<AgentStat> = {}): AgentStat => ({
   lastCheckinMessage: null,
   platform: null,
   tags: [],
+  monitorsAssigned: null,
   ...overrides,
 });
 
@@ -42,6 +43,7 @@ const mockLocationStats = (
     locationLabel: locationId,
     agentPolicyId: `policy-${locationId}`,
     agentPolicyName: `Policy ${locationId}`,
+    isAgentSharding: false,
     agents,
   },
 ];

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/agent_details_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/agent_details_flyout.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { AgentDetailsFlyout } from './agent_details_flyout';
+import type { AgentStat } from '../../../../../../common/types';
+
+jest.mock('../../../contexts', () => ({
+  useSyntheticsSettingsContext: () => ({ basePath: '/s/default' }),
+}));
+
+jest.mock('../../../hooks', () => ({
+  useFleetPermissions: () => ({ canReadAgents: true, canReadAgentPolicies: true }),
+}));
+
+const agent: AgentStat = {
+  host: 'host-a',
+  lastCheckin: Date.parse('2026-08-01T00:00:00.000Z'),
+  healthy: true,
+  totalMemoryMib: 8192,
+  usedMemoryMib: 2048,
+  usedMemoryPct: 0.25,
+  cpuPct: 0.1,
+  agentId: 'agent-1',
+  agentVersion: '9.6.0',
+  agentStatus: 'online',
+  policyRevision: 6,
+  lastCheckinMessage: 'Running',
+  platform: 'linux',
+  tags: ['prod'],
+  monitorsAssigned: 2,
+};
+
+describe('AgentDetailsFlyout', () => {
+  it('renders health, capacity and a Fleet deep link', () => {
+    render(
+      <AgentDetailsFlyout
+        agent={agent}
+        agentPolicyId="policy-1"
+        monitorsRun={2}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('syntheticsAgentDetailsFlyout')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'host-a' })).toBeInTheDocument();
+    expect(screen.getAllByText('agent-1').length).toBeGreaterThan(0);
+    expect(screen.getByText('2')).toBeInTheDocument();
+    const fleetLink = screen.getByTestId('syntheticsAgentFlyoutFleetLink');
+    expect(fleetLink).toHaveAttribute('href', '/s/default/app/fleet/agents/agent-1');
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/agent_details_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/agent_details_flyout.tsx
@@ -57,7 +57,7 @@ export const AgentDetailsFlyout = ({
 }: {
   agent: AgentStat;
   agentPolicyId: string;
-  /** Monitors this agent runs (all of the location's monitors in the single-agent model). */
+  /** Monitors this agent runs (assigned count on a sharded location, else the location total). */
   monitorsRun: number;
   onClose: () => void;
 }) => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/agent_policy_details_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/agent_policy_details_flyout.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { AgentPolicyDetailsFlyout } from './agent_policy_details_flyout';
+import type { LocationAgentStats } from '../../../../../../common/types';
+
+jest.mock('../../../contexts', () => ({
+  useSyntheticsSettingsContext: () => ({ basePath: '/s/default' }),
+}));
+
+jest.mock('../../../hooks', () => ({
+  useFleetPermissions: () => ({ canReadAgents: true, canReadAgentPolicies: true }),
+}));
+
+jest.mock('react-redux-v7', () => ({
+  useSelector: (selector: (state: unknown) => unknown) =>
+    selector({
+      agentPolicies: {
+        data: [
+          {
+            id: 'policy-1',
+            name: 'Policy One',
+            agents: 1,
+            status: 'active',
+            namespace: 'default',
+            description: 'Synthetics policy',
+            spaceIds: ['default'],
+          },
+        ],
+      },
+    }),
+}));
+
+const locationStats: LocationAgentStats = {
+  locationId: 'loc-1',
+  locationLabel: 'Local Docker PL',
+  agentPolicyId: 'policy-1',
+  agentPolicyName: 'Policy One',
+  isAgentSharding: false,
+  agents: [
+    {
+      host: 'host-a',
+      lastCheckin: Date.now(),
+      healthy: true,
+      totalMemoryMib: 8192,
+      usedMemoryMib: 2048,
+      usedMemoryPct: 0.25,
+      cpuPct: 0.1,
+      agentId: 'agent-1',
+      agentVersion: '9.6.0',
+      agentStatus: 'online',
+      policyRevision: 6,
+      lastCheckinMessage: 'Running',
+      platform: 'linux',
+      tags: [],
+      monitorsAssigned: null,
+    },
+  ],
+};
+
+describe('AgentPolicyDetailsFlyout', () => {
+  it('renders policy overview and a Fleet deep link', () => {
+    render(
+      <AgentPolicyDetailsFlyout
+        agentPolicyId="policy-1"
+        locationStats={locationStats}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('syntheticsAgentPolicyDetailsFlyout')).toBeInTheDocument();
+    expect(screen.getByText('Policy One')).toBeInTheDocument();
+    expect(screen.getByText('1/1')).toBeInTheDocument();
+    expect(screen.getByTestId('syntheticsPolicyFlyoutFleetLink')).toHaveAttribute(
+      'href',
+      '/s/default/app/fleet/policies/policy-1'
+    );
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_monitor_agent_assignments.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_monitor_agent_assignments.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { fetchMonitorAgentAssignments } from '../../../../state/agent_stats/api';
+import { useMonitorAgentAssignments } from './use_monitor_agent_assignments';
+import type { MonitorLocationAssignment } from '../../../../../../../common/types';
+
+jest.mock('../../../../state/agent_stats/api');
+jest.mock('../../../../contexts', () => ({
+  useSyntheticsRefreshContext: () => ({ lastRefresh: 0 }),
+}));
+
+const mockFetch = fetchMonitorAgentAssignments as jest.MockedFunction<
+  typeof fetchMonitorAgentAssignments
+>;
+
+const assignment = (agentId: string): MonitorLocationAssignment => ({
+  locationId: 'loc-1',
+  locationLabel: 'Location 1',
+  isAgentSharding: true,
+  agentPolicyId: 'policy-1',
+  agentPolicyName: 'Policy One',
+  agents: [{ agentId, host: agentId, healthy: true, agentVersion: '9.6.0', enrolled: true }],
+});
+
+describe('useMonitorAgentAssignments', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('clears previous assignments when the monitor id changes', async () => {
+    mockFetch
+      .mockResolvedValueOnce([assignment('agent-a')])
+      .mockImplementation(() => new Promise(() => undefined));
+
+    const { result, rerender } = renderHook(
+      ({ monitorId }: { monitorId?: string }) => useMonitorAgentAssignments(monitorId),
+      { initialProps: { monitorId: 'mon-a' } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.assignments[0]?.agents[0]?.agentId).toBe('agent-a');
+    });
+
+    rerender({ monitorId: 'mon-b' });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.assignments).toEqual([]);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_monitor_agent_assignments.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_monitor_agent_assignments.ts
@@ -14,28 +14,39 @@ import { useSyntheticsRefreshContext } from '../../../../contexts';
  * Per-location agents that run a monitor. Slim assignment payload — not the
  * full agent_stats capacity row.
  */
-export const useMonitorAgentAssignments = (monitorId?: string) => {
+export const useMonitorAgentAssignments = (
+  monitorId?: string
+): {
+  assignments: MonitorLocationAssignment[];
+  loading: boolean;
+  error: boolean;
+} => {
   const { lastRefresh } = useSyntheticsRefreshContext();
   const [assignments, setAssignments] = useState<MonitorLocationAssignment[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(Boolean(monitorId));
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     if (!monitorId) {
       setAssignments([]);
+      setLoading(false);
+      setError(false);
       return;
     }
 
     let cancelled = false;
     setLoading(true);
+    setError(false);
     fetchMonitorAgentAssignments(monitorId)
       .then((result) => {
         if (!cancelled) {
           setAssignments(result);
+          setError(false);
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setAssignments([]);
+          setError(true);
         }
       })
       .finally(() => {
@@ -49,5 +60,5 @@ export const useMonitorAgentAssignments = (monitorId?: string) => {
     };
   }, [monitorId, lastRefresh]);
 
-  return { assignments, loading };
+  return { assignments, loading, error };
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_monitor_agent_assignments.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_monitor_agent_assignments.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { MonitorLocationAssignment } from '../../../../../../../common/types';
 import { fetchMonitorAgentAssignments } from '../../../../state/agent_stats/api';
 import { useSyntheticsRefreshContext } from '../../../../contexts';
@@ -25,13 +25,21 @@ export const useMonitorAgentAssignments = (
   const [assignments, setAssignments] = useState<MonitorLocationAssignment[]>([]);
   const [loading, setLoading] = useState(Boolean(monitorId));
   const [error, setError] = useState(false);
+  const loadedMonitorIdRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     if (!monitorId) {
+      loadedMonitorIdRef.current = undefined;
       setAssignments([]);
       setLoading(false);
       setError(false);
       return;
+    }
+
+    // Drop the previous monitor's rows immediately so a shared location id
+    // cannot flash the wrong assigned agent while the next fetch is in flight.
+    if (loadedMonitorIdRef.current !== monitorId) {
+      setAssignments([]);
     }
 
     let cancelled = false;
@@ -40,6 +48,7 @@ export const useMonitorAgentAssignments = (
     fetchMonitorAgentAssignments(monitorId)
       .then((result) => {
         if (!cancelled) {
+          loadedMonitorIdRef.current = monitorId;
           setAssignments(result);
           setError(false);
         }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_monitor_agent_assignments.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/hooks/use_monitor_agent_assignments.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState } from 'react';
+import type { MonitorLocationAssignment } from '../../../../../../../common/types';
+import { fetchMonitorAgentAssignments } from '../../../../state/agent_stats/api';
+import { useSyntheticsRefreshContext } from '../../../../contexts';
+
+/**
+ * Per-location agents that run a monitor. Slim assignment payload — not the
+ * full agent_stats capacity row.
+ */
+export const useMonitorAgentAssignments = (monitorId?: string) => {
+  const { lastRefresh } = useSyntheticsRefreshContext();
+  const [assignments, setAssignments] = useState<MonitorLocationAssignment[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!monitorId) {
+      setAssignments([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    fetchMonitorAgentAssignments(monitorId)
+      .then((result) => {
+        if (!cancelled) {
+          setAssignments(result);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAssignments([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [monitorId, lastRefresh]);
+
+  return { assignments, loading };
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/location_agent_details.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/location_agent_details.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { LocationAgentDetails } from './location_agent_details';
 import type { AgentStat, LocationAgentStats } from '../../../../../../common/types';
 
@@ -37,15 +38,21 @@ const agent = (overrides: Partial<AgentStat> = {}): AgentStat => ({
   lastCheckinMessage: 'Running',
   platform: 'linux',
   tags: [],
+  monitorsAssigned: null,
   ...overrides,
 });
 
-const stats = (agents: AgentStat[]): LocationAgentStats => ({
+const stats = (
+  agents: AgentStat[],
+  overrides: Partial<LocationAgentStats> = {}
+): LocationAgentStats => ({
   locationId: 'loc-1',
   locationLabel: 'Local Docker PL',
   agentPolicyId: 'policy-1',
   agentPolicyName: 'synthetics-private-pol',
+  isAgentSharding: false,
   agents,
+  ...overrides,
 });
 
 describe('LocationAgentDetails', () => {
@@ -122,5 +129,48 @@ describe('LocationAgentDetails', () => {
 
     // Memory and CPU both render the N/A fallback.
     expect(screen.getAllByText('N/A').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows the assigned share for a sharded location instead of 100%', () => {
+    render(
+      <LocationAgentDetails
+        stats={stats(
+          [
+            agent({ monitorsAssigned: 1 }),
+            agent({ host: 'agent-b', agentId: 'agent-b-id', monitorsAssigned: 2 }),
+          ],
+          { isAgentSharding: true }
+        )}
+        loading={false}
+        agentPolicyId="policy-1"
+        locationLabel="Local Docker PL"
+        locationMonitorCount={3}
+      />
+    );
+
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    expect(screen.getByText('67%')).toBeInTheDocument();
+    expect(screen.queryByText('100%')).not.toBeInTheDocument();
+  });
+
+  it('opens the agent details flyout from a per-agent row', async () => {
+    const user = userEvent.setup();
+    render(
+      <LocationAgentDetails
+        stats={stats([agent()])}
+        loading={false}
+        agentPolicyId="policy-1"
+        locationLabel="Local Docker PL"
+        locationMonitorCount={3}
+      />
+    );
+
+    await user.click(screen.getByTestId('syntheticsAgentDetailsLink'));
+
+    expect(screen.getByTestId('syntheticsAgentDetailsFlyout')).toBeInTheDocument();
+    expect(screen.getByTestId('syntheticsAgentFlyoutFleetLink')).toHaveAttribute(
+      'href',
+      '/app/fleet/agents/agent-a-id'
+    );
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/location_agent_details.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/settings/private_locations/location_agent_details.tsx
@@ -71,6 +71,7 @@ export const LocationAgentDetails = ({
   }
 
   const agents = stats?.agents ?? [];
+  const isAgentSharding = stats?.isAgentSharding === true;
   const healthyAgents = agents.filter((agent) => agent.healthy).length;
   const unhealthyAgents = agents.filter((agent) => !agent.healthy);
   const pressuredAgents = agents.filter(
@@ -121,44 +122,47 @@ export const LocationAgentDetails = ({
       name: MONITORS_LABEL,
       width: '90px',
       align: 'right',
-      // Every enrolled agent runs all of the location's monitors today.
-      render: (agent: AgentStat) =>
-        locationMonitorCount > 0 ? (
+      render: (agent: AgentStat) => {
+        const monitorsRun = agent.monitorsAssigned ?? locationMonitorCount;
+        return monitorsRun > 0 ? (
           <EuiLink
             data-test-subj="syntheticsAgentMonitorsLink"
             href={locationMonitorsHref}
             title={VIEW_LOCATION_MONITORS}
             className="eui-textNoWrap"
           >
-            <strong>{locationMonitorCount}</strong>
+            <strong>{monitorsRun}</strong>
           </EuiLink>
         ) : (
           <EuiText size="s" color="subdued" className="eui-textNoWrap">
-            {locationMonitorCount}
+            {monitorsRun}
           </EuiText>
-        ),
+        );
+      },
     },
     {
       name: DISTRIBUTION_COLUMN,
       width: '200px',
-      // In the single-agent model each agent runs the full set (100%).
-      render: (agent: AgentStat) => (
-        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-          <EuiFlexItem>
-            <EuiProgress
-              value={locationMonitorCount > 0 ? 1 : 0}
-              max={1}
-              size="s"
-              color={agent.healthy ? 'success' : 'danger'}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs" color="subdued" className="eui-textNoWrap">
-              {locationMonitorCount > 0 ? '100%' : '—'}
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      ),
+      render: (agent: AgentStat) => {
+        const share = agentShare(agent, locationMonitorCount, isAgentSharding);
+        return (
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem>
+              <EuiProgress
+                value={share ?? 0}
+                max={1}
+                size="s"
+                color={agent.healthy ? 'success' : 'danger'}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued" className="eui-textNoWrap">
+                {share == null ? '—' : `${Math.round(share * 100)}%`}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+      },
     },
     {
       field: 'usedMemoryPct',
@@ -368,7 +372,11 @@ export const LocationAgentDetails = ({
         <EuiTitle size="xxs">
           <h4>
             {DISTRIBUTION_TITLE}{' '}
-            <EuiIconTip content={DISTRIBUTION_HELP} position="right" type="question" />
+            <EuiIconTip
+              content={isAgentSharding ? DISTRIBUTION_HELP_SHARDED : DISTRIBUTION_HELP}
+              position="right"
+              type="question"
+            />
           </h4>
         </EuiTitle>
         <EuiSpacer size="s" />
@@ -384,12 +392,26 @@ export const LocationAgentDetails = ({
         <AgentDetailsFlyout
           agent={flyoutAgent}
           agentPolicyId={agentPolicyId}
-          monitorsRun={locationMonitorCount}
+          monitorsRun={flyoutAgent.monitorsAssigned ?? locationMonitorCount}
           onClose={() => setFlyoutAgent(null)}
         />
       )}
     </>
   );
+};
+
+const agentShare = (
+  agent: AgentStat,
+  locationMonitorCount: number,
+  isAgentSharding: boolean
+): number | null => {
+  if (locationMonitorCount <= 0) {
+    return null;
+  }
+  if (!isAgentSharding || agent.monitorsAssigned == null) {
+    return 1;
+  }
+  return agent.monitorsAssigned / locationMonitorCount;
 };
 
 /**
@@ -590,6 +612,14 @@ const DISTRIBUTION_HELP = i18n.translate(
   {
     defaultMessage:
       "Every enrolled agent on this location's agent policy currently runs all of the location's monitors.",
+  }
+);
+
+const DISTRIBUTION_HELP_SHARDED = i18n.translate(
+  'xpack.synthetics.privateLocation.agentDetails.distributionShardedHelpDescription',
+  {
+    defaultMessage:
+      "Share of this location's monitors assigned to each agent via a per-monitor host condition.",
   }
 );
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/agent_stats/api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/agent_stats/api.ts
@@ -5,10 +5,21 @@
  * 2.0.
  */
 
-import type { LocationAgentStats } from '../../../../../common/types';
+import type { LocationAgentStats, MonitorLocationAssignment } from '../../../../../common/types';
 import { SYNTHETICS_API_URLS } from '../../../../../common/constants';
 import { apiService } from '../../../../utils/api_service/api_service';
 
 export const fetchPrivateLocationAgentStats = async (): Promise<LocationAgentStats[]> => {
   return await apiService.get(SYNTHETICS_API_URLS.PRIVATE_LOCATION_AGENT_STATS);
+};
+
+export const fetchMonitorAgentAssignments = async (
+  monitorId: string
+): Promise<MonitorLocationAssignment[]> => {
+  return await apiService.get(
+    SYNTHETICS_API_URLS.MONITOR_AGENT_ASSIGNMENT.replace(
+      '{monitorId}',
+      encodeURIComponent(monitorId)
+    )
+  );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -74,6 +74,7 @@ import { deletePrivateLocationRoute } from './settings/private_locations/delete_
 import { editPrivateLocationRoute } from './settings/private_locations/edit_private_location';
 import { getPrivateLocationsRoute } from './settings/private_locations/get_private_locations';
 import { getPrivateLocationAgentStats } from './settings/private_locations/get_agent_stats';
+import { getMonitorAgentAssignment } from './settings/private_locations/get_monitor_agent_assignment';
 import { getSyntheticsFilters } from './filters/filters';
 import { getAllSyntheticsMonitorRoute } from './monitor_cruds/get_monitors_list';
 import { getLocationMonitors } from './settings/private_locations/get_location_monitors';
@@ -144,6 +145,7 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   getMonitorSummaryStatsRoute,
   getSyntheticsDiagnosticsRoute,
   getPrivateLocationAgentStats,
+  getMonitorAgentAssignment,
   getMaintenanceWindowsRoute,
 ];
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_agent_stats.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_agent_stats.test.ts
@@ -234,9 +234,9 @@ describe('getPrivateLocationAgentStats route', () => {
       agentPolicies: [{ id: 'policy-1', name: 'Policy One' }],
     });
     mockListByAgentPolicy.mockResolvedValue([
-      { condition: agentIdCondition('agent-1') },
-      { condition: agentIdCondition('agent-1') },
-      { condition: agentIdCondition('other-agent') },
+      { id: 'mon-a-loc-1', condition: agentIdCondition('agent-1') },
+      { id: 'mon-b-loc-1', condition: agentIdCondition('agent-1') },
+      { id: 'mon-c-loc-1', condition: agentIdCondition('other-agent') },
     ]);
     const listAgents = jest.fn().mockResolvedValue({ agents: [agent()], total: 1 });
     const { routeContext } = makeContext({ listAgentsImpl: listAgents });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_agent_stats.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_agent_stats.test.ts
@@ -6,12 +6,20 @@
  */
 
 import type { LocationAgentStats } from '../../../../common/types';
+import { agentIdCondition } from '../../../synthetics_service/private_location/assign_by_condition';
+import { PackagePolicyService } from '../../../synthetics_service/private_location/package_policy_service';
 import { getPrivateLocationAgentStats } from './get_agent_stats';
 import { getPrivateLocationsAndAgentPolicies } from './get_private_locations';
 
 jest.mock('./get_private_locations');
+jest.mock('../../../synthetics_service/private_location/package_policy_service');
 
 const mockGetLocations = getPrivateLocationsAndAgentPolicies as jest.Mock;
+const mockListByAgentPolicy = jest.fn();
+
+const mockPackagePolicyService = PackagePolicyService as jest.MockedClass<
+  typeof PackagePolicyService
+>;
 
 const GIB = 1024 * 1024 * 1024;
 
@@ -93,6 +101,13 @@ describe('getPrivateLocationAgentStats route', () => {
       locations: [{ id: 'loc-1', label: 'Location 1', agentPolicyId: 'policy-1' }],
       agentPolicies: [{ id: 'policy-1', name: 'Policy One' }],
     });
+    mockListByAgentPolicy.mockResolvedValue([]);
+    mockPackagePolicyService.mockImplementation(
+      () =>
+        ({
+          listByAgentPolicy: mockListByAgentPolicy,
+        } as unknown as PackagePolicyService)
+    );
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -201,5 +216,35 @@ describe('getPrivateLocationAgentStats route', () => {
 
     expect(result[0].agentPolicyName).toBe('Policy One');
     expect(result[0].locationLabel).toBe('Location 1');
+    expect(result[0].isAgentSharding).toBe(false);
+    expect(result[0].agents[0].monitorsAssigned).toBeNull();
+    expect(mockListByAgentPolicy).not.toHaveBeenCalled();
+  });
+
+  it('counts assigned monitors from stamped conditions on a sharded location', async () => {
+    mockGetLocations.mockResolvedValue({
+      locations: [
+        {
+          id: 'loc-1',
+          label: 'Location 1',
+          agentPolicyId: 'policy-1',
+          isAgentSharding: true,
+        },
+      ],
+      agentPolicies: [{ id: 'policy-1', name: 'Policy One' }],
+    });
+    mockListByAgentPolicy.mockResolvedValue([
+      { condition: agentIdCondition('agent-1') },
+      { condition: agentIdCondition('agent-1') },
+      { condition: agentIdCondition('other-agent') },
+    ]);
+    const listAgents = jest.fn().mockResolvedValue({ agents: [agent()], total: 1 });
+    const { routeContext } = makeContext({ listAgentsImpl: listAgents });
+
+    const result = await run(routeContext);
+
+    expect(result[0].isAgentSharding).toBe(true);
+    expect(result[0].agents[0].monitorsAssigned).toBe(2);
+    expect(mockListByAgentPolicy).toHaveBeenCalledWith({ agentPolicyId: 'policy-1' });
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_agent_stats.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_agent_stats.ts
@@ -11,6 +11,11 @@ import type { SyntheticsServerSetup } from '../../../types';
 import type { SyntheticsRestApiRouteFactory } from '../../types';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import type { AgentStat, LocationAgentStats } from '../../../../common/types';
+import {
+  countMonitorsByAssignedAgent,
+  isConditionShardedLocation,
+} from '../../../synthetics_service/private_location/assign_by_condition';
+import { PackagePolicyService } from '../../../synthetics_service/private_location/package_policy_service';
 
 const BYTES_PER_MIB = 1024 * 1024;
 
@@ -43,7 +48,7 @@ interface AgentLocalMetadata {
  * One entry per enrolled Fleet agent (`agent.id`) on the location's policy.
  * Host memory from agent metadata is optional; `metrics-system.*` fills gaps.
  */
-const getEnrolledAgents = async (
+export const getEnrolledAgents = async (
   server: SyntheticsServerSetup,
   agentPolicyId: string
 ): Promise<Map<string, EnrolledAgentMeta>> => {
@@ -198,15 +203,25 @@ export const getPrivateLocationAgentStats: SyntheticsRestApiRouteFactory<
       syntheticsMonitorClient
     );
     const policyNameById = new Map(agentPolicies.map((policy) => [policy.id, policy.name]));
+    const packagePolicyService = new PackagePolicyService(server);
 
     const { elasticsearch } = await context.core;
     const esClient = elasticsearch.client.asCurrentUser;
 
     return Promise.all(
       locations.map(async (location): Promise<LocationAgentStats> => {
-        const enrolled = await getEnrolledAgents(server, location.agentPolicyId).catch(
-          () => new Map<string, EnrolledAgentMeta>()
-        );
+        const isAgentSharding = isConditionShardedLocation(location);
+        const [enrolled, assignmentCounts] = await Promise.all([
+          getEnrolledAgents(server, location.agentPolicyId).catch(
+            () => new Map<string, EnrolledAgentMeta>()
+          ),
+          isAgentSharding
+            ? packagePolicyService
+                .listByAgentPolicy({ agentPolicyId: location.agentPolicyId })
+                .then(countMonitorsByAssignedAgent)
+                .catch(() => new Map<string, number>())
+            : Promise.resolve(new Map<string, number>()),
+        ]);
 
         // Unique original-case host names for the metrics terms query.
         const metricHostNames = [
@@ -241,6 +256,7 @@ export const getPrivateLocationAgentStats: SyntheticsRestApiRouteFactory<
               lastCheckinMessage: meta.lastCheckinMessage,
               platform: meta.platform,
               tags: meta.tags,
+              monitorsAssigned: isAgentSharding ? assignmentCounts.get(meta.agentId) ?? 0 : null,
             };
           })
           .sort((a, b) => {
@@ -253,6 +269,7 @@ export const getPrivateLocationAgentStats: SyntheticsRestApiRouteFactory<
           locationLabel: location.label,
           agentPolicyId: location.agentPolicyId,
           agentPolicyName: policyNameById.get(location.agentPolicyId) ?? location.agentPolicyId,
+          isAgentSharding,
           agents,
         };
       })

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_agent_stats.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_agent_stats.ts
@@ -218,7 +218,7 @@ export const getPrivateLocationAgentStats: SyntheticsRestApiRouteFactory<
           isAgentSharding
             ? packagePolicyService
                 .listByAgentPolicy({ agentPolicyId: location.agentPolicyId })
-                .then(countMonitorsByAssignedAgent)
+                .then((policies) => countMonitorsByAssignedAgent(policies, location.id))
                 .catch(() => new Map<string, number>())
             : Promise.resolve(new Map<string, number>()),
         ]);

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.test.ts
@@ -187,7 +187,7 @@ describe('getMonitorAgentAssignment route', () => {
       expect.objectContaining({
         spaceId: 'default',
         packagePolicyIds: expect.arrayContaining(['mon-1-loc-1', 'mon-1-loc-1-default']),
-        fields: ['name', 'condition'],
+        fields: ['id', 'name', 'condition'],
       })
     );
   });
@@ -211,6 +211,30 @@ describe('getMonitorAgentAssignment route', () => {
 
     const result = (await run(routeContext)) as MonitorLocationAssignment[];
 
+    expect(result[0].agents).toEqual([]);
+  });
+
+  it('returns the sharded location unassigned when package-policy reads fail', async () => {
+    mockGetLocations.mockResolvedValue({
+      locations: [
+        { id: 'loc-1', label: 'Location 1', agentPolicyId: 'policy-1', isAgentSharding: true },
+      ],
+      agentPolicies: [{ id: 'policy-1', name: 'Policy One' }],
+    });
+    mockGetByIds.mockRejectedValue(new Error('Fleet unavailable'));
+    const getMonitor = jest.fn().mockResolvedValue({
+      attributes: { locations: [{ id: 'loc-1', isServiceManaged: false }] },
+    });
+    const listAgents = jest.fn().mockResolvedValue({ agents: [agent()], total: 1 });
+    const { routeContext } = makeContext({
+      listAgentsImpl: listAgents,
+      getMonitorImpl: getMonitor,
+    });
+
+    const result = (await run(routeContext)) as MonitorLocationAssignment[];
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isAgentSharding).toBe(true);
     expect(result[0].agents).toEqual([]);
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { agentIdCondition } from '../../../synthetics_service/private_location/assign_by_condition';
+import { PackagePolicyService } from '../../../synthetics_service/private_location/package_policy_service';
+import { getPrivateLocationsAndAgentPolicies } from './get_private_locations';
+import { getMonitorAgentAssignment } from './get_monitor_agent_assignment';
+import type { MonitorLocationAssignment } from '../../../../common/types';
+
+jest.mock('./get_private_locations');
+jest.mock('../../../synthetics_service/private_location/package_policy_service');
+
+const mockGetLocations = getPrivateLocationsAndAgentPolicies as jest.Mock;
+const mockGetByIds = jest.fn();
+const mockPackagePolicyService = PackagePolicyService as jest.MockedClass<
+  typeof PackagePolicyService
+>;
+
+const agent = (over: Record<string, unknown> = {}) => ({
+  id: 'agent-1',
+  status: 'online',
+  last_checkin: '2026-08-01T00:00:00.000Z',
+  local_metadata: {
+    host: { name: 'host-a' },
+    elastic: { agent: { version: '9.6.0' } },
+  },
+  ...over,
+});
+
+const makeContext = ({
+  monitorId = 'mon-1',
+  listAgentsImpl,
+  getMonitorImpl,
+}: {
+  monitorId?: string;
+  listAgentsImpl: jest.Mock;
+  getMonitorImpl: jest.Mock;
+}) => {
+  const notFound = jest.fn((opts) => ({ status: 404, ...opts }));
+  const routeContext = {
+    request: { params: { monitorId } },
+    response: { notFound },
+    spaceId: 'default',
+    monitorConfigRepository: { get: getMonitorImpl },
+    server: { fleet: { agentService: { asInternalUser: { listAgents: listAgentsImpl } } } },
+    savedObjectsClient: {},
+    syntheticsMonitorClient: {},
+  } as any;
+  return { routeContext, notFound };
+};
+
+const run = async (routeContext: any) => getMonitorAgentAssignment().handler(routeContext);
+
+describe('getMonitorAgentAssignment route', () => {
+  beforeEach(() => {
+    mockGetLocations.mockResolvedValue({
+      locations: [
+        { id: 'loc-1', label: 'Location 1', agentPolicyId: 'policy-1', isAgentSharding: false },
+      ],
+      agentPolicies: [{ id: 'policy-1', name: 'Policy One' }],
+    });
+    mockGetByIds.mockResolvedValue([]);
+    mockPackagePolicyService.mockImplementation(
+      () =>
+        ({
+          getByIds: mockGetByIds,
+        } as unknown as PackagePolicyService)
+    );
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns 404 when the monitor does not exist', async () => {
+    const getMonitor = jest
+      .fn()
+      .mockRejectedValue(
+        SavedObjectsErrorHelpers.createGenericNotFoundError('synthetics-monitor', 'missing')
+      );
+    const listAgents = jest.fn();
+    const { routeContext, notFound } = makeContext({
+      monitorId: 'missing',
+      listAgentsImpl: listAgents,
+      getMonitorImpl: getMonitor,
+    });
+
+    const result = await run(routeContext);
+
+    expect(notFound).toHaveBeenCalledWith({
+      body: { message: 'Monitor id missing not found!' },
+    });
+    expect(result).toEqual(expect.objectContaining({ status: 404 }));
+    expect(listAgents).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list when the monitor has no private locations', async () => {
+    const getMonitor = jest.fn().mockResolvedValue({
+      attributes: { locations: [{ id: 'us-east', isServiceManaged: true }] },
+    });
+    const { routeContext } = makeContext({
+      listAgentsImpl: jest.fn(),
+      getMonitorImpl: getMonitor,
+    });
+
+    const result = await run(routeContext);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns every enrolled agent for a classic private location', async () => {
+    const getMonitor = jest.fn().mockResolvedValue({
+      attributes: { locations: [{ id: 'loc-1', label: 'Location 1', isServiceManaged: false }] },
+    });
+    const listAgents = jest.fn().mockResolvedValue({
+      agents: [
+        agent(),
+        agent({
+          id: 'agent-2',
+          status: 'offline',
+          local_metadata: { host: { name: 'host-b' }, elastic: { agent: { version: '9.5.0' } } },
+        }),
+      ],
+      total: 2,
+    });
+    const { routeContext } = makeContext({
+      listAgentsImpl: listAgents,
+      getMonitorImpl: getMonitor,
+    });
+
+    const result = (await run(routeContext)) as MonitorLocationAssignment[];
+
+    expect(result).toEqual([
+      {
+        locationId: 'loc-1',
+        locationLabel: 'Location 1',
+        isAgentSharding: false,
+        agentPolicyId: 'policy-1',
+        agentPolicyName: 'Policy One',
+        agents: [
+          { agentId: 'agent-1', host: 'host-a', healthy: true, agentVersion: '9.6.0' },
+          { agentId: 'agent-2', host: 'host-b', healthy: false, agentVersion: '9.5.0' },
+        ],
+      },
+    ]);
+    expect(result[0]).not.toHaveProperty('usedMemoryPct');
+    expect(mockGetByIds).not.toHaveBeenCalled();
+  });
+
+  it('returns only the assigned agent for a sharded private location', async () => {
+    mockGetLocations.mockResolvedValue({
+      locations: [
+        { id: 'loc-1', label: 'Location 1', agentPolicyId: 'policy-1', isAgentSharding: true },
+      ],
+      agentPolicies: [{ id: 'policy-1', name: 'Policy One' }],
+    });
+    mockGetByIds.mockResolvedValue([{ id: 'mon-1-loc-1', condition: agentIdCondition('agent-2') }]);
+    const getMonitor = jest.fn().mockResolvedValue({
+      attributes: { locations: [{ id: 'loc-1', isServiceManaged: false }] },
+    });
+    const listAgents = jest.fn().mockResolvedValue({
+      agents: [
+        agent(),
+        agent({
+          id: 'agent-2',
+          local_metadata: { host: { name: 'host-b' }, elastic: { agent: { version: '9.5.0' } } },
+        }),
+      ],
+      total: 2,
+    });
+    const { routeContext } = makeContext({
+      listAgentsImpl: listAgents,
+      getMonitorImpl: getMonitor,
+    });
+
+    const result = (await run(routeContext)) as MonitorLocationAssignment[];
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isAgentSharding).toBe(true);
+    expect(result[0].agents).toEqual([
+      { agentId: 'agent-2', host: 'host-b', healthy: true, agentVersion: '9.5.0' },
+    ]);
+    expect(mockGetByIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spaceId: 'default',
+        packagePolicyIds: expect.arrayContaining(['mon-1-loc-1', 'mon-1-loc-1-default']),
+        fields: ['name', 'condition'],
+      })
+    );
+  });
+
+  it('returns no agents when a sharded monitor is still unassigned', async () => {
+    mockGetLocations.mockResolvedValue({
+      locations: [
+        { id: 'loc-1', label: 'Location 1', agentPolicyId: 'policy-1', isAgentSharding: true },
+      ],
+      agentPolicies: [{ id: 'policy-1', name: 'Policy One' }],
+    });
+    mockGetByIds.mockResolvedValue([]);
+    const getMonitor = jest.fn().mockResolvedValue({
+      attributes: { locations: [{ id: 'loc-1', isServiceManaged: false }] },
+    });
+    const listAgents = jest.fn().mockResolvedValue({ agents: [agent()], total: 1 });
+    const { routeContext } = makeContext({
+      listAgentsImpl: listAgents,
+      getMonitorImpl: getMonitor,
+    });
+
+    const result = (await run(routeContext)) as MonitorLocationAssignment[];
+
+    expect(result[0].agents).toEqual([]);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.test.ts
@@ -222,6 +222,63 @@ describe('getMonitorAgentAssignment route', () => {
     );
   });
 
+  it('looks up package policies by MONITOR_QUERY_ID when it differs from the saved-object id', async () => {
+    mockGetLocations.mockResolvedValue({
+      locations: [
+        { id: 'loc-1', label: 'Location 1', agentPolicyId: 'policy-1', isAgentSharding: true },
+      ],
+      agentPolicies: [{ id: 'policy-1', name: 'Policy One' }],
+    });
+    mockGetByIds.mockResolvedValue([
+      { id: 'journey-project-default-loc-1', condition: agentIdCondition('agent-2') },
+    ]);
+    const getMonitor = jest.fn().mockResolvedValue({
+      attributes: {
+        id: 'journey-project-default',
+        locations: [{ id: 'loc-1', isServiceManaged: false }],
+      },
+    });
+    const listAgents = jest.fn().mockResolvedValue({
+      agents: [
+        agent({
+          id: 'agent-2',
+          local_metadata: { host: { name: 'host-b' }, elastic: { agent: { version: '9.5.0' } } },
+        }),
+      ],
+      total: 1,
+    });
+    const { routeContext } = makeContext({
+      monitorId: 'so-uuid',
+      listAgentsImpl: listAgents,
+      getMonitorImpl: getMonitor,
+    });
+
+    const result = (await run(routeContext)) as MonitorLocationAssignment[];
+
+    expect(mockGetByIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packagePolicyIds: expect.arrayContaining([
+          'journey-project-default-loc-1',
+          'journey-project-default-loc-1-default',
+        ]),
+      })
+    );
+    expect(mockGetByIds).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        packagePolicyIds: expect.arrayContaining(['so-uuid-loc-1']),
+      })
+    );
+    expect(result[0].agents).toEqual([
+      {
+        agentId: 'agent-2',
+        host: 'host-b',
+        healthy: true,
+        agentVersion: '9.5.0',
+        enrolled: true,
+      },
+    ]);
+  });
+
   it('returns no agents when a sharded monitor is still unassigned', async () => {
     mockGetLocations.mockResolvedValue({
       locations: [

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.ts
@@ -11,6 +11,7 @@ import { getPrivateLocationsAndAgentPolicies } from './get_private_locations';
 import { getEnrolledAgents } from './get_agent_stats';
 import type { SyntheticsRestApiRouteFactory } from '../../types';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { ConfigKey } from '../../../../common/runtime_types';
 import type { MonitorAssignedAgent, MonitorLocationAssignment } from '../../../../common/types';
 import { getMonitorNotFoundResponse } from '../../synthetics_service/service_errors';
 import {
@@ -64,6 +65,10 @@ export const getMonitorAgentAssignment: SyntheticsRestApiRouteFactory<
 
     try {
       const monitor = await monitorConfigRepository.get(monitorId);
+      // Fleet package-policy ids use HeartbeatConfig.id (MONITOR_QUERY_ID /
+      // custom_heartbeat_id), which differs from the saved-object config_id on
+      // project monitors. Looking up by monitorId would miss the pin.
+      const policyMonitorId = monitor.attributes[ConfigKey.MONITOR_QUERY_ID] || monitorId;
       const privateMonitorLocations = (monitor.attributes.locations ?? []).filter(
         (location) => !location.isServiceManaged
       );
@@ -88,8 +93,8 @@ export const getMonitorAgentAssignment: SyntheticsRestApiRouteFactory<
           ? await new PackagePolicyService(server).getByIds({
               spaceId,
               packagePolicyIds: shardedMonitorLocations.flatMap((location) => [
-                `${monitorId}-${location.id}`,
-                `${monitorId}-${location.id}-${spaceId}`,
+                `${policyMonitorId}-${location.id}`,
+                `${policyMonitorId}-${location.id}-${spaceId}`,
               ]),
               fields: ['id', 'name', 'condition'],
             })
@@ -120,7 +125,7 @@ export const getMonitorAgentAssignment: SyntheticsRestApiRouteFactory<
               (policy): policy is { id: string; condition?: string | null } =>
                 typeof policy.id === 'string'
             ),
-            monitorId,
+            policyMonitorId,
             monitorLocation.id,
             spaceId
           );

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { getPrivateLocationsAndAgentPolicies } from './get_private_locations';
+import { getEnrolledAgents } from './get_agent_stats';
+import type { SyntheticsRestApiRouteFactory } from '../../types';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import type { MonitorAssignedAgent, MonitorLocationAssignment } from '../../../../common/types';
+import { getMonitorNotFoundResponse } from '../../synthetics_service/service_errors';
+import {
+  assignedAgentIdForMonitorLocation,
+  isConditionShardedLocation,
+} from '../../../synthetics_service/private_location/assign_by_condition';
+import { PackagePolicyService } from '../../../synthetics_service/private_location/package_policy_service';
+
+const toAssignedAgent = (meta: {
+  agentId: string;
+  host: string;
+  agentStatus: string | null;
+  agentVersion: string | null;
+}): MonitorAssignedAgent => ({
+  agentId: meta.agentId,
+  host: meta.host,
+  healthy: meta.agentStatus === 'online',
+  agentVersion: meta.agentVersion,
+});
+
+export const getMonitorAgentAssignment: SyntheticsRestApiRouteFactory<
+  MonitorLocationAssignment[]
+> = () => ({
+  method: 'GET',
+  path: SYNTHETICS_API_URLS.MONITOR_AGENT_ASSIGNMENT,
+  validate: {},
+  validation: {
+    request: {
+      params: schema.object({
+        monitorId: schema.string({ minLength: 1, maxLength: 1024 }),
+      }),
+    },
+  },
+  handler: async ({
+    request,
+    response,
+    spaceId,
+    monitorConfigRepository,
+    server,
+    savedObjectsClient,
+    syntheticsMonitorClient,
+  }) => {
+    const { monitorId } = request.params;
+
+    try {
+      const monitor = await monitorConfigRepository.get(monitorId);
+      const privateMonitorLocations = (monitor.attributes.locations ?? []).filter(
+        (location) => !location.isServiceManaged
+      );
+      if (privateMonitorLocations.length === 0) {
+        return [];
+      }
+
+      const { locations, agentPolicies } = await getPrivateLocationsAndAgentPolicies(
+        savedObjectsClient,
+        syntheticsMonitorClient
+      );
+      const locationById = new Map(locations.map((location) => [location.id, location]));
+      const policyNameById = new Map(agentPolicies.map((policy) => [policy.id, policy.name]));
+
+      const shardedMonitorLocations = privateMonitorLocations.filter((location) => {
+        const privateLocation = locationById.get(location.id);
+        return privateLocation != null && isConditionShardedLocation(privateLocation);
+      });
+
+      const packagePolicies =
+        shardedMonitorLocations.length > 0
+          ? await new PackagePolicyService(server).getByIds({
+              spaceId,
+              packagePolicyIds: shardedMonitorLocations.flatMap((location) => [
+                `${monitorId}-${location.id}`,
+                `${monitorId}-${location.id}-${spaceId}`,
+              ]),
+              fields: ['name', 'condition'],
+            })
+          : [];
+
+      const enrolledByPolicyId = new Map<string, Awaited<ReturnType<typeof getEnrolledAgents>>>();
+      const assignments: MonitorLocationAssignment[] = [];
+
+      for (const monitorLocation of privateMonitorLocations) {
+        const privateLocation = locationById.get(monitorLocation.id);
+        if (!privateLocation) {
+          continue;
+        }
+
+        let enrolled = enrolledByPolicyId.get(privateLocation.agentPolicyId);
+        if (!enrolled) {
+          enrolled = await getEnrolledAgents(server, privateLocation.agentPolicyId).catch(
+            () => new Map()
+          );
+          enrolledByPolicyId.set(privateLocation.agentPolicyId, enrolled);
+        }
+        const isAgentSharding = isConditionShardedLocation(privateLocation);
+
+        let agents: MonitorAssignedAgent[];
+        if (isAgentSharding) {
+          const assignedAgentId = assignedAgentIdForMonitorLocation(
+            packagePolicies.filter(
+              (policy): policy is { id: string; condition?: string | null } =>
+                typeof policy.id === 'string'
+            ),
+            monitorId,
+            monitorLocation.id
+          );
+          const assigned = assignedAgentId ? enrolled.get(assignedAgentId) : undefined;
+          agents = assigned ? [toAssignedAgent(assigned)] : [];
+        } else {
+          agents = [...enrolled.values()].map(toAssignedAgent);
+        }
+
+        assignments.push({
+          locationId: privateLocation.id,
+          locationLabel: privateLocation.label,
+          isAgentSharding,
+          agentPolicyId: privateLocation.agentPolicyId,
+          agentPolicyName:
+            policyNameById.get(privateLocation.agentPolicyId) ?? privateLocation.agentPolicyId,
+          agents,
+        });
+      }
+
+      return assignments;
+    } catch (error) {
+      if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
+        return getMonitorNotFoundResponse(response, monitorId);
+      }
+      throw error;
+    }
+  },
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/private_locations/get_monitor_agent_assignment.ts
@@ -78,14 +78,16 @@ export const getMonitorAgentAssignment: SyntheticsRestApiRouteFactory<
 
       const packagePolicies =
         shardedMonitorLocations.length > 0
-          ? await new PackagePolicyService(server).getByIds({
-              spaceId,
-              packagePolicyIds: shardedMonitorLocations.flatMap((location) => [
-                `${monitorId}-${location.id}`,
-                `${monitorId}-${location.id}-${spaceId}`,
-              ]),
-              fields: ['name', 'condition'],
-            })
+          ? await new PackagePolicyService(server)
+              .getByIds({
+                spaceId,
+                packagePolicyIds: shardedMonitorLocations.flatMap((location) => [
+                  `${monitorId}-${location.id}`,
+                  `${monitorId}-${location.id}-${spaceId}`,
+                ]),
+                fields: ['id', 'name', 'condition'],
+              })
+              .catch(() => [])
           : [];
 
       const enrolledByPolicyId = new Map<string, Awaited<ReturnType<typeof getEnrolledAgents>>>();

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/assign_by_condition.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/assign_by_condition.test.ts
@@ -111,19 +111,52 @@ describe('assignAgentById', () => {
 });
 
 describe('countMonitorsByAssignedAgent', () => {
-  it('counts package policies per stamped agent id and skips unassigned', () => {
-    const counts = countMonitorsByAssignedAgent([
-      { condition: agentIdCondition('agent-a') },
-      { condition: agentIdCondition('agent-a') },
-      { condition: agentIdCondition('agent-b') },
-      { condition: UNASSIGNED_CONDITION },
-      { condition: null },
-    ]);
+  const locationId = 'loc-1';
+
+  it('counts unique monitors per stamped agent id and skips unassigned', () => {
+    const counts = countMonitorsByAssignedAgent(
+      [
+        { id: `mon-a-${locationId}`, condition: agentIdCondition('agent-a') },
+        { id: `mon-b-${locationId}`, condition: agentIdCondition('agent-a') },
+        { id: `mon-c-${locationId}`, condition: agentIdCondition('agent-b') },
+        { id: `mon-d-${locationId}`, condition: UNASSIGNED_CONDITION },
+        { id: `mon-e-${locationId}`, condition: null },
+      ],
+      locationId
+    );
 
     expect(counts.get('agent-a')).toBe(2);
     expect(counts.get('agent-b')).toBe(1);
     expect(counts.has('__synthetics_unassigned__')).toBe(false);
     expect(counts.size).toBe(2);
+  });
+
+  it('counts a new-format policy and its leftover legacy twin as one monitor', () => {
+    const counts = countMonitorsByAssignedAgent(
+      [
+        { id: `mon-1-${locationId}`, condition: agentIdCondition('agent-a') },
+        { id: `mon-1-${locationId}-default`, condition: agentIdCondition('agent-a') },
+        { id: `mon-2-${locationId}`, condition: agentIdCondition('agent-b') },
+      ],
+      locationId
+    );
+
+    expect(counts.get('agent-a')).toBe(1);
+    expect(counts.get('agent-b')).toBe(1);
+    expect(counts.size).toBe(2);
+  });
+
+  it('prefers the new-format policy when a twin is pinned to a different agent', () => {
+    const counts = countMonitorsByAssignedAgent(
+      [
+        { id: `mon-1-${locationId}-default`, condition: agentIdCondition('legacy-agent') },
+        { id: `mon-1-${locationId}`, condition: agentIdCondition('new-agent') },
+      ],
+      locationId
+    );
+
+    expect(counts.get('new-agent')).toBe(1);
+    expect(counts.has('legacy-agent')).toBe(false);
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/assign_by_condition.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/assign_by_condition.test.ts
@@ -8,8 +8,10 @@
 import {
   agentIdCondition,
   agentIdFromCondition,
+  assignedAgentIdForMonitorLocation,
   assignAgentById,
   balanceAgentsByCost,
+  countMonitorsByAssignedAgent,
   isConditionShardedLocation,
   isEqlSafeLiteral,
   UNASSIGNED_CONDITION,
@@ -105,6 +107,59 @@ describe('assignAgentById', () => {
         expect(now).toBe(before.get(id));
       }
     }
+  });
+});
+
+describe('countMonitorsByAssignedAgent', () => {
+  it('counts package policies per stamped agent id and skips unassigned', () => {
+    const counts = countMonitorsByAssignedAgent([
+      { condition: agentIdCondition('agent-a') },
+      { condition: agentIdCondition('agent-a') },
+      { condition: agentIdCondition('agent-b') },
+      { condition: UNASSIGNED_CONDITION },
+      { condition: null },
+    ]);
+
+    expect(counts.get('agent-a')).toBe(2);
+    expect(counts.get('agent-b')).toBe(1);
+    expect(counts.has('__synthetics_unassigned__')).toBe(false);
+    expect(counts.size).toBe(2);
+  });
+});
+
+describe('assignedAgentIdForMonitorLocation', () => {
+  it('prefers the new-format package policy over a legacy space-suffixed id', () => {
+    const agentId = assignedAgentIdForMonitorLocation(
+      [
+        { id: 'mon-1-loc-1-default', condition: agentIdCondition('legacy-agent') },
+        { id: 'mon-1-loc-1', condition: agentIdCondition('new-agent') },
+      ],
+      'mon-1',
+      'loc-1'
+    );
+
+    expect(agentId).toBe('new-agent');
+  });
+
+  it('falls back to a legacy space-suffixed policy when the new id is absent', () => {
+    const agentId = assignedAgentIdForMonitorLocation(
+      [{ id: 'mon-1-loc-1-default', condition: agentIdCondition('legacy-agent') }],
+      'mon-1',
+      'loc-1'
+    );
+
+    expect(agentId).toBe('legacy-agent');
+  });
+
+  it('returns undefined when no matching policy is assigned', () => {
+    expect(assignedAgentIdForMonitorLocation([], 'mon-1', 'loc-1')).toBeUndefined();
+    expect(
+      assignedAgentIdForMonitorLocation(
+        [{ id: 'mon-1-loc-1', condition: UNASSIGNED_CONDITION }],
+        'mon-1',
+        'loc-1'
+      )
+    ).toBeUndefined();
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/assign_by_condition.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/assign_by_condition.ts
@@ -94,6 +94,41 @@ export const agentIdFromCondition = (condition?: string | null): string | undefi
   return match ? match[1] : undefined;
 };
 
+/** Counts monitors pinned to each agent via a stamped `${agent.id}` condition. */
+export const countMonitorsByAssignedAgent = (
+  packagePolicies: ReadonlyArray<{ condition?: string | null }>
+): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const policy of packagePolicies) {
+    const agentId = agentIdFromCondition(policy.condition);
+    if (!agentId) {
+      continue;
+    }
+    counts.set(agentId, (counts.get(agentId) ?? 0) + 1);
+  }
+  return counts;
+};
+
+/**
+ * Assigned agent for one monitor at one location. Prefers the current
+ * `${configId}-${locationId}` package policy; falls back to a legacy
+ * space-suffixed id when the new format is absent.
+ */
+export const assignedAgentIdForMonitorLocation = (
+  packagePolicies: ReadonlyArray<{ id: string; condition?: string | null }>,
+  monitorId: string,
+  locationId: string
+): string | undefined => {
+  const newId = `${monitorId}-${locationId}`;
+  const exact = packagePolicies.find((policy) => policy.id === newId);
+  if (exact) {
+    return agentIdFromCondition(exact.condition);
+  }
+  const legacyPrefix = `${newId}-`;
+  const legacy = packagePolicies.find((policy) => policy.id.startsWith(legacyPrefix));
+  return legacy ? agentIdFromCondition(legacy.condition) : undefined;
+};
+
 /**
  * Rendezvous placement of a monitor onto one of the location's enrolled agents.
  * Returns the assigned agent id and its ready-to-stamp condition, or undefined

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/assign_by_condition.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/assign_by_condition.ts
@@ -94,13 +94,51 @@ export const agentIdFromCondition = (condition?: string | null): string | undefi
   return match ? match[1] : undefined;
 };
 
-/** Counts monitors pinned to each agent via a stamped `${agent.id}` condition. */
+/**
+ * Config id embedded in a package-policy id, or undefined when the id doesn't
+ * belong to this location. New format is `${configId}-${locationId}`; legacy
+ * space-suffixed format is `${configId}-${locationId}-${spaceId}`, so the
+ * location id is an infix — `indexOf` (not a fixed trailing strip) handles both.
+ */
+export const configIdOf = (policyId: string, locationId: string): string | undefined => {
+  const idx = policyId.indexOf(`-${locationId}`);
+  return idx > 0 ? policyId.slice(0, idx) : undefined;
+};
+
+const isNewFormatPolicyId = (policyId: string, locationId: string): boolean =>
+  policyId.endsWith(`-${locationId}`);
+
+/**
+ * Counts unique monitors pinned to each agent via a stamped `${agent.id}`
+ * condition. A monitor can have both a new-format package policy
+ * (`${configId}-${locationId}`) and a leftover legacy twin
+ * (`${configId}-${locationId}-${spaceId}`); those count as one monitor. The
+ * new-format policy wins when both exist. Policies with no condition, or the
+ * all-agents sentinel, are skipped.
+ */
 export const countMonitorsByAssignedAgent = (
-  packagePolicies: ReadonlyArray<{ condition?: string | null }>
+  packagePolicies: ReadonlyArray<{ id: string; condition?: string | null }>,
+  locationId: string
 ): Map<string, number> => {
-  const counts = new Map<string, number>();
+  const chosen = new Map<string, { condition?: string | null; isNewFormat: boolean }>();
   for (const policy of packagePolicies) {
-    const agentId = agentIdFromCondition(policy.condition);
+    const configId = configIdOf(policy.id, locationId);
+    if (!configId) {
+      continue;
+    }
+    const isNewFormat = isNewFormatPolicyId(policy.id, locationId);
+    const existing = chosen.get(configId);
+    if (existing?.isNewFormat && !isNewFormat) {
+      continue;
+    }
+    if (!existing || isNewFormat) {
+      chosen.set(configId, { condition: policy.condition, isNewFormat });
+    }
+  }
+
+  const counts = new Map<string, number>();
+  for (const { condition } of chosen.values()) {
+    const agentId = agentIdFromCondition(condition);
     if (!agentId) {
       continue;
     }

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/rebalance_writes.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/rebalance_writes.ts
@@ -7,19 +7,10 @@
 
 import type { PackagePolicy, UpdatePackagePolicyWithId } from '@kbn/fleet-plugin/common';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
-import { agentIdCondition, agentIdFromCondition } from './assign_by_condition';
+import { agentIdCondition, agentIdFromCondition, configIdOf } from './assign_by_condition';
 import { getMonitorCostMib, type MonitorPlacement } from './assign_shards';
 
-/**
- * Config id embedded in a package-policy id, or undefined when the id doesn't
- * belong to this location. New format is `${configId}-${locationId}`; legacy
- * space-suffixed format is `${configId}-${locationId}-${spaceId}`, so the
- * location id is an infix — `indexOf` (not a fixed trailing strip) handles both.
- */
-export const configIdOf = (policyId: string, locationId: string): string | undefined => {
-  const idx = policyId.indexOf(`-${locationId}`);
-  return idx > 0 ? policyId.slice(0, idx) : undefined;
-};
+export { configIdOf };
 
 /**
  * Monitor type of a synthetics package policy, read from its single enabled


### PR DESCRIPTION
## 📋 Summary

Finishes the leftover slice of **#281845**. [#282390](https://github.com/elastic/kibana/pull/282390) shipped the private-location agents table, flyouts, and a classic **Location agents** list. This PR wires those surfaces to the stamped `${agent.id}` conditions so scalable locations show **real per-agent distribution** and a true **Assigned agent** on monitor details.

Closes #281845

## ✨ What's included

| Surface | Classic (`isAgentSharding` off) | Scalable (`isAgentSharding: true`) |
|---|---|---|
| Private locations table | Location monitor count + **100%** per enrolled agent | Monitors assigned to that agent + **share %** |
| Monitor details | **Location agents** — every enrolled host | **Assigned agent** — the one matching the package-policy condition, or **Not yet assigned** |
| Agent flyout | Same monitors-run count as the location | Assigned-monitor count |

- New internal route **`GET /internal/synthetics/monitors/{monitorId}/agent_assignment`** — slim payload (`agentId`, `host`, `healthy`, `agentVersion` + location/policy metadata). Classic locations skip package-policy reads.
- **`GET /internal/synthetics/private_locations/agent_stats`** now returns `isAgentSharding` and `monitorsAssigned` (`null` on classic so the UI keeps 100%).
- Assignment helpers count / look up agents from stamped conditions (`countMonitorsByAssignedAgent`, `assignedAgentIdForMonitorLocation`).

## 📸 Screenshots

<table>
  <tr>
    <td align="center" width="50%">
      <a href="https://raw.githubusercontent.com/shahzad31/kibana/screenshots/screenshots/286781/02_private_locations_expanded.png"><img src="https://raw.githubusercontent.com/shahzad31/kibana/screenshots/screenshots/286781/02_private_locations_expanded.png" width="440"/></a><br/>
      <sub><b>Private locations</b> — scalable row expanded; agents show 1/3 → 33% and 2/3 → 67%</sub>
    </td>
    <td align="center" width="50%">
      <a href="https://raw.githubusercontent.com/shahzad31/kibana/screenshots/screenshots/286781/01_agents_overview_sharded.png"><img src="https://raw.githubusercontent.com/shahzad31/kibana/screenshots/screenshots/286781/01_agents_overview_sharded.png" width="440"/></a><br/>
      <sub><b>Agents overview</b> — real assigned-monitor counts and share %</sub>
    </td>
  </tr>
  <tr>
    <td align="center">
      <a href="https://raw.githubusercontent.com/shahzad31/kibana/screenshots/screenshots/286781/03_agent_details_flyout.png"><img src="https://raw.githubusercontent.com/shahzad31/kibana/screenshots/screenshots/286781/03_agent_details_flyout.png" width="280"/></a><br/>
      <sub><b>Agent flyout</b> — monitors run is the assigned count (1)</sub>
    </td>
    <td align="center">
      <a href="https://raw.githubusercontent.com/shahzad31/kibana/screenshots/screenshots/286781/04_assigned_agent_monitor_details.png"><img src="https://raw.githubusercontent.com/shahzad31/kibana/screenshots/screenshots/286781/04_assigned_agent_monitor_details.png" width="440"/></a><br/>
      <sub><b>Monitor details</b> — <b>Assigned agent</b> is the single host matching the condition</sub>
    </td>
  </tr>
</table>

> Click any thumbnail to open it full size.

## 🎯 Scope notes

- Operators still cannot turn sharding on from the UI — that is **#281844**. Until that ships, set `isAgentSharding: true` via the private-location API to exercise this PR.
- Classic locations are unchanged: every enrolled agent still runs every monitor.
- Create/edit toggle + Scalable badge are **out of scope**.

## ✅ Test plan

- [ ] **Classic location** — expand Agents overview: each agent shows the location monitor count and **100%**. Monitor details still lists every enrolled host under **Location agents**.
- [ ] **Scalable location** (`isAgentSharding: true`, ≥2 agents, monitors assigned) — table shows real assigned counts and shares (e.g. 1/3 → 33%, 2/3 → 67%). Agent flyout matches the assigned count.
- [ ] **Monitor details (scalable)** — **Assigned agent** shows the single host matching the package-policy condition; Fleet agent + policy links work when the user has `fleet.readAgents` / `fleet.readAgentPolicies`.
- [ ] **Unassigned** — sentinel / missing condition shows **Not yet assigned** (not every enrolled host).
- [ ] **Flyouts** — row click still opens agent / policy flyouts; Fleet deep links still work.
- [ ] **No System integration** — memory/CPU stay **N/A** (unchanged from #282390).

## 🧪 Automated

- Jest: assignment helpers, `get_agent_stats`, assignment route, location table shares, assigned-agent section, agent + policy flyouts.
