### PR TITLE
[EUI] Replace removed icon aliases with current glyph names

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/import_workflows/ui/import_workflows_flyout.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/import_workflows/ui/import_workflows_flyout.tsx
@@ -398,7 +398,7 @@ export const ImportWorkflowsFlyout: React.FC<ImportWorkflowsFlyoutProps> = ({ on
             if (status === 'failed') {
               return (
                 <EuiIcon
-                  type="crossInACircleFilled"
+                  type="error"
                   color="danger"
                   data-test-subj={`import-preview-failed-${id}`}
                   aria-label={i18n.translate('workflows.importFlyout.preview.failedIcon', {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.tsx
@@ -246,7 +246,7 @@ export const WorkflowYamlValidationAccordion = React.memo(function WorkflowYamlV
                       ? 'errorFill'
                       : error.severity === 'warning'
                       ? 'warningFill'
-                      : 'iInCircle'
+                      : 'info'
                   }
                   color={
                     error.severity === 'error'

--- a/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/results_links/results_links.tsx
+++ b/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/results_links/results_links.tsx
@@ -247,7 +247,7 @@ export const ResultsLinks: FC<Props> = ({
         <EuiFlexItem>
           <EuiCard
             hasBorder
-            icon={<EuiIcon aria-hidden={true} size="xxl" type={`productRobot`} />}
+            icon={<EuiIcon aria-hidden={true} size="xxl" type="productAgent" />}
             title={
               <FormattedMessage
                 id="xpack.fileUpload.resultsLinks.agentBuilder"

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/errors/errors_over_time_chart.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/errors/errors_over_time_chart.tsx
@@ -263,7 +263,7 @@ export const ErrorsOverTimeChart = ({
       </div>
       <EuiSpacer size="xs" />
       <EuiText size="xs" color="subdued" textAlign="center">
-        <EuiIcon type="iInCircle" size="s" aria-hidden={true} /> {BRUSH_HINT}
+        <EuiIcon type="info" size="s" aria-hidden={true} /> {BRUSH_HINT}
       </EuiText>
     </EuiPanel>
   );


### PR DESCRIPTION
## Summary
- Replace removed EUI glyph aliases that fail type-checking on a tightened `EuiIcon` `type`: `iInCircle` → `info`, `productRobot` → `productAgent`, `crossInACircleFilled` → `error`.
- Staging for elastic/eui#9940. Does not bump `@elastic/eui`.

## Test plan
- [ ] Confirm the four call sites render the replacement glyphs and render correctly.

Made with [Cursor](https://cursor.com)