### PR TITLE
[ResponseOps][SnoozeSchedule] Fix custom snooze schedule mismatch on edit

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/helpers.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/helpers.test.tsx
@@ -12,6 +12,7 @@ import {
   generateNthByweekday,
   getInitialByweekday,
   getWeekdayInfo,
+  isCustomRecurrenceFrequency,
   recurrenceSummary,
   rRuleWeekdayToWeekdayName,
 } from './helpers';
@@ -151,6 +152,16 @@ describe('Recurrence scheduler helper', () => {
           interval: 1,
         })
       ).toEqual('every month');
+    });
+
+    test('should give a detailed msg with monthly bymonthday', () => {
+      expect(
+        recurrenceSummary({
+          freq: RRuleFrequency.MONTHLY,
+          interval: 1,
+          bymonthday: [15],
+        })
+      ).toEqual('every month on day 15');
     });
   });
 
@@ -297,6 +308,66 @@ describe('Recurrence scheduler helper', () => {
         freq: 0,
         interval: 2,
       });
+    });
+  });
+
+  describe('isCustomRecurrenceFrequency', () => {
+    test('monthly + bymonthday is custom', () => {
+      expect(
+        isCustomRecurrenceFrequency({
+          freq: RRuleFrequency.MONTHLY,
+          interval: 1,
+          bymonthday: [15],
+        })
+      ).toBe(true);
+    });
+
+    test('monthly + nth byweekday is not custom', () => {
+      expect(
+        isCustomRecurrenceFrequency({
+          freq: RRuleFrequency.MONTHLY,
+          interval: 1,
+          byweekday: ['+4TU'],
+        })
+      ).toBe(false);
+    });
+
+    test('weekly single weekday is not custom', () => {
+      expect(
+        isCustomRecurrenceFrequency({
+          freq: RRuleFrequency.WEEKLY,
+          interval: 1,
+          byweekday: ['TU'],
+        })
+      ).toBe(false);
+    });
+
+    test('daily interval 1 is not custom', () => {
+      expect(
+        isCustomRecurrenceFrequency({
+          freq: RRuleFrequency.DAILY,
+          interval: 1,
+        })
+      ).toBe(false);
+    });
+
+    test('weekly multi-weekday is custom', () => {
+      expect(
+        isCustomRecurrenceFrequency({
+          freq: RRuleFrequency.WEEKLY,
+          interval: 1,
+          byweekday: ['MO', 'WE'],
+        })
+      ).toBe(true);
+    });
+
+    test('interval greater than 1 is custom', () => {
+      expect(
+        isCustomRecurrenceFrequency({
+          freq: RRuleFrequency.DAILY,
+          interval: 2,
+        })
+      ).toBe(true);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/helpers.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/helpers.tsx
@@ -156,6 +156,24 @@ export const recurrenceSummary = ({
 export const rRuleWeekdayToWeekdayName = (weekday: string) =>
   moment().isoWeekday(RRULE_WEEKDAYS_TO_ISO_WEEKDAYS[weekday.slice(-2)]).format('dddd');
 
+export const isCustomRecurrenceFrequency = ({
+  freq,
+  interval,
+  byweekday,
+  bymonthday,
+}: RecurrenceSchedule): boolean => {
+  if (interval > 1) {
+    return true;
+  }
+  if (freq === RRuleFrequency.WEEKLY && (byweekday?.length ?? 0) > 1) {
+    return true;
+  }
+  if (freq === RRuleFrequency.MONTHLY && (bymonthday?.length ?? 0) > 0) {
+    return true;
+  }
+  return false;
+};
+
 export const buildCustomRecurrenceSchedulerState = ({
   frequency,
   interval,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/index.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/index.test.tsx
@@ -30,17 +30,11 @@ describe('RecurrenceScheduler', () => {
         onChange={onChange}
       />
     );
+    expect(await screen.findByTestId('recurrenceSchedulerRepeat')).toHaveValue('CUSTOM');
 
-    await waitFor(() => {
-      expect(screen.getByTestId('recurrenceSchedulerRepeat')).toHaveValue('CUSTOM');
-    });
+    expect(await screen.findByTestId('customRecurrenceSchedulerMonthly')).toBeInTheDocument();
 
-    expect(screen.getByTestId('customRecurrenceSchedulerMonthly')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'On day 23' })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    );
-    expect(screen.getByText('Repeats every month on day 23')).toBeInTheDocument();
+    expect(await screen.findByText('Repeats every month on day 23')).toBeInTheDocument();
 
     await waitFor(() => {
       const lastCall = onChange.mock.calls.at(-1)?.[0];

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/index.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/index.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import moment from 'moment';
+import React from 'react';
+import { RRuleFrequency } from '../../../../../../types';
+import { RecurrenceScheduler } from '.';
+
+describe('RecurrenceScheduler', () => {
+  test('hydrates a monthly bymonthday schedule as custom on day N', async () => {
+    const startDate = moment('11/23/2021');
+    const endDate = moment('11/23/2021').add(2, 'hours');
+    const onChange = jest.fn();
+
+    renderWithI18n(
+      <RecurrenceScheduler
+        startDate={startDate}
+        endDate={endDate}
+        initialState={{
+          freq: RRuleFrequency.MONTHLY,
+          interval: 1,
+          bymonthday: [23],
+        }}
+        onChange={onChange}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('recurrenceSchedulerRepeat')).toHaveValue('CUSTOM');
+    });
+
+    expect(screen.getByTestId('customRecurrenceSchedulerMonthly')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'On day 23' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByText('Repeats every month on day 23')).toBeInTheDocument();
+
+    await waitFor(() => {
+      const lastCall = onChange.mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({
+          freq: RRuleFrequency.MONTHLY,
+          interval: 1,
+          bymonthday: [23],
+        })
+      );
+      expect(lastCall.byweekday).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/index.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/recurrence_scheduler/index.tsx
@@ -32,7 +32,12 @@ import {
 } from './constants';
 import { CustomRecurrenceScheduler } from './custom_recurrence_scheduler';
 import type { CustomFrequencyState } from './helpers';
-import { generateNthByweekday, getWeekdayInfo, recurrenceSummary } from './helpers';
+import {
+  generateNthByweekday,
+  getWeekdayInfo,
+  isCustomRecurrenceFrequency,
+  recurrenceSummary,
+} from './helpers';
 import { i18nNthWeekday } from './translations';
 
 interface ComponentOpts {
@@ -90,8 +95,7 @@ export const RecurrenceScheduler: React.FC<ComponentOpts> = ({
 
   useEffect(() => {
     if (initialState && !hasInitialized.current) {
-      const isCustomFrequency =
-        initialState.interval > 1 || (initialState.byweekday ?? []).length > 1;
+      const isCustomFrequency = isCustomRecurrenceFrequency(initialState);
       setFrequency(isCustomFrequency ? 'CUSTOM' : initialState.freq);
       if (isCustomFrequency) {
         setCustomFrequency(initialState as CustomFrequencyState);
@@ -230,6 +234,7 @@ export const RecurrenceScheduler: React.FC<ComponentOpts> = ({
               setFrequency(e.target.value === 'CUSTOM' ? 'CUSTOM' : Number(e.target.value))
             }
             compressed
+            data-test-subj="recurrenceSchedulerRepeat"
           />
         </EuiFormRow>
         {frequency === 'CUSTOM' && (


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/286237

<img width="1476" height="630" alt="Screenshot 2026-08-24 at 13 15 17" src="https://github.com/user-attachments/assets/84b64b6c-ab39-4d3f-9766-a35294552376" />

<img width="1726" height="868" alt="Screenshot 2026-08-24 at 13 15 32" src="https://github.com/user-attachments/assets/2dceb9bb-4272-4e3c-bb09-9718744f6ac2" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->