### PR TITLE
[9.5] [Streams] Un-skip Stream data quality scout UI tests (#285948)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/.meta/ui/standard.json
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/.meta/ui/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "9a06eae7775e86cc362aea86d7c15f260639ec15",
+  "sha1": "34c543aaaa66e1c1020c74560357c2000d1d15eb",
   "testChannels": [
     "ci-on-commit",
     "ci-batch-3h"
@@ -39,7 +39,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 84,
+        "line": 125,
         "column": 9
       }
     },
@@ -55,7 +55,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 101,
+        "line": 140,
         "column": 9
       }
     },
@@ -71,7 +71,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 119,
+        "line": 159,
         "column": 9
       }
     },
@@ -87,7 +87,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 133,
+        "line": 173,
         "column": 9
       }
     },
@@ -103,7 +103,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 151,
+        "line": 191,
         "column": 9
       }
     },
@@ -119,7 +119,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 184,
+        "line": 224,
         "column": 9
       }
     },
@@ -135,7 +135,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 207,
+        "line": 247,
         "column": 9
       }
     },
@@ -151,7 +151,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 217,
+        "line": 259,
         "column": 9
       }
     },
@@ -167,7 +167,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 242,
+        "line": 283,
         "column": 9
       }
     },
@@ -183,7 +183,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 269,
+        "line": 297,
         "column": 9
       }
     },
@@ -199,7 +199,7 @@
       ],
       "location": {
         "file": "x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts",
-        "line": 294,
+        "line": 310,
         "column": 9
       }
     }

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/fixtures/data_quality_helpers.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/fixtures/data_quality_helpers.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { type ScoutPage } from '@kbn/scout';
+import { type Locator, type ScoutPage } from '@kbn/scout';
 import { expect } from '@kbn/scout/ui';
+
+const FAILED_DOCS_ISSUE = 'Documents indexing failed';
 
 /**
  * Saves failure store changes in the shared failure store modal
@@ -16,4 +18,55 @@ export async function saveFailureStoreChanges(page: ScoutPage): Promise<void> {
   const saveButton = page.getByTestId('failureStoreModalSaveButton');
   await expect(saveButton).toBeEnabled();
   await saveButton.click();
+}
+
+export function getQualityIssueRow(table: Locator, issue: string): Locator {
+  return table.getByTestId('datasetQualityDetailsDegradedTableRow').filter({ hasText: issue });
+}
+
+/**
+ * Waits for the quality issues table to show the degraded field and the failed docs rows.
+ * Both are fetched independently and each response re-sorts the table, so interacting with a
+ * row before the two have landed can hit a row that has just been re-pointed at the other issue.
+ */
+export async function waitForQualityIssuesTable(
+  page: ScoutPage,
+  degradedField: string
+): Promise<Locator> {
+  const table = page.getByTestId('datasetQualityDetailsDegradedFieldTable');
+  await expect(table).toBeVisible();
+  await expect(getQualityIssueRow(table, degradedField)).toBeVisible();
+  await expect(getQualityIssueRow(table, FAILED_DOCS_ISSUE)).toBeVisible();
+  return table;
+}
+
+/**
+ * Expands the quality issue of a degraded field and returns its flyout.
+ */
+export async function openDegradedFieldFlyout(
+  page: ScoutPage,
+  degradedField: string
+): Promise<Locator> {
+  const table = await waitForQualityIssuesTable(page, degradedField);
+  await getQualityIssueRow(table, degradedField)
+    .getByTestId('datasetQualityDetailsQualityIssuesExpandButton')
+    .click();
+
+  const flyout = page.getByTestId('datasetQualityDetailsDegradedFieldFlyout');
+  await expect(flyout).toBeVisible();
+  return flyout;
+}
+
+/**
+ * Waits for the failed documents KPI card to hold a resolved value. The card renders a `--`
+ * placeholder while the data stream details load and is swapped for the "No failure store" card
+ * when the stream has no failure store, so it is only actionable once the details have loaded.
+ */
+export async function waitForFailedDocsCard(page: ScoutPage): Promise<Locator> {
+  const card = page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents');
+  await expect(card).toBeVisible();
+  await expect(
+    card.getByTestId('datasetQualityDetailsSummaryKpiValue-Failed documents')
+  ).not.toHaveText('--');
+  return card;
 }

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/tests/data_quality.spec.ts
@@ -9,20 +9,28 @@ import { expect } from '@kbn/scout/ui';
 import { tags } from '@kbn/scout';
 import { test } from '../fixtures';
 import { generateLogsData } from '../fixtures/generators';
