### PR TITLE
[Security Solution] Add confirmation dialog before deleting rule exception list items

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/all_exception_items_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/all_exception_items_table/index.test.tsx
@@ -7,10 +7,14 @@
 
 import React, { useReducer } from 'react';
 import { mount, shallow } from 'enzyme';
+import { fireEvent, render as rtlRender, waitFor } from '@testing-library/react';
 
 import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 
-import { fetchExceptionListsItemsByListIds } from '@kbn/securitysolution-list-api';
+import {
+  deleteExceptionListItemById,
+  fetchExceptionListsItemsByListIds,
+} from '@kbn/securitysolution-list-api';
 
 import { ExceptionsViewer } from '.';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -590,6 +594,85 @@ describe('ExceptionsViewer', () => {
           wrapper.find('[data-test-subj="EndpointExceptionsMovedCallout"]').exists()
         ).toBeFalsy();
       });
+    });
+  });
+
+  describe('deleting an exception item', () => {
+    beforeEach(() => {
+      (deleteExceptionListItemById as jest.Mock).mockClear();
+      (deleteExceptionListItemById as jest.Mock).mockResolvedValue({});
+
+      (useReducer as jest.Mock).mockReturnValue([
+        {
+          exceptions: [sampleExceptionItem],
+          pagination: { pageIndex: 0, pageSize: 25, totalItemCount: 1, pageSizeOptions: [25, 50] },
+          currenFlyout: null,
+          exceptionToEdit: null,
+          viewerState: null,
+          exceptionLists: [],
+          exceptionsToShow: { active: true },
+        },
+        jest.fn(),
+      ]);
+    });
+
+    const renderViewerAndOpenDeleteModal = () => {
+      const wrapper = rtlRender(
+        <TestProviders>
+          <ExceptionsViewer
+            rule={{
+              ...getMockRule(),
+              exceptions_list: [
+                {
+                  id: '5b543420',
+                  list_id: 'list_id',
+                  type: 'detection',
+                  namespace_type: 'single',
+                },
+              ],
+            }}
+            listTypes={[ExceptionListTypeEnum.DETECTION]}
+            isViewReadOnly={false}
+          />
+        </TestProviders>
+      );
+
+      fireEvent.click(wrapper.getByTestId('exceptionItemCardHeader-actionButton'));
+      fireEvent.click(wrapper.getByTestId('exceptionItemCardHeader-actionItem-delete'));
+
+      return wrapper;
+    };
+
+    it('shows the delete confirmation modal without deleting the item', () => {
+      const wrapper = renderViewerAndOpenDeleteModal();
+
+      expect(wrapper.getByTestId('exceptionItemDeleteConfirmModal')).toBeTruthy();
+      expect(deleteExceptionListItemById).not.toHaveBeenCalled();
+    });
+
+    it('deletes the item on confirm', async () => {
+      const wrapper = renderViewerAndOpenDeleteModal();
+
+      fireEvent.click(wrapper.getByTestId('confirmModalConfirmButton'));
+
+      await waitFor(() => {
+        expect(deleteExceptionListItemById).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: sampleExceptionItem.id,
+            namespaceType: sampleExceptionItem.namespace_type,
+          })
+        );
+      });
+      expect(wrapper.queryByTestId('exceptionItemDeleteConfirmModal')).toBeNull();
+    });
+
+    it('does not delete the item on cancel', () => {
+      const wrapper = renderViewerAndOpenDeleteModal();
+
+      fireEvent.click(wrapper.getByTestId('confirmModalCancelButton'));
+
+      expect(deleteExceptionListItemById).not.toHaveBeenCalled();
+      expect(wrapper.queryByTestId('exceptionItemDeleteConfirmModal')).toBeNull();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/all_exception_items_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/all_exception_items_table/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import styled from '@emotion/styled';
 
 import { EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
@@ -46,6 +46,7 @@ import { ExceptionsViewerUtility } from './utility_bar';
 import { ExceptionsViewerItems } from './all_items';
 import { EditExceptionFlyout } from '../edit_exception_flyout';
 import { AddExceptionFlyout } from '../add_exception_flyout';
+import { ExceptionItemDeleteConfirmModal } from '../exception_item_delete_confirm_modal';
 import * as i18n from './translations';
 import { useFindExceptionListReferences } from '../../logic/use_find_references';
 import type { Rule } from '../../../rule_management/logic/types';
@@ -432,6 +433,10 @@ const ExceptionsViewerComponent = ({
     [setFlyoutType, handleGetExceptionListItems, onRuleChange]
   );
 
+  const [exceptionToDelete, setExceptionToDelete] = useState<ExceptionListItemIdentifiers | null>(
+    null
+  );
+
   const handleDeleteException = useCallback(
     async ({ id: itemId, name, namespaceType }: ExceptionListItemIdentifiers) => {
       const abortCtrl = new AbortController();
@@ -462,6 +467,17 @@ const ExceptionsViewerComponent = ({
     },
     [handleGetExceptionListItems, services.http, setViewerState, toasts]
   );
+
+  const handleCancelDeleteException = useCallback(() => {
+    setExceptionToDelete(null);
+  }, []);
+
+  const handleConfirmDeleteException = useCallback(() => {
+    if (exceptionToDelete != null) {
+      handleDeleteException(exceptionToDelete);
+    }
+    setExceptionToDelete(null);
+  }, [exceptionToDelete, handleDeleteException]);
 
   // User privileges checks
   useEffect((): void => {
@@ -571,6 +587,14 @@ const ExceptionsViewerComponent = ({
           />
         )}
 
+      {exceptionToDelete != null && (
+        <ExceptionItemDeleteConfirmModal
+          exceptionItemName={exceptionToDelete.name}
+          onCancel={handleCancelDeleteException}
+          onConfirm={handleConfirmDeleteException}
+        />
+      )}
+
       {currenFlyout === 'addException' && rule != null && (
         <AddExceptionFlyout
           rules={[rule]}
@@ -619,7 +643,7 @@ const ExceptionsViewerComponent = ({
             isEndpoint={isEndpointSpecified}
             ruleReferences={allReferences}
             viewerState={viewerState}
-            onDeleteException={handleDeleteException}
+            onDeleteException={setExceptionToDelete}
             onEditExceptionItem={handleEditException}
             onCreateExceptionListItem={handleAddException}
           />

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_delete_confirm_modal/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_delete_confirm_modal/index.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { ExceptionItemDeleteConfirmModal } from '.';
+
+describe('ExceptionItemDeleteConfirmModal', () => {
+  it('renders the exception item name in the body', () => {
+    render(
+      <ExceptionItemDeleteConfirmModal
+        exceptionItemName="My exception"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('exceptionItemDeleteConfirmModal')).toHaveTextContent(
+      'This action will delete the exception "My exception". Click "Delete" to continue.'
+    );
+  });
+
+  it('invokes onConfirm when the confirm button is clicked', () => {
+    const onConfirm = jest.fn();
+    render(
+      <ExceptionItemDeleteConfirmModal
+        exceptionItemName="My exception"
+        onCancel={jest.fn()}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('confirmModalConfirmButton'));
+
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('invokes onCancel when the cancel button is clicked', () => {
+    const onCancel = jest.fn();
+    render(
+      <ExceptionItemDeleteConfirmModal
+        exceptionItemName="My exception"
+        onCancel={onCancel}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('confirmModalCancelButton'));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_delete_confirm_modal/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_delete_confirm_modal/index.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
+
+import * as i18n from './translations';
+
+export interface ExceptionItemDeleteConfirmModalProps {
+  exceptionItemName: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export const ExceptionItemDeleteConfirmModal = React.memo(
+  ({ exceptionItemName, onCancel, onConfirm }: ExceptionItemDeleteConfirmModalProps) => {
+    const modalTitleId = useGeneratedHtmlId();
+
+    return (
+      <EuiConfirmModal
+        aria-labelledby={modalTitleId}
+        titleProps={{ id: modalTitleId }}
+        title={i18n.DELETE_EXCEPTION_ITEM_CONFIRMATION_TITLE}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        confirmButtonText={i18n.DELETE_EXCEPTION_ITEM_CONFIRMATION_CONFIRM}
+        cancelButtonText={i18n.DELETE_EXCEPTION_ITEM_CONFIRMATION_CANCEL}
+        buttonColor="danger"
+        defaultFocusedButton="confirm"
+        data-test-subj="exceptionItemDeleteConfirmModal"
+      >
+        {i18n.DELETE_EXCEPTION_ITEM_CONFIRMATION_BODY(exceptionItemName)}
+      </EuiConfirmModal>
+    );
+  }
+);
+
+ExceptionItemDeleteConfirmModal.displayName = 'ExceptionItemDeleteConfirmModal';

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_delete_confirm_modal/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/components/exception_item_delete_confirm_modal/translations.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const DELETE_EXCEPTION_ITEM_CONFIRMATION_TITLE = i18n.translate(
+  'xpack.securitySolution.ruleExceptions.exceptionItemDeleteConfirmModal.title',
+  {
+    defaultMessage: 'Confirm deletion',
+  }
+);
+
+export const DELETE_EXCEPTION_ITEM_CONFIRMATION_BODY = (exceptionItemName: string) =>
+  i18n.translate('xpack.securitySolution.ruleExceptions.exceptionItemDeleteConfirmModal.body', {
+    values: { exceptionItemName },
+    defaultMessage:
+      'This action will delete the exception "{exceptionItemName}". Click "Delete" to continue.',
+  });
+
+export const DELETE_EXCEPTION_ITEM_CONFIRMATION_CONFIRM = i18n.translate(
+  'xpack.securitySolution.ruleExceptions.exceptionItemDeleteConfirmModal.confirm',
+  {
+    defaultMessage: 'Delete',
+  }
+);
+
+export const DELETE_EXCEPTION_ITEM_CONFIRMATION_CANCEL = i18n.translate(
+  'xpack.securitySolution.ruleExceptions.exceptionItemDeleteConfirmModal.cancel',
+  {
+    defaultMessage: 'Cancel',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/exceptions_list_card/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/exceptions_list_card/index.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 import { ExceptionsListCard } from '.';
@@ -104,5 +104,64 @@ describe('ExceptionsListCard', () => {
       </TestProviders>
     );
     expect(wrapper.getByTestId('includeExpiredExceptionsConfirmationModal')).toBeTruthy();
+  });
+
+  describe('deleting an exception item', () => {
+    const renderCardAndOpenDeleteModal = (onDeleteException: jest.Mock) => {
+      (useExceptionsListCard as jest.Mock).mockReturnValue({
+        ...getMockUseExceptionsListCard(),
+        onDeleteException,
+      });
+
+      const wrapper = render(
+        <TestProviders>
+          <ExceptionsListCard
+            exceptionsList={{ ...getExceptionListSchemaMock(), rules: [] }}
+            handleDelete={jest.fn()}
+            handleExport={jest.fn()}
+            handleDuplicate={jest.fn()}
+            readOnly={false}
+          />
+        </TestProviders>
+      );
+
+      fireEvent.click(wrapper.getByTestId('exceptionItemCardHeaderButtonIcon'));
+      fireEvent.click(wrapper.getByTestId('exceptionItemCardHeaderActionItemdelete'));
+
+      return wrapper;
+    };
+
+    it('shows the confirmation modal without deleting the item', () => {
+      const onDeleteException = jest.fn();
+      const wrapper = renderCardAndOpenDeleteModal(onDeleteException);
+
+      expect(wrapper.getByTestId('exceptionItemDeleteConfirmModal')).toBeTruthy();
+      expect(onDeleteException).not.toHaveBeenCalled();
+    });
+
+    it('deletes the item on confirm', () => {
+      const onDeleteException = jest.fn();
+      const wrapper = renderCardAndOpenDeleteModal(onDeleteException);
+
+      fireEvent.click(wrapper.getByTestId('confirmModalConfirmButton'));
+
+      const exceptionItem = getExceptionListItemSchemaMock();
+      expect(onDeleteException).toHaveBeenCalledWith({
+        id: exceptionItem.id,
+        name: exceptionItem.name,
+        namespaceType: exceptionItem.namespace_type,
+      });
+      expect(wrapper.queryByTestId('exceptionItemDeleteConfirmModal')).toBeNull();
+    });
+
+    it('does not delete the item on cancel', () => {
+      const onDeleteException = jest.fn();
+      const wrapper = renderCardAndOpenDeleteModal(onDeleteException);
+
+      fireEvent.click(wrapper.getByTestId('confirmModalCancelButton'));
+
+      expect(onDeleteException).not.toHaveBeenCalled();
+      expect(wrapper.queryByTestId('exceptionItemDeleteConfirmModal')).toBeNull();
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/exceptions_list_card/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/exceptions_list_card/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useMemo } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
 
 import {
   EuiLink,
@@ -23,9 +23,11 @@ import styled from '@emotion/styled';
 import { ExceptionListTypeEnum } from '@kbn/securitysolution-io-ts-list-types';
 import type { NamespaceType } from '@kbn/securitysolution-io-ts-list-types';
 import { HeaderMenu } from '@kbn/securitysolution-exception-list-components';
+import type { ExceptionListItemIdentifiers } from '@kbn/securitysolution-exception-list-components';
 import type { Rule } from '../../../detection_engine/rule_management/logic/types';
 import { EditExceptionFlyout } from '../../../detection_engine/rule_exceptions/components/edit_exception_flyout';
 import { AddExceptionFlyout } from '../../../detection_engine/rule_exceptions/components/add_exception_flyout';
+import { ExceptionItemDeleteConfirmModal } from '../../../detection_engine/rule_exceptions/components/exception_item_delete_confirm_modal';
 import type { ExceptionListInfo } from '../../hooks/use_all_exception_lists';
 import { TitleBadge } from '../title_badge';
 import * as i18n from '../../translations';
@@ -157,6 +159,21 @@ export const ExceptionsListCard = memo<ExceptionsListCardProps>(
       handleManageRules: onManageRules,
     });
 
+    const [exceptionToDelete, setExceptionToDelete] = useState<ExceptionListItemIdentifiers | null>(
+      null
+    );
+
+    const handleCancelDeleteException = useCallback(() => {
+      setExceptionToDelete(null);
+    }, []);
+
+    const handleConfirmDeleteException = useCallback(() => {
+      if (exceptionToDelete != null) {
+        onDeleteException(exceptionToDelete);
+      }
+      setExceptionToDelete(null);
+    }, [exceptionToDelete, onDeleteException]);
+
     return (
       <>
         <EuiAccordion
@@ -225,7 +242,7 @@ export const ExceptionsListCard = memo<ExceptionsListCardProps>(
               hideUtility
               viewerStatus={exceptionViewerStatus}
               ruleReferences={ruleReferences}
-              onDeleteException={onDeleteException}
+              onDeleteException={setExceptionToDelete}
               onEditExceptionItem={onEditExceptionItem}
               onPaginationChange={onPaginationChange}
               onCreateExceptionListItem={onAddExceptionClick}
@@ -236,6 +253,13 @@ export const ExceptionsListCard = memo<ExceptionsListCardProps>(
             />
           </ExceptionPanel>
         </EuiAccordion>
+        {exceptionToDelete != null ? (
+          <ExceptionItemDeleteConfirmModal
+            exceptionItemName={exceptionToDelete.name}
+            onCancel={handleCancelDeleteException}
+            onConfirm={handleConfirmDeleteException}
+          />
+        ) : null}
         {showAddExceptionFlyout ? (
           <AddExceptionFlyout
             rules={null}

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/list_with_search/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/list_with_search/index.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+
+import { getExceptionListSchemaMock } from '@kbn/lists-plugin/common/schemas/response/exception_list_schema.mock';
+import { getExceptionListItemSchemaMock } from '@kbn/lists-plugin/common/schemas/response/exception_list_item_schema.mock';
+
+import { ListWithSearch } from '.';
+import { useListWithSearchComponent } from '../../hooks/use_list_with_search';
+import { TestProviders } from '../../../common/mock';
+
+jest.mock('../../hooks/use_list_with_search');
+jest.mock('../../hooks/use_endpoint_exceptions_capability', () => ({
+  useEndpointExceptionsCapability: jest.fn().mockReturnValue(true),
+}));
+jest.mock('../../../common/components/user_privileges', () => ({
+  useUserPrivileges: jest.fn().mockReturnValue({
+    rulesPrivileges: { exceptions: { edit: true, read: true } },
+  }),
+}));
+
+const getMockUseListWithSearchComponent = () => ({
+  exceptionViewerStatus: '',
+  listName: 'Exception list',
+  exceptions: [{ ...getExceptionListItemSchemaMock() }],
+  listType: 'detection',
+  lastUpdated: null,
+  pagination: { pageIndex: 0, pageSize: 5, totalItemCount: 1 },
+  viewerStatus: '',
+  emptyViewerTitle: 'Empty View',
+  emptyViewerBody: 'This is the empty view description.',
+  emptyViewerButtonText: 'Take action',
+  ruleReferences: {},
+  showAddExceptionFlyout: false,
+  showEditExceptionFlyout: false,
+  exceptionToEdit: undefined,
+  onSearch: jest.fn(),
+  onAddExceptionClick: jest.fn(),
+  onDeleteException: jest.fn(),
+  onEditExceptionItem: jest.fn(),
+  onPaginationChange: jest.fn(),
+  handleCancelExceptionItemFlyout: jest.fn(),
+  handleConfirmExceptionFlyout: jest.fn(),
+});
+
+describe('ListWithSearch', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderListAndOpenDeleteModal = (onDeleteException: jest.Mock) => {
+    (useListWithSearchComponent as jest.Mock).mockReturnValue({
+      ...getMockUseListWithSearchComponent(),
+      onDeleteException,
+    });
+
+    const wrapper = render(
+      <TestProviders>
+        <ListWithSearch list={getExceptionListSchemaMock()} isReadOnly={false} />
+      </TestProviders>
+    );
+
+    fireEvent.click(wrapper.getByTestId('exceptionItemCardHeaderButtonIcon'));
+    fireEvent.click(wrapper.getByTestId('exceptionItemCardHeaderActionItemdelete'));
+
+    return wrapper;
+  };
+
+  it('shows the delete confirmation modal without deleting the item', () => {
+    const onDeleteException = jest.fn();
+    const wrapper = renderListAndOpenDeleteModal(onDeleteException);
+
+    expect(wrapper.getByTestId('exceptionItemDeleteConfirmModal')).toBeTruthy();
+    expect(onDeleteException).not.toHaveBeenCalled();
+  });
+
+  it('deletes the item on confirm', () => {
+    const onDeleteException = jest.fn();
+    const wrapper = renderListAndOpenDeleteModal(onDeleteException);
+
+    fireEvent.click(wrapper.getByTestId('confirmModalConfirmButton'));
+
+    const exceptionItem = getExceptionListItemSchemaMock();
+    expect(onDeleteException).toHaveBeenCalledWith({
+      id: exceptionItem.id,
+      name: exceptionItem.name,
+      namespaceType: exceptionItem.namespace_type,
+    });
+    expect(wrapper.queryByTestId('exceptionItemDeleteConfirmModal')).toBeNull();
+  });
+
+  it('does not delete the item on cancel', () => {
+    const onDeleteException = jest.fn();
+    const wrapper = renderListAndOpenDeleteModal(onDeleteException);
+
+    fireEvent.click(wrapper.getByTestId('confirmModalCancelButton'));
+
+    expect(onDeleteException).not.toHaveBeenCalled();
+    expect(wrapper.queryByTestId('exceptionItemDeleteConfirmModal')).toBeNull();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/list_with_search/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/components/list_with_search/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import type { FC } from 'react';
 import { EuiPanel } from '@elastic/eui';
 
@@ -17,10 +17,12 @@ import {
   EmptyViewerState,
   ViewerStatus,
 } from '@kbn/securitysolution-exception-list-components';
+import type { ExceptionListItemIdentifiers } from '@kbn/securitysolution-exception-list-components';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
 import { useEndpointExceptionsCapability } from '../../hooks/use_endpoint_exceptions_capability';
 import { AddExceptionFlyout } from '../../../detection_engine/rule_exceptions/components/add_exception_flyout';
 import { EditExceptionFlyout } from '../../../detection_engine/rule_exceptions/components/edit_exception_flyout';
+import { ExceptionItemDeleteConfirmModal } from '../../../detection_engine/rule_exceptions/components/exception_item_delete_confirm_modal';
 import * as i18n from '../../translations';
 import { useListWithSearchComponent } from '../../hooks/use_list_with_search';
 import { ListExceptionItems } from '..';
@@ -64,6 +66,21 @@ const ListWithSearchComponent: FC<ListWithSearchComponentProps> = ({
 
   const canAddException =
     listType === ExceptionListTypeEnum.ENDPOINT ? canWriteEndpointExceptions : canEditExceptions;
+
+  const [exceptionToDelete, setExceptionToDelete] = useState<ExceptionListItemIdentifiers | null>(
+    null
+  );
+
+  const handleCancelDeleteException = useCallback(() => {
+    setExceptionToDelete(null);
+  }, []);
+
+  const handleConfirmDeleteException = useCallback(() => {
+    if (exceptionToDelete != null) {
+      onDeleteException(exceptionToDelete);
+    }
+    setExceptionToDelete(null);
+  }, [exceptionToDelete, onDeleteException]);
 
   return (
     <>
@@ -129,9 +146,16 @@ const ListWithSearchComponent: FC<ListWithSearchComponentProps> = ({
               lastUpdated={lastUpdated}
               onPaginationChange={onPaginationChange}
               onEditExceptionItem={onEditExceptionItem}
-              onDeleteException={onDeleteException}
+              onDeleteException={setExceptionToDelete}
               onCreateExceptionListItem={onAddExceptionClick}
             />
+            {exceptionToDelete != null && (
+              <ExceptionItemDeleteConfirmModal
+                exceptionItemName={exceptionToDelete.name}
+                onCancel={handleCancelDeleteException}
+                onConfirm={handleConfirmDeleteException}
+              />
+            )}
           </>
         </EuiPanel>
       )}

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/exceptions.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/screens/exceptions.ts
@@ -250,4 +250,10 @@ export const EXCEPTION_ITEM_OVERFLOW_ACTION_DELETE =
 
 export const EXECPTION_ITEM_CARD_HEADER_TITLE = '[data-test-subj="exceptionItemCardHeaderTitle"]';
 
+export const EXCEPTION_ITEM_DELETE_CONFIRM_MODAL =
+  '[data-test-subj="exceptionItemDeleteConfirmModal"]';
+
+export const EXCEPTION_ITEM_DELETE_CONFIRM_MODAL_CONFIRM_BTN =
+  '[data-test-subj="confirmModalConfirmButton"]';
+
 export const EMPTY_EXCEPTIONS_VIEWER = '[data-test-subj="emptyViewerState"]';

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/exceptions/all_lists.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/exceptions/all_lists.ts
@@ -6,6 +6,8 @@
  */
 
 import {
+  EXCEPTION_ITEM_DELETE_CONFIRM_MODAL,
+  EXCEPTION_ITEM_DELETE_CONFIRM_MODAL_CONFIRM_BTN,
   EXCEPTION_ITEM_HEADER_ACTION_MENU,
   EXCEPTION_ITEM_OVERFLOW_ACTION_DELETE,
   EXCEPTION_ITEM_OVERFLOW_ACTION_EDIT,
@@ -24,4 +26,8 @@ export const deleteFirstExceptionItemInListDetailPage = () => {
 
   // Delete exception
   cy.get(EXCEPTION_ITEM_OVERFLOW_ACTION_DELETE).click();
+
+  // Confirm deletion in the confirmation modal
+  cy.get(EXCEPTION_ITEM_DELETE_CONFIRM_MODAL).should('be.visible');
+  cy.get(EXCEPTION_ITEM_DELETE_CONFIRM_MODAL_CONFIRM_BTN).click();
 };

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/rule_details.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/rule_details.ts
@@ -12,6 +12,8 @@ import { RULE_STATUS } from '../screens/create_new_rule';
 import {
   ADD_EXCEPTIONS_BTN_FROM_EMPTY_PROMPT_BTN,
   ADD_EXCEPTIONS_BTN_FROM_VIEWER_HEADER,
+  EXCEPTION_ITEM_DELETE_CONFIRM_MODAL,
+  EXCEPTION_ITEM_DELETE_CONFIRM_MODAL_CONFIRM_BTN,
   EXCEPTION_ITEM_VIEWER_SEARCH,
   FIELD_INPUT,
 } from '../screens/exceptions';
@@ -155,6 +157,10 @@ export const removeException = () => {
   cy.get(EXCEPTION_ITEM_ACTIONS_BUTTON).click();
 
   cy.get(REMOVE_EXCEPTION_BTN).click();
+
+  // Confirm deletion in the confirmation modal
+  cy.get(EXCEPTION_ITEM_DELETE_CONFIRM_MODAL).should('be.visible');
+  cy.get(EXCEPTION_ITEM_DELETE_CONFIRM_MODAL_CONFIRM_BTN).click();
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/284851

Before this change, the **Delete rule exception** action in the three-dots menu deleted the exception item immediately. Kibana showed no confirmation. Other destructive actions in the same UI ask for confirmation first. Examples: delete a shared exception list, delete a rule.

This PR adds a confirmation modal, `ExceptionItemDeleteConfirmModal`, based on `EuiConfirmModal`. The delete action now opens this modal on all three surfaces where a user can delete an exception item:

1. **Rule details page > Rule exceptions tab** (`all_exception_items_table`)
2. **Shared Exception Lists page > expanded list card** (`exceptions_list_card`)
3. **Exception list detail view** (`list_with_search`)

The modal follows the pattern of the rules table delete confirmation. It uses `EuiConfirmModal` with `buttonColor="danger"` and `defaultFocusedButton="confirm"`. Each surface stores the pending `ExceptionListItemIdentifiers` in local state. The **Delete rule exception** action opens the modal. The confirm button calls the original delete handler. The cancel button clears the pending state and does not delete the item.

This PR does not change the shared `kbn-securitysolution-exception-list-components` package, which renders the three-dots menu. The confirmation lives at the consumer render sites. This keeps Security Solution behavior out of the shared package.

### Screenshots

| Page | Before | After |
| --- | --- | --- |
| Rule Exceptions List |  https://github.com/user-attachments/assets/6f3a885c-abdb-4b20-b8af-fc6e03044bef | https://github.com/user-attachments/assets/d9c33f5f-5811-4a99-9c07-50500aa17f23 |
| Shared Exception List | https://github.com/user-attachments/assets/50e0a162-ee58-4f61-864f-92fbb3250789 | https://github.com/user-attachments/assets/2720fe34-3754-4a01-8f8f-15478e4494b9 |
| Shared Exception List Details | https://github.com/user-attachments/assets/32ae59f6-f0c6-4b4a-813d-5773a2a5deb4 | https://github.com/user-attachments/assets/39604fa4-99fa-47b4-badc-06195f35a9fa |

### Testing

- Unit tests cover the new modal component and each of the three surfaces. They check that the modal appears on delete, that the delete handler runs only after confirm, and that cancel keeps the item.
- Cypress tasks now confirm the modal: `removeException` (`cypress/tasks/rule_details.ts`) and `deleteFirstExceptionItemInListDetailPage` (`cypress/tasks/exceptions/all_lists.ts`). New selectors are in `cypress/screens/exceptions.ts`. Affected specs: `add_edit_exception.cy.ts`, `add_edit_exception_data_view.cy.ts`, `manage_exceptions.cy.ts`.

To verify manually:

1. Open a rule that has exceptions. Go to the **Rule exceptions** tab. Open the three-dots menu. Select **Delete rule exception**.
2. Check that a confirmation modal appears. Cancel keeps the item. Confirm deletes it.
3. Repeat from **Rules > Shared Exception Lists**, on the expanded list card and on the list detail view.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~ N/A
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the docker list~ N/A
- [ ] ~This was checked for breaking HTTP API changes~ N/A — UI-only change
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Low — automation/workflow disruption:** external automation or E2E suites that delete exception items through the UI now need one more confirmation click. This PR updates the in-repo Cypress tasks. No FTR tests exercise this UI.
- No API, schema, or data changes. The delete request is unchanged. The UI only asks for user confirmation before it sends the request.

## Release note

Fixes rule exception items being deleted immediately from the actions menu with no warning. Kibana now shows a confirmation dialog before it deletes the exception item.


<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->