### PR TITLE
[8.19] Implement PKI HTTP/2 functional tests (#274000)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/pki/stateful/base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/pki/stateful/base.config.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { readFileSync } from 'fs';
+import { CA_CERT_PATH } from '@kbn/dev-utils';
+import {
+  MOCK_IDP_ATTRIBUTE_EMAIL,
+  MOCK_IDP_ATTRIBUTE_NAME,
+  MOCK_IDP_ATTRIBUTE_PRINCIPAL,
+  MOCK_IDP_ATTRIBUTE_ROLES,
+  MOCK_IDP_ENTITY_ID,
+  MOCK_IDP_REALM_NAME,
+  MOCK_IDP_SP_BASE_URL,
+} from '@kbn/mock-idp-utils';
+import type { ScoutServerConfig } from '../../../../../types';
+import { defaultConfig } from '../../default/stateful/base.config';
+import { STATEFUL_IDP_METADATA_PATH } from '../../../constants';
+
+const addOrReplaceArg = (serverArgs: string[], argName: string, newValue: string) => {
+  const argPrefix = `--${argName}=`;
+  const idx = serverArgs.findIndex((a) => a.startsWith(argPrefix));
+  if (idx === -1) {
+    serverArgs.push(`${argPrefix}${newValue}`);
+  } else {
+    serverArgs[idx] = `${argPrefix}${newValue}`;
+  }
+};
+
+const kbnServerArgs = [...defaultConfig.kbnTestServer.serverArgs];
+
+addOrReplaceArg(
+  kbnServerArgs,
+  'xpack.security.authc.providers',
+  JSON.stringify({
+    pki: { pki1: { order: 0 } },
+    saml: { 'cloud-saml-kibana': { order: 1, realm: MOCK_IDP_REALM_NAME } },
+    basic: { basic1: { order: 2 } },
+  })
+);
+addOrReplaceArg(kbnServerArgs, 'xpack.security.authc.selector.enabled', 'false');
+addOrReplaceArg(kbnServerArgs, 'elasticsearch.hosts', 'https://localhost:9220');
+addOrReplaceArg(kbnServerArgs, 'elasticsearch.ssl.certificateAuthorities', CA_CERT_PATH);
+addOrReplaceArg(kbnServerArgs, 'server.ssl.clientAuthentication', 'optional');
+
+export const pkiConfig: ScoutServerConfig = {
+  servers: {
+    ...defaultConfig.servers,
+    elasticsearch: {
+      ...defaultConfig.servers.elasticsearch,
+      protocol: 'https',
+      certificateAuthorities: [readFileSync(CA_CERT_PATH)],
+    },
+  },
+  dockerServers: defaultConfig.dockerServers,
+  esTestCluster: {
+    from: 'snapshot',
+    license: 'trial',
+    files: defaultConfig.esTestCluster.files,
+    ssl: true,
+    serverArgs: [
+      'xpack.security.authc.token.enabled=true',
+      'xpack.security.http.ssl.client_authentication=optional',
+      'xpack.security.http.ssl.verification_mode=certificate',
+      'xpack.security.authc.realms.native.native1.order=0',
+      'xpack.security.authc.realms.pki.pki1.order=1',
+      'xpack.security.authc.realms.pki.pki1.delegation.enabled=true',
+      `xpack.security.authc.realms.pki.pki1.certificate_authorities=${CA_CERT_PATH}`,
+      // SAML realm required by Scout's startup steps
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.order=2`,
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.idp.metadata.path=${STATEFUL_IDP_METADATA_PATH}`,
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.idp.entity_id=${MOCK_IDP_ENTITY_ID}`,
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.sp.entity_id=${MOCK_IDP_SP_BASE_URL}`,
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.sp.acs=${MOCK_IDP_SP_BASE_URL}/api/security/saml/callback`,
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.sp.logout=${MOCK_IDP_SP_BASE_URL}/logout`,
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.attributes.principal=${MOCK_IDP_ATTRIBUTE_PRINCIPAL}`,
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.attributes.groups=${MOCK_IDP_ATTRIBUTE_ROLES}`,
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.attributes.name=${MOCK_IDP_ATTRIBUTE_NAME}`,
+      `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.attributes.mail=${MOCK_IDP_ATTRIBUTE_EMAIL}`,
+    ],
+  },
+  kbnTestServer: {
+    ...defaultConfig.kbnTestServer,
+    serverArgs: kbnServerArgs,
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/pki/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/pki/stateful/classic.stateful.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { pkiConfig } from './base.config';
+
+export const servers: ScoutServerConfig = {
+  ...pkiConfig,
+  http2: true,
+};

--- a/x-pack/platform/plugins/shared/security/test/scout_pki/ui/fixtures/constants.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki/ui/fixtures/constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { readFileSync } from 'fs';
+
+export const FIRST_CLIENT_P12 = readFileSync(
+  require.resolve('@kbn/security-api-integration-helpers/pki/first_client.p12')
+);
+
+export const SECOND_CLIENT_P12 = readFileSync(
+  require.resolve('@kbn/security-api-integration-helpers/pki/second_client.p12')
+);
+
+// Must match the `pki` config set's pinned Kibana host:port (set via configureHTTP2)
+export const KIBANA_TLS_ORIGIN = 'https://localhost:5620';

--- a/x-pack/platform/plugins/shared/security/test/scout_pki/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki/ui/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/platform/plugins/shared/security/test/scout_pki/ui/tests/pki_login.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki/ui/tests/pki_login.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags, test } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+
+import { FIRST_CLIENT_P12, KIBANA_TLS_ORIGIN } from '../fixtures/constants';
+
+test.use({
+  clientCertificates: [{ origin: KIBANA_TLS_ORIGIN, pfx: FIRST_CLIENT_P12, passphrase: '' }],
+});
+
+test.describe('PKI authentication — with role mapping', { tag: tags.stateful.classic }, () => {
+  test.beforeAll(async ({ esClient }) => {
+    await esClient.security.putRoleMapping({
+      name: 'first_client_pki',
+      enabled: true,
+      roles: ['kibana_admin'],
+      rules: { field: { dn: 'CN=first_client' } },
+    });
+  });
+
+  test.afterAll(async ({ esClient }) => {
+    await esClient.security.deleteRoleMapping({ name: 'first_client_pki' }, { ignore: [404] });
+  });
+
+  test('logs in via client certificate without the login form', async ({ page }) => {
+    await page.goto(`${KIBANA_TLS_ORIGIN}/app/home`);
+    await expect(page.testSubj.locator('userMenuButton')).toBeVisible();
+    await expect(page.testSubj.locator('loginUsername')).toHaveCount(0);
+  });
+});

--- a/x-pack/platform/plugins/shared/security/test/scout_pki/ui/tests/pki_no_role_mapping.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_pki/ui/tests/pki_no_role_mapping.spec.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags, test } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+
+import { KIBANA_TLS_ORIGIN, SECOND_CLIENT_P12 } from '../fixtures/constants';
+
+test.use({
+  clientCertificates: [{ origin: KIBANA_TLS_ORIGIN, pfx: SECOND_CLIENT_P12, passphrase: '' }],
+});
+
+test.describe('PKI authentication — no role mapping', { tag: tags.stateful.classic }, () => {
+  test('redirects to the reset session page when the cert user has no privileges', async ({
+    page,
+  }) => {
+    await page.goto(`${KIBANA_TLS_ORIGIN}/app/home`);
+    await page.waitForURL(`${KIBANA_TLS_ORIGIN}/security/reset_session?next=%2Fapp%2Fhome`);
+    await expect(page.testSubj.locator('promptPage')).toBeVisible();
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Implement PKI HTTP/2 functional tests (#274000)](https://github.com/elastic/kibana/pull/274000)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-06-26T16:05:33Z","message":"Implement PKI HTTP/2 functional tests (#274000)\n\nAdds Scout-based UI PKI login tests, using http2.\n\nCopilot drafted a bogus test suite using the FTR, so I (@legrego) took\ncontrol of this PR to create what I actually wanted.\n\n\nResolves https://github.com/elastic/kibana/issues/267535\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1f1bea552d77fba70b27d3b185c064a5660c37a8","branchLabelMapping":{"^v9.5.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:skip","💝community","v9.5.0","reviewer:scout"],"title":"Implement PKI HTTP/2 functional tests","number":274000,"url":"https://github.com/elastic/kibana/pull/274000","mergeCommit":{"message":"Implement PKI HTTP/2 functional tests (#274000)\n\nAdds Scout-based UI PKI login tests, using http2.\n\nCopilot drafted a bogus test suite using the FTR, so I (@legrego) took\ncontrol of this PR to create what I actually wanted.\n\n\nResolves https://github.com/elastic/kibana/issues/267535\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1f1bea552d77fba70b27d3b185c064a5660c37a8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.5.0","branchLabelMappingKey":"^v9.5.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/274000","number":274000,"mergeCommit":{"message":"Implement PKI HTTP/2 functional tests (#274000)\n\nAdds Scout-based UI PKI login tests, using http2.\n\nCopilot drafted a bogus test suite using the FTR, so I (@legrego) took\ncontrol of this PR to create what I actually wanted.\n\n\nResolves https://github.com/elastic/kibana/issues/267535\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1f1bea552d77fba70b27d3b185c064a5660c37a8"}}]}] BACKPORT-->