### PR TITLE
[9.5] [One Workflow] Allow cloning schema-invalid workflows (#276632)

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.test.ts
@@ -105,11 +105,6 @@ describe('WorkflowsManagementApi', () => {
 
       const result = await api.cloneWorkflow(originalWorkflow, 'default', mockRequest);
 
-      expect(mockWorkflowsService.getWorkflowZodSchema).toHaveBeenCalledWith(
-        { loose: false },
-        'default',
-        mockRequest
-      );
       expect(mockWorkflowsService.createWorkflow).toHaveBeenCalledWith(
         expect.objectContaining({
           yaml: expect.stringContaining('name: Original Workflow Copy'),
@@ -125,9 +120,6 @@ describe('WorkflowsManagementApi', () => {
       const originalWorkflow = createMockWorkflow({
         yaml: 'name: Original Workflow\ndescription: A workflow to be cloned\nenabled: true',
       });
-
-      const mockZodSchema = createMockZodSchema();
-      mockWorkflowsService.getWorkflowZodSchema.mockResolvedValue(mockZodSchema);
 
       const clonedWorkflow: WorkflowDetailDto = {
         ...originalWorkflow,
@@ -175,16 +167,6 @@ steps:
     action: test-action`,
       });
 
-      const mockZodSchema = z.object({
-        name: z.string(),
-        description: z.string().optional(),
-        enabled: z.boolean().optional(),
-        tags: z.array(z.string()).optional(),
-        steps: z.array(z.any()).optional(),
-      });
-
-      mockWorkflowsService.getWorkflowZodSchema.mockResolvedValue(mockZodSchema);
-
       mockWorkflowsService.createWorkflow.mockImplementation((command) => {
         const yamlString = command.yaml;
         // Verify all properties are preserved
@@ -214,42 +196,64 @@ steps:
       expect(mockWorkflowsService.createWorkflow).toHaveBeenCalled();
     });
 
-    it('should handle YAML parsing errors gracefully', async () => {
+    it('should clone a schema-invalid workflow without throwing', async () => {
+      // Missing required `triggers`/`steps` makes this schema-invalid, but it is
+      // still an editable workflow the user should be able to clone.
+      const invalidYaml = `name: Broken Workflow
+description: Missing required fields
+enabled: true`;
       const originalWorkflow = createMockWorkflow({
-        yaml: 'invalid: yaml: content: with: multiple: colons',
+        name: 'Broken Workflow',
+        yaml: invalidYaml,
+        valid: false,
       });
 
-      const mockZodSchema = createMockZodSchema();
-      mockWorkflowsService.getWorkflowZodSchema.mockResolvedValue(mockZodSchema);
+      mockWorkflowsService.createWorkflow.mockImplementation((command) =>
+        Promise.resolve({
+          ...originalWorkflow,
+          id: 'workflow-clone-invalid',
+          name: 'Broken Workflow Copy',
+          yaml: command.yaml,
+          valid: false,
+        })
+      );
 
-      await expect(api.cloneWorkflow(originalWorkflow, 'default', mockRequest)).rejects.toThrow();
+      await expect(
+        api.cloneWorkflow(originalWorkflow, 'default', mockRequest)
+      ).resolves.toBeDefined();
 
-      expect(mockWorkflowsService.getWorkflowZodSchema).toHaveBeenCalled();
-      expect(mockWorkflowsService.createWorkflow).not.toHaveBeenCalled();
+      const clonedYaml = mockWorkflowsService.createWorkflow.mock.calls[0][0].yaml;
+      // Name is renamed while the rest of the (invalid) content is preserved.
+      expect(clonedYaml).toContain('name: Broken Workflow Copy');
+      expect(clonedYaml).toContain('description: Missing required fields');
+    });
+
+    it('should not call getWorkflowZodSchema when cloning', async () => {
+      const originalWorkflow = createMockWorkflow();
+      mockWorkflowsService.createWorkflow.mockResolvedValue(originalWorkflow);
+
+      await api.cloneWorkflow(originalWorkflow, 'default', mockRequest);
+
+      expect(mockWorkflowsService.getWorkflowZodSchema).not.toHaveBeenCalled();
     });
 
     it('should handle workflow creation errors', async () => {
       const originalWorkflow = createMockWorkflow();
-      const mockZodSchema = createMockZodSchema();
       const creationError = new Error('Failed to create workflow');
 
-      mockWorkflowsService.getWorkflowZodSchema.mockResolvedValue(mockZodSchema);
       mockWorkflowsService.createWorkflow.mockRejectedValue(creationError);
 
       await expect(api.cloneWorkflow(originalWorkflow, 'default', mockRequest)).rejects.toThrow(
         'Failed to create workflow'
       );
 
-      expect(mockWorkflowsService.getWorkflowZodSchema).toHaveBeenCalled();
       expect(mockWorkflowsService.createWorkflow).toHaveBeenCalled();
     });
 
     it('should work with different space contexts', async () => {
       const originalWorkflow = createMockWorkflow();
-      const mockZodSchema = createMockZodSchema();
       const spaceId = 'custom-space';
 
-      mockWorkflowsService.getWorkflowZodSchema.mockResolvedValue(mockZodSchema);
       mockWorkflowsService.createWorkflow.mockResolvedValue({
         ...originalWorkflow,
         id: 'workflow-clone-789',
@@ -258,11 +262,6 @@ steps:
 
       await api.cloneWorkflow(originalWorkflow, spaceId, mockRequest);
 
-      expect(mockWorkflowsService.getWorkflowZodSchema).toHaveBeenCalledWith(
-        { loose: false },
-        spaceId,
-        mockRequest
-      );
       expect(mockWorkflowsService.createWorkflow).toHaveBeenCalledWith(
         expect.any(Object),
         spaceId,

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -56,12 +56,7 @@ import type {
   StepLogsParams,
 } from '@kbn/workflows-execution-engine/server/workflow_event_logger/types';
 import type { ServerTriggerDefinition } from '@kbn/workflows-extensions/server';
-import {
-  parseWorkflowYamlToJSON,
-  parseYamlToJSONWithoutValidation,
-  stringifyWorkflowDefinition,
-  WorkflowValidationError,
-} from '@kbn/workflows-yaml';
+import { parseYamlToJSONWithoutValidation, WorkflowValidationError } from '@kbn/workflows-yaml';
 import type { z } from '@kbn/zod/v4';
 import {
   type ExternalResumeFormPageParams,
@@ -79,12 +74,12 @@ import type {
   SearchWorkflowExecutionsParams,
   WorkflowsService,
 } from './workflows_management_service';
-import { connectorParamsSchemaResolver } from '../../common/lib/connector_params_schema_resolver';
 import { formatWorkflowDiagnostic } from '../../common/lib/format_workflow_diagnostic';
 import type {
   RestoreWorkflowVersionResponseDto,
   WorkflowChangesHistoryResponse,
 } from '../../common/lib/workflow_change_history/types';
+import { updateWorkflowYamlFields } from '../../common/lib/yaml/update_workflow_yaml_fields';
 import type { BulkCreateWorkflowsResult } from '../services/workflow_crud_service';
 import type {
   ProcessedWaitForInputFacets,
@@ -367,28 +362,15 @@ export class WorkflowsManagementApi {
     spaceId: string,
     request: KibanaRequest
   ): Promise<WorkflowDetailDto> {
-    // Parse and update the YAML to change the name
-    const zodSchema = await this.workflowsService.getWorkflowZodSchema(
-      { loose: false },
-      spaceId,
-      request
-    );
-    const parsedYaml = parseWorkflowYamlToJSON(workflow.yaml, zodSchema, {
-      connectorParamsSchemaResolver,
-    });
-    if (parsedYaml.error) {
-      throw parsedYaml.error;
-    }
-
-    const updatedYaml = {
-      ...parsedYaml.data,
+    // Rewrite only the `name` field directly in the YAML text so that cloning
+    // works even when the source workflow's YAML is schema-invalid. Strictly
+    // parsing/validating here would reject invalid-but-editable workflows.
+    const clonedYaml = updateWorkflowYamlFields(workflow.yaml, {
       name: `${workflow.name} ${i18n.translate('workflowsManagement.cloneSuffix', {
         defaultMessage: 'Copy',
       })}`,
-    };
+    });
 
-    // Convert back to YAML string using proper YAML stringification
-    const clonedYaml = stringifyWorkflowDefinition(updatedYaml as unknown as WorkflowYaml);
     const result = await this.workflowsService.createWorkflow(
       { yaml: clonedYaml },
       spaceId,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[One Workflow] Allow cloning schema-invalid workflows (#276632)](https://github.com/elastic/kibana/pull/276632)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2026-08-24T13:12:24Z","message":"[One Workflow] Allow cloning schema-invalid workflows (#276632)\n\n## Summary\n\nBug ticket https://github.com/elastic/kibana/issues/276640\n\nCloning a workflow whose stored YAML fails **schema validation**\npreviously failed with `Error: Bad Request` (HTTP 400) instead of\nproducing an invalid-but-editable copy.\n\nThe root cause was in `cloneWorkflow`\n(`server/api/workflows_management_api.ts`): it re-parsed **and strictly\nvalidated** the source YAML purely to rewrite the `name` field to\n`\"<name> Copy\"`. For a schema-invalid workflow,\n`parseWorkflowYamlToJSON` returned an `InvalidYamlSchemaError`, which\nwas thrown and mapped to `400 Bad Request` by `handleRouteError`.\n\nThis PR rewrites only the `name` field directly in the YAML **text**\nusing the existing `updateWorkflowYamlFields` helper (which edits YAML\nwithout validating), then hands off to `createWorkflow`. Since\n`createWorkflow` already tolerates invalid YAML (storing it with `valid:\nfalse`), cloning an invalid workflow now succeeds and remains editable.\n\n## Changes\n\n| File | Change |\n| --------------------------------------------- |\n-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n|\n| `server/api/workflows_management_api.ts` | `cloneWorkflow` now\nrewrites the YAML `name` via `updateWorkflowYamlFields` instead of\nstrict parse + throw; removed the now-unused `parseWorkflowYamlToJSON`,\n`stringifyWorkflowDefinition`, and `connectorParamsSchemaResolver`\nimports |\n| `server/api/workflows_management_api.test.ts` | Added regression\ncoverage for cloning schema-invalid workflows; updated existing clone\ntests to match the new (non-throwing) behavior |\n\n## Verification\n\n### Manual\n\n1. Open Kibana → **Workflows**.\n2. Create a workflow with an intentional schema error (e.g. an empty\n`steps` list) and save it — it should persist as an **invalid**\nworkflow. For example:\n\n   ```yaml\n   name: New workflow\n   enabled: false\n   description: This is a new workflow\n   triggers:\n     - type: alert\n\n   steps:\n     \n   ```\n\n3. Clone that workflow.\n4. **Expected:** the clone succeeds (no `Bad Request` error) and appears\nas an invalid workflow named `\"<original name> Copy\"`, with the rest of\nthe invalid YAML preserved and editable.\n5. **Regression:** cloning a **valid** workflow still produces a `\"…\nCopy\"` named copy as before.\n\n## Screenshots\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/afc6658d-0e29-4b99-8742-9435397f0d8e\n\n### After\n\n\nhttps://github.com/user-attachments/assets/826240a1-e52b-47de-97ac-44d09e450b63\n\n---\n\n_PR developed with Cursor + Claude Opus 4.8_","sha":"513667f73305262734e763cb12a4935a833b3b67","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Team:One Workflow","v9.5.0","v9.6.0"],"title":"[One Workflow] Allow cloning schema-invalid workflows","number":276632,"url":"https://github.com/elastic/kibana/pull/276632","mergeCommit":{"message":"[One Workflow] Allow cloning schema-invalid workflows (#276632)\n\n## Summary\n\nBug ticket https://github.com/elastic/kibana/issues/276640\n\nCloning a workflow whose stored YAML fails **schema validation**\npreviously failed with `Error: Bad Request` (HTTP 400) instead of\nproducing an invalid-but-editable copy.\n\nThe root cause was in `cloneWorkflow`\n(`server/api/workflows_management_api.ts`): it re-parsed **and strictly\nvalidated** the source YAML purely to rewrite the `name` field to\n`\"<name> Copy\"`. For a schema-invalid workflow,\n`parseWorkflowYamlToJSON` returned an `InvalidYamlSchemaError`, which\nwas thrown and mapped to `400 Bad Request` by `handleRouteError`.\n\nThis PR rewrites only the `name` field directly in the YAML **text**\nusing the existing `updateWorkflowYamlFields` helper (which edits YAML\nwithout validating), then hands off to `createWorkflow`. Since\n`createWorkflow` already tolerates invalid YAML (storing it with `valid:\nfalse`), cloning an invalid workflow now succeeds and remains editable.\n\n## Changes\n\n| File | Change |\n| --------------------------------------------- |\n-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n|\n| `server/api/workflows_management_api.ts` | `cloneWorkflow` now\nrewrites the YAML `name` via `updateWorkflowYamlFields` instead of\nstrict parse + throw; removed the now-unused `parseWorkflowYamlToJSON`,\n`stringifyWorkflowDefinition`, and `connectorParamsSchemaResolver`\nimports |\n| `server/api/workflows_management_api.test.ts` | Added regression\ncoverage for cloning schema-invalid workflows; updated existing clone\ntests to match the new (non-throwing) behavior |\n\n## Verification\n\n### Manual\n\n1. Open Kibana → **Workflows**.\n2. Create a workflow with an intentional schema error (e.g. an empty\n`steps` list) and save it — it should persist as an **invalid**\nworkflow. For example:\n\n   ```yaml\n   name: New workflow\n   enabled: false\n   description: This is a new workflow\n   triggers:\n     - type: alert\n\n   steps:\n     \n   ```\n\n3. Clone that workflow.\n4. **Expected:** the clone succeeds (no `Bad Request` error) and appears\nas an invalid workflow named `\"<original name> Copy\"`, with the rest of\nthe invalid YAML preserved and editable.\n5. **Regression:** cloning a **valid** workflow still produces a `\"…\nCopy\"` named copy as before.\n\n## Screenshots\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/afc6658d-0e29-4b99-8742-9435397f0d8e\n\n### After\n\n\nhttps://github.com/user-attachments/assets/826240a1-e52b-47de-97ac-44d09e450b63\n\n---\n\n_PR developed with Cursor + Claude Opus 4.8_","sha":"513667f73305262734e763cb12a4935a833b3b67"}},"sourceBranch":"main","suggestedTargetBranches":["9.5"],"targetPullRequestStates":[{"branch":"9.5","label":"v9.5.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/276632","number":276632,"mergeCommit":{"message":"[One Workflow] Allow cloning schema-invalid workflows (#276632)\n\n## Summary\n\nBug ticket https://github.com/elastic/kibana/issues/276640\n\nCloning a workflow whose stored YAML fails **schema validation**\npreviously failed with `Error: Bad Request` (HTTP 400) instead of\nproducing an invalid-but-editable copy.\n\nThe root cause was in `cloneWorkflow`\n(`server/api/workflows_management_api.ts`): it re-parsed **and strictly\nvalidated** the source YAML purely to rewrite the `name` field to\n`\"<name> Copy\"`. For a schema-invalid workflow,\n`parseWorkflowYamlToJSON` returned an `InvalidYamlSchemaError`, which\nwas thrown and mapped to `400 Bad Request` by `handleRouteError`.\n\nThis PR rewrites only the `name` field directly in the YAML **text**\nusing the existing `updateWorkflowYamlFields` helper (which edits YAML\nwithout validating), then hands off to `createWorkflow`. Since\n`createWorkflow` already tolerates invalid YAML (storing it with `valid:\nfalse`), cloning an invalid workflow now succeeds and remains editable.\n\n## Changes\n\n| File | Change |\n| --------------------------------------------- |\n-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n|\n| `server/api/workflows_management_api.ts` | `cloneWorkflow` now\nrewrites the YAML `name` via `updateWorkflowYamlFields` instead of\nstrict parse + throw; removed the now-unused `parseWorkflowYamlToJSON`,\n`stringifyWorkflowDefinition`, and `connectorParamsSchemaResolver`\nimports |\n| `server/api/workflows_management_api.test.ts` | Added regression\ncoverage for cloning schema-invalid workflows; updated existing clone\ntests to match the new (non-throwing) behavior |\n\n## Verification\n\n### Manual\n\n1. Open Kibana → **Workflows**.\n2. Create a workflow with an intentional schema error (e.g. an empty\n`steps` list) and save it — it should persist as an **invalid**\nworkflow. For example:\n\n   ```yaml\n   name: New workflow\n   enabled: false\n   description: This is a new workflow\n   triggers:\n     - type: alert\n\n   steps:\n     \n   ```\n\n3. Clone that workflow.\n4. **Expected:** the clone succeeds (no `Bad Request` error) and appears\nas an invalid workflow named `\"<original name> Copy\"`, with the rest of\nthe invalid YAML preserved and editable.\n5. **Regression:** cloning a **valid** workflow still produces a `\"…\nCopy\"` named copy as before.\n\n## Screenshots\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/afc6658d-0e29-4b99-8742-9435397f0d8e\n\n### After\n\n\nhttps://github.com/user-attachments/assets/826240a1-e52b-47de-97ac-44d09e450b63\n\n---\n\n_PR developed with Cursor + Claude Opus 4.8_","sha":"513667f73305262734e763cb12a4935a833b3b67"}}]}] BACKPORT-->