### PR TITLE
[Agent Builder] execution: show message's author

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/processed_input.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/processed_input.ts
@@ -44,10 +44,6 @@ export interface ProcessedRoundInput {
   attachment_refs?: ProcessedAttachmentVersionRef[];
   /** Pre-rendered, immutable attachment prompt context for this round (see RoundInput). */
   attachment_context?: string;
-  /**
-   * Author attributed to this input. Mirrors `ConversationRound.author` for
-   * previous rounds; on the next input, this is the author of the current
-   * (in-progress) round.
-   */
+  /** Author attributed to this input */
   author?: ConversationRoundAuthor;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/processed_input.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/processed_input.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Attachment, AttachmentVersionRef } from '@kbn/agent-builder-common/attachments';
+import type { ConversationRoundAuthor } from '@kbn/agent-builder-common';
 import type { AttachmentBoundedTool, AttachmentRepresentation } from './attachments';
 
 /**
@@ -43,4 +44,10 @@ export interface ProcessedRoundInput {
   attachment_refs?: ProcessedAttachmentVersionRef[];
   /** Pre-rendered, immutable attachment prompt context for this round (see RoundInput). */
   attachment_context?: string;
+  /**
+   * Author attributed to this input. Mirrors `ConversationRound.author` for
+   * previous rounds; on the next input, this is the author of the current
+   * (in-progress) round.
+   */
+  author?: ConversationRoundAuthor;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/run_chat_agent.ts
@@ -185,6 +185,7 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
   // Pass action so regenerate uses the last round's original input instead of request input
   let processedConversation = await prepareConversation({
     nextInput,
+    nextInputAuthor: pendingRound?.author ?? author,
     previousRounds: conversation?.rounds ?? [],
     context,
     action,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/prepare_conversation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/prepare_conversation.ts
@@ -9,6 +9,7 @@ import type {
   CompactionSummary,
   ConversationAction,
   ConversationRound,
+  ConversationRoundAuthor,
   ConverseInput,
   RoundInput,
   MetadataFieldValue,
@@ -151,6 +152,7 @@ const prepareForAction = ({
 export const prepareConversation = async ({
   previousRounds,
   nextInput,
+  nextInputAuthor,
   context,
   action,
   metadata,
@@ -158,6 +160,7 @@ export const prepareConversation = async ({
 }: {
   previousRounds: ConversationRound[];
   nextInput: ConverseInput;
+  nextInputAuthor?: ConversationRoundAuthor;
   context: AgentHandlerContext;
   action?: ConversationAction;
   metadata?: Record<string, MetadataFieldValue>;
@@ -210,7 +213,9 @@ export const prepareConversation = async ({
         attachment_refs: attachmentRefs,
       },
     };
-    processedRounds.push(prepareRound({ round: strippedRound, attachmentStateManager }));
+    processedRounds.push(
+      prepareRound({ round: strippedRound, author: round.author, attachmentStateManager })
+    );
   }
 
   attachmentStateManager.clearAccessTracking();
@@ -234,6 +239,7 @@ export const prepareConversation = async ({
   };
   const processedNextInput = prepareRoundInput({
     input: strippedNextInput,
+    author: nextInputAuthor,
     attachmentStateManager,
   });
 
@@ -272,22 +278,26 @@ export const prepareConversation = async ({
 
 const prepareRound = ({
   round,
+  author,
   attachmentStateManager,
 }: {
   round: ConversationRound;
+  author?: ConversationRoundAuthor;
   attachmentStateManager: AttachmentStateManager;
 }): ProcessedConversationRound => {
   return {
     ...round,
-    input: prepareRoundInput({ input: round.input, attachmentStateManager }),
+    input: prepareRoundInput({ input: round.input, author, attachmentStateManager }),
   };
 };
 
 const prepareRoundInput = ({
   input,
+  author,
   attachmentStateManager,
 }: {
   input: RoundInput | ConverseInput;
+  author?: ConversationRoundAuthor;
   attachmentStateManager: AttachmentStateManager;
 }): ProcessedRoundInput => {
   const inputAttachments: Partial<ProcessedRoundInput> = {};
@@ -311,6 +321,7 @@ const prepareRoundInput = ({
     // attachments are always stripped before this function. this is here to satisfy the type
     // for legacy compatibility
     attachments: [],
+    ...(author !== undefined ? { author } : {}),
     ...inputAttachments,
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.test.ts
@@ -36,7 +36,9 @@ describe('convertPreviousRounds', () => {
   const makeRoundInput = (
     message: string,
     attachments: ProcessedAttachment[] = [],
-    overrides: Partial<Pick<ProcessedRoundInput, 'attachment_refs' | 'attachment_context'>> = {}
+    overrides: Partial<
+      Pick<ProcessedRoundInput, 'attachment_refs' | 'attachment_context' | 'author'>
+    > = {}
   ): ProcessedRoundInput => ({
     message,
     attachments,
@@ -141,6 +143,89 @@ describe('convertPreviousRounds', () => {
     expect(result).toHaveLength(1);
     expect(isHumanMessage(result[0])).toBe(true);
     expect(result[0].content).toBe(`[Sent: ${formatDate(now)}]\n\nhello`);
+  });
+
+  it('includes the author in the next-input prefix when provided', async () => {
+    const nextInput = makeRoundInput('hello', [], { author: { id: 'u1', username: 'alice' } });
+    const result = await convertPreviousRounds({
+      conversation: createConversation({ nextInput }),
+      conversationTimestamp: now,
+    });
+    expect(result).toHaveLength(1);
+    expect(isHumanMessage(result[0])).toBe(true);
+    expect(result[0].content).toBe(`[User: alice — Sent: ${formatDate(now)}]\n\nhello`);
+  });
+
+  it('emits a user-only prefix when the author is provided without a timestamp', async () => {
+    const nextInput = makeRoundInput('hello', [], { author: { id: 'u1', username: 'alice' } });
+    const result = await convertPreviousRounds({
+      conversation: createConversation({ nextInput }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe(`[User: alice]\n\nhello`);
+  });
+
+  it('falls back to full_name then id when username is missing', async () => {
+    const nameOnlyInput = makeRoundInput('hello', [], {
+      author: { id: 'u1', full_name: 'Alice Smith' },
+    });
+    const nameOnlyResult = await convertPreviousRounds({
+      conversation: createConversation({ nextInput: nameOnlyInput }),
+    });
+    expect(nameOnlyResult[0].content).toBe(`[User: Alice Smith]\n\nhello`);
+
+    const idOnlyInput = makeRoundInput('hello', [], { author: { id: 'u1' } });
+    const idOnlyResult = await convertPreviousRounds({
+      conversation: createConversation({ nextInput: idOnlyInput }),
+    });
+    expect(idOnlyResult[0].content).toBe(`[User: u1]\n\nhello`);
+  });
+
+  it('emits the author carried by a previous round input', async () => {
+    const previousRounds = [
+      createRound({
+        id: 'round-1',
+        input: makeRoundInput('hi', [], { author: { id: 'u1', username: 'alice' } }),
+        response: makeAssistantResponse('hello!'),
+        started_at: now,
+      }),
+    ];
+    const nextInput = makeRoundInput('how are you?');
+    const result = await convertPreviousRounds({
+      conversation: createConversation({ previousRounds, nextInput }),
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result[0].content).toBe(`[User: alice — Sent: ${formatDate(now)}]\n\nhi`);
+    expect(result[2].content).toBe('how are you?');
+  });
+
+  it('uses the pending round input (with its author) when an awaiting-prompt round is promoted to next input', async () => {
+    const pendingStartedAt = '2026-06-30T12:34:56.000Z';
+    const previousRounds = [
+      createRound({
+        id: 'round-1',
+        status: ConversationRoundStatus.awaitingPrompt,
+        input: makeRoundInput('original user request', [], {
+          author: { id: 'u1', username: 'alice' },
+        }),
+        started_at: pendingStartedAt,
+      }),
+    ];
+
+    const result = await convertPreviousRounds({
+      conversation: createConversation({
+        previousRounds,
+        nextInput: makeRoundInput('prompt answer', [], {
+          author: { id: 'u2', username: 'bob' },
+        }),
+      }),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe(
+      `[User: alice — Sent: ${formatDate(pendingStartedAt)}]\n\noriginal user request`
+    );
   });
 
   it('places the next-input date prefix above attachment XML', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/utils/to_langchain_messages.ts
@@ -9,6 +9,7 @@ import type { BaseMessage, HumanMessage } from '@langchain/core/messages';
 import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import type {
   AssistantResponse,
+  ConversationRoundAuthor,
   ConversationRoundStep,
   ReasoningStep,
   ToolCallStep,
@@ -229,7 +230,7 @@ const formatRoundInput = ({
   attachmentTypes?: ProcessedAttachmentType[];
   attachmentTypeInstructionsProvided?: Set<string>;
 }): HumanMessage => {
-  const { message, attachments, attachment_context, attachment_refs } = input;
+  const { message, attachments, attachment_context, attachment_refs, author } = input;
 
   let content = message;
 
@@ -270,11 +271,38 @@ const formatRoundInput = ({
     }
   }
 
-  if (timestamp && timestamp !== new Date(0).toISOString()) {
-    content = `[Sent: ${formatDate(timestamp)}]\n\n${content}`;
+  const prefix = formatInputPrefix({ author, timestamp });
+  if (prefix) {
+    content = `${prefix}\n\n${content}`;
   }
 
   return createUserMessage(content);
+};
+
+const formatInputPrefix = ({
+  author,
+  timestamp,
+}: {
+  author?: ConversationRoundAuthor;
+  timestamp?: string;
+}): string | undefined => {
+  const parts: string[] = [];
+  const authorLabel = getAuthorLabel(author);
+  if (authorLabel) {
+    parts.push(`User: ${authorLabel}`);
+  }
+  if (timestamp && timestamp !== new Date(0).toISOString()) {
+    parts.push(`Sent: ${formatDate(timestamp)}`);
+  }
+  if (parts.length === 0) {
+    return undefined;
+  }
+  return `[${parts.join(' — ')}]`;
+};
+
+const getAuthorLabel = (author?: ConversationRoundAuthor): string | undefined => {
+  if (!author) return undefined;
+  return author.username || author.full_name || author.id || undefined;
 };
 
 const formatAttachment = ({ attachment }: { attachment: ProcessedAttachment }): XmlNode => {


### PR DESCRIPTION
## Summary

In context of multi-user conversations, add the author's username for each user message, similar to how we added the timestamp, so that the agent/llm can differentiate different users.
