### PR TITLE
Keep framed application outline stable on focus

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout/index.ts
+++ b/src/core/packages/chrome/layout/core-chrome-layout/index.ts
@@ -47,6 +47,7 @@ export {
   getHighContrastSeparator,
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
+  focusMainContent,
 } from '@kbn/ui-chrome-layout';
 
 export { APP_FIXED_VIEWPORT_ID } from './kibana_layout_constants';

--- a/src/core/packages/chrome/layout/core-chrome-layout/index.ts
+++ b/src/core/packages/chrome/layout/core-chrome-layout/index.ts
@@ -47,7 +47,6 @@ export {
   getHighContrastSeparator,
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
-  focusMainContent,
 } from '@kbn/ui-chrome-layout';
 
 export { APP_FIXED_VIEWPORT_ID } from './kibana_layout_constants';

--- a/src/core/packages/chrome/sidebar/sidebar-components/src/components/sidebar_panel.tsx
+++ b/src/core/packages/chrome/sidebar/sidebar-components/src/components/sidebar_panel.tsx
@@ -11,7 +11,7 @@ import type { FC, ReactNode } from 'react';
 import React, { useCallback, useId, useLayoutEffect, useMemo, useRef } from 'react';
 import type { UseEuiTheme } from '@elastic/eui';
 import { EuiPanel, euiShadow } from '@elastic/eui';
