### PR TITLE
Run tests in IPv6-only mode daily

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-batch-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-batch-testing.yml
@@ -55,6 +55,13 @@ spec:
           branch: main
           env:
             TEST_CHANNELS: 'ci-batch-daily'
+        'Daily (IPv6)':
+          cronline: 0 2 * * 0-5
+          message: 'Scheduled batch (daily, IPv6-only)'
+          branch: main
+          env:
+            TEST_CHANNELS: 'ci-on-commit,ci-batch-3h,ci-batch-daily'
+            KIBANA_TEST_IPV6_ONLY: 'true'
         Weekly:
           cronline: 0 6 * * 5
           message: 'Scheduled batch (weekly)'

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/load_servers_config.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/load_servers_config.test.ts
@@ -161,6 +161,42 @@ describe('loadServersConfig', () => {
     expect(result).toBe(mockConfigInstance);
   });
 
+  describe('KIBANA_TEST_IPV6_ONLY', () => {
+    const originalEnvValue = process.env.KIBANA_TEST_IPV6_ONLY;
+
+    afterEach(() => {
+      if (originalEnvValue === undefined) {
+        delete process.env.KIBANA_TEST_IPV6_ONLY;
+      } else {
+        process.env.KIBANA_TEST_IPV6_ONLY = originalEnvValue;
+      }
+    });
+
+    it('should override Kibana hostname to ::1 when KIBANA_TEST_IPV6_ONLY=true', async () => {
+      const configRootDir = '/mock/config/root/default/serverless';
+      (getConfigFilePath as jest.Mock).mockReturnValue(mockConfigPath);
+      (loadRawServerConfig as jest.Mock).mockResolvedValue(structuredClone(mockRawConfig));
+      process.env.KIBANA_TEST_IPV6_ONLY = 'true';
+
+      await loadServersConfig(mockTestTarget, mockLog, configRootDir);
+
+      const rawConfigPassedToConstructor = (Config as unknown as jest.Mock).mock.calls[0][0];
+      expect(rawConfigPassedToConstructor.servers.kibana.hostname).toBe('::1');
+    });
+
+    it('should not override Kibana hostname when KIBANA_TEST_IPV6_ONLY is unset', async () => {
+      const configRootDir = '/mock/config/root/default/serverless';
+      (getConfigFilePath as jest.Mock).mockReturnValue(mockConfigPath);
+      (loadRawServerConfig as jest.Mock).mockResolvedValue(structuredClone(mockRawConfig));
+      delete process.env.KIBANA_TEST_IPV6_ONLY;
+
+      await loadServersConfig(mockTestTarget, mockLog, configRootDir);
+
+      const rawConfigPassedToConstructor = (Config as unknown as jest.Mock).mock.calls[0][0];
+      expect(rawConfigPassedToConstructor.servers.kibana.hostname).toBe('localhost');
+    });
+  });
+
   it('should throw error when config file does not exist', async () => {
     const configRootDir = '/mock/config/root/custom/uiam_local/serverless';
     (getConfigFilePath as jest.Mock).mockReturnValue(mockConfigPath);

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/load_servers_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/utils/load_servers_config.ts
@@ -54,6 +54,13 @@ export async function loadServersConfig(
     configureHTTP2(rawConfig);
   }
 
+  if (process.env.KIBANA_TEST_IPV6_ONLY === 'true') {
+    log.info(
+      'scout: Overriding Kibana hostname to ::1 (got KIBANA_TEST_IPV6_ONLY=true in the environment)'
+    );
+    rawConfig.servers.kibana.hostname = '::1';
+  }
+
   const clusterConfig = new Config(rawConfig);
   // construct config for Playwright Test
   const scoutServerConfig = clusterConfig.getScoutTestConfig();

--- a/src/platform/packages/shared/kbn-scout/src/servers/run_kibana_server.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/run_kibana_server.ts
@@ -27,16 +27,20 @@ export async function runKibanaServer(options: {
 }
 
 export function getExtraKbnOpts(installDir: string | undefined, isServerless: boolean) {
-  if (installDir) {
-    return [];
+  const extraOpts: string[] = [];
+
+  if (!installDir) {
+    extraOpts.push(
+      '--dev',
+      '--no-dev-config',
+      '--no-dev-credentials',
+      `--server.versioned.versionResolution=${isServerless ? 'newest' : 'oldest'}`
+    );
   }
 
-  return [
-    '--dev',
-    '--no-dev-config',
-    '--no-dev-credentials',
-    isServerless
-      ? '--server.versioned.versionResolution=newest'
-      : '--server.versioned.versionResolution=oldest',
-  ];
+  if (process.env.KIBANA_TEST_IPV6_ONLY === 'true') {
+    extraOpts.push('--server.host=::1');
+  }
+
+  return extraOpts;
 }

--- a/src/platform/packages/shared/kbn-test/src/functional_tests/start_servers/start_servers.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_tests/start_servers/start_servers.ts
@@ -43,20 +43,26 @@ export async function startServers(log: ToolingLog, options: StartServerOptions)
       logsDir: options.logsDir,
     });
 
+    const extraKbnOpts: string[] = [];
+
+    if (!options.installDir) {
+      extraKbnOpts.push(
+        '--dev',
+        '--no-dev-config',
+        '--no-dev-credentials',
+        `--server.versioned.versionResolution=${config.get('serverless') ? 'newest' : 'oldest'}`
+      );
+    }
+
+    if (process.env.KIBANA_TEST_IPV6_ONLY === 'true') {
+      extraKbnOpts.push('--server.host=::1');
+    }
+
     await runKibanaServer({
       procs,
       config,
       installDir: options.installDir,
-      extraKbnOpts: options.installDir
-        ? []
-        : [
-            '--dev',
-            '--no-dev-config',
-            '--no-dev-credentials',
-            config.get('serverless')
-              ? '--server.versioned.versionResolution=newest'
-              : '--server.versioned.versionResolution=oldest',
-          ],
+      extraKbnOpts,
     });
 
     const startRemoteKibana = config.get('kbnTestServer.startRemoteKibana');
@@ -81,16 +87,7 @@ export async function startServers(log: ToolingLog, options: StartServerOptions)
           module: config.module,
         }),
         installDir: options.installDir,
-        extraKbnOpts: options.installDir
-          ? []
-          : [
-              '--dev',
-              '--no-dev-config',
-              '--no-dev-credentials',
-              config.get('serverless')
-                ? '--server.versioned.versionResolution=newest'
-                : '--server.versioned.versionResolution=oldest',
-            ],
+        extraKbnOpts,
         remote: true,
       });
     }


### PR DESCRIPTION
## Summary

Adds a new schedule to the batch testing pipeline that runs tests with Kibana running in IPv6-only mode.

To support this change, test server startup logic has been modified to accept a `KIBANA_TEST_IPV6_ONLY` environment variable that will set `server.host: '::1'` in the Kibana server configuration if the value is set to `true`.

Sample BK run [here](https://buildkite.com/elastic/kibana-batch-testing/builds/12).