### PR TITLE
[synthetics] Skip failing custom status alert Scout test

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/tests/custom_status_alert.spec.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/tests/custom_status_alert.spec.ts
@@ -23,7 +23,8 @@ test.describe(
       await syntheticsServices.cleanUp();
     });
 
-    test('creates a custom status alert rule', async ({
+    // Failing: See https://github.com/elastic/kibana/issues/268088
+    test.skip('creates a custom status alert rule', async ({
       pageObjects,
       page,
       browserAuth,


### PR DESCRIPTION
## Summary

- skips the failing custom status alert Scout test
- links the skip to the tracked failure issue

Addresses #268088

## Validation

- `node scripts/eslint x-pack/solutions/observability/plugins/synthetics/test/scout/alerting_and_reset/ui/tests/custom_status_alert.spec.ts`
- `git diff --check`