### PR TITLE
[9.5] Remove `ci-batch-3h` from default test channel list (#286785)

### DIFF
--- a/src/platform/packages/private/kbn-scout-info/src/test_channels.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/test_channels.ts
@@ -41,7 +41,7 @@ export const testChannels: {
   current(): ScoutTestChannel[];
 } = {
   all: ScoutTestChannelSchema.options,
-  default: ['ci-on-commit', 'ci-batch-3h'],
+  default: ['ci-on-commit'],
   match(pattern) {
     return this.all.filter((channel) => channel.match(pattern));
   },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Remove `ci-batch-3h` from default test channel list (#286785)](https://github.com/elastic/kibana/pull/286785)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"David Olaru","email":"dolaru@elastic.co"},"sourceCommit":{"committedDate":"2026-08-24T10:29:16Z","message":"Remove `ci-batch-3h` from default test channel list (#286785)\n\n## Summary\nOnly `ci-on-commit` needs to be in the default test channel list. Batch\npipelines can choose to include `ci-on-commit` when it makes sense\nrather than having everything added to the 3h batch channel by default.","sha":"364e5b7bef97e38e58f98f31f7785cbf4dba5f5f","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","reviewer:scout","v9.6.0"],"title":"Remove `ci-batch-3h` from default test channel list","number":286785,"url":"https://github.com/elastic/kibana/pull/286785","mergeCommit":{"message":"Remove `ci-batch-3h` from default test channel list (#286785)\n\n## Summary\nOnly `ci-on-commit` needs to be in the default test channel list. Batch\npipelines can choose to include `ci-on-commit` when it makes sense\nrather than having everything added to the 3h batch channel by default.","sha":"364e5b7bef97e38e58f98f31f7785cbf4dba5f5f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/286785","number":286785,"mergeCommit":{"message":"Remove `ci-batch-3h` from default test channel list (#286785)\n\n## Summary\nOnly `ci-on-commit` needs to be in the default test channel list. Batch\npipelines can choose to include `ci-on-commit` when it makes sense\nrather than having everything added to the 3h batch channel by default.","sha":"364e5b7bef97e38e58f98f31f7785cbf4dba5f5f"}}]}] BACKPORT-->