-import { saveFailureStoreChanges } from '../fixtures/data_quality_helpers';
+import {
+  getQualityIssueRow,
+  openDegradedFieldFlyout,
+  saveFailureStoreChanges,
+  waitForFailedDocsCard,
+  waitForQualityIssuesTable,
+} from '../fixtures/data_quality_helpers';
 
 const TEST_STREAM = 'logs-nginx-default';
+const FORKED_STREAM = 'logs.otel.nginx';
+const DEGRADED_FIELD = 'log.level';
 
 test.describe(
   'Stream data quality',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
-    test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+    test.beforeAll(async ({ apiServices, esClient, logsSynthtraceEsClient }) => {
       const currentTime = Date.now();
       const generateLogs = generateLogsData(logsSynthtraceEsClient);
 
       // Create a test stream with routing rules first
-      await apiServices.streams.forkStream('logs.otel', 'logs.otel.nginx', {
+      await apiServices.streams.forkStream('logs.otel', FORKED_STREAM, {
         field: 'service.name',
         eq: 'nginx',
       });
@@ -45,17 +53,26 @@ test.describe(
         isMalformed: true,
       });
 
-      // Add a processor that always fails to create failed docs
-      await apiServices.streams.updateStreamProcessors(TEST_STREAM, {
-        steps: [
-          {
-            action: 'rename',
-            from: 'non_existent_field',
-            to: 'renamed_field',
-            ignore_missing: false,
-            override: false,
+      // Add a processor that always fails to create failed docs, and enable the failure store so
+      // those docs are stored instead of dropped: classic streams inherit it from the index
+      // template, which enables it on stateful but not on serverless
+      const { stream } = await apiServices.streams.getStreamDefinition(TEST_STREAM);
+      await apiServices.streams.updateStream(TEST_STREAM, {
+        ingest: {
+          ...stream.ingest,
+          processing: {
+            steps: [
+              {
+                action: 'rename',
+                from: 'non_existent_field',
+                to: 'renamed_field',
+                ignore_missing: false,
+                override: false,
+              },
+            ],
           },
-        ],
+          failure_store: { lifecycle: { enabled: {} } },
+        },
       });
 
       // Add 1 failed doc
@@ -65,6 +82,29 @@ test.describe(
         endTime: new Date(currentTime).toISOString(),
         docsPerMinute: 1,
       });
+
+      // The failure store is a separate index that the synthtrace refresh doesn't cover and that
+      // refreshes on its own interval (30s on serverless), so refresh it until the failed document
+      // is searchable for the UI
+      const failureStoreIndex = `${TEST_STREAM}::failures`;
+      await expect
+        .poll(
+          async () => {
+            await esClient.indices.refresh({
+              index: failureStoreIndex,
+              allow_no_indices: true,
+              ignore_unavailable: true,
+            });
+            const { count } = await esClient.count({
+              index: failureStoreIndex,
+              allow_no_indices: true,
+              ignore_unavailable: true,
+            });
+            return count;
+          },
+          { timeout: 60_000 }
+        )
+        .toBeGreaterThan(0);
     });
 
     test.beforeEach(async ({ browserAuth, pageObjects }) => {
@@ -73,8 +113,9 @@ test.describe(
     });
 
     test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-      // Clear existing rules
-      await apiServices.streams.clearStreamChildren('logs.otel');
+      // Delete only the fork this suite created, so unrelated children of the shared
+      // `logs.otel` root are left untouched
+      await apiServices.streams.deleteStream(FORKED_STREAM);
       // Clean up the test stream
       await apiServices.streams.deleteStream(TEST_STREAM);
       // Clean up synthetic logs
@@ -86,12 +127,10 @@ test.describe(
       await expect(
         page.getByTestId('datasetQualityDetailsSummaryKpiCard-Degraded documents')
       ).toBeVisible();
-      await expect(
-        page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents')
-      ).toBeVisible();
+      const failedDocsCard = await waitForFailedDocsCard(page);
 
-      // Edit failure store button should not be visible for wired streams
-      await page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents').click();
+      // Edit failure store button should be visible for wired streams
+      await failedDocsCard.click();
       await expect(page.getByTestId('datasetQualityDetailsEditFailureStore')).toBeVisible();
 
       // Quality issues table should be visible
@@ -103,6 +142,7 @@ test.describe(
     }) => {
       // Go to Main page
       await pageObjects.streams.gotoStreamMainPage();
+      await pageObjects.streams.expectStreamsTableVisible();
       const mainTimeRange = {
         from: 'Sep 20, 2023 @ 00:00:00.000',
         to: 'Sep 20, 2023 @ 00:30:00.000',
@@ -111,7 +151,7 @@ test.describe(
       await pageObjects.datePicker.setAbsoluteRange(mainTimeRange);
 
       // Go to Data Quality tab
-      await pageObjects.streams.clickStreamNameLink('logs.otel.nginx');
+      await pageObjects.streams.clickStreamNameLink(FORKED_STREAM);
       await pageObjects.streams.clickDataQualityTab();
       await pageObjects.streams.verifyDatePickerTimeRange(mainTimeRange);
     });
@@ -199,7 +239,7 @@ test.describe(
       await pageObjects.streams.verifyDatePickerTimeRange(timeRange);
 
       // Navigate to a different stream and verify time persists
-      await pageObjects.streams.clickStreamNameLink('logs.otel.nginx');
+      await pageObjects.streams.clickStreamNameLink(FORKED_STREAM);
       await pageObjects.streams.clickDataQualityTab();
       await pageObjects.streams.verifyDatePickerTimeRange(timeRange);
     });
@@ -211,13 +251,14 @@ test.describe(
       await expect(page.getByTestId('datasetQualityDetailsLinkToDiscover')).toBeVisible();
 
       // Click to show failed docs chart
-      await page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents').click();
+      const failedDocsCard = await waitForFailedDocsCard(page);
+      await failedDocsCard.click();
+      await expect(failedDocsCard).toHaveAttribute('aria-pressed', 'true');
     });
 
     test('should show degraded fields table with data', async ({ page }) => {
       // Quality issues table should be visible
-      const degradedFieldTable = page.getByTestId('datasetQualityDetailsDegradedFieldTable');
-      await expect(degradedFieldTable).toBeVisible();
+      const degradedFieldTable = await waitForQualityIssuesTable(page, DEGRADED_FIELD);
 
       // Should show table headers (scope to the table to avoid ambiguity)
       await expect(degradedFieldTable.getByRole('columnheader', { name: 'Field' })).toBeVisible();
@@ -230,58 +271,33 @@ test.describe(
       ).toBeVisible();
 
       // Verify there is at least one degraded field row
-      const degradedFieldRows = degradedFieldTable.locator('tbody tr');
+      const degradedFieldRows = degradedFieldTable.getByTestId(
+        'datasetQualityDetailsDegradedTableRow'
+      );
       expect(await degradedFieldRows.count()).toBeGreaterThan(0);
 
       // Verify the log.level field is present (from malformed data)
-      await expect(
-        degradedFieldTable.getByRole('row').filter({ hasText: 'log.level' })
-      ).toBeVisible();
+      await expect(getQualityIssueRow(degradedFieldTable, DEGRADED_FIELD)).toBeVisible();
     });
 
     test('should open and close degraded field flyout', async ({ page, pageObjects }) => {
-      // Wait for degraded fields table to be visible
-      const degradedFieldTable = page.getByTestId('datasetQualityDetailsDegradedFieldTable');
-      await expect(degradedFieldTable).toBeVisible();
-
-      // Get the row for log.level field (which we created as malformed)
-      const logLevelRow = degradedFieldTable.getByRole('row').filter({ hasText: 'log.level' });
-      await expect(logLevelRow).toBeVisible();
-
-      // Click on the expand button for log.level
-      await logLevelRow.locator('button[aria-label="Expand"]').click();
-
-      // Flyout should be visible
-      await expect(page.getByTestId('datasetQualityDetailsDegradedFieldFlyout')).toBeVisible();
+      // Expand the row of the log.level field (which we created as malformed)
+      const flyout = await openDegradedFieldFlyout(page, DEGRADED_FIELD);
 
       // Verify flyout shows the field name
-      await expect(page.getByTestId('datasetQualityDetailsDegradedFieldFlyout')).toContainText(
-        'log.level'
-      );
+      await expect(flyout).toContainText(DEGRADED_FIELD);
 
       // Close the flyout
       await pageObjects.streams.closeFlyout();
 
       // Flyout should be hidden
-      await expect(page.getByTestId('datasetQualityDetailsDegradedFieldFlyout')).toBeHidden();
+      await expect(flyout).toBeHidden();
     });
 
     test('should navigate to Discover from degraded field flyout', async ({ page }) => {
-      // Wait for degraded fields table to be visible
-      const degradedFieldTable = page.getByTestId('datasetQualityDetailsDegradedFieldTable');
-      await expect(degradedFieldTable).toBeVisible();
-
-      // Get the row for log.level field (which we created as malformed)
-      const logLevelRow = degradedFieldTable.getByRole('row').filter({ hasText: 'log.level' });
-      await expect(logLevelRow).toBeVisible();
-
-      // Click on the expand button for log.level
-      await logLevelRow.locator('button[aria-label="Expand"]').click();
-
-      // Flyout should be visible and show the degraded field name
-      const flyout = page.getByTestId('datasetQualityDetailsDegradedFieldFlyout');
-      await expect(flyout).toBeVisible();
-      await expect(flyout).toContainText('log.level');
+      // Expand the row of the log.level field (which we created as malformed)
+      const flyout = await openDegradedFieldFlyout(page, DEGRADED_FIELD);
+      await expect(flyout).toContainText(DEGRADED_FIELD);
 
       // Click the link to Discover in the flyout
       await page.getByTestId('datasetQualityDetailsDegradedFieldFlyoutTitleLinkToDiscover').click();
@@ -293,7 +309,8 @@ test.describe(
 
     test('should edit failure store for wired streams', async ({ page }) => {
       // Open failed documents panel
-      await page.getByTestId('datasetQualityDetailsSummaryKpiCard-Failed documents').click();
+      const failedDocsCard = await waitForFailedDocsCard(page);
+      await failedDocsCard.click();
 
       // Click the edit button to open the failure store modal
       await page.getByTestId('datasetQualityDetailsEditFailureStore').click();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Streams] Un-skip Stream data quality scout UI tests (#285948)](https://github.com/elastic/kibana/pull/285948)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2026-08-20T08:46:01Z","message":"[Streams] Un-skip Stream data quality scout UI tests (#285948)\n\nCloses https://github.com/elastic/kibana/issues/248951\nCloses https://github.com/elastic/kibana/issues/267064\n\n## Summary\n\nUn-skips the `Stream data quality` Scout suite (skipped under #267204)\nand fixes the races behind its failures.\n\n- The quality issues table is filled by two independent requests\n(degraded fields and failed docs) and re-sorted on each response.\nBecause the table rows have no stable React keys, the expand button the\ntest had resolved could end up belonging to the other row by the time\nthe click landed, opening the failed docs flyout instead of the\n`log.level` one. Tests now wait for both rows before interacting, and\nclick the button by its own `data-test-subj`.\n- The `Failed documents` KPI card is only actionable once the data\nstream details have loaded (it shows a `--` placeholder meanwhile, and\nis replaced by the `No failure store` card otherwise), so clicks on it\nnow wait for a resolved value.\n- `beforeAll` waits for the failed document to be searchable in the\nfailure store, which the synthtrace refresh does not cover.\n- Teardown deletes only the fork this suite creates instead of clearing\nevery child of the shared `logs.otel` root, which is what hit the\nstreams lock with a `409`.\n\nThe date picker timeouts in #267064 were diagnosed as CI environment\nfailures (Kibana's app shell never loaded); this adds a readiness wait\non the Streams table, and the shared date picker page object has since\nbeen reworked.\n\n### Test plan\n\nLocal, stateful classic — 3 consecutive green runs (13/13 each):\n\n```bash\nnode scripts/scout start-server --arch stateful --domain classic\nnode scripts/playwright test --config x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts --project local --grep @local-stateful-classic\n```\n\nLocal, serverless observability complete — 3 consecutive green runs\n(13/13 each):\n```bash\nnode scripts/scout start-server --arch serverless --domain observability_complete\nnode scripts/playwright test --config x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts --project local --grep @local-serverless-observability_complete\n```\n\nFlaky test runner: `/flaky\nscoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts:30`","sha":"389740fd69ccfaf735eca048c93a2bb9a14d6b95","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport missing","backport:version","Feature:Streams","reviewer:scout","v9.6.0","Team:streams-ui","v9.4.6","v9.5.2"],"title":"[Streams] Un-skip Stream data quality scout UI tests","number":285948,"url":"https://github.com/elastic/kibana/pull/285948","mergeCommit":{"message":"[Streams] Un-skip Stream data quality scout UI tests (#285948)\n\nCloses https://github.com/elastic/kibana/issues/248951\nCloses https://github.com/elastic/kibana/issues/267064\n\n## Summary\n\nUn-skips the `Stream data quality` Scout suite (skipped under #267204)\nand fixes the races behind its failures.\n\n- The quality issues table is filled by two independent requests\n(degraded fields and failed docs) and re-sorted on each response.\nBecause the table rows have no stable React keys, the expand button the\ntest had resolved could end up belonging to the other row by the time\nthe click landed, opening the failed docs flyout instead of the\n`log.level` one. Tests now wait for both rows before interacting, and\nclick the button by its own `data-test-subj`.\n- The `Failed documents` KPI card is only actionable once the data\nstream details have loaded (it shows a `--` placeholder meanwhile, and\nis replaced by the `No failure store` card otherwise), so clicks on it\nnow wait for a resolved value.\n- `beforeAll` waits for the failed document to be searchable in the\nfailure store, which the synthtrace refresh does not cover.\n- Teardown deletes only the fork this suite creates instead of clearing\nevery child of the shared `logs.otel` root, which is what hit the\nstreams lock with a `409`.\n\nThe date picker timeouts in #267064 were diagnosed as CI environment\nfailures (Kibana's app shell never loaded); this adds a readiness wait\non the Streams table, and the shared date picker page object has since\nbeen reworked.\n\n### Test plan\n\nLocal, stateful classic — 3 consecutive green runs (13/13 each):\n\n```bash\nnode scripts/scout start-server --arch stateful --domain classic\nnode scripts/playwright test --config x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts --project local --grep @local-stateful-classic\n```\n\nLocal, serverless observability complete — 3 consecutive green runs\n(13/13 each):\n```bash\nnode scripts/scout start-server --arch serverless --domain observability_complete\nnode scripts/playwright test --config x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts --project local --grep @local-serverless-observability_complete\n```\n\nFlaky test runner: `/flaky\nscoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts:30`","sha":"389740fd69ccfaf735eca048c93a2bb9a14d6b95"}},"sourceBranch":"main","suggestedTargetBranches":["9.4","9.5"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/285948","number":285948,"mergeCommit":{"message":"[Streams] Un-skip Stream data quality scout UI tests (#285948)\n\nCloses https://github.com/elastic/kibana/issues/248951\nCloses https://github.com/elastic/kibana/issues/267064\n\n## Summary\n\nUn-skips the `Stream data quality` Scout suite (skipped under #267204)\nand fixes the races behind its failures.\n\n- The quality issues table is filled by two independent requests\n(degraded fields and failed docs) and re-sorted on each response.\nBecause the table rows have no stable React keys, the expand button the\ntest had resolved could end up belonging to the other row by the time\nthe click landed, opening the failed docs flyout instead of the\n`log.level` one. Tests now wait for both rows before interacting, and\nclick the button by its own `data-test-subj`.\n- The `Failed documents` KPI card is only actionable once the data\nstream details have loaded (it shows a `--` placeholder meanwhile, and\nis replaced by the `No failure store` card otherwise), so clicks on it\nnow wait for a resolved value.\n- `beforeAll` waits for the failed document to be searchable in the\nfailure store, which the synthtrace refresh does not cover.\n- Teardown deletes only the fork this suite creates instead of clearing\nevery child of the shared `logs.otel` root, which is what hit the\nstreams lock with a `409`.\n\nThe date picker timeouts in #267064 were diagnosed as CI environment\nfailures (Kibana's app shell never loaded); this adds a readiness wait\non the Streams table, and the shared date picker page object has since\nbeen reworked.\n\n### Test plan\n\nLocal, stateful classic — 3 consecutive green runs (13/13 each):\n\n```bash\nnode scripts/scout start-server --arch stateful --domain classic\nnode scripts/playwright test --config x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts --project local --grep @local-stateful-classic\n```\n\nLocal, serverless observability complete — 3 consecutive green runs\n(13/13 each):\n```bash\nnode scripts/scout start-server --arch serverless --domain observability_complete\nnode scripts/playwright test --config x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts --project local --grep @local-serverless-observability_complete\n```\n\nFlaky test runner: `/flaky\nscoutConfig:x-pack/platform/plugins/shared/streams_app/test/scout/data_quality/ui/playwright.config.ts:30`","sha":"389740fd69ccfaf735eca048c93a2bb9a14d6b95"}},{"branch":"9.4","label":"v9.4.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->