### PR TITLE
[Agent Builder] Keep disabled pre-execution workflows visible in settings

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/tools/contract.ts
@@ -27,6 +27,7 @@ export interface WorkflowListItem {
   id: string;
   name: string;
   description?: string;
+  enabled: boolean;
 }
 
 export interface ListWorkflowsResponse {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/workflow_combo_box/workflow_combo_box.test.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/workflow_combo_box/workflow_combo_box.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WorkflowComboBox } from './workflow_combo_box';
+
+const workflows = [
+  { id: 'wf-enabled', name: 'Enabled Workflow', enabled: true },
+  { id: 'wf-disabled', name: 'Disabled Workflow', enabled: false },
+];
+
+function renderComboBox(
+  props: Partial<React.ComponentProps<typeof WorkflowComboBox>> = {}
+): ReturnType<typeof render> {
+  return render(
+    <WorkflowComboBox
+      workflows={workflows}
+      value={[]}
+      onChange={jest.fn()}
+      aria-label="Workflows"
+      {...props}
+    />
+  );
+}
+
+describe('WorkflowComboBox', () => {
+  it('shows a selected disabled workflow with a disabled label', () => {
+    renderComboBox({ value: ['wf-disabled'] });
+
+    expect(screen.getByText('Disabled Workflow (disabled)')).toBeTruthy();
+  });
+
+  it('does not offer unselected disabled workflows as options', async () => {
+    const user = userEvent.setup();
+    renderComboBox();
+
+    await user.click(screen.getByRole('combobox', { name: 'Workflows' }));
+
+    expect(screen.getByRole('option', { name: 'Enabled Workflow' })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: /Disabled Workflow/ })).toBeNull();
+  });
+
+  it('allows removing a selected disabled workflow', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    renderComboBox({ value: ['wf-disabled'], onChange });
+
+    await user.click(
+      screen.getByRole('button', { name: /Remove Disabled Workflow \(disabled\)/i })
+    );
+
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/workflow_combo_box/workflow_combo_box.tsx
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/workflow_combo_box/workflow_combo_box.tsx
@@ -7,11 +7,13 @@
 
 import { EuiComboBox } from '@elastic/eui';
 import type { EuiComboBoxOptionOption, EuiComboBoxProps } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
 
 export interface WorkflowComboBoxOption {
   id: string;
   name: string;
+  enabled?: boolean;
 }
 
 export interface WorkflowComboBoxProps
@@ -25,6 +27,18 @@ export interface WorkflowComboBoxProps
   singleSelection?: boolean;
 }
 
+const toOption = (workflow: WorkflowComboBoxOption): EuiComboBoxOptionOption<string> => ({
+  key: workflow.id,
+  label:
+    workflow.enabled === false
+      ? i18n.translate('xpack.agentBuilder.workflowComboBox.disabledOptionLabel', {
+          defaultMessage: '{name} (disabled)',
+          values: { name: workflow.name },
+        })
+      : workflow.name,
+  value: workflow.id,
+});
+
 export const WorkflowComboBox: React.FC<WorkflowComboBoxProps> = ({
   workflows,
   value,
@@ -33,15 +47,12 @@ export const WorkflowComboBox: React.FC<WorkflowComboBoxProps> = ({
   'data-test-subj': dataTestSubj = 'workflowComboBox',
   ...comboBoxProps
 }) => {
-  const toOption = (workflow: WorkflowComboBoxOption): EuiComboBoxOptionOption<string> => ({
-    key: workflow.id,
-    label: workflow.name,
-    value: workflow.id,
-  });
-
   const options: Array<EuiComboBoxOptionOption<string>> = useMemo(
-    () => workflows.map(toOption),
-    [workflows]
+    () =>
+      workflows
+        .filter((workflow) => workflow.enabled !== false || value.includes(workflow.id))
+        .map(toOption),
+    [workflows, value]
   );
 
   const workflowsById = useMemo(

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/pre_prompt_workflow_section/pre_prompt_workflow_section.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/pre_prompt_workflow_section/pre_prompt_workflow_section.tsx
@@ -50,7 +50,11 @@ export const PrePromptWorkflowSection: React.FC = () => {
         return [];
       }
       const response = await agentBuilder.tools.listWorkflows({ page: 1, limit: 1000 });
-      return response.results.map((workflow) => ({ id: workflow.id, name: workflow.name }));
+      return response.results.map((workflow) => ({
+        id: workflow.id,
+        name: workflow.name,
+        enabled: workflow.enabled,
+      }));
     },
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/tools.ts
@@ -89,6 +89,7 @@ export interface WorkflowItem {
   id: string;
   name: string;
   description: string;
+  enabled: boolean;
 }
 
 export interface GetWorkflowResponse {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/workflow/workflow_picker.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/components/workflow/workflow_picker.test.tsx
@@ -119,4 +119,22 @@ describe('WorkflowPicker', () => {
     const combobox = screen.getByRole('combobox', { name: /workflow selection/i });
     expect(combobox).toBeDisabled();
   });
+
+  it('keeps a configured disabled workflow selected', () => {
+    mockUseListWorkflows.mockReturnValue({
+      data: [
+        { id: 'wf-1', name: 'Workflow One', enabled: true },
+        { id: 'wf-disabled', name: 'Disabled Workflow', enabled: false },
+      ],
+      isLoading: false,
+    });
+
+    render(
+      <TestWrapper defaultValues={{ configuration: { workflow_ids: ['wf-disabled'] } }}>
+        <WorkflowPicker name="configuration.workflow_ids" singleSelection={false} />
+      </TestWrapper>
+    );
+
+    expect(screen.getByText('Disabled Workflow (disabled)')).toBeInTheDocument();
+  });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
@@ -367,7 +367,7 @@ export function registerInternalToolsRoutes({
       }
 
       const { results } = await workflowsManagement.management.getWorkflows(
-        { page: request.query.page, size: request.query.limit, enabled: [true] },
+        { page: request.query.page, size: request.query.limit },
         currentSpace
       );
 
@@ -377,6 +377,7 @@ export function registerInternalToolsRoutes({
             id: workflow.id,
             name: workflow.name,
             description: workflow.description,
+            enabled: workflow.enabled,
           })),
         },
       });


### PR DESCRIPTION
## TL;DR
Disabled pre-execution workflows stay visible in the agent picker as `{name} (disabled)` so they can be removed, instead of disappearing while the runtime still executes them.

## Summary
- `_list_workflows` now returns disabled workflows with an `enabled` flag
- The picker keeps configured disabled workflows selected and removable
- Disabled workflows that are not already configured cannot be newly selected

## Test plan
- [ ] Attach an enabled workflow as a pre-execution workflow, save, then disable it
- [ ] Confirm Settings still shows it as selected with `(disabled)`
- [ ] Remove it and save; confirm `configuration.workflow_ids` no longer includes it
- [ ] Confirm other disabled workflows do not appear as new options

## References
Closes elastic/security-team#19056

Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->