### PR TITLE
[Synthetics] Persist missing-rules callout dismiss in local storage

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/alerting_callout/alerting_callout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/alerting_callout/alerting_callout.tsx
@@ -11,7 +11,7 @@ import { useDispatch, useSelector } from 'react-redux-v7';
 import { EuiButton, EuiButtonEmpty, EuiCallOut, EuiMarkdownFormat, EuiSpacer } from '@elastic/eui';
 import { syntheticsSettingsLocatorID } from '@kbn/observability-plugin/common';
 import { useFetcher } from '@kbn/observability-shared-plugin/public';
-import useSessionStorage from 'react-use/lib/useSessionStorage';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -88,7 +88,7 @@ const MissingRulesCallout = ({
   missingConfig?: boolean;
   missingRules?: boolean;
 }) => {
-  const [isHidden, setIsHidden] = useSessionStorage('MissingRulesCalloutHidden', false);
+  const [isHidden, setIsHidden] = useLocalStorage('MissingRulesCalloutHidden', false);
 
   if ((!missingConfig && !missingRules) || isHidden) {
     return null;


### PR DESCRIPTION
## 📝 Summary

- Persist **Remind me later** for the missing-rules / missing-connector alerting callout in **local storage** instead of session storage.
- Dismissing the callout now survives tab and session close, matching other Synthetics UI preferences (`react-use/lib/useLocalStorage`).

## 🧪 Test plan

- [ ] Open Synthetics with a missing default connector or missing default rules so the **Alerts are not being sent** callout appears.
- [ ] Click **Remind me later** and confirm the callout disappears.
- [ ] Refresh the page and confirm the callout stays hidden.
- [ ] Close the tab (or restart the browser) and confirm the callout is still hidden.
- [ ] In DevTools, clear `localStorage` key `MissingRulesCalloutHidden` and confirm the callout returns when conditions still apply.

<!--ONMERGE {"backportTargets":["8.19","9.4","9.5"]} ONMERGE-->