### PR TITLE
[Agent Builder] bash tool - return `err` result for exit code > 0

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/bash.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/bash.test.ts
@@ -32,6 +32,40 @@ describe('bash tool', () => {
     });
   });
 
+  it('returns an error result when the command exits non-zero with stderr output', async () => {
+    const execResult: BashExecResult = {
+      stdout: 'partial\n',
+      stderr: 'boom\n',
+      exit_code: 2,
+    };
+    const exec = jest.fn<Promise<BashExecResult>, [string]>().mockResolvedValue(execResult);
+    const bashService = { exec } as unknown as IBashService;
+    const tool = createBashTool({ bashService });
+    const result = (await tool.handler({ command: 'do-it' }, {} as never)) as {
+      results: Array<{ type: string; data: { message: string; metadata: BashExecResult } }>;
+    };
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].type).toBe('error');
+    expect(result.results[0].data.message).toBe('Command exited with code 2');
+    expect(result.results[0].data.metadata).toEqual(execResult);
+  });
+
+  it('returns an other result when the command exits non-zero without stderr (e.g. grep no match)', async () => {
+    const exec = jest.fn<Promise<BashExecResult>, [string]>().mockResolvedValue({
+      stdout: '',
+      stderr: '',
+      exit_code: 1,
+    });
+    const bashService = { exec } as unknown as IBashService;
+    const tool = createBashTool({ bashService });
+    const result = (await tool.handler({ command: 'grep foo file' }, {} as never)) as {
+      results: Array<{ type: string; data: BashExecResult }>;
+    };
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].type).toBe('other');
+    expect(result.results[0].data.exit_code).toBe(1);
+  });
+
   it('raises the tool-result length guardrail budget to cover its own worst case', () => {
     const bashService = { exec: jest.fn() } as unknown as IBashService;
     const tool = createBashTool({ bashService });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/bash.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/bash.ts
@@ -131,7 +131,7 @@ export const createBashTool = ({
     maxResultTokens: SAFEGUARD_TOKEN_COUNT * 2,
     handler: async ({ command }) => {
       const result = await bashService.exec(command);
-      if (result.exit_code !== 0) {
+      if (result.exit_code !== 0 && result.stderr) {
         return {
           results: [
             createErrorResult({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/bash.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/run_agent/tools/bash.ts
@@ -8,7 +8,7 @@
 import { z } from '@kbn/zod/v4';
 import { ToolType } from '@kbn/agent-builder-common';
 import { internalTools } from '@kbn/agent-builder-common/tools';
-import { createOtherResult } from '@kbn/agent-builder-server';
+import { createErrorResult, createOtherResult } from '@kbn/agent-builder-server';
 import type { InternalBuiltinToolDefinition } from '@kbn/agent-builder-server/tools';
 import type { IBashService } from '@kbn/agent-builder-server/runner';
 import { SAFEGUARD_TOKEN_COUNT } from '../bash/output_truncation';
@@ -131,6 +131,16 @@ export const createBashTool = ({
     maxResultTokens: SAFEGUARD_TOKEN_COUNT * 2,
     handler: async ({ command }) => {
       const result = await bashService.exec(command);
+      if (result.exit_code !== 0) {
+        return {
+          results: [
+            createErrorResult({
+              message: `Command exited with code ${result.exit_code}`,
+              metadata: { ...result },
+            }),
+          ],
+        };
+      }
       return { results: [createOtherResult(result)] };
     },
   };


### PR DESCRIPTION
## Summary

Change the result wrapping logic for the `bash` tool so that it returns an `error` instead of `other` result type when the bash execution returns a non-zero return code.

