### PR TITLE
[8.19] [Console] Fix duplicate Cut, Copy, and Paste context menu actions (#286704)

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/index.ts
+++ b/src/platform/packages/shared/kbn-monaco/index.ts
@@ -17,7 +17,9 @@ export {
   markdownLanguage,
   yamlConf,
   yamlLanguage,
+  setClipboardContextMenuLabels,
 } from './src/monaco_imports';
+export type { ClipboardContextMenuLabels } from './src/monaco_imports';
 export { XJsonLang } from './src/xjson';
 export { SQLLang } from './src/sql';
 export { ESQL_LANG_ID, ESQL_DARK_THEME_ID, ESQL_LIGHT_THEME_ID, ESQLLang } from './src/esql';

--- a/src/platform/packages/shared/kbn-monaco/src/monaco_imports.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/monaco_imports.test.ts
@@ -7,7 +7,41 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { monaco } from './monaco_imports';
+import { getClipboardMenuActions, monaco, setClipboardContextMenuLabels } from './monaco_imports';
+
+describe('WHEN the Monaco clipboard contribution is loaded', () => {
+  it('SHOULD register localized context menu actions with writable guards', () => {
+    setClipboardContextMenuLabels({
+      cut: 'Translated Cut',
+      copy: 'Translated Copy',
+      paste: 'Translated Paste',
+    });
+
+    const clipboardActions = getClipboardMenuActions().map((menuItem) => ({
+      id: menuItem.command?.id,
+      title: menuItem.command?.title,
+      when: menuItem.when?.serialize(),
+    }));
+
+    expect(clipboardActions).toEqual([
+      {
+        id: 'editor.action.clipboardCutAction',
+        title: 'Translated Cut',
+        when: '!editorReadonly',
+      },
+      {
+        id: 'editor.action.clipboardCopyAction',
+        title: 'Translated Copy',
+        when: undefined,
+      },
+      {
+        id: 'editor.action.clipboardPasteAction',
+        title: 'Translated Paste',
+        when: '!editorReadonly',
+      },
+    ]);
+  });
+});
 
 describe('monaco augmentation', () => {
   describe('getLanguageThemeResolver', () => {

--- a/src/platform/packages/shared/kbn-monaco/src/monaco_imports.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/monaco_imports.ts
@@ -9,6 +9,11 @@
 
 /* eslint-disable @kbn/eslint/module_migration */
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import {
+  MenuId,
+  MenuRegistry,
+  type MenuItem,
+} from 'monaco-editor/esm/vs/platform/actions/common/actions.js';
 
 import 'monaco-editor/esm/vs/base/common/worker/simpleWorker';
 import 'monaco-editor/esm/vs/base/browser/defaultWorkerFactory';
@@ -34,6 +39,7 @@ import 'monaco-editor/esm/vs/editor/contrib/codeAction/browser/codeActionModel.j
 import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController'; // Needed for Search bar functionality
 import 'monaco-editor/esm/vs/editor/standalone/browser/inspectTokens/inspectTokens.js'; // Needed for inspect tokens functionality
 import 'monaco-editor/esm/vs/editor/contrib/contextmenu/browser/contextmenu.js'; // Needed for enabling custom Monaco context menu
+import 'monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js'; // Needed for native Cut/Copy/Paste context menu actions (#284086)
 
 import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
 import 'monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution.js'; // Needed for basic javascript support
@@ -55,6 +61,46 @@ export {
 } from 'monaco-editor/esm/vs/basic-languages/yaml/yaml';
 
 import type { CustomLangModuleType } from './types';
+
+const CLIPBOARD_ACTION_IDS = new Set([
+  'editor.action.clipboardCutAction',
+  'editor.action.clipboardCopyAction',
+  'editor.action.clipboardPasteAction',
+]);
+
+/** Returns Monaco's native clipboard actions for the editor context menu. */
+export const getClipboardMenuActions = (): MenuItem[] =>
+  MenuRegistry.getMenuItems(MenuId.EditorContext).filter((menuItem) =>
+    CLIPBOARD_ACTION_IDS.has(menuItem.command?.id ?? '')
+  );
+
+export interface ClipboardContextMenuLabels {
+  cut: string;
+  copy: string;
+  paste: string;
+}
+
+/** Applies translated labels to Monaco's native clipboard context menu actions. */
+export const setClipboardContextMenuLabels = ({
+  cut,
+  copy,
+  paste,
+}: ClipboardContextMenuLabels): void => {
+  const actionLabels = new Map([
+    ['editor.action.clipboardCutAction', cut],
+    ['editor.action.clipboardCopyAction', copy],
+    ['editor.action.clipboardPasteAction', paste],
+  ]);
+
+  for (const menuItem of getClipboardMenuActions()) {
+    if (menuItem.command) {
+      const actionLabel = actionLabels.get(menuItem.command.id);
+      if (actionLabel) {
+        menuItem.command.title = actionLabel;
+      }
+    }
+  }
+};
 
 const languageThemeResolverDefinitions = new Map<
   string,

--- a/src/platform/packages/shared/kbn-monaco/src/typings.d.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/typings.d.ts
@@ -11,3 +11,23 @@
 declare module 'monaco-editor/esm/vs/basic-languages/markdown/markdown';
 declare module 'monaco-editor/esm/vs/basic-languages/css/css';
 declare module 'monaco-editor/esm/vs/basic-languages/yaml/yaml';
+
+declare module 'monaco-editor/esm/vs/platform/actions/common/actions.js' {
+  export interface MenuItem {
+    command?: {
+      id: string;
+      title: string | { value: string; original: string };
+    };
+    when?: {
+      serialize(): string;
+    };
+  }
+
+  export const MenuId: {
+    EditorContext: unknown;
+  };
+
+  export const MenuRegistry: {
+    getMenuItems(menuId: unknown): MenuItem[];
+  };
+}

--- a/src/platform/packages/shared/kbn-test/src/jest/setup/polyfills.jsdom.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/setup/polyfills.jsdom.js
@@ -13,6 +13,12 @@ Object.defineProperty(window, 'MutationObserver', { value: MutationObserver });
 // Required until JSDOM supports fetch: https://github.com/jsdom/jsdom/issues/1724
 require('whatwg-fetch');
 
+// Monaco's clipboard contribution calls this deprecated browser API during module evaluation.
+// JSDOM does not implement it; node environments may not define `document`.
+if (typeof document !== 'undefined' && typeof document.queryCommandSupported !== 'function') {
+  Object.defineProperty(document, 'queryCommandSupported', { value: () => true });
+}
+
 if (!Object.hasOwn(global.URL, 'createObjectURL')) {
   Object.defineProperty(global.URL, 'createObjectURL', { value: () => '' });
 }

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/use_context_menu_utils.test.ts
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/use_context_menu_utils.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { monaco } from '@kbn/monaco';
+import { useContextMenuUtils } from './use_context_menu_utils';
+
+const CLIPBOARD_GROUP = '9_cutcopypaste';
+
+const registerBuiltInMonacoClipboardActions = (editor: monaco.editor.IStandaloneCodeEditor) => {
+  const builtIn = [
+    { id: 'editor.action.clipboardCutAction', label: 'Cut', order: 1.5 },
+    { id: 'editor.action.clipboardCopyAction', label: 'Copy', order: 1.6 },
+    { id: 'editor.action.clipboardPasteAction', label: 'Paste', order: 1.7 },
+  ];
+
+  for (const action of builtIn) {
+    editor.addAction({
+      id: action.id,
+      label: action.label,
+      contextMenuGroupId: CLIPBOARD_GROUP,
+      contextMenuOrder: action.order,
+      run: () => {},
+    });
+  }
+};
+
+describe('WHEN Monaco clipboard actions are already registered', () => {
+  it('SHOULD not add duplicate clipboard actions to the context menu group', () => {
+    const registered: Array<{ id: string; label: string }> = [];
+    const editor = {
+      addAction: (descriptor: monaco.editor.IActionDescriptor) => {
+        if (descriptor.contextMenuGroupId === CLIPBOARD_GROUP) {
+          registered.push({ id: descriptor.id, label: descriptor.label });
+        }
+        return { dispose: jest.fn() };
+      },
+    } as unknown as monaco.editor.IStandaloneCodeEditor;
+
+    registerBuiltInMonacoClipboardActions(editor);
+
+    const { registerContextMenuActions } = useContextMenuUtils();
+    registerContextMenuActions({
+      editor,
+      enableWriteActions: true,
+    });
+
+    const labelCounts = registered.reduce<Record<string, number>>((counts, action) => {
+      counts[action.label] = (counts[action.label] ?? 0) + 1;
+      return counts;
+    }, {});
+
+    expect(labelCounts).toEqual({
+      Cut: 1,
+      Copy: 1,
+      Paste: 1,
+    });
+  });
+});

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/use_context_menu_utils.ts
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/use_context_menu_utils.ts
@@ -8,8 +8,19 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { monaco } from '@kbn/monaco';
-import { copyToClipboard } from '@elastic/eui';
+import { setClipboardContextMenuLabels, type monaco } from '@kbn/monaco';
+
+setClipboardContextMenuLabels({
+  cut: i18n.translate('sharedUXPackages.codeEditor.contextMenuAction.cutActionLabel', {
+    defaultMessage: 'Cut',
+  }),
+  copy: i18n.translate('sharedUXPackages.codeEditor.contextMenuAction.copyActionLabel', {
+    defaultMessage: 'Copy',
+  }),
+  paste: i18n.translate('sharedUXPackages.codeEditor.contextMenuAction.pasteActionLabel', {
+    defaultMessage: 'Paste',
+  }),
+});
 
 interface RegisterContextMenuActionsParams {
   editor: monaco.editor.IStandaloneCodeEditor;
@@ -21,72 +32,6 @@ export interface ContextMenuAction {
   actionDescriptor: monaco.editor.IActionDescriptor;
   writeAction: boolean;
 }
-
-const CUT_ACTION_ID = 'cutAction';
-const COPY_ACTION_ID = 'copyAction';
-const PASTE_ACTION_ID = 'pasteAction';
-
-const DEFAULT_ACTIONS: ContextMenuAction[] = [
-  {
-    actionDescriptor: {
-      id: CUT_ACTION_ID,
-      label: i18n.translate('sharedUXPackages.codeEditor.contextMenuAction.cutActionLabel', {
-        defaultMessage: 'Cut',
-      }),
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 1,
-      run: async (ed) => {
-        const selection = ed.getSelection();
-        const model = ed.getModel();
-        if (selection && model) {
-          const selectedText = model.getValueInRange(selection);
-          copyToClipboard(selectedText);
-          ed.executeEdits('Cut selection', [{ range: selection, text: '' }]);
-        }
-      },
-    },
-    writeAction: true,
-  },
-  {
-    actionDescriptor: {
-      id: COPY_ACTION_ID,
-      label: i18n.translate('sharedUXPackages.codeEditor.contextMenuAction.copyActionLabel', {
-        defaultMessage: 'Copy',
-      }),
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 2,
-      run: async (ed) => {
-        const selection = ed.getSelection();
-        const model = ed.getModel();
-        if (selection && model) {
-          const selectedText = model.getValueInRange(selection);
-          copyToClipboard(selectedText);
-        }
-      },
-    },
-    writeAction: false,
-  },
-  {
-    actionDescriptor: {
-      id: PASTE_ACTION_ID,
-      label: i18n.translate('sharedUXPackages.codeEditor.contextMenuAction.pasteActionLabel', {
-        defaultMessage: 'Paste',
-      }),
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 3,
-      run: async (ed) => {
-        const selection = ed.getSelection();
-        if (selection) {
-          const clipboardText = await navigator.clipboard?.readText();
-          if (clipboardText) {
-            ed.executeEdits('Paste from clipboard', [{ range: selection, text: clipboardText }]);
-          }
-        }
-      },
-    },
-    writeAction: true,
-  },
-];
 
 type RegisteredAction = ContextMenuAction & {
   refObject: { current: monaco.IDisposable | null };
@@ -112,9 +57,7 @@ export const useContextMenuUtils = () => {
   }: RegisterContextMenuActionsParams) => {
     disposeAllActions();
 
-    const allActions = [...DEFAULT_ACTIONS, ...customActions];
-
-    registeredActions = allActions.map(({ actionDescriptor, writeAction }) => {
+    registeredActions = customActions.map(({ actionDescriptor, writeAction }) => {
       const refObject = { current: null as monaco.IDisposable | null };
 
       if (!writeAction || enableWriteActions) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Fix duplicate Cut, Copy, and Paste context menu actions (#286704)](https://github.com/elastic/kibana/pull/286704)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-08-24T09:37:10Z","message":"[Console] Fix duplicate Cut, Copy, and Paste context menu actions (#286704)\n\nCloses #284086\n\n## Summary\n\n- Removes duplicate Cut, Copy, and Paste entries from Dev Tools Console\ncontext menus.\n- Keeps one Cut, Copy, and Paste action in the writable request editor\nand one Copy action in the read-only output editor.\n\n## Root Cause\n\n- Console custom clipboard actions and Monaco native clipboard actions\nboth registered in the same global context-menu group after\n`monaco-promql` began loading the full Monaco editor.\n\n## Fix\n\n- Uses Monaco native clipboard actions, preserves Kibana translations,\nand removes the duplicate custom actions.\n- Adds registration, localization, writable-guard, and\nduplicate-prevention tests.\n\n## Before/After Screenshots\n\nBoth pairs use the same viewport, content, selection, and context-menu\nposition.\n\n### Writable request editor\n\n#### Before\n\n<img width=\"560\" height=\"360\" alt=\"Before: Console request editor\nshowing duplicated Cut, Copy, and Paste actions\"\nsrc=\"https://github.com/user-attachments/assets/c815597c-d466-4ac7-8098-802e13187e09\"\n/>\n\n#### After\n\n<img width=\"560\" height=\"360\" alt=\"After: Console request editor showing\none Cut, Copy, and Paste action\"\nsrc=\"https://github.com/user-attachments/assets/e4312a3a-a37e-47f5-94db-9bf85ed3bbf3\"\n/>\n\n### Read-only output editor\n\n#### Before\n\n<img width=\"620\" height=\"440\" alt=\"Before: Console output editor showing\nduplicated Copy actions\"\nsrc=\"https://github.com/user-attachments/assets/e32c5201-4d50-4046-a776-2375b9667e77\"\n/>\n\n#### After\n\n<img width=\"620\" height=\"440\" alt=\"After: Console output editor showing\none Copy action and no Cut or Paste actions\"\nsrc=\"https://github.com/user-attachments/assets/ec530354-fcd9-4a9c-a695-5bbcb325fd1f\"\n/>\n\n## Test Plan\n\n- `node scripts/check.js --scope=local` — passed 3 TypeScript projects,\nlint for 7 files, 619 Jest tests, and `tsc`.\n- `node scripts/i18n_check --fix` — passed.\n- In local Dev Tools Console, verified one Cut, Copy, and Paste action\nin the request editor and Copy-only in the output editor.\n- Verified Copy and Cut behavior. Automated Paste verification used\nMonaco’s clipboard-service fallback because Chromium did not insert text\nthrough `document.execCommand('paste')`.\n\n## Release Note\n\n- Fixes duplicated Cut, Copy, and Paste actions in Dev Tools Console\ncontext menus.\n\nAssisted with Cursor using GPT-5.6 Sol\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"f1544dd232800c1d2cc2e63ca5f1d660e4009d9c","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","release_note:fix","Team:Kibana Management","backport:all-open","v9.6.0","v9.4.6","reviewer:libra","v9.5.3"],"title":"[Console] Fix duplicate Cut, Copy, and Paste context menu actions","number":286704,"url":"https://github.com/elastic/kibana/pull/286704","mergeCommit":{"message":"[Console] Fix duplicate Cut, Copy, and Paste context menu actions (#286704)\n\nCloses #284086\n\n## Summary\n\n- Removes duplicate Cut, Copy, and Paste entries from Dev Tools Console\ncontext menus.\n- Keeps one Cut, Copy, and Paste action in the writable request editor\nand one Copy action in the read-only output editor.\n\n## Root Cause\n\n- Console custom clipboard actions and Monaco native clipboard actions\nboth registered in the same global context-menu group after\n`monaco-promql` began loading the full Monaco editor.\n\n## Fix\n\n- Uses Monaco native clipboard actions, preserves Kibana translations,\nand removes the duplicate custom actions.\n- Adds registration, localization, writable-guard, and\nduplicate-prevention tests.\n\n## Before/After Screenshots\n\nBoth pairs use the same viewport, content, selection, and context-menu\nposition.\n\n### Writable request editor\n\n#### Before\n\n<img width=\"560\" height=\"360\" alt=\"Before: Console request editor\nshowing duplicated Cut, Copy, and Paste actions\"\nsrc=\"https://github.com/user-attachments/assets/c815597c-d466-4ac7-8098-802e13187e09\"\n/>\n\n#### After\n\n<img width=\"560\" height=\"360\" alt=\"After: Console request editor showing\none Cut, Copy, and Paste action\"\nsrc=\"https://github.com/user-attachments/assets/e4312a3a-a37e-47f5-94db-9bf85ed3bbf3\"\n/>\n\n### Read-only output editor\n\n#### Before\n\n<img width=\"620\" height=\"440\" alt=\"Before: Console output editor showing\nduplicated Copy actions\"\nsrc=\"https://github.com/user-attachments/assets/e32c5201-4d50-4046-a776-2375b9667e77\"\n/>\n\n#### After\n\n<img width=\"620\" height=\"440\" alt=\"After: Console output editor showing\none Copy action and no Cut or Paste actions\"\nsrc=\"https://github.com/user-attachments/assets/ec530354-fcd9-4a9c-a695-5bbcb325fd1f\"\n/>\n\n## Test Plan\n\n- `node scripts/check.js --scope=local` — passed 3 TypeScript projects,\nlint for 7 files, 619 Jest tests, and `tsc`.\n- `node scripts/i18n_check --fix` — passed.\n- In local Dev Tools Console, verified one Cut, Copy, and Paste action\nin the request editor and Copy-only in the output editor.\n- Verified Copy and Cut behavior. Automated Paste verification used\nMonaco’s clipboard-service fallback because Chromium did not insert text\nthrough `document.execCommand('paste')`.\n\n## Release Note\n\n- Fixes duplicated Cut, Copy, and Paste actions in Dev Tools Console\ncontext menus.\n\nAssisted with Cursor using GPT-5.6 Sol\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"f1544dd232800c1d2cc2e63ca5f1d660e4009d9c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/286704","number":286704,"mergeCommit":{"message":"[Console] Fix duplicate Cut, Copy, and Paste context menu actions (#286704)\n\nCloses #284086\n\n## Summary\n\n- Removes duplicate Cut, Copy, and Paste entries from Dev Tools Console\ncontext menus.\n- Keeps one Cut, Copy, and Paste action in the writable request editor\nand one Copy action in the read-only output editor.\n\n## Root Cause\n\n- Console custom clipboard actions and Monaco native clipboard actions\nboth registered in the same global context-menu group after\n`monaco-promql` began loading the full Monaco editor.\n\n## Fix\n\n- Uses Monaco native clipboard actions, preserves Kibana translations,\nand removes the duplicate custom actions.\n- Adds registration, localization, writable-guard, and\nduplicate-prevention tests.\n\n## Before/After Screenshots\n\nBoth pairs use the same viewport, content, selection, and context-menu\nposition.\n\n### Writable request editor\n\n#### Before\n\n<img width=\"560\" height=\"360\" alt=\"Before: Console request editor\nshowing duplicated Cut, Copy, and Paste actions\"\nsrc=\"https://github.com/user-attachments/assets/c815597c-d466-4ac7-8098-802e13187e09\"\n/>\n\n#### After\n\n<img width=\"560\" height=\"360\" alt=\"After: Console request editor showing\none Cut, Copy, and Paste action\"\nsrc=\"https://github.com/user-attachments/assets/e4312a3a-a37e-47f5-94db-9bf85ed3bbf3\"\n/>\n\n### Read-only output editor\n\n#### Before\n\n<img width=\"620\" height=\"440\" alt=\"Before: Console output editor showing\nduplicated Copy actions\"\nsrc=\"https://github.com/user-attachments/assets/e32c5201-4d50-4046-a776-2375b9667e77\"\n/>\n\n#### After\n\n<img width=\"620\" height=\"440\" alt=\"After: Console output editor showing\none Copy action and no Cut or Paste actions\"\nsrc=\"https://github.com/user-attachments/assets/ec530354-fcd9-4a9c-a695-5bbcb325fd1f\"\n/>\n\n## Test Plan\n\n- `node scripts/check.js --scope=local` — passed 3 TypeScript projects,\nlint for 7 files, 619 Jest tests, and `tsc`.\n- `node scripts/i18n_check --fix` — passed.\n- In local Dev Tools Console, verified one Cut, Copy, and Paste action\nin the request editor and Copy-only in the output editor.\n- Verified Copy and Cut behavior. Automated Paste verification used\nMonaco’s clipboard-service fallback because Chromium did not insert text\nthrough `document.execCommand('paste')`.\n\n## Release Note\n\n- Fixes duplicated Cut, Copy, and Paste actions in Dev Tools Console\ncontext menus.\n\nAssisted with Cursor using GPT-5.6 Sol\n\nCo-authored-by: Cursor <cursoragent@cursor.com>","sha":"f1544dd232800c1d2cc2e63ca5f1d660e4009d9c"}},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/286797","number":286797,"state":"MERGED","mergeCommit":{"sha":"dfd24b1f4a58c5716d2e874fecfce02f9f61ac3d","message":"[9.4] [Console] Fix duplicate Cut, Copy, and Paste context menu actions (#286704) (#286797)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.4`:\n- [[Console] Fix duplicate Cut, Copy, and Paste context menu actions\n(#286704)](https://github.com/elastic/kibana/pull/286704)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}},{"branch":"9.5","label":"v9.5.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/286799","number":286799,"state":"MERGED","mergeCommit":{"sha":"e509e04badb3afe75ce2c95f078e8e1f7dcca306","message":"[9.5] [Console] Fix duplicate Cut, Copy, and Paste context menu actions (#286704) (#286799)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.5`:\n- [[Console] Fix duplicate Cut, Copy, and Paste context menu actions\n(#286704)](https://github.com/elastic/kibana/pull/286704)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>\nCo-authored-by: Cursor <cursoragent@cursor.com>"}}]}] BACKPORT-->