### PR TITLE
Remove `ci-batch-3h` from default test channel list

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/env_config.test.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/env_config.test.ts
@@ -31,9 +31,9 @@ describe('loadRunOrderConfig', () => {
     process.env = originalEnv;
   });
 
-  it('defaults ftrTestChannels to {ci-on-commit, ci-batch-3h} when FTR_TEST_CHANNELS is unset', () => {
+  it('defaults ftrTestChannels to {ci-on-commit} when FTR_TEST_CHANNELS is unset', () => {
     const cfg = loadRunOrderConfig();
-    expect(cfg.ftrTestChannels).toEqual(new Set(['ci-on-commit', 'ci-batch-3h']));
+    expect(cfg.ftrTestChannels).toEqual(new Set(['ci-on-commit']));
   });
 
   it('applies sensible defaults when nothing is set', () => {

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/ftr_manifests.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/ftr_manifests.ts
@@ -52,7 +52,7 @@ export const ftrManifest: {
 } = {
   default: {
     queue: 'n2-4-spot',
-    channels: new Set(['ci-on-commit', 'ci-batch-3h']),
+    channels: new Set(['ci-on-commit']),
   },
   paths: {
     stateful: statefulFTRManifestPaths,

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/test_channels.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order/test_channels.ts
@@ -29,7 +29,7 @@ export const ftrTestChannels: {
   default: Set<FTRTestChannel>;
 } = {
   all: new Set(COMPLETE_CHANNEL_LIST),
-  default: new Set(['ci-on-commit', 'ci-batch-3h']),
+  default: new Set(['ci-on-commit']),
 };
 
 export const ftrTestChannel = {

--- a/src/platform/packages/private/kbn-scout-info/src/test_channels.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/test_channels.ts
@@ -41,7 +41,7 @@ export const testChannels: {
   current(): ScoutTestChannel[];
 } = {
   all: ScoutTestChannelSchema.options,
-  default: ['ci-on-commit', 'ci-batch-3h'],
+  default: ['ci-on-commit'],
   match(pattern) {
     return this.all.filter((channel) => channel.match(pattern));
   },


### PR DESCRIPTION
## Summary
Only `ci-on-commit` needs to be in the default test channel list. Batch pipelines can choose to include `ci-on-commit` when it makes sense rather than having everything added to the 3h batch channel by default.

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->