### PR TITLE
[8.19] [Security] Fix PKI session invalidation on HTTP/2 stream destruction (#285153)

### DIFF
--- a/src/core/packages/http/router-server-internal/src/socket.test.ts
+++ b/src/core/packages/http/router-server-internal/src/socket.test.ts
@@ -169,4 +169,41 @@ describe('KibanaSocket', () => {
       await expect(fakeSocket.renegotiate({})).resolves.toBeUndefined();
     });
   });
+
+  describe('HTTP/2 stream-destruction degraded state', () => {
+    // When an HTTP/2 stream is destroyed mid-request (RST_STREAM from an AbortController cancel,
+    // browser navigation, or search abort), Node.js clears the stream's internal session reference.
+    // The Http2ServerRequest.socket proxy's getPrototypeOf trap then falls back from the TLSSocket
+    // prototype to the Http2Stream prototype, causing instanceof TLSSocket to return false.
+    //
+    // KibanaSocket wraps this proxy. With instanceof TLSSocket returning false, all TLS-specific
+    // accessors degrade. A plain net.Socket (not TLSSocket) produces the same behaviour from
+    // KibanaSocket's perspective and is used here as a test double for the destroyed-stream proxy.
+    //
+    // The critical invariant this tests: authorized === undefined means "socket state is unknown"
+    // (the stream was destroyed before we could read it), NOT "the cert was rejected." Code that
+    // reads authorized must treat undefined differently from false. See kibana#258232.
+
+    it('returns undefined for authorized when the underlying socket is not a TLSSocket', () => {
+      const socket = new KibanaSocket(new Socket());
+      // undefined = state unknown; false = cert explicitly rejected. These are not equivalent.
+      expect(socket.authorized).toBeUndefined();
+      expect(socket.authorized).not.toBe(false);
+    });
+
+    it('returns null for getPeerCertificate when the underlying socket is not a TLSSocket', () => {
+      const socket = new KibanaSocket(new Socket());
+      expect(socket.getPeerCertificate(true)).toBeNull();
+    });
+
+    it('returns null for getProtocol when the underlying socket is not a TLSSocket', () => {
+      const socket = new KibanaSocket(new Socket());
+      expect(socket.getProtocol()).toBeNull();
+    });
+
+    it('returns undefined for authorizationError when the underlying socket is not a TLSSocket', () => {
+      const socket = new KibanaSocket(new Socket());
+      expect(socket.authorizationError).toBeUndefined();
+    });
+  });
 });

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/pki_stress/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/pki_stress/stateful/classic.stateful.config.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { resolve } from 'path';
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { ScoutServerConfig } from '../../../../../types';
+import { pkiConfig } from '../../pki/stateful/base.config';
+
+// PKI stress/regression suites (test/scout_pki_stress) drive test-only routes — currently the
+// pre-auth holds used to park a request inside PKI authenticate — that are exposed by the security
+// functional-test plugin, so it has to be loaded at startup.
+//
+// This lives here rather than in the shared `pki` config set so the PKI login specs
+// (test/scout_pki/ui) don't boot a plugin they never call. That matters beyond boot cost: those
+// specs authenticate via PKI, and this plugin patches `PKIAuthenticationProvider.authenticate`,
+// so keeping it out means they exercise an unmodified auth provider.
+const pluginPath = `--plugin-path=${resolve(
+  REPO_ROOT,
+  'x-pack/platform/test/security_functional/plugins/test_endpoints'
+)}`;
+
+export const servers: ScoutServerConfig = {
+  ...pkiConfig,
+  // Matches the `pki` set. Required by the HTTP/2 stream-cancel spec, which needs RST_STREAM.
+  http2: true,
+  kbnTestServer: {
+    ...pkiConfig.kbnTestServer,
+    serverArgs: [...pkiConfig.kbnTestServer.serverArgs, pluginPath],
+  },
+};

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/pki.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/pki.test.ts
@@ -130,6 +130,24 @@ describe('PKIAuthenticationProvider', () => {
       );
     });
 
