### PR TITLE
[Fleet] Fixes for dynamic Kafka topics validation

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.test.tsx
@@ -287,6 +287,38 @@ describe('EditOutputFlyout', () => {
     });
   });
 
+  it('should send dynamic kafka topic verbatim without wrapping on save', async () => {
+    const { utils } = renderFlyout({
+      type: 'kafka',
+      name: 'kafka output',
+      id: 'outputK',
+      is_default: false,
+      is_default_monitoring: false,
+      hosts: ['kafka:443'],
+      topic: '%{[data_stream.type]}-%{[data_stream.namespace]}',
+      auth_type: 'none',
+      version: '1.0.0',
+      compression: 'none',
+    });
+
+    mockSendPutOutput.mockResolvedValue({ data: {} } as any);
+
+    fireEvent.change(utils.getByTestId('settingsOutputsFlyout.nameInput'), {
+      target: { value: 'kafka output updated' },
+    });
+
+    fireEvent.click(utils.getByText('Save and apply settings'));
+
+    await waitFor(() => {
+      expect(mockSendPutOutput).toHaveBeenCalledWith(
+        'outputK',
+        expect.objectContaining({
+          topic: '%{[data_stream.type]}-%{[data_stream.namespace]}',
+        })
+      );
+    });
+  });
+
   it('should populate secret password input with plain text value when editing kafka output', async () => {
     jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({} as any);
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.test.tsx
@@ -436,5 +436,43 @@ describe('Output form validation', () => {
       const res = validateDynamicKafkaTopics(invalidPercentTopic);
       expect(res).toEqual(['Opening brackets should be preceded by a percent sign']);
     });
+    it('should return error when fallback terminator is missing', () => {
+      const res = validateDynamicKafkaTopics([
+        { label: 'field', value: '%{[service.common_name]:agent-monitoring' },
+      ]);
+      expect(res).toEqual([
+        'The topic should have a matching number of opening and closing brackets',
+      ]);
+    });
+    it('should return error when closing bracket appears before opening bracket', () => {
+      const res = validateDynamicKafkaTopics([{ label: 'field', value: ']}%{[field' }]);
+      expect(res).toEqual([
+        'The topic should have a matching number of opening and closing brackets',
+      ]);
+    });
+    it('should return error when opening square bracket is missing from token', () => {
+      const res = validateDynamicKafkaTopics([{ label: 'field', value: '%{field]}' }]);
+      expect(res).toEqual([
+        'The topic should have a matching number of opening and closing brackets',
+      ]);
+    });
+    it('should return error when square brackets are omitted entirely', () => {
+      const res = validateDynamicKafkaTopics([{ label: 'field', value: '%{field}' }]);
+      expect(res).toEqual([
+        'The topic should have a matching number of opening and closing brackets',
+      ]);
+    });
+    it('should return error when orphan closing delimiter precedes a valid token', () => {
+      const res = validateDynamicKafkaTopics([{ label: 'field', value: ']}%{[field]}' }]);
+      expect(res).toEqual([
+        'The topic should have a matching number of opening and closing brackets',
+      ]);
+    });
+    it('should return error when orphan closing delimiter follows a valid token', () => {
+      const res = validateDynamicKafkaTopics([{ label: 'field', value: '%{[field]}]}' }]);
+      expect(res).toEqual([
+        'The topic should have a matching number of opening and closing brackets',
+      ]);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
@@ -21,15 +21,7 @@ const toSecretValidator =
     return validator(value ?? '');
   };
 
-const getAllIndices = (str: string, substring: string): number[] => {
-  const indices = [];
-  let index = str.indexOf(substring);
-  while (index !== -1) {
-    indices.push(index);
-    index = str.indexOf(substring, index + 1);
-  }
-  return indices;
-};
+const validKafkaTopicToken = /%\{\[[^\]]+\](?::[^}]*)?\}/g;
 
 export function validateKafkaHosts(value: string[]) {
   const res: Array<{ message: string; index?: number }> = [];
@@ -386,10 +378,8 @@ export function validateDynamicKafkaTopics(value: Array<EuiComboBoxOptionOption<
       );
     } else {
       const topic = val.value;
-      const openingBrackets = getAllIndices(topic, '{[');
-      const closingBracketCount =
-        getAllIndices(topic, ']}').length + getAllIndices(topic, ']:').length;
-      if (openingBrackets.length !== closingBracketCount) {
+      const stripped = topic.replace(validKafkaTopicToken, '');
+      if (stripped.includes('%{') || (!stripped.includes('{[') && stripped.includes(']}'))) {
         res.push(
           i18n.translate('xpack.fleet.settings.outputForm.kafkaTopicBracketsError', {
             defaultMessage:
@@ -397,8 +387,7 @@ export function validateDynamicKafkaTopics(value: Array<EuiComboBoxOptionOption<
           })
         );
       }
-      // check for preceding percent sign
-      if (!openingBrackets.every((item) => topic[item - 1] === '%')) {
+      if (/(?<!%)\{\[/.test(stripped)) {
         res.push(
           i18n.translate('xpack.fleet.settings.outputForm.kafkaTopicPercentError', {
             defaultMessage: 'Opening brackets should be preceded by a percent sign',

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.test.tsx
@@ -46,7 +46,7 @@ describe('use_output_form', () => {
 
       expect(res).toEqual([
         {
-          label: '%{[default.dataset]}',
+          label: 'default.dataset',
           value: '%{[default.dataset]}',
         },
       ]);
@@ -63,7 +63,7 @@ describe('use_output_form', () => {
 
       expect(res).toEqual([
         {
-          label: '%{[@timestamp]}',
+          label: '@timestamp',
           value: '%{[@timestamp]}',
         },
       ]);
@@ -80,8 +80,25 @@ describe('use_output_form', () => {
 
       expect(res).toEqual([
         {
-          label: '%{[something]}',
+          label: 'something',
           value: '%{[something]}',
+        },
+      ]);
+    });
+
+    it('should return the full expression as label and value for multi-token topics', () => {
+      const res = extractDefaultDynamicKafkaTopics({
+        type: 'kafka',
+        name: 'new',
+        is_default: false,
+        is_default_monitoring: false,
+        topic: '%{[data_stream.type]}-%{[data_stream.namespace]}',
+      });
+
+      expect(res).toEqual([
+        {
+          label: '%{[data_stream.type]}-%{[data_stream.namespace]}',
+          value: '%{[data_stream.type]}-%{[data_stream.namespace]}',
         },
       ]);
     });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -193,10 +193,12 @@ export function extractDefaultDynamicKafkaTopics(
   if (!o?.topic || (o?.topic && !o.topic?.includes('%{['))) {
     return [];
   }
+  const topic = o.topic;
+  const simpleToken = topic.match(/^%\{\[([^\]]+)\]\}$/);
   return [
     {
-      label: o.topic,
-      value: o.topic,
+      label: simpleToken ? simpleToken[1] : topic,
+      value: topic,
     },
   ];
 }


### PR DESCRIPTION
## Summary

Followup to https://github.com/elastic/kibana/pull/285581

Further fixes were added to the 8.19 backport, which was added after merging. This PR adds them, reconciling the code across 8.19, 9.4, 9.5 and 9.6.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk: the fix tightens validation (previously-invalid inputs that silently passed will now be correctly rejected) and does not alter any save/load data paths.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->