### PR TITLE
[8.19] [ResponseOps] Add missing error message to rule form. (#284656)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/cases_params.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/cases_params.test.tsx
@@ -234,6 +234,20 @@ describe('CasesParamsFields renders', () => {
       expect(editAction.mock.calls[0][1].groupingBy).toEqual(['alert.name']);
     });
 
+    it('shows an error when the typed grouping by field does not match any field', async () => {
+      render(<CasesParamsFields {...defaultProps} />);
+
+      await user.click(await screen.findByTestId('group-by-alert-field-combobox'));
+
+      await showEuiComboBoxOptions();
+
+      await user.type(await screen.findByTestId('comboBoxSearchInput'), 'foobar');
+
+      expect(
+        await screen.findByText('Invalid field. Select a field from the list.')
+      ).toBeInTheDocument();
+    });
+
     it('renders default template correctly', async () => {
       render(<CasesParamsFields {...defaultProps} />);
 

--- a/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/cases_params.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/cases_params.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useEffect, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { ActionParamsProps } from '@kbn/triggers-actions-ui-plugin/public/types';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
@@ -162,6 +162,19 @@ export const CasesParamsFieldsComponent: React.FunctionComponent<
     [editSubActionProperty]
   );
 
+  /**
+   * EuiComboBox marks itself as invalid when the typed text does not resolve to a selected option,
+   * so the same condition drives the error message shown to the user.
+   */
+  const [groupingByInvalidSearch, setGroupingByInvalidSearch] = useState(false);
+
+  const onGroupingBySearchChange = useCallback(
+    (searchValue: string, hasMatchingOptions = false) => {
+      setGroupingByInvalidSearch(searchValue.length > 0 && !hasMatchingOptions);
+    },
+    []
+  );
+
   const options: Array<EuiComboBoxOptionOption<string>> = useMemo(() => {
     if (!dataView) {
       return [];
@@ -214,7 +227,13 @@ export const CasesParamsFieldsComponent: React.FunctionComponent<
     <>
       <EuiFlexGroup>
         <EuiFlexItem grow={true}>
-          <EuiFormRow fullWidth label={i18n.GROUP_BY_ALERT} labelAppend={OptionalFieldLabel}>
+          <EuiFormRow
+            fullWidth
+            label={i18n.GROUP_BY_ALERT}
+            labelAppend={OptionalFieldLabel}
+            isInvalid={groupingByInvalidSearch}
+            error={groupingByInvalidSearch ? [i18n.GROUP_BY_ALERT_INVALID_FIELD_ERROR] : []}
+          >
             <EuiComboBox
               fullWidth
               isClearable={true}
@@ -222,8 +241,10 @@ export const CasesParamsFieldsComponent: React.FunctionComponent<
               data-test-subj="group-by-alert-field-combobox"
               isLoading={loadingAlertDataViews}
               isDisabled={loadingAlertDataViews}
+              isInvalid={groupingByInvalidSearch}
               options={options}
               onChange={onChangeComboBox}
+              onSearchChange={onGroupingBySearchChange}
               selectedOptions={selectedOptions}
             />
           </EuiFormRow>

--- a/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/system_actions/cases/translations.ts
@@ -21,6 +21,13 @@ export const GROUP_BY_ALERT = i18n.translate(
   }
 );
 
+export const GROUP_BY_ALERT_INVALID_FIELD_ERROR = i18n.translate(
+  'xpack.cases.systemActions.casesConnector.groupByAlertInvalidFieldError',
+  {
+    defaultMessage: 'Invalid field. Select a field from the list.',
+  }
+);
+
 export const TIME_WINDOW = i18n.translate(
   'xpack.cases.systemActions.casesConnector.timeWindowLabel',
   {


### PR DESCRIPTION
Backport
This will backport the following commits from main to 8.19:

https://github.com/elastic/kibana/pull/284656
Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)