+    it('does not handle requests when socket authorization state is unknown due to HTTP/2 stream destruction.', async () => {
+      // Simulates the HTTP/2 degraded socket: when a stream is destroyed (RST_STREAM / AbortController
+      // cancel), Node's Http2ServerRequest.socket proxy's getPrototypeOf trap falls back to the
+      // Http2Stream prototype, causing instanceof TLSSocket to return false in KibanaSocket. This
+      // makes authorized === undefined and getPeerCertificate === null. A plain net.Socket (not a
+      // TLSSocket) produces the same KibanaSocket behaviour and is used here to simulate that state.
+      const request = httpServerMock.createKibanaRequest({ socket: new Socket() });
+
+      await expect(operation(request)).resolves.toEqual(AuthenticationResult.notHandled());
+
+      expect(mockOptions.client.asScoped).not.toHaveBeenCalled();
+      expect(mockOptions.client.asInternalUser.transport.request).not.toHaveBeenCalled();
+      expectDebugLogs(
+        'Peer certificate chain: []',
+        'Authentication is not possible since socket authorization state is unknown (the HTTP/2 stream may have been cancelled before authentication completed).'
+      );
+    });
+
     it('does not handle requests with a missing certificate chain.', async () => {
       const { socket } = getMockSocket({ authorized: true, peerCertificate: null });
       const request = httpServerMock.createKibanaRequest({ socket });
@@ -460,6 +478,36 @@ describe('PKIAuthenticationProvider', () => {
         AuthenticationResult.failed(new Error('Peer certificate is not available'))
       );
 
+      expect(mockOptions.tokens.invalidate).not.toHaveBeenCalled();
+    });
+
+    it('does not invalidate token or destroy session when socket state is unknown due to HTTP/2 stream destruction.', async () => {
+      // Regression test for kibana#258232. When a stream is destroyed (RST_STREAM from an
+      // AbortController or browser navigation cancel), Node's Http2ServerRequest.socket proxy's
+      // getPrototypeOf trap falls back to Http2Stream prototype. instanceof TLSSocket returns false
+      // in KibanaSocket, making authorized === undefined and getPeerCertificate === null.
+      //
+      // The old guard `peerCertificate === null && request.socket.authorized` evaluated
+      // `true && undefined` as falsy and missed. The code then entered the token-invalidation
+      // block, revoked the ES access token, and returned notHandled() — which authenticate()
+      // converted to Boom.unauthorized(), causing updateSessionValue() to delete the session.
+      //
+      // The fix changes the guard to `authorized !== false`, treating undefined (unknown TLS state)
+      // the same as true (known-authorized state). Only false (definitively unauthorized) should
+      // trigger token invalidation. A plain net.Socket (not TLSSocket) produces the same
+      // KibanaSocket behaviour as the destroyed-stream proxy and is used here as a test double.
+      const request = httpServerMock.createKibanaRequest({ socket: new Socket() });
+      const sessionValue = sessionMock.createValue({
+        state: { accessToken: 'token', peerCertificateFingerprint256: '2A:7A:C2:DD' },
+      });
+
+      await expect(provider.authenticate(request, sessionValue)).resolves.toEqual(
+        AuthenticationResult.failed(new Error('Peer certificate is not available'))
+      );
+
+      // Token MUST NOT be invalidated: socket state is unknown, not definitively unauthorized.
+      // Invalidating the token here revokes the ES access token shared by all concurrent requests
+      // on this Kibana session and triggers session destruction via updateSessionValue() on 401.
       expect(mockOptions.tokens.invalidate).not.toHaveBeenCalled();
     });
 

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/pki.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/pki.ts
@@ -204,8 +204,16 @@ export class PKIAuthenticationProvider extends BaseAuthenticationProvider {
     // If peer is authorized, but its certificate isn't available, that likely means the connection
     // with the peer is closed already. We shouldn't invalidate peer's access token in this case
     // since we cannot guarantee that there is a mismatch in access token and peer certificate.
+    //
+    // Under HTTP/2, when a stream is destroyed mid-request (e.g. RST_STREAM from an AbortController
+    // cancellation), Node's Http2ServerRequest.socket returns a Proxy over the destroyed stream.
+    // After stream destruction, stream.session is cleared and the Proxy's getPrototypeOf trap
+    // falls back to the Http2Stream prototype, causing `instanceof TLSSocket` to return false in
+    // KibanaSocket. This makes `socket.authorized` return `undefined` (not `true` or `false`).
+    // We must treat `undefined` the same as `true` here — both indicate the socket state is
+    // indeterminate or was previously authorized. Only `false` means "definitively unauthorized."
     const peerCertificate = request.socket.getPeerCertificate(true);
-    if (peerCertificate === null && request.socket.authorized) {
+    if (peerCertificate === null && request.socket.authorized !== false) {
       this.logger.debug(
         'Cannot validate state access token with the peer certificate since it is not available.'
       );
@@ -266,8 +274,14 @@ export class PKIAuthenticationProvider extends BaseAuthenticationProvider {
     );
 
     if (!request.socket.authorized) {
+      // `authorized === false` means the peer cert was presented but rejected (e.g. untrusted CA).
+      // `authorized === undefined` means socket state is unknowable, typically because the HTTP/2
+      // stream was destroyed (RST_STREAM) before or during the auth lifecycle — see pki.ts comment
+      // in authenticateViaState for details.
       this.logger.debug(
-        `Authentication is not possible since peer certificate was not authorized: ${request.socket.authorizationError}.`
+        request.socket.authorized === false
+          ? `Authentication is not possible since peer certificate was not authorized: ${request.socket.authorizationError}.`
+          : 'Authentication is not possible since socket authorization state is unknown (the HTTP/2 stream may have been cancelled before authentication completed).'
       );
       return AuthenticationResult.notHandled();
     }

--- a/x-pack/platform/plugins/shared/security/test/scout_pki_stress/.meta/api/standard.json
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki_stress/.meta/api/standard.json
@@ -1,0 +1,23 @@
+{
+  "sha1": "",
+  "testChannels": [
+    "ci-on-commit",
+    "ci-batch-3h"
+  ],
+  "tests": [
+    {
+      "id": "ef1a2f35345926a-0680a03337668fd",
+      "title": "PKI HTTP/2 stream cancel cancelling one stream during PKI auth does not revoke the session",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/tests/pki_http2_stream_cancel.spec.ts",
+        "line": 35,
+        "column": 5
+      }
+    }
+  ]
+}

--- a/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/fixtures/constants.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/fixtures/constants.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { readFileSync } from 'fs';
+
+export const COMMON_HEADERS = {
+  'kbn-xsrf': 'some-xsrf-token',
+  'x-elastic-internal-origin': 'kibana',
+  'Content-Type': 'application/json;charset=UTF-8',
+};
+
+export const FIRST_CLIENT_P12 = readFileSync(
+  require.resolve('@kbn/security-api-integration-helpers/pki/first_client.p12')
+);

--- a/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/fixtures/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest as baseApiTest } from '@kbn/scout';
+
+import { FIRST_CLIENT_P12 } from './constants';
+import { PkiHttp2Client } from './pki_http2_client';
+
+export interface PkiApiTestFixtures {
+  pkiHttp2: PkiHttp2Client;
+}
+
+export const apiTest = baseApiTest.extend<PkiApiTestFixtures>({
+  pkiHttp2: async ({ config }, use) => {
+    const client = new PkiHttp2Client(config.hosts.kibana, FIRST_CLIENT_P12);
+    await client.connect();
+    await use(client);
+    client.close();
+  },
+});
+
+export * as testData from './constants';

--- a/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/fixtures/pki_http2_client.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/fixtures/pki_http2_client.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { readFileSync } from 'fs';
+import http2 from 'http2';
+import type { IncomingHttpHeaders } from 'http2';
+
+import { CA_CERT_PATH } from '@kbn/dev-utils';
+import { findSessionCookie } from '@kbn/security-api-integration-helpers';
+
+export interface PkiHttp2RequestOptions {
+  path: string;
+  headers?: Record<string, string>;
+}
+
+export interface PkiHttp2Response {
+  statusCode: number;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+/** HTTP/2 client that exposes streams so tests can RST after a server-side pre-auth hold parks. */
+export class PkiHttp2Client {
+  private session: http2.ClientHttp2Session | undefined;
+
+  constructor(private readonly kibanaUrl: string, private readonly pfx: Buffer) {}
+
+  async connect(): Promise<void> {
+    const session = http2.connect(this.kibanaUrl, {
+      pfx: this.pfx,
+      passphrase: '',
+      ca: readFileSync(CA_CERT_PATH),
+    });
+
+    this.session = await new Promise<http2.ClientHttp2Session>((resolve, reject) => {
+      session.once('connect', () => resolve(session));
+      session.once('error', reject);
+    });
+  }
+
+  request({ path, headers = {} }: PkiHttp2RequestOptions): {
+    stream: http2.ClientHttp2Stream;
+    response: Promise<PkiHttp2Response>;
+  } {
+    if (!this.session) {
+      throw new Error('PkiHttp2Client.connect() must be called before request()');
+    }
+
+    const stream = this.session.request({
+      ':method': 'GET',
+      ':path': path,
+      ...headers,
+    });
+    stream.end();
+
+    let statusCode = 0;
+    let responseHeaders: IncomingHttpHeaders = {};
+    let body = '';
+
+    const response = new Promise<PkiHttp2Response>((resolve) => {
+      stream.on('response', (h) => {
+        responseHeaders = h;
+        statusCode = Number(h[':status']);
+      });
+      stream.setEncoding('utf8');
+      stream.on('data', (chunk) => {
+        body += chunk;
+      });
+      stream.on('end', () => {
+        resolve({ statusCode, headers: responseHeaders, body });
+      });
+      // RST_STREAM (NGHTTP2_CANCEL) is an expected test signal. A locally cancelled stream
+      // emits 'close' without 'end' or 'error', so settle on 'close' as well.
+      stream.on('error', () => {
+        resolve({ statusCode, headers: responseHeaders, body });
+      });
+      stream.on('close', () => {
+        resolve({ statusCode, headers: responseHeaders, body });
+      });
+    });
+
+    return { stream, response };
+  }
+
+  sidCookieString(headers: IncomingHttpHeaders): string {
+    return findSessionCookie(headers['set-cookie']).cookieString();
+  }
+
+  close(): void {
+    this.session?.close();
+    this.session = undefined;
+  }
+}

--- a/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/tests/pki_http2_stream_cancel.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki_stress/api/tests/pki_http2_stream_cancel.spec.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { randomUUID } from 'crypto';
+import http2 from 'http2';
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+
+import { apiTest, testData } from '../fixtures';
+
+const PREAUTH_HOLD_HEADER = 'x-elastic-preauth-hold';
+
+// Parks inside PKI authenticate (not onPreAuth). RST during onPreAuth makes Hapi skip Auth, so
+// the session is never at risk and this spec would pass even without the pki.ts guard.
+apiTest.describe('PKI HTTP/2 stream cancel', { tag: tags.stateful.classic }, () => {
+  apiTest.beforeAll(async ({ esClient }) => {
+    await esClient.security.putRoleMapping({
+      name: 'first_client_pki',
+      enabled: true,
+      roles: ['kibana_admin'],
+      rules: { field: { dn: 'CN=first_client' } },
+    });
+  });
+
+  apiTest.afterAll(async ({ esClient }) => {
+    await esClient.security.deleteRoleMapping({ name: 'first_client_pki' }, { ignore: [404] });
+  });
+
+  apiTest(
+    'cancelling one stream during PKI auth does not revoke the session',
+    async ({ apiClient, pkiHttp2 }) => {
+      const holdId = randomUUID();
+
+      const sidCookie = await apiTest.step('login', async () => {
+        const login = pkiHttp2.request({ path: '/security/account' });
+        const loginResponse = await login.response;
+        expect(loginResponse.statusCode).toBe(200);
+        return pkiHttp2.sidCookieString(loginResponse.headers);
+      });
+
+      const getHoldStatus = async () => {
+        const status = await apiClient.get(`authentication/preauth_holds/${holdId}`, {
+          headers: testData.COMMON_HEADERS,
+          responseType: 'json',
+        });
+        return status.body as {
+          parked: boolean;
+          continuedAfterHold: boolean;
+          authCompleted: boolean;
+          authorized: boolean | null;
+          peerCertificateNull: boolean;
+        };
+      };
+
+      const victim = pkiHttp2.request({
+        path: '/internal/security/me',
+        headers: {
+          ...testData.COMMON_HEADERS,
+          cookie: sidCookie,
+          [PREAUTH_HOLD_HEADER]: holdId,
+        },
+      });
+
+      await apiTest.step('park inside PKI authenticate', async () => {
+        await expect.poll(async () => (await getHoldStatus()).parked).toBe(true);
+        const parked = await getHoldStatus();
+        expect(parked.authorized).toBe(true);
+        expect(parked.peerCertificateNull).toBe(false);
+      });
+
+      await apiTest.step('RST until the parked socket is degraded', async () => {
+        victim.stream.close(http2.constants.NGHTTP2_CANCEL);
+        // Requiring `continuedAfterHold === false` pins the degradation to the RST arriving
+        // while the hold is still parked. Without it, a hold that times out degrades the
+        // socket the same way once the request completes normally, and this step would pass
+        // without exercising the destroyed-socket-during-auth path.
+        await expect
+          .poll(async () => {
+            const hold = await getHoldStatus();
+            return (
+              hold.continuedAfterHold === false &&
+              hold.peerCertificateNull === true &&
+              hold.authorized !== true
+            );
+          })
+          .toBe(true);
+      });
+
+      await apiTest.step('release', async () => {
+        const releaseResponse = await apiClient.post(
+          `authentication/preauth_holds/${holdId}/release`,
+          {
+            headers: testData.COMMON_HEADERS,
+            responseType: 'json',
+          }
+        );
+        expect(releaseResponse).toHaveStatusCode(200);
+
+        await expect.poll(async () => (await getHoldStatus()).continuedAfterHold).toBe(true);
+        // Wait until authenticateViaState has finished invalidating (or preserving) the session.
+        // continuedAfterHold is set before that work runs; following up too early races a 200.
+        await expect.poll(async () => (await getHoldStatus()).authCompleted).toBe(true);
+      });
+
+      await apiTest.step('follow-up', async () => {
+        const followUp = pkiHttp2.request({
+          path: '/internal/security/me',
+          headers: {
+            ...testData.COMMON_HEADERS,
+            cookie: sidCookie,
+          },
+        });
+        const followUpResponse = await followUp.response;
+        expect(followUpResponse.statusCode).toBe(200);
+        expect(JSON.parse(followUpResponse.body)).toMatchObject({
+          username: 'first_client',
+          authentication_provider: { type: 'pki', name: 'pki1' },
+        });
+      });
+    }
+  );
+});

--- a/x-pack/platform/test/security_api_integration/tests/pki/pki_http2_stress.ts
+++ b/x-pack/platform/test/security_api_integration/tests/pki/pki_http2_stress.ts
@@ -180,11 +180,15 @@ export default function ({ getService }: FtrProviderContext) {
           authorized: boolean | null;
           peerCertificateNull: boolean;
         }> => {
-          // The hold status route has authc.enabled=false — no client cert required.
-          // CA cert is still needed because Kibana is running with TLS enabled.
+          // The client certificate is required even though this route sets authc.enabled=false:
+          // pki.config.ts runs Kibana with `server.ssl.clientAuthentication=required`, which maps to
+          // Node TLS `requestCert: true, rejectUnauthorized: true` (see kbn-server-http-tools
+          // ssl_config.ts). A certless connection is rejected during the TLS handshake, before
+          // routing — so skipping app-layer auth does not remove the mutual-TLS requirement.
           const response = await supertest
             .get(`/authentication/preauth_holds/${holdId}`)
             .ca(CA_CERT)
+            .pfx(FIRST_CLIENT_CERT)
             .set('kbn-xsrf', 'xxx')
             .expect(200);
           return response.body;
@@ -203,7 +207,9 @@ export default function ({ getService }: FtrProviderContext) {
 
         // Wait until parked — the hold route reports parked=true once the wrapped authenticate
         // function has received the request and is waiting for the release signal.
-        await retry.tryForTime(8000, async () => {
+        // Kept well under PREAUTH_HOLD_TIMEOUT_MS (10s): that budget starts when the request parks
+        // and has to cover step 3 too, so a failure to park must surface quickly rather than eat it.
+        await retry.tryForTime(5000, async () => {
           const status = await getHoldStatus();
           if (!status.parked) {
             throw new Error(`Hold ${holdId} not yet parked`);
@@ -222,26 +228,43 @@ export default function ({ getService }: FtrProviderContext) {
         // normal hold timeout, which would also degrade the socket after the fact).
         victim.stream.close(http2.constants.NGHTTP2_CANCEL);
 
+        // continuedAfterHold latches true permanently once the hold resolves, so once it is true the
+        // condition below can never be satisfied: the RST failed to degrade the socket before
+        // PREAUTH_HOLD_TIMEOUT_MS (10s) expired and the hold self-released. retry.tryForTime() retries
+        // on any throw, so signalling that by throwing would just poll for the full timeout and report
+        // a misleading "not yet degraded". Instead, record it and return so the retry exits at once,
+        // then surface the real cause outside the loop.
+        let holdExpiredBeforeDegradation: string | undefined;
+
         await retry.tryForTime(8000, async () => {
           const hold = await getHoldStatus();
-          if (
-            !(
-              hold.continuedAfterHold === false &&
-              hold.peerCertificateNull === true &&
-              hold.authorized !== true
-            )
-          ) {
+
+          if (hold.continuedAfterHold === true) {
+            holdExpiredBeforeDegradation =
+              `Hold ${holdId} self-released before the RST degraded the socket ` +
+              `(PREAUTH_HOLD_TIMEOUT_MS elapsed). The test is not exercising the ` +
+              `destroyed-socket-during-auth path. ` +
+              `peerCertificateNull=${hold.peerCertificateNull} authorized=${hold.authorized}`;
+            return;
+          }
+
+          if (!(hold.peerCertificateNull === true && hold.authorized !== true)) {
             throw new Error(
               `Socket not yet degraded while parked: continuedAfterHold=${hold.continuedAfterHold} peerCertificateNull=${hold.peerCertificateNull} authorized=${hold.authorized}`
             );
           }
         });
 
+        if (holdExpiredBeforeDegradation) {
+          throw new Error(holdExpiredBeforeDegradation);
+        }
+
         // Step 4: release — let PKI authenticate continue with the degraded socket.
-        // The release route also has authc.enabled=false.
+        // Client certificate required for the TLS handshake, as above.
         await supertest
           .post(`/authentication/preauth_holds/${holdId}/release`)
           .ca(CA_CERT)
+          .pfx(FIRST_CLIENT_CERT)
           .set('kbn-xsrf', 'xxx')
           .expect(200);
 
@@ -273,7 +296,10 @@ export default function ({ getService }: FtrProviderContext) {
 
         const followUpBody = JSON.parse(followUpResponse.body);
         expect(followUpBody.username).to.be('first_client');
-        expect(followUpBody.authentication_provider).to.eql({ type: 'pki', name: 'pki1' });
+        // The Kibana *provider* is named 'pki' because pki.config.ts uses the array form
+        // `authc.providers=['pki','basic']`, where the provider name equals its type. 'pki1' is the
+        // Elasticsearch *realm* name and surfaces in `authentication_realm`, not here.
+        expect(followUpBody.authentication_provider).to.eql({ name: 'pki', type: 'pki' });
       } finally {
         pkiHttp2.close();
       }

--- a/x-pack/platform/test/security_functional/plugins/test_endpoints/server/init_routes.ts
+++ b/x-pack/platform/test/security_functional/plugins/test_endpoints/server/init_routes.ts
@@ -8,7 +8,12 @@
 import { errors } from '@elastic/elasticsearch';
 
 import { schema } from '@kbn/config-schema';
-import type { CoreSetup, CoreStart, PluginInitializerContext } from '@kbn/core/server';
+import type {
+  CoreSetup,
+  CoreStart,
+  KibanaRequest,
+  PluginInitializerContext,
+} from '@kbn/core/server';
 import { ROUTE_TAG_AUTH_FLOW } from '@kbn/security-plugin/server';
 import { restApiKeySchema } from '@kbn/security-plugin-types-server';
 import type {
@@ -42,6 +47,230 @@ export function initRoutes(
   );
 
   const router = core.http.createRouter();
+
+  const PREAUTH_HOLD_HEADER = 'x-elastic-preauth-hold';
+  const PREAUTH_HOLD_ID_MAX_LENGTH = 64;
+  const PREAUTH_HOLD_TIMEOUT_MS = 10_000;
+  const PREAUTH_HOLD_PATH_PREFIX = '/authentication/preauth_holds';
+
+  interface PreauthHoldSocketSnapshot {
+    authorized: boolean | null;
+    peerCertificateNull: boolean;
+  }
+
+  interface PreauthHoldState {
+    parked: boolean;
+    continuedAfterHold: boolean;
+    authCompleted: boolean;
+    snapshotSocket: () => PreauthHoldSocketSnapshot;
+    release: () => void;
+  }
+
+  const preauthHolds = new Map<string, PreauthHoldState>();
+
+  const readHoldId = (value: string | string[] | undefined): string | undefined => {
+    if (value === undefined) {
+      return undefined;
+    }
+    const holdId = Array.isArray(value) ? value[0] : value;
+    if (!holdId || holdId.length > PREAUTH_HOLD_ID_MAX_LENGTH) {
+      return undefined;
+    }
+    return holdId;
+  };
+
+  const snapshotSocket = (request: KibanaRequest): PreauthHoldSocketSnapshot => ({
+    authorized: request.socket.authorized ?? null,
+    peerCertificateNull: request.socket.getPeerCertificate(true) === null,
+  });
+
+  // Park inside PKIAuthenticationProvider.authenticate, not onPreAuth.
+  // Hapi's request cycle bails when `_isReplied` is set (see @hapi/hapi Request._lifecycle).
+  // RST_STREAM during onPreAuth emits `aborted`, Hapi replies immediately, and Auth never runs —
+  // so PKI never sees the destroyed-stream socket and the Scout test false-greens.
+  // Wrapping the already-loaded provider keeps us inside the in-flight Auth cycle function after
+  // session lookup, which is the window that invalidates the shared ES token (kibana#258232).
+  const findPkiAuthenticationProvider = () => {
+    for (const [moduleId, cached] of Object.entries(require.cache)) {
+      const normalizedId = moduleId.replaceAll('\\', '/');
+      if (normalizedId.includes('.test.')) {
+        continue;
+      }
+      if (
+        !normalizedId.endsWith('/authentication/providers/pki.ts') &&
+        !normalizedId.endsWith('/authentication/providers/pki.js')
+      ) {
+        continue;
+      }
+      const providerClass = (
+        cached?.exports as
+          | {
+              PKIAuthenticationProvider?: {
+                prototype: {
+                  authenticate: (request: KibanaRequest, session?: unknown) => Promise<unknown>;
+                };
+              };
+            }
+          | undefined
+      )?.PKIAuthenticationProvider;
+      if (typeof providerClass?.prototype.authenticate === 'function') {
+        return providerClass;
+      }
+    }
+    const pkiModules = Object.keys(require.cache)
+      .filter((moduleId) => moduleId.includes('pki'))
+      .join(', ');
+    throw new Error(
+      `security-test-endpoints could not locate PKIAuthenticationProvider to install the HTTP/2 preauth hold. pki modules in require.cache: ${
+        pkiModules || '(none)'
+      }`
+    );
+  };
+
+  let pkiAuthenticateHoldInstalled = false;
+  const installPkiAuthenticateHold = () => {
+    if (pkiAuthenticateHoldInstalled) {
+      return;
+    }
+
+    const pkiProviderClass = findPkiAuthenticationProvider();
+    const originalPkiAuthenticate = pkiProviderClass.prototype.authenticate;
+    pkiProviderClass.prototype.authenticate = async function wrappedPkiAuthenticate(
+      this: unknown,
+      request: KibanaRequest,
+      session?: unknown
+    ) {
+      const holdId = readHoldId(request.headers[PREAUTH_HOLD_HEADER]);
+      if (!holdId) {
+        return originalPkiAuthenticate.call(this, request, session);
+      }
+
+      preauthHolds.get(holdId)?.release();
+
+      const deferred: { resolve: () => void } = { resolve: () => undefined };
+      const released = new Promise<void>((resolve) => {
+        deferred.resolve = resolve;
+      });
+
+      const hold: PreauthHoldState = {
+        parked: true,
+        continuedAfterHold: false,
+        authCompleted: false,
+        snapshotSocket: () => snapshotSocket(request),
+        release: () => deferred.resolve(),
+      };
+      preauthHolds.set(holdId, hold);
+
+      let timeoutId: NodeJS.Timeout | undefined;
+      try {
+        await Promise.race([
+          released,
+          new Promise<void>((resolve) => {
+            timeoutId = setTimeout(resolve, PREAUTH_HOLD_TIMEOUT_MS);
+          }),
+        ]);
+      } finally {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
+      }
+
+      hold.continuedAfterHold = true;
+      try {
+        return await originalPkiAuthenticate.call(this, request, session);
+      } finally {
+        hold.authCompleted = true;
+        hold.parked = false;
+        // Keep the completed hold around long enough for the test to observe `authCompleted`,
+        // then evict so the map does not retain the request (and its socket) indefinitely.
+        setTimeout(() => {
+          if (preauthHolds.get(holdId) === hold) {
+            preauthHolds.delete(holdId);
+          }
+        }, PREAUTH_HOLD_TIMEOUT_MS).unref();
+      }
+    };
+
+    pkiAuthenticateHoldInstalled = true;
+    logger.info('Installed PKI authenticate preauth hold for HTTP/2 stream-cancel tests.');
+  };
+
+  try {
+    installPkiAuthenticateHold();
+  } catch (err) {
+    logger.warn(
+      `PKI preauth hold was not installed during setup; will retry at start. ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+
+  void core
+    .getStartServices()
+    .then(() => installPkiAuthenticateHold())
+    .catch((err) => {
+      logger.error(
+        `PKI preauth hold could not be installed at start; the preauth hold test routes will not function. ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    });
+
+  const unauthenticatedTestRouteSecurity = {
+    authc: {
+      enabled: false as const,
+      reason:
+        'This route is part of a security functional test plugin and does not require authentication.',
+    },
+    authz: {
+      enabled: false as const,
+      reason: 'This route is opted out from authorization',
+    },
+  };
+
+  const holdIdParams = {
+    params: schema.object({
+      id: schema.string({ minLength: 1, maxLength: PREAUTH_HOLD_ID_MAX_LENGTH }),
+    }),
+  };
+
+  router.get(
+    {
+      path: `${PREAUTH_HOLD_PATH_PREFIX}/{id}`,
+      security: unauthenticatedTestRouteSecurity,
+      validate: holdIdParams,
+    },
+    (_context, request, response) => {
+      const hold = preauthHolds.get(request.params.id);
+      const socket = hold?.snapshotSocket();
+      return response.ok({
+        body: {
+          parked: hold?.parked ?? false,
+          continuedAfterHold: hold?.continuedAfterHold ?? false,
+          authCompleted: hold?.authCompleted ?? false,
+          authorized: socket?.authorized ?? null,
+          peerCertificateNull: socket?.peerCertificateNull ?? false,
+        },
+      });
+    }
+  );
+
+  router.post(
+    {
+      path: `${PREAUTH_HOLD_PATH_PREFIX}/{id}/release`,
+      security: unauthenticatedTestRouteSecurity,
+      validate: holdIdParams,
+      options: { xsrfRequired: false },
+    },
+    (_context, request, response) => {
+      const hold = preauthHolds.get(request.params.id);
+      if (!hold) {
+        return response.notFound();
+      }
+      hold.release();
+      return response.ok();
+    }
+  );
 
   for (const isAuthFlow of [true, false]) {
     router.get(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security] Fix PKI session invalidation on HTTP/2 stream destruction (#285153)](https://github.com/elastic/kibana/pull/285153)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2026-08-24T09:23:24Z","message":"[Security] Fix PKI session invalidation on HTTP/2 stream destruction (#285153)\n\n## Summary\n\nFixes #258232.\n\nPKI sessions were being unexpectedly invalidated on Kibana 9.x when\n`server.protocol: http2` was active (the new default when `ssl.enabled:\ntrue`). Setting `server.protocol: http1` was the customer workaround.\n\n### Root cause\n\nWhen an HTTP/2 stream is destroyed mid-request — by an `AbortController`\ncancel, browser navigation abort, or any other cause that sends\n`RST_STREAM` — Node.js clears the stream's session reference\n(`stream.session = undefined`). The `Http2ServerRequest.socket` proxy\nthen falls back from the TLS socket to the stream itself, causing every\n`instanceof TLSSocket` check in `KibanaSocket` to return `false`. The\nresult:\n\n- `socket.authorized` → `undefined` (not `true` or `false`)\n- `socket.getPeerCertificate()` → `null`\n\nThe guard in `authenticateViaState` (pki.ts line ~208) was written for\nexactly this \"connection closed\" case:\n\n```ts\n// Before (buggy):\nif (peerCertificate === null && request.socket.authorized) {\n  // return non-401 soft fail — session preserved\n}\n```\n\nOn HTTP/1.1 a closed `TLSSocket` keeps `authorized === true`, so the\nguard fired correctly. On HTTP/2, `authorized === undefined` is falsy,\nso the guard was silently skipped. The code then fell through to the\ntoken-invalidation block, revoked the ES access token, and returned\n`notHandled()` — which `authenticate()` converted to\n`Boom.unauthorized()`. `updateSessionValue()` saw the 401 on an owned\nsession and **deleted the server-side session**, logging the user out.\n\n### Fix\n\nChange the guard from a truthy check to `!== false`:\n\n```ts\n// After (fixed):\nif (peerCertificate === null && request.socket.authorized !== false) {\n  // return non-401 soft fail — session preserved\n}\n```\n\n`false` = cert was presented but rejected → token invalidation is\ncorrect.\n`undefined` = socket state is unknowable (HTTP/2 stream destroyed) →\ntreat same as `true`, preserve session.\n`true` = socket explicitly authorized → original behaviour unchanged.\n\nAlso improves the diagnostic log in `authenticateViaPeerCertificate` to\ndistinguish `false` (rejected cert) from `undefined` (unknown state),\nmaking production logs actionable.\n\n### Why this is new in 9.x\n\n`http_config.ts` defaults `server.protocol` to `http2` when\n`ssl.enabled: true` — a silent breaking change from 8.x. HTTP/1.1 is\nunaffected because each request has a dedicated `TLSSocket` that keeps\n`authorized === true` as a plain property after the connection closes.\n\n## Test plan\n\n- [x] New regression test in `pki.test.ts`: `does not invalidate token\nor destroy session when socket state is unknown due to HTTP/2 stream\ndestruction` — fails on `main`, passes after fix\n- [x] New test in `pki.test.ts`: `does not handle requests when socket\nauthorization state is unknown due to HTTP/2 stream destruction` —\ncovers `login` and session-less `authenticate`, verifies correct log\nmessage\n- [x] All 40 existing PKI unit tests continue to pass\n\nRun tests:\n```\nnode scripts/jest --config x-pack/platform/plugins/shared/security/jest.config.js --testPathPattern=\"authentication/providers/pki\" --no-coverage\n```\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---\n\n## FTR stress test (regression coverage for RST_STREAM)\n\n`pki.test.ts` unit tests are the authoritative regression lock — they're\ndeterministic and always catch a revert. An additional FTR test is\nincluded to provide end-to-end coverage of the exact failure mode:\n\n\n**`x-pack/platform/test/security_api_integration/tests/pki/pki_http2_stress.ts`**\nRegistered in `pki.http2.stress.config.ts` and added to\n`ftr_platform_stateful_configs.yml`.\n\n### Why supertest can't cover this\n\nThe existing `pki_auth.ts` concurrent-request test (5 streams) uses\nsupertest, which speaks HTTP/1.1. RST_STREAM is an HTTP/2-only signal —\nsupertest has no way to emit it. That is why the bug wasn't caught by\nthe existing concurrent-auth test.\n\n### What the FTR test does\n\n1. Establishes a PKI session via supertest (HTTP/1.1 — simple,\nreliable).\n2. Opens a raw `http2.connect()` connection to Kibana with the same PKI\nclient certificate.\n3. Fires 20 concurrent slow requests against the test endpoints plugin\n(10s hold, giving Kibana time to enter the async session-lookup window).\n4. After 150ms, cancels all 20 streams with `RST_STREAM NGHTTP2_CANCEL`.\n5. Sends a normal (non-cancelled) `GET /internal/security/me` on the\nsame HTTP/2 session.\n6. Asserts `200` + `username === 'first_client'` — the session was NOT\ninvalidated.\n\nBefore the fix: at least one RST_STREAM would destroy the stream during\nthe auth lifecycle, causing `authorized → undefined`, which bypassed the\nguard, invalidated the ES token, and returned 401.\nAfter the fix: all RST_STREAM frames are handled gracefully; the session\nsurvives.\n\n### Stability note\n\nAfter the fix is applied, the test is unconditionally stable — the guard\nchange means RST_STREAM never reaches the token-invalidation path\nregardless of timing. The test cannot produce a false positive (failing\nwhen the fix is present). Before the fix it might occasionally miss the\nnarrow timing window (false negative), but this is acceptable for a\nregression test: it cannot regress silently if the fix is reverted,\nbecause the unit test in `pki.test.ts` will always catch it.\n\n## Release note\nFixes an issue where PKI authentication sessions were unexpectedly\ninvalidated when in-flight requests were cancelled over HTTP/2, logging\nusers out. This affects deployments on server.protocol: http2, which\nbecame the default in 9.0.0 when TLS is enabled.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"a0520264b3fca9841b7e85f9c4b1996eb038b60e","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Security","backport:all-open","reviewer:scout","v9.6.0"],"title":"[Security] Fix PKI session invalidation on HTTP/2 stream destruction","number":285153,"url":"https://github.com/elastic/kibana/pull/285153","mergeCommit":{"message":"[Security] Fix PKI session invalidation on HTTP/2 stream destruction (#285153)\n\n## Summary\n\nFixes #258232.\n\nPKI sessions were being unexpectedly invalidated on Kibana 9.x when\n`server.protocol: http2` was active (the new default when `ssl.enabled:\ntrue`). Setting `server.protocol: http1` was the customer workaround.\n\n### Root cause\n\nWhen an HTTP/2 stream is destroyed mid-request — by an `AbortController`\ncancel, browser navigation abort, or any other cause that sends\n`RST_STREAM` — Node.js clears the stream's session reference\n(`stream.session = undefined`). The `Http2ServerRequest.socket` proxy\nthen falls back from the TLS socket to the stream itself, causing every\n`instanceof TLSSocket` check in `KibanaSocket` to return `false`. The\nresult:\n\n- `socket.authorized` → `undefined` (not `true` or `false`)\n- `socket.getPeerCertificate()` → `null`\n\nThe guard in `authenticateViaState` (pki.ts line ~208) was written for\nexactly this \"connection closed\" case:\n\n```ts\n// Before (buggy):\nif (peerCertificate === null && request.socket.authorized) {\n  // return non-401 soft fail — session preserved\n}\n```\n\nOn HTTP/1.1 a closed `TLSSocket` keeps `authorized === true`, so the\nguard fired correctly. On HTTP/2, `authorized === undefined` is falsy,\nso the guard was silently skipped. The code then fell through to the\ntoken-invalidation block, revoked the ES access token, and returned\n`notHandled()` — which `authenticate()` converted to\n`Boom.unauthorized()`. `updateSessionValue()` saw the 401 on an owned\nsession and **deleted the server-side session**, logging the user out.\n\n### Fix\n\nChange the guard from a truthy check to `!== false`:\n\n```ts\n// After (fixed):\nif (peerCertificate === null && request.socket.authorized !== false) {\n  // return non-401 soft fail — session preserved\n}\n```\n\n`false` = cert was presented but rejected → token invalidation is\ncorrect.\n`undefined` = socket state is unknowable (HTTP/2 stream destroyed) →\ntreat same as `true`, preserve session.\n`true` = socket explicitly authorized → original behaviour unchanged.\n\nAlso improves the diagnostic log in `authenticateViaPeerCertificate` to\ndistinguish `false` (rejected cert) from `undefined` (unknown state),\nmaking production logs actionable.\n\n### Why this is new in 9.x\n\n`http_config.ts` defaults `server.protocol` to `http2` when\n`ssl.enabled: true` — a silent breaking change from 8.x. HTTP/1.1 is\nunaffected because each request has a dedicated `TLSSocket` that keeps\n`authorized === true` as a plain property after the connection closes.\n\n## Test plan\n\n- [x] New regression test in `pki.test.ts`: `does not invalidate token\nor destroy session when socket state is unknown due to HTTP/2 stream\ndestruction` — fails on `main`, passes after fix\n- [x] New test in `pki.test.ts`: `does not handle requests when socket\nauthorization state is unknown due to HTTP/2 stream destruction` —\ncovers `login` and session-less `authenticate`, verifies correct log\nmessage\n- [x] All 40 existing PKI unit tests continue to pass\n\nRun tests:\n```\nnode scripts/jest --config x-pack/platform/plugins/shared/security/jest.config.js --testPathPattern=\"authentication/providers/pki\" --no-coverage\n```\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---\n\n## FTR stress test (regression coverage for RST_STREAM)\n\n`pki.test.ts` unit tests are the authoritative regression lock — they're\ndeterministic and always catch a revert. An additional FTR test is\nincluded to provide end-to-end coverage of the exact failure mode:\n\n\n**`x-pack/platform/test/security_api_integration/tests/pki/pki_http2_stress.ts`**\nRegistered in `pki.http2.stress.config.ts` and added to\n`ftr_platform_stateful_configs.yml`.\n\n### Why supertest can't cover this\n\nThe existing `pki_auth.ts` concurrent-request test (5 streams) uses\nsupertest, which speaks HTTP/1.1. RST_STREAM is an HTTP/2-only signal —\nsupertest has no way to emit it. That is why the bug wasn't caught by\nthe existing concurrent-auth test.\n\n### What the FTR test does\n\n1. Establishes a PKI session via supertest (HTTP/1.1 — simple,\nreliable).\n2. Opens a raw `http2.connect()` connection to Kibana with the same PKI\nclient certificate.\n3. Fires 20 concurrent slow requests against the test endpoints plugin\n(10s hold, giving Kibana time to enter the async session-lookup window).\n4. After 150ms, cancels all 20 streams with `RST_STREAM NGHTTP2_CANCEL`.\n5. Sends a normal (non-cancelled) `GET /internal/security/me` on the\nsame HTTP/2 session.\n6. Asserts `200` + `username === 'first_client'` — the session was NOT\ninvalidated.\n\nBefore the fix: at least one RST_STREAM would destroy the stream during\nthe auth lifecycle, causing `authorized → undefined`, which bypassed the\nguard, invalidated the ES token, and returned 401.\nAfter the fix: all RST_STREAM frames are handled gracefully; the session\nsurvives.\n\n### Stability note\n\nAfter the fix is applied, the test is unconditionally stable — the guard\nchange means RST_STREAM never reaches the token-invalidation path\nregardless of timing. The test cannot produce a false positive (failing\nwhen the fix is present). Before the fix it might occasionally miss the\nnarrow timing window (false negative), but this is acceptable for a\nregression test: it cannot regress silently if the fix is reverted,\nbecause the unit test in `pki.test.ts` will always catch it.\n\n## Release note\nFixes an issue where PKI authentication sessions were unexpectedly\ninvalidated when in-flight requests were cancelled over HTTP/2, logging\nusers out. This affects deployments on server.protocol: http2, which\nbecame the default in 9.0.0 when TLS is enabled.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"a0520264b3fca9841b7e85f9c4b1996eb038b60e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/285153","number":285153,"mergeCommit":{"message":"[Security] Fix PKI session invalidation on HTTP/2 stream destruction (#285153)\n\n## Summary\n\nFixes #258232.\n\nPKI sessions were being unexpectedly invalidated on Kibana 9.x when\n`server.protocol: http2` was active (the new default when `ssl.enabled:\ntrue`). Setting `server.protocol: http1` was the customer workaround.\n\n### Root cause\n\nWhen an HTTP/2 stream is destroyed mid-request — by an `AbortController`\ncancel, browser navigation abort, or any other cause that sends\n`RST_STREAM` — Node.js clears the stream's session reference\n(`stream.session = undefined`). The `Http2ServerRequest.socket` proxy\nthen falls back from the TLS socket to the stream itself, causing every\n`instanceof TLSSocket` check in `KibanaSocket` to return `false`. The\nresult:\n\n- `socket.authorized` → `undefined` (not `true` or `false`)\n- `socket.getPeerCertificate()` → `null`\n\nThe guard in `authenticateViaState` (pki.ts line ~208) was written for\nexactly this \"connection closed\" case:\n\n```ts\n// Before (buggy):\nif (peerCertificate === null && request.socket.authorized) {\n  // return non-401 soft fail — session preserved\n}\n```\n\nOn HTTP/1.1 a closed `TLSSocket` keeps `authorized === true`, so the\nguard fired correctly. On HTTP/2, `authorized === undefined` is falsy,\nso the guard was silently skipped. The code then fell through to the\ntoken-invalidation block, revoked the ES access token, and returned\n`notHandled()` — which `authenticate()` converted to\n`Boom.unauthorized()`. `updateSessionValue()` saw the 401 on an owned\nsession and **deleted the server-side session**, logging the user out.\n\n### Fix\n\nChange the guard from a truthy check to `!== false`:\n\n```ts\n// After (fixed):\nif (peerCertificate === null && request.socket.authorized !== false) {\n  // return non-401 soft fail — session preserved\n}\n```\n\n`false` = cert was presented but rejected → token invalidation is\ncorrect.\n`undefined` = socket state is unknowable (HTTP/2 stream destroyed) →\ntreat same as `true`, preserve session.\n`true` = socket explicitly authorized → original behaviour unchanged.\n\nAlso improves the diagnostic log in `authenticateViaPeerCertificate` to\ndistinguish `false` (rejected cert) from `undefined` (unknown state),\nmaking production logs actionable.\n\n### Why this is new in 9.x\n\n`http_config.ts` defaults `server.protocol` to `http2` when\n`ssl.enabled: true` — a silent breaking change from 8.x. HTTP/1.1 is\nunaffected because each request has a dedicated `TLSSocket` that keeps\n`authorized === true` as a plain property after the connection closes.\n\n## Test plan\n\n- [x] New regression test in `pki.test.ts`: `does not invalidate token\nor destroy session when socket state is unknown due to HTTP/2 stream\ndestruction` — fails on `main`, passes after fix\n- [x] New test in `pki.test.ts`: `does not handle requests when socket\nauthorization state is unknown due to HTTP/2 stream destruction` —\ncovers `login` and session-less `authenticate`, verifies correct log\nmessage\n- [x] All 40 existing PKI unit tests continue to pass\n\nRun tests:\n```\nnode scripts/jest --config x-pack/platform/plugins/shared/security/jest.config.js --testPathPattern=\"authentication/providers/pki\" --no-coverage\n```\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---\n\n## FTR stress test (regression coverage for RST_STREAM)\n\n`pki.test.ts` unit tests are the authoritative regression lock — they're\ndeterministic and always catch a revert. An additional FTR test is\nincluded to provide end-to-end coverage of the exact failure mode:\n\n\n**`x-pack/platform/test/security_api_integration/tests/pki/pki_http2_stress.ts`**\nRegistered in `pki.http2.stress.config.ts` and added to\n`ftr_platform_stateful_configs.yml`.\n\n### Why supertest can't cover this\n\nThe existing `pki_auth.ts` concurrent-request test (5 streams) uses\nsupertest, which speaks HTTP/1.1. RST_STREAM is an HTTP/2-only signal —\nsupertest has no way to emit it. That is why the bug wasn't caught by\nthe existing concurrent-auth test.\n\n### What the FTR test does\n\n1. Establishes a PKI session via supertest (HTTP/1.1 — simple,\nreliable).\n2. Opens a raw `http2.connect()` connection to Kibana with the same PKI\nclient certificate.\n3. Fires 20 concurrent slow requests against the test endpoints plugin\n(10s hold, giving Kibana time to enter the async session-lookup window).\n4. After 150ms, cancels all 20 streams with `RST_STREAM NGHTTP2_CANCEL`.\n5. Sends a normal (non-cancelled) `GET /internal/security/me` on the\nsame HTTP/2 session.\n6. Asserts `200` + `username === 'first_client'` — the session was NOT\ninvalidated.\n\nBefore the fix: at least one RST_STREAM would destroy the stream during\nthe auth lifecycle, causing `authorized → undefined`, which bypassed the\nguard, invalidated the ES token, and returned 401.\nAfter the fix: all RST_STREAM frames are handled gracefully; the session\nsurvives.\n\n### Stability note\n\nAfter the fix is applied, the test is unconditionally stable — the guard\nchange means RST_STREAM never reaches the token-invalidation path\nregardless of timing. The test cannot produce a false positive (failing\nwhen the fix is present). Before the fix it might occasionally miss the\nnarrow timing window (false negative), but this is acceptable for a\nregression test: it cannot regress silently if the fix is reverted,\nbecause the unit test in `pki.test.ts` will always catch it.\n\n## Release note\nFixes an issue where PKI authentication sessions were unexpectedly\ninvalidated when in-flight requests were cancelled over HTTP/2, logging\nusers out. This affects deployments on server.protocol: http2, which\nbecame the default in 9.0.0 when TLS is enabled.\n\n---------\n\nCo-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"a0520264b3fca9841b7e85f9c4b1996eb038b60e"}},{"url":"https://github.com/elastic/kibana/pull/286786","number":286786,"branch":"9.4","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/286787","number":286787,"branch":"9.5","state":"OPEN"}]}] BACKPORT-->

---

## 8.19 backport adjustments

### Scout test suite replaced with FTR equivalent

On `main`, the regression suite lives in
`x-pack/platform/plugins/shared/security/test/scout_pki_stress/` and uses Scout's HTTP/2 server
configuration (`http2: true` in the server config, landed in #274000). That Scout HTTP/2 plumbing
was not backported to 8.19 (`backport:skip` on #274000; backporting it would require ~19 files of
shared Scout code). PR #286876 (the Scout HTTP/2 backport) is being closed as a result.

The Scout files have been dropped from this backport. The test coverage is preserved via a direct
FTR port of the same deterministic test:

**`x-pack/platform/test/security_api_integration/tests/pki/pki_http2_stress.ts`**

The test logic is identical to the Scout spec — same four steps (login / park inside
`PKIAuthenticationProvider.authenticate` via the pre-auth hold / RST until socket is confirmed
degraded / release and follow-up). Only the harness glue differs (`retry.tryForTime` replaces
`expect.poll`; `tough-cookie` `parseCookie` replaces `findSessionCookie` whose root barrel is absent
on 8.19). The pre-auth hold infrastructure in `init_routes.ts` is retained; it is what makes the
test deterministic.

Note: the `main` PR description's "FTR stress test" section describes a timing-based design
(commit `3d344b8d46c5`, which fired 20 slow requests and RST'd them after 150ms). That commit was
removed in `24d55c0727ac` in favour of the Scout API test and the description was never updated. The
FTR test in this 8.19 backport uses the deterministic pre-auth-hold design, not the timing-based
one.

`pki.http2.stress.config.ts` registered in `ftr_platform_stateful_configs.yml`.