-import { focusMainContent, getHighContrastBorder } from '@kbn/ui-chrome-layout';
+import { getHighContrastBorder, MAIN_CONTENT_SELECTORS } from '@kbn/ui-chrome-layout';
 import { useChromeStyle } from '@kbn/core-chrome-browser-hooks';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -49,6 +49,13 @@ export interface SidebarPanelProps {
 const defaultAriaLabel = i18n.translate('core.ui.chrome.sidebar.sidebarAriaLabel', {
   defaultMessage: 'Side panel',
 });
+
+const focusMainContent = () => {
+  const mainElement = document.querySelector(MAIN_CONTENT_SELECTORS.join(','));
+  if (mainElement instanceof HTMLElement) {
+    mainElement.focus();
+  }
+};
 
 /** Rescues focus to main content (or custom callback) when the panel unmounts with focus inside. */
 const useFocusRescue = () => {

--- a/src/core/packages/chrome/sidebar/sidebar-components/src/components/sidebar_panel.tsx
+++ b/src/core/packages/chrome/sidebar/sidebar-components/src/components/sidebar_panel.tsx
@@ -11,7 +11,7 @@ import type { FC, ReactNode } from 'react';
 import React, { useCallback, useId, useLayoutEffect, useMemo, useRef } from 'react';
 import type { UseEuiTheme } from '@elastic/eui';
 import { EuiPanel, euiShadow } from '@elastic/eui';
-import { getHighContrastBorder, MAIN_CONTENT_SELECTORS } from '@kbn/ui-chrome-layout';
+import { focusMainContent, getHighContrastBorder } from '@kbn/ui-chrome-layout';
 import { useChromeStyle } from '@kbn/core-chrome-browser-hooks';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -49,13 +49,6 @@ export interface SidebarPanelProps {
 const defaultAriaLabel = i18n.translate('core.ui.chrome.sidebar.sidebarAriaLabel', {
   defaultMessage: 'Side panel',
 });
-
-const focusMainContent = () => {
-  const mainElement = document.querySelector(MAIN_CONTENT_SELECTORS.join(','));
-  if (mainElement instanceof HTMLElement) {
-    mainElement.focus();
-  }
-};
 
 /** Rescues focus to main content (or custom callback) when the panel unmounts with focus inside. */
 const useFocusRescue = () => {

--- a/src/platform/kbn-ui/chrome-layout/index.ts
+++ b/src/platform/kbn-ui/chrome-layout/index.ts
@@ -62,5 +62,4 @@ export {
   getHighContrastSeparator,
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
-  focusMainContent,
 } from './src/utils';

--- a/src/platform/kbn-ui/chrome-layout/index.ts
+++ b/src/platform/kbn-ui/chrome-layout/index.ts
@@ -62,4 +62,5 @@ export {
   getHighContrastSeparator,
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
+  focusMainContent,
 } from './src/utils';

--- a/src/platform/kbn-ui/chrome-layout/packaging/react/index.tsx
+++ b/src/platform/kbn-ui/chrome-layout/packaging/react/index.tsx
@@ -50,6 +50,7 @@ import {
   getHighContrastSeparator,
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
+  focusMainContent,
 } from '../../src/utils';
 import type { ScrollContainer, HighContrastSeparatorOptions } from '../../src/utils';
 import type {
@@ -107,6 +108,7 @@ export {
   getHighContrastSeparator,
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
+  focusMainContent,
 };
 
 export const ChromeLayoutConfigProvider = LayoutConfigProvider;

--- a/src/platform/kbn-ui/chrome-layout/packaging/react/index.tsx
+++ b/src/platform/kbn-ui/chrome-layout/packaging/react/index.tsx
@@ -50,7 +50,6 @@ import {
   getHighContrastSeparator,
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
-  focusMainContent,
 } from '../../src/utils';
 import type { ScrollContainer, HighContrastSeparatorOptions } from '../../src/utils';
 import type {
@@ -108,7 +107,6 @@ export {
   getHighContrastSeparator,
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
-  focusMainContent,
 };
 
 export const ChromeLayoutConfigProvider = LayoutConfigProvider;

--- a/src/platform/kbn-ui/chrome-layout/packaging/react/types.ts
+++ b/src/platform/kbn-ui/chrome-layout/packaging/react/types.ts
@@ -200,3 +200,5 @@ export declare function useIsWithinChromeApplicationBreakpoints(
   breakpoints: EuiBreakpointSize[],
   isResponsive?: boolean
 ): boolean;
+
+export declare function focusMainContent(): void;

--- a/src/platform/kbn-ui/chrome-layout/packaging/react/types.ts
+++ b/src/platform/kbn-ui/chrome-layout/packaging/react/types.ts
@@ -200,5 +200,3 @@ export declare function useIsWithinChromeApplicationBreakpoints(
   breakpoints: EuiBreakpointSize[],
   isResponsive?: boolean
 ): boolean;
-
-export declare function focusMainContent(): void;

--- a/src/platform/kbn-ui/chrome-layout/src/application/layout_application.styles.ts
+++ b/src/platform/kbn-ui/chrome-layout/src/application/layout_application.styles.ts
@@ -44,6 +44,12 @@ const root = (appearance: LayoutAppearance = 'plain'): EmotionFn => {
         // use outline so it doesn't affect size/layout and cause a scrollbar
         outline: ${getHighContrastBorder(useEuiTheme)};
 
+        // Keep the decorative frame unchanged by global focus-ring styles.
+        &:focus:not(:focus-visible) {
+          outline: ${getHighContrastBorder(useEuiTheme)};
+          outline-offset: 0;
+        }
+
         ${euiShadow(useEuiTheme, 'xs', { border: 'none' })};
       `}
       ${!isFramedAppearance &&

--- a/src/platform/kbn-ui/chrome-layout/src/application/layout_application.tsx
+++ b/src/platform/kbn-ui/chrome-layout/src/application/layout_application.tsx
@@ -38,6 +38,7 @@ export const LayoutApplication = ({
       id={APP_MAIN_SCROLL_CONTAINER_ID}
       className="kbnChromeLayoutApplication"
       data-test-subj="kbnChromeLayoutApplication"
+      tabIndex={-1}
     >
       {topBar && <div css={styles.topBar}>{topBar}</div>}
       <div css={[styles.content]}>{children}</div>

--- a/src/platform/kbn-ui/chrome-layout/src/application/layout_application.tsx
+++ b/src/platform/kbn-ui/chrome-layout/src/application/layout_application.tsx
@@ -38,7 +38,6 @@ export const LayoutApplication = ({
       id={APP_MAIN_SCROLL_CONTAINER_ID}
       className="kbnChromeLayoutApplication"
       data-test-subj="kbnChromeLayoutApplication"
-      tabIndex={-1}
     >
       {topBar && <div css={styles.topBar}>{topBar}</div>}
       <div css={[styles.content]}>{children}</div>

--- a/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.test.ts
+++ b/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.test.ts
@@ -11,36 +11,20 @@ import { APP_MAIN_SCROLL_CONTAINER_ID } from '../constants';
 import { focusMainContent } from './focus_main_content';
 
 describe('focusMainContent', () => {
-  afterEach(() => {
-    document.body.replaceChildren();
-  });
+  it('focuses the first matching main content element', () => {
+    const main = document.createElement('div');
+    main.id = APP_MAIN_SCROLL_CONTAINER_ID;
 
-  it('falls back to the application scroll container', () => {
-    const scroll = document.createElement('div');
-    scroll.id = APP_MAIN_SCROLL_CONTAINER_ID;
-    const focusSpy = jest.spyOn(scroll, 'focus');
-    document.body.appendChild(scroll);
+    const focusSpy = jest.spyOn(main, 'focus');
+
+    document.body.appendChild(main);
 
     focusMainContent();
 
     expect(focusSpy).toHaveBeenCalledTimes(1);
-    expect(scroll.getAttribute('tabindex')).toBe('-1');
-  });
+    expect(main.getAttribute('tabindex')).toBe('-1');
 
-  it('prefers a main landmark over the scroll container', () => {
-    const scroll = document.createElement('div');
-    scroll.id = APP_MAIN_SCROLL_CONTAINER_ID;
-    const landmark = document.createElement('main');
-    scroll.appendChild(landmark);
-    document.body.appendChild(scroll);
-
-    const scrollFocus = jest.spyOn(scroll, 'focus');
-    const landmarkFocus = jest.spyOn(landmark, 'focus');
-
-    focusMainContent();
-
-    expect(landmarkFocus).toHaveBeenCalledTimes(1);
-    expect(scrollFocus).not.toHaveBeenCalled();
+    main.remove();
   });
 
   it('does nothing when no main content element is present', () => {

--- a/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.test.ts
+++ b/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.test.ts
@@ -7,16 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-jest.mock('@kbn/ui-chrome-layout', () => ({
-  MAIN_CONTENT_SELECTORS: ['#main-content'],
-}));
-
+import { APP_MAIN_SCROLL_CONTAINER_ID } from '../constants';
 import { focusMainContent } from './focus_main_content';
 
 describe('focusMainContent', () => {
   it('focuses the first matching main content element', () => {
     const main = document.createElement('div');
-    main.id = 'main-content';
+    main.id = APP_MAIN_SCROLL_CONTAINER_ID;
 
     const focusSpy = jest.spyOn(main, 'focus');
 
@@ -25,6 +22,7 @@ describe('focusMainContent', () => {
     focusMainContent();
 
     expect(focusSpy).toHaveBeenCalledTimes(1);
+    expect(main.getAttribute('tabindex')).toBe('-1');
 
     main.remove();
   });

--- a/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.test.ts
+++ b/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.test.ts
@@ -11,20 +11,36 @@ import { APP_MAIN_SCROLL_CONTAINER_ID } from '../constants';
 import { focusMainContent } from './focus_main_content';
 
 describe('focusMainContent', () => {
-  it('focuses the first matching main content element', () => {
-    const main = document.createElement('div');
-    main.id = APP_MAIN_SCROLL_CONTAINER_ID;
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
 
-    const focusSpy = jest.spyOn(main, 'focus');
-
-    document.body.appendChild(main);
+  it('falls back to the application scroll container', () => {
+    const scroll = document.createElement('div');
+    scroll.id = APP_MAIN_SCROLL_CONTAINER_ID;
+    const focusSpy = jest.spyOn(scroll, 'focus');
+    document.body.appendChild(scroll);
 
     focusMainContent();
 
     expect(focusSpy).toHaveBeenCalledTimes(1);
-    expect(main.getAttribute('tabindex')).toBe('-1');
+    expect(scroll.getAttribute('tabindex')).toBe('-1');
+  });
 
-    main.remove();
+  it('prefers a main landmark over the scroll container', () => {
+    const scroll = document.createElement('div');
+    scroll.id = APP_MAIN_SCROLL_CONTAINER_ID;
+    const landmark = document.createElement('main');
+    scroll.appendChild(landmark);
+    document.body.appendChild(scroll);
+
+    const scrollFocus = jest.spyOn(scroll, 'focus');
+    const landmarkFocus = jest.spyOn(landmark, 'focus');
+
+    focusMainContent();
+
+    expect(landmarkFocus).toHaveBeenCalledTimes(1);
+    expect(scrollFocus).not.toHaveBeenCalled();
   });
 
   it('does nothing when no main content element is present', () => {

--- a/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.ts
+++ b/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.ts
@@ -22,9 +22,12 @@ const focusElement = (element: HTMLElement) => {
  * Focuses the main content landmark.
  */
 export const focusMainContent = () => {
-  const mainElement = document.querySelector(MAIN_CONTENT_SELECTORS.join(','));
+  for (const selector of MAIN_CONTENT_SELECTORS) {
+    const mainElement = document.querySelector(selector);
 
-  if (mainElement instanceof HTMLElement) {
-    focusElement(mainElement);
+    if (mainElement instanceof HTMLElement) {
+      focusElement(mainElement);
+      return;
+    }
   }
 };

--- a/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.ts
+++ b/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.ts
@@ -22,12 +22,9 @@ const focusElement = (element: HTMLElement) => {
  * Focuses the main content landmark.
  */
 export const focusMainContent = () => {
-  for (const selector of MAIN_CONTENT_SELECTORS) {
-    const mainElement = document.querySelector(selector);
+  const mainElement = document.querySelector(MAIN_CONTENT_SELECTORS.join(','));
 
-    if (mainElement instanceof HTMLElement) {
-      focusElement(mainElement);
-      return;
-    }
+  if (mainElement instanceof HTMLElement) {
+    focusElement(mainElement);
   }
 };

--- a/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.ts
+++ b/src/platform/kbn-ui/chrome-layout/src/utils/focus_main_content.ts
@@ -7,15 +7,24 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { MAIN_CONTENT_SELECTORS } from '@kbn/ui-chrome-layout';
+import { MAIN_CONTENT_SELECTORS } from '../constants';
+
+const focusElement = (element: HTMLElement) => {
+  if (element.tabIndex < 0 && !element.hasAttribute('tabindex')) {
+    element.tabIndex = -1;
+    element.addEventListener('blur', () => element.removeAttribute('tabindex'), { once: true });
+  }
+
+  element.focus();
+};
 
 /**
- * Utility function for focusing the main content landmark.
+ * Focuses the main content landmark.
  */
 export const focusMainContent = () => {
   const mainElement = document.querySelector(MAIN_CONTENT_SELECTORS.join(','));
 
   if (mainElement instanceof HTMLElement) {
-    mainElement.focus();
+    focusElement(mainElement);
   }
 };

--- a/src/platform/kbn-ui/chrome-layout/src/utils/index.ts
+++ b/src/platform/kbn-ui/chrome-layout/src/utils/index.ts
@@ -31,5 +31,3 @@ export {
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
 } from './application_breakpoints';
-
-export { focusMainContent } from './focus_main_content';

--- a/src/platform/kbn-ui/chrome-layout/src/utils/index.ts
+++ b/src/platform/kbn-ui/chrome-layout/src/utils/index.ts
@@ -31,3 +31,5 @@ export {
   useCurrentChromeApplicationBreakpoint,
   useIsWithinChromeApplicationBreakpoints,
 } from './application_breakpoints';
+
+export { focusMainContent } from './focus_main_content';

--- a/src/platform/kbn-ui/side-navigation/src/components/footer/item.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/footer/item.tsx
@@ -12,11 +12,11 @@ import type { KeyboardEvent, ForwardedRef, ComponentProps } from 'react';
 import { EuiButtonIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import type { EuiButtonIconProps, IconType } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { focusMainContent } from '@kbn/ui-chrome-layout';
 
 import type { MenuItem } from '../../../types';
 import { BetaBadge } from '../beta_badge';
 import { NAVIGATION_SELECTOR_PREFIX, TOOLTIP_OFFSET } from '../../constants';
-import { focusMainContent } from '../../utils/focus_main_content';
 import { useHighContrastModeStyles } from '../../hooks/use_high_contrast_mode_styles';
 import { NewItemIndicator } from '../new_item_indicator';
 

--- a/src/platform/kbn-ui/side-navigation/src/components/footer/item.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/footer/item.tsx
@@ -12,11 +12,11 @@ import type { KeyboardEvent, ForwardedRef, ComponentProps } from 'react';
 import { EuiButtonIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import type { EuiButtonIconProps, IconType } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { focusMainContent } from '@kbn/ui-chrome-layout';
 
 import type { MenuItem } from '../../../types';
 import { BetaBadge } from '../beta_badge';
 import { NAVIGATION_SELECTOR_PREFIX, TOOLTIP_OFFSET } from '../../constants';
+import { focusMainContent } from '../../utils/focus_main_content';
 import { useHighContrastModeStyles } from '../../hooks/use_high_contrast_mode_styles';
 import { NewItemIndicator } from '../new_item_indicator';
 

--- a/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
@@ -12,7 +12,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { EuiButton, EuiSpacer, useEuiTheme, useIsWithinBreakpoints } from '@elastic/eui';
-import { focusMainContent } from '@kbn/ui-chrome-layout';
 
 import type { NavigationStructure, SideNavLogo, MenuItem, SecondaryMenuItem } from '../../types';
 import {
@@ -24,6 +23,7 @@ import {
 } from '../constants';
 import { SideNav } from './side_nav';
 import { SideNavCollapseButton } from './collapse_button';
+import { focusMainContent } from '../utils/focus_main_content';
 import { getHasSubmenu } from '../utils/get_has_submenu';
 import { useLayoutWidth } from '../hooks/use_layout_width';
 import { useNavigation } from '../hooks/use_navigation';

--- a/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
+++ b/src/platform/kbn-ui/side-navigation/src/components/navigation.tsx
@@ -12,6 +12,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { EuiButton, EuiSpacer, useEuiTheme, useIsWithinBreakpoints } from '@elastic/eui';
+import { focusMainContent } from '@kbn/ui-chrome-layout';
 
 import type { NavigationStructure, SideNavLogo, MenuItem, SecondaryMenuItem } from '../../types';
 import {
@@ -23,7 +24,6 @@ import {
 } from '../constants';
 import { SideNav } from './side_nav';
 import { SideNavCollapseButton } from './collapse_button';
-import { focusMainContent } from '../utils/focus_main_content';
 import { getHasSubmenu } from '../utils/get_has_submenu';
 import { useLayoutWidth } from '../hooks/use_layout_width';
 import { useNavigation } from '../hooks/use_navigation';

--- a/src/platform/kbn-ui/side-navigation/src/utils/focus_main_content.test.ts
+++ b/src/platform/kbn-ui/side-navigation/src/utils/focus_main_content.test.ts
@@ -7,13 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { APP_MAIN_SCROLL_CONTAINER_ID } from '../constants';
+jest.mock('@kbn/ui-chrome-layout', () => ({
+  MAIN_CONTENT_SELECTORS: ['#main-content'],
+}));
+
 import { focusMainContent } from './focus_main_content';
 
 describe('focusMainContent', () => {
   it('focuses the first matching main content element', () => {
     const main = document.createElement('div');
-    main.id = APP_MAIN_SCROLL_CONTAINER_ID;
+    main.id = 'main-content';
 
     const focusSpy = jest.spyOn(main, 'focus');
 
@@ -22,7 +25,6 @@ describe('focusMainContent', () => {
     focusMainContent();
 
     expect(focusSpy).toHaveBeenCalledTimes(1);
-    expect(main.getAttribute('tabindex')).toBe('-1');
 
     main.remove();
   });

--- a/src/platform/kbn-ui/side-navigation/src/utils/focus_main_content.ts
+++ b/src/platform/kbn-ui/side-navigation/src/utils/focus_main_content.ts
@@ -7,24 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { MAIN_CONTENT_SELECTORS } from '../constants';
-
-const focusElement = (element: HTMLElement) => {
-  if (element.tabIndex < 0 && !element.hasAttribute('tabindex')) {
-    element.tabIndex = -1;
-    element.addEventListener('blur', () => element.removeAttribute('tabindex'), { once: true });
-  }
-
-  element.focus();
-};
+import { MAIN_CONTENT_SELECTORS } from '@kbn/ui-chrome-layout';
 
 /**
- * Focuses the main content landmark.
+ * Utility function for focusing the main content landmark.
  */
 export const focusMainContent = () => {
   const mainElement = document.querySelector(MAIN_CONTENT_SELECTORS.join(','));
 
   if (mainElement instanceof HTMLElement) {
-    focusElement(mainElement);
+    mainElement.focus();
   }
 };


### PR DESCRIPTION
https://elastic.slack.com/archives/C0ANQ2123J4/p1787579699647349

## Summary

The framed application area uses `outline` as a decorative border so it does not affect layout. When `#app-main-scroll` receives pointer focus, EUI's global focus styles change the outline and its offset, which shifts the frame inward and makes it appear to disappear.

Keep the existing focus behavior and restore the framed outline with `outline-offset: 0` for non-`:focus-visible` focus. Keyboard focus-visible styles are unchanged.

## Test plan

In project chrome with the dark theme:

- Open Machine Learning > Data Visualizer from the More menu and verify the application frame remains visible after navigation.
- Click empty space in the page and verify the frame remains visible.
- Navigate with the keyboard and verify the normal focus ring is unchanged.