### PR TITLE
[APM] Align service flyout RED charts with the service overview data source

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/contextual_map/contextual_service_map_section.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/contextual_map/contextual_service_map_section.test.tsx
@@ -17,8 +17,13 @@ import { ContextualServiceMapSection } from './contextual_service_map_section';
 import { APM_EBT_ACTIONS } from '../../ebt_constants';
 import { SERVICE_MAP_EBT_ELEMENTS } from '../ebt_constants';
 
+let embeddableProps: Record<string, unknown> | null = null;
+
 jest.mock('../../../../embeddable/service_map/service_map_embeddable', () => ({
-  ServiceMapEmbeddable: () => <div data-test-subj="mockServiceMapEmbeddable" />,
+  ServiceMapEmbeddable: (props: Record<string, unknown>) => {
+    embeddableProps = props;
+    return <div data-test-subj="mockServiceMapEmbeddable" />;
+  },
 }));
 
 const mockGetServiceMapUrl = jest.fn(
@@ -68,6 +73,13 @@ function renderSection(
 describe('ContextualServiceMapSection', () => {
   beforeEach(() => {
     mockGetServiceMapUrl.mockClear();
+    embeddableProps = null;
+  });
+
+  it('forwards the flyout options to the embeddable so the flyout inherits the host filters', () => {
+    renderSection({ flyoutOptions: { transactionType: 'request' } });
+
+    expect(embeddableProps?.flyoutOptions).toEqual({ transactionType: 'request' });
   });
 
   it('renders the map section when platinum license and service map are available', () => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/contextual_map/contextual_service_map_section.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/contextual_map/contextual_service_map_section.tsx
@@ -15,6 +15,7 @@ import { useLicenseContext } from '../../../../context/license/use_license_conte
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { getServiceMapUrl } from '../../../../embeddable/service_map/get_service_map_url';
 import { ServiceMapEmbeddable } from '../../../../embeddable/service_map/service_map_embeddable';
+import type { ServiceFlyoutOptions } from '../../../shared/service_flyout/types';
 import { LicensePrompt } from '../../../shared/license_prompt';
 import { APM_EBT_ACTIONS } from '../../ebt_constants';
 import { DisabledPrompt } from '../disabled_prompt';
@@ -56,6 +57,8 @@ export interface ContextualServiceMapSectionProps {
   sectionTestSubj?: string;
   exploreLinkTestSubj?: string;
   embeddableContainerTestSubj?: string;
+  /** Optional overrides for the service flyout opened from this map. */
+  flyoutOptions?: ServiceFlyoutOptions;
 }
 
 export function ContextualServiceMapSection({
@@ -65,6 +68,7 @@ export function ContextualServiceMapSection({
   environment,
   kuery,
   filterPills,
+  flyoutOptions,
   panelHeight = DEFAULT_CONTEXTUAL_SERVICE_MAP_PANEL_HEIGHT,
   sectionHeight,
   embeddableMinHeight,
@@ -238,6 +242,7 @@ export function ContextualServiceMapSection({
         showFocusMapInPopover
         clearKueryOnPopoverNavigation
         embeddableMinHeight={embeddableMinHeight}
+        flyoutOptions={flyoutOptions}
       />
     </EuiPanel>
   );

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview_service_map_section/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview_service_map_section/index.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { ContextualServiceMapSectionProps } from '../../service_map/contextual_map/contextual_service_map_section';
+import { ServiceOverviewServiceMapSection } from '.';
+
+let sectionProps: ContextualServiceMapSectionProps | null = null;
+
+const mockUseApmServiceContext = jest.fn();
+jest.mock('../../../../context/apm_service/use_apm_service_context', () => ({
+  useApmServiceContext: () => mockUseApmServiceContext(),
+}));
+
+const mockUseApmParams = jest.fn();
+jest.mock('../../../../hooks/use_apm_params', () => ({
+  useApmParams: () => mockUseApmParams(),
+}));
+
+jest.mock('../../service_map/contextual_map/contextual_service_map_section', () => ({
+  ContextualServiceMapSection: (props: ContextualServiceMapSectionProps) => {
+    sectionProps = props;
+    return <div data-test-subj="mockContextualServiceMapSection" />;
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sectionProps = null;
+  mockUseApmServiceContext.mockReturnValue({
+    serviceName: 'opbeans-java',
+    transactionType: 'request',
+  });
+  mockUseApmParams.mockReturnValue({
+    query: {
+      environment: 'production',
+      kuery: '',
+      rangeFrom: 'now-15m',
+      rangeTo: 'now',
+    },
+  });
+});
+
+describe('ServiceOverviewServiceMapSection', () => {
+  it("hands the page's transaction type to the flyout opened from the map", () => {
+    render(<ServiceOverviewServiceMapSection />);
+
+    expect(sectionProps?.flyoutOptions).toEqual({ transactionType: 'request' });
+  });
+
+  it('leaves the transaction type unset when the page has not resolved one', () => {
+    mockUseApmServiceContext.mockReturnValue({
+      serviceName: 'opbeans-java',
+      transactionType: undefined,
+    });
+
+    render(<ServiceOverviewServiceMapSection />);
+
+    expect(sectionProps?.flyoutOptions).toEqual({ transactionType: undefined });
+  });
+
+  it('renders nothing without a service name or time range', () => {
+    mockUseApmServiceContext.mockReturnValue({ serviceName: '', transactionType: 'request' });
+
+    const { container } = render(<ServiceOverviewServiceMapSection />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview_service_map_section/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview_service_map_section/index.tsx
@@ -5,17 +5,21 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useApmParams } from '../../../../hooks/use_apm_params';
 import { ContextualServiceMapSection } from '../../service_map/contextual_map/contextual_service_map_section';
 import { SERVICE_OVERVIEW_CONTEXTUAL_MAP_PANEL_HEIGHT } from '../../service_map/contextual_map/constants';
 
 export function ServiceOverviewServiceMapSection() {
-  const { serviceName } = useApmServiceContext();
+  const { serviceName, transactionType } = useApmServiceContext();
   const {
     query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/{serviceName}/overview');
+
+  // Hand the page's transaction type to the flyout so both show the same charts from the start,
+  // instead of the flyout resolving its own default for the service.
+  const flyoutOptions = useMemo(() => ({ transactionType }), [transactionType]);
 
   if (!serviceName || !rangeFrom || !rangeTo) {
     return null;
@@ -28,6 +32,7 @@ export function ServiceOverviewServiceMapSection() {
       rangeTo={rangeTo}
       environment={environment}
       kuery={kuery}
+      flyoutOptions={flyoutOptions}
       panelHeight={SERVICE_OVERVIEW_CONTEXTUAL_MAP_PANEL_HEIGHT}
       embeddableMinHeight={0}
       sectionTestSubj="apmServiceOverviewServiceMapSection"

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/hooks/use_service_flyout_transaction_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/hooks/use_service_flyout_transaction_type.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { ApmDocumentType } from '../../../../../common/document_type';
+import { RollupInterval } from '../../../../../common/rollup';
+import { FETCH_STATUS } from '../../../../hooks/use_fetcher';
+import { useServiceFlyoutTransactionType } from './use_service_flyout_transaction_type';
+
+const mockUseServiceTransactionTypesFetcher = jest.fn();
+jest.mock('../../../../context/apm_service/use_service_transaction_types_fetcher', () => ({
+  useServiceTransactionTypesFetcher: (...args: unknown[]) =>
+    mockUseServiceTransactionTypesFetcher(...args),
+}));
+
+const mockUsePreferredDataSourceAndBucketSize = jest.fn();
+jest.mock('../../../../hooks/use_preferred_data_source_and_bucket_size', () => ({
+  usePreferredDataSourceAndBucketSize: (...args: unknown[]) =>
+    mockUsePreferredDataSourceAndBucketSize(...args),
+}));
+
+const BASE_PARAMS = {
+  serviceName: 'opbeans-java',
+  agentName: 'java',
+  start: '2024-01-01T00:00:00.000Z',
+  end: '2024-01-01T01:00:00.000Z',
+  transactionType: '',
+};
+
+type HookParams = Parameters<typeof useServiceFlyoutTransactionType>[0];
+
+function renderTransactionType(params: Partial<HookParams> = {}) {
+  return renderHook(() => useServiceFlyoutTransactionType({ ...BASE_PARAMS, ...params }));
+}
+
+describe('useServiceFlyoutTransactionType', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePreferredDataSourceAndBucketSize.mockReturnValue({
+      bucketSizeInSeconds: 60,
+      source: {
+        documentType: ApmDocumentType.TransactionMetric,
+        rollupInterval: RollupInterval.OneMinute,
+      },
+    });
+    mockUseServiceTransactionTypesFetcher.mockReturnValue({
+      transactionTypes: ['request', 'worker'],
+      status: FETCH_STATUS.SUCCESS,
+    });
+  });
+
+  it('reads the transaction types from the source the chart APIs prefer', () => {
+    renderTransactionType();
+
+    expect(mockUseServiceTransactionTypesFetcher).toHaveBeenCalledWith({
+      serviceName: 'opbeans-java',
+      start: BASE_PARAMS.start,
+      end: BASE_PARAMS.end,
+      documentType: ApmDocumentType.TransactionMetric,
+      rollupInterval: RollupInterval.OneMinute,
+    });
+  });
+
+  it('keeps the transaction type the caller already selected', () => {
+    const { result } = renderTransactionType({ transactionType: 'worker' });
+
+    expect(result.current.selectedTransactionType).toBe('worker');
+  });
+
+  it('defaults to the agent default when the caller has no selection', () => {
+    const { result } = renderTransactionType();
+
+    expect(result.current.selectedTransactionType).toBe('request');
+  });
+
+  it('resolves a transaction type even without an agent name', () => {
+    const { result } = renderTransactionType({ agentName: undefined });
+
+    expect(result.current.selectedTransactionType).toBe('request');
+  });
+
+  it('falls back to the first reported type when the default is not available', () => {
+    mockUseServiceTransactionTypesFetcher.mockReturnValue({
+      transactionTypes: ['worker', 'messaging'],
+      status: FETCH_STATUS.SUCCESS,
+    });
+
+    const { result } = renderTransactionType({ agentName: undefined });
+
+    expect(result.current.selectedTransactionType).toBe('worker');
+  });
+
+  it('reports no transaction type when the service has none', () => {
+    mockUseServiceTransactionTypesFetcher.mockReturnValue({
+      transactionTypes: [],
+      status: FETCH_STATUS.SUCCESS,
+    });
+
+    const { result } = renderTransactionType();
+
+    expect(result.current.selectedTransactionType).toBeUndefined();
+    expect(result.current.isResolved).toBe(true);
+  });
+
+  it.each([FETCH_STATUS.LOADING, FETCH_STATUS.NOT_INITIATED])(
+    'is unresolved while the fetch is %s',
+    (status) => {
+      mockUseServiceTransactionTypesFetcher.mockReturnValue({ transactionTypes: [], status });
+
+      const { result } = renderTransactionType();
+
+      expect(result.current.isResolved).toBe(false);
+    }
+  );
+
+  it('pushes the resolved transaction type back to the caller', () => {
+    const setTransactionType = jest.fn();
+
+    renderTransactionType({ setTransactionType });
+
+    expect(setTransactionType).toHaveBeenCalledWith('request');
+  });
+
+  it('does not push the transaction type when it already matches', () => {
+    const setTransactionType = jest.fn();
+
+    renderTransactionType({ transactionType: 'request', setTransactionType });
+
+    expect(setTransactionType).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/hooks/use_service_flyout_transaction_type.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/hooks/use_service_flyout_transaction_type.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useMemo } from 'react';
+import { ApmDocumentType } from '../../../../../common/document_type';
+import { getDefaultTransactionType } from '../../../../../common/transaction_types';
+import { getTransactionType } from '../../../../context/apm_service/apm_service_context';
+import { useServiceTransactionTypesFetcher } from '../../../../context/apm_service/use_service_transaction_types_fetcher';
+import type { FETCH_STATUS } from '../../../../hooks/use_fetcher';
+import { isPending } from '../../../../hooks/use_fetcher';
+import { usePreferredDataSourceAndBucketSize } from '../../../../hooks/use_preferred_data_source_and_bucket_size';
+import { TARGET_BUCKET_COUNT } from '../overview/chart_configs/shared';
+
+interface Params {
+  serviceName: string;
+  agentName?: string;
+  start: string;
+  end: string;
+  transactionType: string;
+  setTransactionType?: (transactionType: string) => void;
+}
+
+interface Result {
+  transactionTypes: string[];
+  status: FETCH_STATUS;
+  selectedTransactionType?: string;
+  /**
+   * Whether the charts can be queried: while the transaction types are in flight there is nothing to
+   * filter on yet, and an unfiltered query would report every transaction type of the service.
+   */
+  isResolved: boolean;
+}
+
+/**
+ * Resolves the transaction type the flyout charts and the transaction type picker share, from the
+ * same rollups the APM service overview page reads.
+ */
+export function useServiceFlyoutTransactionType({
+  serviceName,
+  agentName,
+  start,
+  end,
+  transactionType,
+  setTransactionType,
+}: Params): Result {
+  const preferred = usePreferredDataSourceAndBucketSize({
+    start,
+    end,
+    kuery: '',
+    type: ApmDocumentType.TransactionMetric,
+    numBuckets: TARGET_BUCKET_COUNT,
+  });
+
+  const { transactionTypes, status } = useServiceTransactionTypesFetcher({
+    serviceName,
+    start,
+    end,
+    documentType: preferred?.source.documentType,
+    rollupInterval: preferred?.source.rollupInterval,
+  });
+
+  const selectedTransactionType = useMemo(() => {
+    const resolved = getTransactionType({ transactionType, transactionTypes, agentName });
+    if (resolved || transactionTypes.length === 0) {
+      return resolved;
+    }
+    // Callers such as the service map hand over nodes without an agent name, which makes the shared
+    // helper bail out even though the service does report transaction types.
+    const defaultTransactionType = getDefaultTransactionType(agentName);
+    return transactionTypes.includes(defaultTransactionType)
+      ? defaultTransactionType
+      : transactionTypes[0];
+  }, [agentName, transactionType, transactionTypes]);
+
+  useEffect(() => {
+    if (
+      setTransactionType &&
+      selectedTransactionType !== undefined &&
+      selectedTransactionType !== transactionType
+    ) {
+      setTransactionType(selectedTransactionType);
+    }
+  }, [setTransactionType, selectedTransactionType, transactionType]);
+
+  return {
+    transactionTypes,
+    status,
+    selectedTransactionType,
+    isResolved: !isPending(status),
+  };
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/apm.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/apm.test.ts
@@ -20,10 +20,16 @@ import {
   getCpuUsageChart,
   getMemoryUsageChart,
 } from './apm';
-import { getErrorRateChart, getLatencyChart, getThroughputChart } from './shared';
+import {
+  THROUGHPUT_COLUMN,
+  getErrorRateChart,
+  getLatencyChart,
+  getThroughputChart,
+} from './shared';
 
 const TRANSACTION_INDEXES = 'traces-apm*';
 const METRIC_INDEXES = 'metrics-apm*';
+const BUCKET_SIZE_IN_SECONDS = 600;
 
 const SCOPE = {
   serviceName: 'opbeans-java',
@@ -52,79 +58,88 @@ function esqlOf(config: LensESQLConfig | undefined): string {
   return config.dataset.esql;
 }
 
+function latencyChartOf({
+  scope = SCOPE,
+  latencyAggregationType = LatencyAggregationType.avg,
+  titleAction,
+}: {
+  scope?: typeof SCOPE;
+  latencyAggregationType?: LatencyAggregationType;
+  titleAction?: string;
+} = {}) {
+  return getLatencyChart({
+    indices: TRANSACTION_INDEXES,
+    latencyAggregationType,
+    titleAction,
+    buildQuery: (idx, aggregation) =>
+      buildApmLatencyQuery({
+        indices: idx,
+        scope,
+        aggregation,
+        bucketSizeInSeconds: BUCKET_SIZE_IN_SECONDS,
+      }),
+  });
+}
+
 describe('APM chart configs', () => {
   describe('getLatencyChart / buildApmLatencyQuery', () => {
     it('builds avg latency from average transaction duration', () => {
-      const chart = getLatencyChart({
-        indices: TRANSACTION_INDEXES,
-        latencyAggregationType: LatencyAggregationType.avg,
-        buildQuery: (idx, agg) => buildApmLatencyQuery(idx, SCOPE, agg),
-      });
+      const chart = latencyChartOf();
 
       expect(esqlOf(chart.config)).toEqual(
-        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "production" | EVAL duration_ms = TO_DOUBLE(transaction.duration.us) / 1000 | STATS AVG(duration_ms) BY timestamp = TBUCKET(100)'
+        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "production" | EVAL duration_ms = TO_DOUBLE(transaction.duration.us) / 1000 | STATS AVG(duration_ms) BY timestamp = TBUCKET(600 seconds)'
       );
       expect(seriesLayerOf(chart.config).yAxis[0].value).toBe('AVG(duration_ms)');
     });
 
     it('builds p95 percentile latency', () => {
-      const chart = getLatencyChart({
-        indices: TRANSACTION_INDEXES,
-        latencyAggregationType: LatencyAggregationType.p95,
-        buildQuery: (idx, agg) => buildApmLatencyQuery(idx, SCOPE, agg),
-      });
+      const chart = latencyChartOf({ latencyAggregationType: LatencyAggregationType.p95 });
 
-      expect(esqlOf(chart.config)).toEqual(
-        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "production" | EVAL duration_ms = TO_DOUBLE(transaction.duration.us) / 1000 | STATS PERCENTILE(duration_ms, 95) BY timestamp = TBUCKET(100)'
-      );
+      expect(esqlOf(chart.config)).toContain('STATS PERCENTILE(duration_ms, 95)');
       expect(seriesLayerOf(chart.config).yAxis[0].value).toBe('PERCENTILE(duration_ms, 95)');
     });
 
     it('builds p99 percentile latency', () => {
-      const chart = getLatencyChart({
-        indices: TRANSACTION_INDEXES,
-        latencyAggregationType: LatencyAggregationType.p99,
-        buildQuery: (idx, agg) => buildApmLatencyQuery(idx, SCOPE, agg),
-      });
+      const chart = latencyChartOf({ latencyAggregationType: LatencyAggregationType.p99 });
 
-      expect(esqlOf(chart.config)).toEqual(
-        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "production" | EVAL duration_ms = TO_DOUBLE(transaction.duration.us) / 1000 | STATS PERCENTILE(duration_ms, 99) BY timestamp = TBUCKET(100)'
-      );
+      expect(esqlOf(chart.config)).toContain('STATS PERCENTILE(duration_ms, 99)');
       expect(seriesLayerOf(chart.config).yAxis[0].value).toBe('PERCENTILE(duration_ms, 99)');
     });
 
-    it('filters by the literal sentinel and missing field when environment is ENVIRONMENT_NOT_DEFINED', () => {
+    it('buckets by the resolved bucket size so the series matches the APM chart APIs', () => {
       const chart = getLatencyChart({
         indices: TRANSACTION_INDEXES,
         latencyAggregationType: LatencyAggregationType.avg,
-        buildQuery: (idx, agg) =>
-          buildApmLatencyQuery(idx, { ...SCOPE, environment: ENVIRONMENT_NOT_DEFINED.value }, agg),
+        buildQuery: (idx, aggregation) =>
+          buildApmLatencyQuery({
+            indices: idx,
+            scope: SCOPE,
+            aggregation,
+            bucketSizeInSeconds: 30,
+          }),
       });
 
-      expect(esqlOf(chart.config)).toEqual(
-        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "ENVIRONMENT_NOT_DEFINED" OR `service.environment` IS NULL | EVAL duration_ms = TO_DOUBLE(transaction.duration.us) / 1000 | STATS AVG(duration_ms) BY timestamp = TBUCKET(100)'
+      expect(esqlOf(chart.config)).toContain('BY timestamp = TBUCKET(30 seconds)');
+    });
+
+    it('filters by the literal sentinel and missing field when environment is ENVIRONMENT_NOT_DEFINED', () => {
+      const chart = latencyChartOf({
+        scope: { ...SCOPE, environment: ENVIRONMENT_NOT_DEFINED.value },
+      });
+
+      expect(esqlOf(chart.config)).toContain(
+        'WHERE `service.environment` == "ENVIRONMENT_NOT_DEFINED" OR `service.environment` IS NULL'
       );
     });
 
     it('omits the environment clause when environment is ENVIRONMENT_ALL', () => {
-      const chart = getLatencyChart({
-        indices: TRANSACTION_INDEXES,
-        latencyAggregationType: LatencyAggregationType.avg,
-        buildQuery: (idx, agg) =>
-          buildApmLatencyQuery(idx, { ...SCOPE, environment: ENVIRONMENT_ALL.value }, agg),
-      });
+      const chart = latencyChartOf({ scope: { ...SCOPE, environment: ENVIRONMENT_ALL.value } });
 
-      expect(esqlOf(chart.config)).toEqual(
-        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | EVAL duration_ms = TO_DOUBLE(transaction.duration.us) / 1000 | STATS AVG(duration_ms) BY timestamp = TBUCKET(100)'
-      );
+      expect(esqlOf(chart.config)).not.toContain('service.environment');
     });
 
     it('omits the transaction type clause when transactionType is empty string', () => {
-      const chart = getLatencyChart({
-        indices: TRANSACTION_INDEXES,
-        latencyAggregationType: LatencyAggregationType.avg,
-        buildQuery: (idx, agg) => buildApmLatencyQuery(idx, { ...SCOPE, transactionType: '' }, agg),
-      });
+      const chart = latencyChartOf({ scope: { ...SCOPE, transactionType: '' } });
 
       expect(esqlOf(chart.config)).not.toContain('transaction.type');
     });
@@ -133,36 +148,63 @@ describe('APM chart configs', () => {
       const chart = getLatencyChart({
         indices: undefined,
         latencyAggregationType: LatencyAggregationType.avg,
-        buildQuery: (idx, agg) => buildApmLatencyQuery(idx, SCOPE, agg),
+        buildQuery: (idx, aggregation) =>
+          buildApmLatencyQuery({
+            indices: idx,
+            scope: SCOPE,
+            aggregation,
+            bucketSizeInSeconds: BUCKET_SIZE_IN_SECONDS,
+          }),
       });
 
       expect(chart.id).toBe('latency');
       expect(chart.config).toBeUndefined();
     });
 
-    it('attaches the title action to the chart definition', () => {
+    it('returns no config when the query cannot be built yet', () => {
       const chart = getLatencyChart({
         indices: TRANSACTION_INDEXES,
         latencyAggregationType: LatencyAggregationType.avg,
-        titleAction: 'latency-action',
-        buildQuery: (idx, agg) => buildApmLatencyQuery(idx, SCOPE, agg),
       });
+
+      expect(chart.config).toBeUndefined();
+    });
+
+    it('attaches the title action to the chart definition', () => {
+      const chart = latencyChartOf({ titleAction: 'latency-action' });
 
       expect(chart.titleAction).toBe('latency-action');
     });
   });
 
   describe('getThroughputChart / buildApmThroughputQuery', () => {
-    it('builds throughput from a raw count per bucket', () => {
+    it('builds throughput as transactions per minute', () => {
       const chart = getThroughputChart({
         indices: TRANSACTION_INDEXES,
-        buildQuery: (idx) => buildApmThroughputQuery(idx, SCOPE),
+        valueColumn: THROUGHPUT_COLUMN,
+        buildQuery: (idx) =>
+          buildApmThroughputQuery({
+            indices: idx,
+            scope: SCOPE,
+            bucketSizeInSeconds: BUCKET_SIZE_IN_SECONDS,
+          }),
       });
 
       expect(esqlOf(chart.config)).toEqual(
-        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "production" | STATS COUNT(*) BY timestamp = TBUCKET(100)'
+        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "production" | STATS transactions = COUNT(*) BY timestamp = TBUCKET(600 seconds) | EVAL throughput = TO_DOUBLE(transactions) / 10 | KEEP timestamp, throughput | SORT timestamp'
       );
-      expect(seriesLayerOf(chart.config).yAxis[0].value).toBe('COUNT(*)');
+      expect(seriesLayerOf(chart.config).yAxis[0].value).toBe('throughput');
+    });
+
+    it('divides by a fractional number of minutes for bucket sizes that are not whole minutes', () => {
+      const chart = getThroughputChart({
+        indices: TRANSACTION_INDEXES,
+        valueColumn: THROUGHPUT_COLUMN,
+        buildQuery: (idx) =>
+          buildApmThroughputQuery({ indices: idx, scope: SCOPE, bucketSizeInSeconds: 30 }),
+      });
+
+      expect(esqlOf(chart.config)).toContain('EVAL throughput = TO_DOUBLE(transactions) / 0.5');
     });
   });
 
@@ -171,11 +213,16 @@ describe('APM chart configs', () => {
       const chart = getErrorRateChart({
         indices: TRANSACTION_INDEXES,
         title: APM_ERROR_RATE_TITLE,
-        buildQuery: (idx) => buildApmErrorRateQuery(idx, SCOPE),
+        buildQuery: (idx) =>
+          buildApmErrorRateQuery({
+            indices: idx,
+            scope: SCOPE,
+            bucketSizeInSeconds: BUCKET_SIZE_IN_SECONDS,
+          }),
       });
 
       expect(esqlOf(chart.config)).toEqual(
-        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "production" | STATS failure = COUNT(*) WHERE TO_STRING(event.outcome) == "failure", all = COUNT(*) WHERE (TO_STRING(event.outcome) IN ("failure", "success")) BY timestamp = TBUCKET(100) | EVAL failed_transaction_rate = CASE(all > 0, TO_DOUBLE(failure) / all, NULL) | KEEP timestamp, failed_transaction_rate | SORT timestamp'
+        'SET unmapped_fields="nullify";\nFROM traces-apm* | WHERE `processor.event` == "transaction" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "production" | STATS failure = COUNT(*) WHERE TO_STRING(event.outcome) == "failure", all = COUNT(*) WHERE (TO_STRING(event.outcome) IN ("failure", "success")) BY timestamp = TBUCKET(600 seconds) | EVAL failed_transaction_rate = CASE(all > 0, TO_DOUBLE(failure) / all, NULL) | KEEP timestamp, failed_transaction_rate | SORT timestamp'
       );
       expect(seriesLayerOf(chart.config).yAxis[0].value).toBe('failed_transaction_rate');
       expect((chart.config as XYLensConfig).yBounds).toEqual({

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/apm.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/apm.ts
@@ -24,9 +24,12 @@ import {
   CGROUP_LIMIT_MAX_VALUE,
   TIME_BUCKET_BY,
   TIME_BUCKET_FIELD,
+  TRANSACTION_COUNT_COLUMN,
   applyServiceFilters,
   buildChartDefinition,
+  pipeThroughputPerMinute,
   seriesColor,
+  timeBucketBy,
 } from './shared';
 import type {
   EcsServiceScope,
@@ -53,27 +56,47 @@ function createApmBaseQuery({
   return query;
 }
 
-export function buildApmLatencyQuery(
-  indices: string,
-  scope: EcsServiceScope,
-  aggregation: string
-): ComposerQuery {
+interface ApmTransactionQueryOptions {
+  indices: string;
+  scope: EcsServiceScope;
+  bucketSizeInSeconds: number;
+}
+
+export function buildApmLatencyQuery({
+  indices,
+  scope,
+  bucketSizeInSeconds,
+  aggregation,
+}: ApmTransactionQueryOptions & { aggregation: string }): ComposerQuery {
   const query = createApmBaseQuery({ indices, processorEvent: 'transaction', scope });
   query.pipe(`EVAL duration_ms = TO_DOUBLE(${TRANSACTION_DURATION}) / 1000`);
-  query.pipe(`STATS ${aggregation} BY ${TIME_BUCKET_BY}`);
+  query.pipe(`STATS ${aggregation} BY ${timeBucketBy(bucketSizeInSeconds)}`);
   return query;
 }
 
-export function buildApmThroughputQuery(indices: string, scope: EcsServiceScope): ComposerQuery {
-  const query = createApmBaseQuery({ indices, processorEvent: 'transaction', scope });
-  query.pipe(`STATS COUNT(*) BY ${TIME_BUCKET_BY}`);
-  return query;
-}
-
-export function buildApmErrorRateQuery(indices: string, scope: EcsServiceScope): ComposerQuery {
+export function buildApmThroughputQuery({
+  indices,
+  scope,
+  bucketSizeInSeconds,
+}: ApmTransactionQueryOptions): ComposerQuery {
   const query = createApmBaseQuery({ indices, processorEvent: 'transaction', scope });
   query.pipe(
-    `STATS failure = COUNT(*) WHERE TO_STRING(${EVENT_OUTCOME}) == "failure", all = COUNT(*) WHERE (TO_STRING(${EVENT_OUTCOME}) IN ("failure", "success")) BY ${TIME_BUCKET_BY}`
+    `STATS ${TRANSACTION_COUNT_COLUMN} = COUNT(*) BY ${timeBucketBy(bucketSizeInSeconds)}`
+  );
+  pipeThroughputPerMinute(query, bucketSizeInSeconds);
+  return query;
+}
+
+export function buildApmErrorRateQuery({
+  indices,
+  scope,
+  bucketSizeInSeconds,
+}: ApmTransactionQueryOptions): ComposerQuery {
+  const query = createApmBaseQuery({ indices, processorEvent: 'transaction', scope });
+  query.pipe(
+    `STATS failure = COUNT(*) WHERE TO_STRING(${EVENT_OUTCOME}) == "failure", all = COUNT(*) WHERE (TO_STRING(${EVENT_OUTCOME}) IN ("failure", "success")) BY ${timeBucketBy(
+      bucketSizeInSeconds
+    )}`
   );
   query.pipe('EVAL failed_transaction_rate = CASE(all > 0, TO_DOUBLE(failure) / all, NULL)');
   query.pipe(`KEEP ${TIME_BUCKET_FIELD}, failed_transaction_rate`);

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/apm_rollups.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/apm_rollups.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ApmDocumentType } from '../../../../../../common/document_type';
+import { RollupInterval } from '../../../../../../common/rollup';
+import { LatencyAggregationType } from '../../../../../../common/latency_aggregation_types';
+import {
+  buildApmRollupErrorRateQuery,
+  buildApmRollupLatencyQuery,
+  buildApmRollupThroughputQuery,
+  isApmRollupDocumentType,
+} from './apm_rollups';
+import type { ApmRollupSource } from './apm_rollups';
+import { printQuery } from './shared';
+
+const INDICES = 'metrics-apm*';
+
+const SCOPE = {
+  serviceName: 'opbeans-java',
+  environment: 'production',
+  transactionType: 'request',
+};
+
+const SERVICE_TRANSACTION_SOURCE: ApmRollupSource = {
+  documentType: ApmDocumentType.ServiceTransactionMetric,
+  rollupInterval: RollupInterval.TenMinutes,
+  bucketSizeInSeconds: 600,
+};
+
+const TRANSACTION_SOURCE: ApmRollupSource = {
+  documentType: ApmDocumentType.TransactionMetric,
+  rollupInterval: RollupInterval.OneMinute,
+  bucketSizeInSeconds: 60,
+};
+
+describe('APM rollup chart configs', () => {
+  describe('isApmRollupDocumentType', () => {
+    it.each([ApmDocumentType.ServiceTransactionMetric, ApmDocumentType.TransactionMetric])(
+      'accepts %s',
+      (documentType) => {
+        expect(isApmRollupDocumentType(documentType)).toBe(true);
+      }
+    );
+
+    it.each([ApmDocumentType.TransactionEvent, ApmDocumentType.SpanEvent])(
+      'rejects %s',
+      (documentType) => {
+        expect(isApmRollupDocumentType(documentType)).toBe(false);
+      }
+    );
+  });
+
+  describe('buildApmRollupLatencyQuery', () => {
+    it('averages the duration summary for avg latency', () => {
+      const query = buildApmRollupLatencyQuery({
+        indices: INDICES,
+        scope: SCOPE,
+        source: SERVICE_TRANSACTION_SOURCE,
+        latencyAggregationType: LatencyAggregationType.avg,
+      });
+
+      expect(printQuery(query)).toEqual(
+        'FROM metrics-apm* | WHERE `processor.event` == "metric" | WHERE `metricset.name` == "service_transaction" | WHERE `metricset.interval` == "10m" | WHERE `transaction.type` == "request" | WHERE `service.name` == "opbeans-java" | WHERE `service.environment` == "production" | STATS duration_us = AVG(transaction.duration.summary) BY timestamp = TBUCKET(600 seconds) | EVAL latency = duration_us / 1000 | KEEP timestamp, latency | SORT timestamp'
+      );
+    });
+
+    it.each([
+      [LatencyAggregationType.p95, 95],
+      [LatencyAggregationType.p99, 99],
+    ])(
+      'reads percentiles from the duration histogram for %s',
+      (latencyAggregationType, percent) => {
+        const query = buildApmRollupLatencyQuery({
+          indices: INDICES,
+          scope: SCOPE,
+          source: SERVICE_TRANSACTION_SOURCE,
+          latencyAggregationType,
+        });
+
+        expect(printQuery(query)).toContain(
+          `STATS duration_us = PERCENTILE(transaction.duration.histogram::TDIGEST, ${percent})`
+        );
+      }
+    );
+
+    it('scopes transaction rollups by their own metricset name and interval', () => {
+      const query = buildApmRollupLatencyQuery({
+        indices: INDICES,
+        scope: SCOPE,
+        source: TRANSACTION_SOURCE,
+        latencyAggregationType: LatencyAggregationType.avg,
+      });
+
+      expect(printQuery(query)).toContain('WHERE `metricset.name` == "transaction"');
+      expect(printQuery(query)).toContain('WHERE `metricset.interval` == "1m"');
+    });
+  });
+
+  describe('buildApmRollupThroughputQuery', () => {
+    it('counts transactions from the duration summary and reports them per minute', () => {
+      const query = buildApmRollupThroughputQuery({
+        indices: INDICES,
+        scope: SCOPE,
+        source: SERVICE_TRANSACTION_SOURCE,
+      });
+
+      expect(printQuery(query)).toContain(
+        'STATS transactions = COUNT(transaction.duration.summary) BY timestamp = TBUCKET(600 seconds) | EVAL throughput = TO_DOUBLE(transactions) / 10 | KEEP timestamp, throughput | SORT timestamp'
+      );
+    });
+  });
+
+  describe('buildApmRollupErrorRateQuery', () => {
+    it('derives the failure ratio from event.success_count for service transaction rollups', () => {
+      const query = buildApmRollupErrorRateQuery({
+        indices: INDICES,
+        scope: SCOPE,
+        source: SERVICE_TRANSACTION_SOURCE,
+      });
+
+      expect(printQuery(query)).toContain(
+        'STATS successful = SUM(event.success_count), all = COUNT(event.success_count) BY timestamp = TBUCKET(600 seconds) | EVAL failed_transaction_rate = CASE(all > 0, TO_DOUBLE(all - successful) / all, NULL) | KEEP timestamp, failed_transaction_rate | SORT timestamp'
+      );
+    });
+
+    it('weights the outcome counts by transaction count for transaction rollups', () => {
+      const query = buildApmRollupErrorRateQuery({
+        indices: INDICES,
+        scope: SCOPE,
+        source: TRANSACTION_SOURCE,
+      });
+
+      expect(printQuery(query)).toContain(
+        'STATS failure = COUNT(transaction.duration.summary) WHERE TO_STRING(event.outcome) == "failure", all = COUNT(transaction.duration.summary) WHERE (TO_STRING(event.outcome) IN ("failure", "success")) BY timestamp = TBUCKET(60 seconds) | EVAL failed_transaction_rate = CASE(all > 0, TO_DOUBLE(failure) / all, NULL)'
+      );
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/apm_rollups.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/apm_rollups.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { esql } from '@elastic/esql';
+import { ApmDocumentType } from '../../../../../../common/document_type';
+import type { RollupInterval } from '../../../../../../common/rollup';
+import {
+  EVENT_OUTCOME,
+  EVENT_SUCCESS_COUNT,
+  METRICSET_INTERVAL,
+  METRICSET_NAME,
+  PROCESSOR_EVENT,
+  TRANSACTION_DURATION_HISTOGRAM,
+  TRANSACTION_DURATION_SUMMARY,
+  TRANSACTION_TYPE,
+} from '../../../../../../common/es_fields/apm';
+import { LatencyAggregationType } from '../../../../../../common/latency_aggregation_types';
+import {
+  TIME_BUCKET_FIELD,
+  TRANSACTION_COUNT_COLUMN,
+  applyServiceFilters,
+  pipeThroughputPerMinute,
+  timeBucketBy,
+} from './shared';
+import type { EcsServiceScope } from './shared';
+
+export const ROLLUP_LATENCY_COLUMN = 'latency';
+
+export type ApmRollupDocumentType =
+  | ApmDocumentType.ServiceTransactionMetric
+  | ApmDocumentType.TransactionMetric;
+
+export interface ApmRollupSource {
+  documentType: ApmRollupDocumentType;
+  rollupInterval: RollupInterval;
+  bucketSizeInSeconds: number;
+}
+
+const METRICSET_NAME_BY_DOCUMENT_TYPE: Record<ApmRollupDocumentType, string> = {
+  [ApmDocumentType.ServiceTransactionMetric]: 'service_transaction',
+  [ApmDocumentType.TransactionMetric]: 'transaction',
+};
+
+export const isApmRollupDocumentType = (
+  documentType: ApmDocumentType
+): documentType is ApmRollupDocumentType => documentType in METRICSET_NAME_BY_DOCUMENT_TYPE;
+
+/**
+ * The rollups are only queried when they expose `transaction.duration.summary`, so the
+ * `getBackwardCompatibleDocumentTypeFilter` variant the server applies to 1m transaction metrics is
+ * not needed: deployments holding pre-8.7 documents resolve to a raw transaction source instead.
+ */
+function createRollupBaseQuery({
+  indices,
+  scope,
+  source,
+}: {
+  indices: string;
+  scope: EcsServiceScope;
+  source: ApmRollupSource;
+}): ComposerQuery {
+  const { documentType, rollupInterval } = source;
+  const query = esql.from(indices).where`${esql.col(PROCESSOR_EVENT)} == ${'metric'}`;
+  query.where`${esql.col(METRICSET_NAME)} == ${METRICSET_NAME_BY_DOCUMENT_TYPE[documentType]}`;
+  query.where`${esql.col(METRICSET_INTERVAL)} == ${rollupInterval}`;
+  if (scope.transactionType) {
+    query.where`${esql.col(TRANSACTION_TYPE)} == ${scope.transactionType}`;
+  }
+  applyServiceFilters(query, scope);
+  return query;
+}
+
+export function buildApmRollupLatencyQuery({
+  indices,
+  scope,
+  source,
+  latencyAggregationType,
+}: {
+  indices: string;
+  scope: EcsServiceScope;
+  source: ApmRollupSource;
+  latencyAggregationType: LatencyAggregationType;
+}): ComposerQuery {
+  const query = createRollupBaseQuery({ indices, scope, source });
+  // Percentiles need the histogram: `transaction.duration.summary` only carries sum and value_count.
+  const aggregation =
+    latencyAggregationType === LatencyAggregationType.avg
+      ? `AVG(${TRANSACTION_DURATION_SUMMARY})`
+      : `PERCENTILE(${TRANSACTION_DURATION_HISTOGRAM}::tdigest, ${
+          latencyAggregationType === LatencyAggregationType.p99 ? 99 : 95
+        })`;
+
+  query.pipe(`STATS duration_us = ${aggregation} BY ${timeBucketBy(source.bucketSizeInSeconds)}`);
+  query.pipe(`EVAL ${ROLLUP_LATENCY_COLUMN} = duration_us / 1000`);
+  query.pipe(`KEEP ${TIME_BUCKET_FIELD}, ${ROLLUP_LATENCY_COLUMN}`);
+  query.pipe(`SORT ${TIME_BUCKET_FIELD}`);
+  return query;
+}
+
+export function buildApmRollupThroughputQuery({
+  indices,
+  scope,
+  source,
+}: {
+  indices: string;
+  scope: EcsServiceScope;
+  source: ApmRollupSource;
+}): ComposerQuery {
+  const query = createRollupBaseQuery({ indices, scope, source });
+  // COUNT over an aggregate_metric_double sums its value_count, so this is the transaction count
+  // rather than the number of rollup documents.
+  query.pipe(
+    `STATS ${TRANSACTION_COUNT_COLUMN} = COUNT(${TRANSACTION_DURATION_SUMMARY}) BY ${timeBucketBy(
+      source.bucketSizeInSeconds
+    )}`
+  );
+  pipeThroughputPerMinute(query, source.bucketSizeInSeconds);
+  return query;
+}
+
+export function buildApmRollupErrorRateQuery({
+  indices,
+  scope,
+  source,
+}: {
+  indices: string;
+  scope: EcsServiceScope;
+  source: ApmRollupSource;
+}): ComposerQuery {
+  const query = createRollupBaseQuery({ indices, scope, source });
+  const bucket = timeBucketBy(source.bucketSizeInSeconds);
+
+  if (source.documentType === ApmDocumentType.ServiceTransactionMetric) {
+    // service_transaction rollups fold both outcomes into `event.success_count`: its value_count is
+    // every transaction with a known outcome and its sum is the successful ones.
+    query.pipe(
+      `STATS successful = SUM(${EVENT_SUCCESS_COUNT}), all = COUNT(${EVENT_SUCCESS_COUNT}) BY ${bucket}`
+    );
+    query.pipe(
+      'EVAL failed_transaction_rate = CASE(all > 0, TO_DOUBLE(all - successful) / all, NULL)'
+    );
+  } else {
+    // transaction rollups are grouped by outcome instead, so the counts have to be weighted by the
+    // number of transactions each document stands for.
+    query.pipe(
+      `STATS failure = COUNT(${TRANSACTION_DURATION_SUMMARY}) WHERE TO_STRING(${EVENT_OUTCOME}) == "failure", all = COUNT(${TRANSACTION_DURATION_SUMMARY}) WHERE (TO_STRING(${EVENT_OUTCOME}) IN ("failure", "success")) BY ${bucket}`
+    );
+    query.pipe('EVAL failed_transaction_rate = CASE(all > 0, TO_DOUBLE(failure) / all, NULL)');
+  }
+
+  query.pipe(`KEEP ${TIME_BUCKET_FIELD}, failed_transaction_rate`);
+  query.pipe(`SORT ${TIME_BUCKET_FIELD}`);
+  return query;
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/index.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/index.test.ts
@@ -5,9 +5,12 @@
  * 2.0.
  */
 
+import { ApmDocumentType } from '../../../../../../common/document_type';
+import { RollupInterval } from '../../../../../../common/rollup';
 import { LatencyAggregationType } from '../../../../../../common/latency_aggregation_types';
 import { ChartType } from '../../../charts/helper/get_timeseries_color';
 import { getChartDefinitions, getLatencyChartType } from '.';
+import type { FlyoutChartDataSource } from './shared';
 
 const TRANSACTION_INDEXES = 'traces-apm*';
 const SPAN_INDEXES = 'traces-apm*'; // same value as TRANSACTION_INDEXES in MOCK_INDICES
@@ -22,6 +25,22 @@ const MOCK_INDICES = {
   sourcemap: 'apm-*',
 };
 
+const SERVICE_TRANSACTION_SOURCE: FlyoutChartDataSource = {
+  documentType: ApmDocumentType.ServiceTransactionMetric,
+  rollupInterval: RollupInterval.TenMinutes,
+  hasDurationSummaryField: true,
+  hasDocs: true,
+  bucketSizeInSeconds: 600,
+};
+
+const TRANSACTION_EVENT_SOURCE: FlyoutChartDataSource = {
+  documentType: ApmDocumentType.TransactionEvent,
+  rollupInterval: RollupInterval.None,
+  hasDurationSummaryField: false,
+  hasDocs: true,
+  bucketSizeInSeconds: 60,
+};
+
 function buildDefinitions(
   overrides: Partial<Parameters<typeof getChartDefinitions>[0]> = {}
 ): ReturnType<typeof getChartDefinitions> {
@@ -31,6 +50,8 @@ function buildDefinitions(
     serviceName: 'opbeans-java',
     environment: 'production',
     transactionType: 'request',
+    isTransactionTypeResolved: true,
+    dataSource: SERVICE_TRANSACTION_SOURCE,
     latencyAggregationType: LatencyAggregationType.avg,
     ...overrides,
   });
@@ -70,20 +91,70 @@ describe('service flyout chart_configs', () => {
       expect(infrastructureMetrics.map((c) => c.id)).toEqual(['cpuUsage', 'memoryUsage']);
     });
 
-    it('scopes APM key metrics to the transaction index only', () => {
+    it('reads APM key metrics from the rollups the chart APIs prefer', () => {
       const { keyMetrics } = buildDefinitions();
 
       keyMetrics.forEach(({ config }) => {
-        // single index pattern — not combined with span indices
-        expect(config?.dataset.esql).toContain(`FROM ${TRANSACTION_INDEXES} |`);
+        expect(config?.dataset.esql).toContain(`FROM ${METRIC_INDEXES} |`);
+        expect(config?.dataset.esql).toContain('WHERE `metricset.name` == "service_transaction"');
+        expect(config?.dataset.esql).toContain('WHERE `metricset.interval` == "10m"');
+        expect(config?.dataset.esql).toContain('BY timestamp = TBUCKET(600 seconds)');
       });
     });
 
-    it('combines transaction and span indices for OTel key metrics', () => {
-      const { keyMetrics } = buildDefinitions({ schema: 'otel' });
+    it('falls back to raw transactions when the preferred source has no rollups', () => {
+      const { keyMetrics } = buildDefinitions({ dataSource: TRANSACTION_EVENT_SOURCE });
+
+      keyMetrics.forEach(({ config }) => {
+        expect(config?.dataset.esql).toContain(`FROM ${TRANSACTION_INDEXES} |`);
+        expect(config?.dataset.esql).toContain('WHERE `processor.event` == "transaction"');
+        expect(config?.dataset.esql).toContain('BY timestamp = TBUCKET(60 seconds)');
+      });
+    });
+
+    it('falls back to raw transactions when the rollups predate the duration summary field', () => {
+      const { keyMetrics } = buildDefinitions({
+        dataSource: {
+          ...SERVICE_TRANSACTION_SOURCE,
+          documentType: ApmDocumentType.TransactionMetric,
+          rollupInterval: RollupInterval.OneMinute,
+          hasDurationSummaryField: false,
+        },
+      });
+
+      keyMetrics.forEach(({ config }) => {
+        expect(config?.dataset.esql).toContain(`FROM ${TRANSACTION_INDEXES} |`);
+        expect(config?.dataset.esql).not.toContain('metricset.name');
+      });
+    });
+
+    it('holds the APM key metric queries until the data source is known', () => {
+      const { keyMetrics } = buildDefinitions({ dataSource: undefined });
+
+      keyMetrics.forEach((chart) => {
+        expect(chart.title).toEqual(expect.any(String));
+        expect(chart.config).toBeUndefined();
+      });
+    });
+
+    it('holds the APM key metric queries until the transaction type is resolved', () => {
+      const { keyMetrics } = buildDefinitions({ isTransactionTypeResolved: false });
+
+      keyMetrics.forEach((chart) => {
+        expect(chart.config).toBeUndefined();
+      });
+    });
+
+    it('builds OTel key metrics without waiting for an APM data source', () => {
+      const { keyMetrics } = buildDefinitions({
+        schema: 'otel',
+        dataSource: undefined,
+        isTransactionTypeResolved: false,
+      });
 
       keyMetrics.forEach(({ config }) => {
         expect(config?.dataset.esql).toContain(`FROM ${TRANSACTION_INDEXES}, ${SPAN_INDEXES}`);
+        expect(config?.dataset.esql).toContain('BY timestamp = TBUCKET(100)');
       });
     });
 
@@ -169,11 +240,31 @@ describe('service flyout chart_configs', () => {
       });
     });
 
-    it('buckets every chart by a timestamp TBUCKET aliased to the date histogram x-axis', () => {
+    it('labels the APM throughput axis with the per-minute unit', () => {
+      const { keyMetrics } = buildDefinitions();
+      const layer = keyMetrics[2].config?.layers[0];
+
+      expect(layer && 'yAxis' in layer ? layer.yAxis[0] : undefined).toMatchObject({
+        value: 'throughput',
+        suffix: ' tpm',
+      });
+    });
+
+    it('leaves the OTel throughput axis as a per-bucket count', () => {
+      const { keyMetrics } = buildDefinitions({ schema: 'otel' });
+      const layer = keyMetrics[2].config?.layers[0];
+
+      expect(layer && 'yAxis' in layer ? layer.yAxis[0] : undefined).toMatchObject({
+        value: 'COUNT(*)',
+      });
+      expect(layer && 'yAxis' in layer ? layer.yAxis[0] : undefined).not.toHaveProperty('suffix');
+    });
+
+    it('aliases the time bucket to the date histogram x-axis in every chart', () => {
       const { keyMetrics, infrastructureMetrics } = buildDefinitions();
 
       [...keyMetrics, ...infrastructureMetrics].forEach(({ config }) => {
-        expect(config?.dataset.esql).toContain('BY timestamp = TBUCKET(100)');
+        expect(config?.dataset.esql).toContain('BY timestamp = TBUCKET(');
         const layer = config?.layers[0];
         expect(layer && 'xAxis' in layer ? layer.xAxis : undefined).toEqual({
           field: 'timestamp',

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ReactNode } from 'react';
+import type { ComposerQuery } from '@elastic/esql';
 import type { APMIndices } from '@kbn/apm-sources-access-plugin/common/config_schema';
 import type { ServiceSchemaType } from '@kbn/apm-types';
 import type { LatencyAggregationType } from '../../../../../../common/latency_aggregation_types';
@@ -18,20 +19,166 @@ import {
   getMemoryUsageChart,
 } from './apm';
 import {
+  ROLLUP_LATENCY_COLUMN,
+  buildApmRollupErrorRateQuery,
+  buildApmRollupLatencyQuery,
+  buildApmRollupThroughputQuery,
+  isApmRollupDocumentType,
+} from './apm_rollups';
+import {
   OTEL_ERROR_RATE_TITLE,
   buildOtelErrorRateQuery,
   buildOtelLatencyQuery,
   buildOtelThroughputQuery,
 } from './otel';
 import {
+  THROUGHPUT_COLUMN,
+  THROUGHPUT_SUFFIX,
   getErrorRateChart,
   getLatencyChart,
   getLatencyChartType,
   getThroughputChart,
 } from './shared';
-import type { EcsServiceScope, FlyoutLensChartConfigDefinition, ServiceScope } from './shared';
+import type {
+  EcsServiceScope,
+  FlyoutChartDataSource,
+  FlyoutLensChartConfigDefinition,
+  ServiceScope,
+} from './shared';
 
 export { getLatencyChartType };
+
+interface EcsQueryBuilders {
+  latencyValueColumn?: string;
+  usesRollups: boolean;
+  buildLatency: (indices: string, aggregation: string) => ComposerQuery;
+  buildErrorRate: (indices: string) => ComposerQuery;
+  buildThroughput: (indices: string) => ComposerQuery;
+}
+
+/**
+ * Picks the documents the APM chart APIs would read for the same time range. The rollups only stand
+ * in for raw transactions once they carry `transaction.duration.summary`; before that the APIs fall
+ * back to raw events as well, so the flyout follows them there.
+ */
+function getEcsQueryBuilders({
+  dataSource,
+  scope,
+  latencyAggregationType,
+}: {
+  dataSource: FlyoutChartDataSource;
+  scope: EcsServiceScope;
+  latencyAggregationType: LatencyAggregationType;
+}): EcsQueryBuilders {
+  const { documentType, rollupInterval, bucketSizeInSeconds, hasDurationSummaryField } = dataSource;
+
+  if (hasDurationSummaryField && isApmRollupDocumentType(documentType)) {
+    const source = { documentType, rollupInterval, bucketSizeInSeconds };
+    return {
+      latencyValueColumn: ROLLUP_LATENCY_COLUMN,
+      usesRollups: true,
+      buildLatency: (indices) =>
+        buildApmRollupLatencyQuery({ indices, scope, source, latencyAggregationType }),
+      buildErrorRate: (indices) => buildApmRollupErrorRateQuery({ indices, scope, source }),
+      buildThroughput: (indices) => buildApmRollupThroughputQuery({ indices, scope, source }),
+    };
+  }
+
+  return {
+    usesRollups: false,
+    buildLatency: (indices, aggregation) =>
+      buildApmLatencyQuery({ indices, scope, aggregation, bucketSizeInSeconds }),
+    buildErrorRate: (indices) => buildApmErrorRateQuery({ indices, scope, bucketSizeInSeconds }),
+    buildThroughput: (indices) => buildApmThroughputQuery({ indices, scope, bucketSizeInSeconds }),
+  };
+}
+
+function getEcsKeyMetrics({
+  indices,
+  scope,
+  dataSource,
+  isTransactionTypeResolved,
+  latencyAggregationType,
+  latencyTitleAction,
+  projectRouting,
+}: {
+  indices: APMIndices | undefined;
+  scope: EcsServiceScope;
+  dataSource: FlyoutChartDataSource | undefined;
+  isTransactionTypeResolved: boolean;
+  latencyAggregationType: LatencyAggregationType;
+  latencyTitleAction?: ReactNode;
+  projectRouting?: string;
+}): FlyoutLensChartConfigDefinition[] {
+  // Leaving out the query keeps the charts in their loading state, which is what we want until the
+  // data source and the transaction type are known: querying earlier would plot unfiltered or raw
+  // numbers and then swap them for the aggregated ones.
+  const builders =
+    dataSource && isTransactionTypeResolved
+      ? getEcsQueryBuilders({ dataSource, scope, latencyAggregationType })
+      : undefined;
+  const chartIndices = builders?.usesRollups ? indices?.metric : indices?.transaction;
+
+  return [
+    getLatencyChart({
+      indices: chartIndices,
+      latencyAggregationType,
+      titleAction: latencyTitleAction,
+      valueColumn: builders?.latencyValueColumn,
+      buildQuery: builders && ((idx, aggregation) => builders.buildLatency(idx, aggregation)),
+      projectRouting,
+    }),
+    getErrorRateChart({
+      indices: chartIndices,
+      title: APM_ERROR_RATE_TITLE,
+      buildQuery: builders && ((idx) => builders.buildErrorRate(idx)),
+      projectRouting,
+    }),
+    getThroughputChart({
+      indices: chartIndices,
+      valueColumn: THROUGHPUT_COLUMN,
+      suffix: THROUGHPUT_SUFFIX,
+      decimals: 1,
+      buildQuery: builders && ((idx) => builders.buildThroughput(idx)),
+      projectRouting,
+    }),
+  ];
+}
+
+function getOtelKeyMetrics({
+  indices,
+  scope,
+  latencyAggregationType,
+  latencyTitleAction,
+  projectRouting,
+}: {
+  indices: string | undefined;
+  scope: ServiceScope;
+  latencyAggregationType: LatencyAggregationType;
+  latencyTitleAction?: ReactNode;
+  projectRouting?: string;
+}): FlyoutLensChartConfigDefinition[] {
+  return [
+    getLatencyChart({
+      indices,
+      latencyAggregationType,
+      titleAction: latencyTitleAction,
+      buildQuery: (idx, aggregation) => buildOtelLatencyQuery(idx, scope, aggregation),
+      projectRouting,
+    }),
+    getErrorRateChart({
+      indices,
+      title: OTEL_ERROR_RATE_TITLE,
+      buildQuery: (idx) => buildOtelErrorRateQuery(idx, scope),
+      projectRouting,
+    }),
+    getThroughputChart({
+      indices,
+      buildQuery: (idx) => buildOtelThroughputQuery(idx, scope),
+      projectRouting,
+    }),
+  ];
+}
 
 export function getChartDefinitions({
   indices,
@@ -39,6 +186,8 @@ export function getChartDefinitions({
   serviceName,
   environment,
   transactionType,
+  isTransactionTypeResolved,
+  dataSource,
   latencyAggregationType,
   latencyTitleAction,
   projectRouting,
@@ -48,6 +197,8 @@ export function getChartDefinitions({
   serviceName: string;
   environment: string;
   transactionType: string;
+  isTransactionTypeResolved: boolean;
+  dataSource: FlyoutChartDataSource | undefined;
   latencyAggregationType: LatencyAggregationType;
   latencyTitleAction?: ReactNode;
   projectRouting?: string;
@@ -55,45 +206,31 @@ export function getChartDefinitions({
   keyMetrics: FlyoutLensChartConfigDefinition[];
   infrastructureMetrics: FlyoutLensChartConfigDefinition[];
 } {
-  const transactionIndexes = indices?.transaction;
-  const otelIndexes = [indices?.transaction, indices?.span].filter(Boolean).join(',') || undefined;
-  const metricIndexes = indices?.metric;
-  const ecsScope: EcsServiceScope = { serviceName, environment, transactionType };
-  const otelScope: ServiceScope = { serviceName, environment };
-  const metricScope: ServiceScope = { serviceName, environment };
+  const serviceScope: ServiceScope = { serviceName, environment };
   const isOtel = schema === 'otel';
-  const chartIndices = isOtel ? otelIndexes : transactionIndexes;
 
   return {
-    keyMetrics: [
-      getLatencyChart({
-        indices: chartIndices,
-        latencyAggregationType,
-        titleAction: latencyTitleAction,
-        buildQuery: isOtel
-          ? (idx, agg) => buildOtelLatencyQuery(idx, otelScope, agg)
-          : (idx, agg) => buildApmLatencyQuery(idx, ecsScope, agg),
-        projectRouting,
-      }),
-      getErrorRateChart({
-        indices: chartIndices,
-        title: isOtel ? OTEL_ERROR_RATE_TITLE : APM_ERROR_RATE_TITLE,
-        buildQuery: isOtel
-          ? (idx) => buildOtelErrorRateQuery(idx, otelScope)
-          : (idx) => buildApmErrorRateQuery(idx, ecsScope),
-        projectRouting,
-      }),
-      getThroughputChart({
-        indices: chartIndices,
-        buildQuery: isOtel
-          ? (idx) => buildOtelThroughputQuery(idx, otelScope)
-          : (idx) => buildApmThroughputQuery(idx, ecsScope),
-        projectRouting,
-      }),
-    ],
+    // OTel native services have no APM rollups to read from, so they keep aggregating raw spans.
+    keyMetrics: isOtel
+      ? getOtelKeyMetrics({
+          indices: [indices?.transaction, indices?.span].filter(Boolean).join(',') || undefined,
+          scope: serviceScope,
+          latencyAggregationType,
+          latencyTitleAction,
+          projectRouting,
+        })
+      : getEcsKeyMetrics({
+          indices,
+          scope: { ...serviceScope, transactionType },
+          dataSource,
+          isTransactionTypeResolved,
+          latencyAggregationType,
+          latencyTitleAction,
+          projectRouting,
+        }),
     infrastructureMetrics: [
-      getCpuUsageChart(metricIndexes, metricScope, projectRouting),
-      getMemoryUsageChart(metricIndexes, metricScope, projectRouting),
+      getCpuUsageChart(indices?.metric, serviceScope, projectRouting),
+      getMemoryUsageChart(indices?.metric, serviceScope, projectRouting),
     ],
   };
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/chart_builders.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/chart_builders.ts
@@ -60,17 +60,20 @@ export function getLatencyChartType(latencyAggregationType: LatencyAggregationTy
 }
 
 // buildQuery receives the aggregation expression so the STATS column name matches
-// the yAxis value without the caller having to compute it twice.
+// the yAxis value without the caller having to compute it twice. Builders that cannot aggregate the
+// raw field directly, such as the rollup ones, name their output column and pass it as valueColumn.
 export function getLatencyChart({
   indices,
   buildQuery,
   latencyAggregationType,
+  valueColumn,
   titleAction,
   projectRouting,
 }: {
   indices: string | undefined;
-  buildQuery: (indices: string, aggregation: string) => ComposerQuery;
+  buildQuery?: (indices: string, aggregation: string) => ComposerQuery;
   latencyAggregationType: LatencyAggregationType;
+  valueColumn?: string;
   titleAction?: ReactNode;
   projectRouting?: string;
 }): FlyoutLensChartConfigDefinition {
@@ -83,12 +86,12 @@ export function getLatencyChart({
     }),
     titleAction,
     indices,
-    buildQuery: (idx) => buildQuery(idx, aggregation),
+    buildQuery: buildQuery && ((idx: string) => buildQuery(idx, aggregation)),
     projectRouting,
     yAxis: [
       {
         label,
-        value: aggregation,
+        value: valueColumn ?? aggregation,
         format: 'number',
         decimals: 0,
         suffix: ' ms',
@@ -101,10 +104,17 @@ export function getLatencyChart({
 export function getThroughputChart({
   indices,
   buildQuery,
+  valueColumn = 'COUNT(*)',
+  suffix,
+  decimals = 0,
   projectRouting,
 }: {
   indices: string | undefined;
-  buildQuery: (indices: string) => ComposerQuery;
+  buildQuery?: (indices: string) => ComposerQuery;
+  valueColumn?: string;
+  /** Set when the query reports a rate rather than a per-bucket count, e.g. ` tpm`. */
+  suffix?: string;
+  decimals?: number;
   projectRouting?: string;
 }): FlyoutLensChartConfigDefinition {
   return buildChartDefinition({
@@ -120,9 +130,10 @@ export function getThroughputChart({
         label: i18n.translate('xpack.apm.serviceFlyout.throughputSeriesLabel', {
           defaultMessage: 'Throughput',
         }),
-        value: 'COUNT(*)',
+        value: valueColumn,
         format: 'number',
-        decimals: 0,
+        decimals,
+        ...(suffix ? { suffix } : {}),
         seriesColor: seriesColor(ChartType.THROUGHPUT),
       },
     ],
@@ -136,7 +147,7 @@ export function getErrorRateChart({
   projectRouting,
 }: {
   indices: string | undefined;
-  buildQuery: (indices: string) => ComposerQuery;
+  buildQuery?: (indices: string) => ComposerQuery;
   title: string;
   projectRouting?: string;
 }): FlyoutLensChartConfigDefinition {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/chart_definition.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/chart_definition.ts
@@ -37,12 +37,14 @@ export function buildChartDefinition({
   title: string;
   titleAction?: ReactNode;
   indices: string | undefined;
-  buildQuery: (indices: string) => ComposerQuery;
+  buildQuery?: (indices: string) => ComposerQuery;
   yAxis: LensYAxis[];
   yBounds?: LensYBounds;
   projectRouting?: string;
 }): FlyoutLensChartConfigDefinition {
-  if (!indices) {
+  // A definition without a config renders as a loading chart, which is how callers signal that the
+  // indices or the data source behind the query are not resolved yet.
+  if (!indices || !buildQuery) {
     return { id, title, titleAction };
   }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/constants.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/constants.ts
@@ -6,7 +6,19 @@
  */
 
 export const TIME_BUCKET_FIELD = 'timestamp';
-export const TIME_BUCKET_BY = `${TIME_BUCKET_FIELD} = TBUCKET(100)`;
+export const TARGET_BUCKET_COUNT = 100;
+
+/**
+ * `TBUCKET` derives the time range from the Kibana time filter. An explicit span keeps the interval
+ * identical to the `fixed_interval` the APM chart APIs use, so the same data lands in the same
+ * bucket; without it Elasticsearch picks its own span and the two charts dilute spikes differently.
+ */
+export const timeBucketBy = (bucketSizeInSeconds?: number) =>
+  `${TIME_BUCKET_FIELD} = TBUCKET(${
+    bucketSizeInSeconds ? `${bucketSizeInSeconds} seconds` : TARGET_BUCKET_COUNT
+  })`;
+
+export const TIME_BUCKET_BY = timeBucketBy();
 export const ESQL_NULLIFY_UNMAPPED_FIELDS = 'SET unmapped_fields="nullify";';
 
 /**

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/index.ts
@@ -9,4 +9,5 @@ export type * from './types';
 export * from './constants';
 export * from './chart_definition';
 export * from './filters';
+export * from './query_helpers';
 export * from './chart_builders';

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/query_helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/query_helpers.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ComposerQuery } from '@elastic/esql';
+import { TIME_BUCKET_FIELD } from './constants';
+
+export const TRANSACTION_COUNT_COLUMN = 'transactions';
+export const THROUGHPUT_COLUMN = 'throughput';
+/** Transactions per minute, the same unit the APM service overview page labels throughput with. */
+export const THROUGHPUT_SUFFIX = ' tpm';
+
+/**
+ * Turns a per-bucket transaction count into transactions per minute, the unit the APM throughput API
+ * reports through its `rate` aggregation, so both charts plot the same numbers.
+ */
+export function pipeThroughputPerMinute(query: ComposerQuery, bucketSizeInSeconds: number): void {
+  const bucketSizeInMinutes = Number((bucketSizeInSeconds / 60).toFixed(6));
+  query.pipe(
+    `EVAL ${THROUGHPUT_COLUMN} = TO_DOUBLE(${TRANSACTION_COUNT_COLUMN}) / ${bucketSizeInMinutes}`
+  );
+  query.pipe(`KEEP ${TIME_BUCKET_FIELD}, ${THROUGHPUT_COLUMN}`);
+  query.pipe(`SORT ${TIME_BUCKET_FIELD}`);
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/types.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/chart_configs/shared/types.ts
@@ -7,9 +7,16 @@
 
 import type { ReactNode } from 'react';
 import type { LensConfig, LensSeriesLayer } from '@kbn/lens-embeddable-utils';
+import type { ApmDataSourceWithSummary } from '../../../../../../../common/data_source';
 import type { LensESQLConfig } from '../../types';
 
 export type FlyoutLensChartProcessorEvent = 'transaction' | 'metric';
+
+/**
+ * The documents and bucket span the APM chart APIs resolved for the current time range. Reusing them
+ * is what keeps the flyout charts aligned with the ones on the service overview page.
+ */
+export type FlyoutChartDataSource = ApmDataSourceWithSummary & { bucketSizeInSeconds: number };
 
 export interface FlyoutLensChartConfigDefinition {
   id: string;

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/index.test.tsx
@@ -33,6 +33,20 @@ jest.mock('../hooks/use_project_routing', () => ({
   useProjectRouting: () => undefined,
 }));
 
+// Both depend on the time range metadata context, which this test renders the overview without.
+jest.mock('../hooks/use_service_flyout_transaction_type', () => ({
+  useServiceFlyoutTransactionType: () => ({
+    transactionTypes: ['request'],
+    status: 'success',
+    selectedTransactionType: 'request',
+    isResolved: true,
+  }),
+}));
+
+jest.mock('../../../../hooks/use_preferred_data_source_and_bucket_size', () => ({
+  usePreferredDataSourceAndBucketSize: () => null,
+}));
+
 jest.mock('@kbn/apm-ui-shared', () => ({
   ServiceFlyoutTransactionsSection: (
     props: React.ComponentProps<typeof ServiceFlyoutTransactionsSection>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/index.tsx
@@ -23,13 +23,17 @@ import { KbnWarningCallout } from '@kbn/ui-callout';
 import React, { useMemo, useState } from 'react';
 import { SERVICE_FLYOUT_EBT_ELEMENTS } from '../ebt_constants';
 import type { LensESQLConfig } from './types';
+import { ApmDocumentType } from '../../../../../common/document_type';
 import { LatencyAggregationType } from '../../../../../common/latency_aggregation_types';
 import { useServiceFlyoutContext } from '../service_flyout_context';
+import { usePreferredDataSourceAndBucketSize } from '../../../../hooks/use_preferred_data_source_and_bucket_size';
 import { useTimeRange } from '../../../../hooks/use_time_range';
 import { LatencyAggregationTypeSelect } from '../../charts/latency_chart/latency_aggregation_type_select';
 import { useServiceHasSystemMetrics } from '../hooks/use_service_has_system_metrics';
+import { useServiceFlyoutTransactionType } from '../hooks/use_service_flyout_transaction_type';
 import { useProjectRouting } from '../hooks/use_project_routing';
 import { getChartDefinitions } from './chart_configs';
+import { TARGET_BUCKET_COUNT } from './chart_configs/shared';
 import { ServiceFlyoutLensChart } from './lens_chart';
 import { ServiceFlyoutQueryControls } from './query_controls';
 
@@ -172,7 +176,7 @@ export function ServiceFlyoutOverview() {
     service,
     capabilities,
     indices,
-    filters: { environment, rangeFrom, rangeTo, transactionType, refreshToken },
+    filters: { environment, rangeFrom, rangeTo, transactionType, setTransactionType, refreshToken },
   } = useServiceFlyoutContext();
 
   const { start, end } = useTimeRange({ rangeFrom, rangeTo });
@@ -186,6 +190,30 @@ export function ServiceFlyoutOverview() {
   // the same projects as the surrounding APM APIs (which forward it via `x-project-routing`).
   const projectRouting = useProjectRouting();
 
+  const {
+    transactionTypes,
+    status: transactionTypeStatus,
+    selectedTransactionType,
+    isResolved: isTransactionTypeResolved,
+  } = useServiceFlyoutTransactionType({
+    serviceName: service.name,
+    agentName: service.agentName,
+    start,
+    end,
+    transactionType: transactionType ?? '',
+    setTransactionType,
+  });
+
+  // Reading the documents and bucket span the APM chart APIs prefer is what keeps these charts in
+  // sync with the ones on the service overview page.
+  const preferred = usePreferredDataSourceAndBucketSize({
+    start,
+    end,
+    kuery: '',
+    type: ApmDocumentType.ServiceTransactionMetric,
+    numBuckets: TARGET_BUCKET_COUNT,
+  });
+
   const { keyMetrics, infrastructureMetrics } = useMemo(
     () =>
       getChartDefinitions({
@@ -193,7 +221,11 @@ export function ServiceFlyoutOverview() {
         schema: capabilities.schema,
         serviceName: service.name,
         environment,
-        transactionType: transactionType ?? '',
+        transactionType: selectedTransactionType ?? transactionType ?? '',
+        isTransactionTypeResolved,
+        dataSource: preferred
+          ? { ...preferred.source, bucketSizeInSeconds: preferred.bucketSizeInSeconds }
+          : undefined,
         latencyAggregationType,
         latencyTitleAction: (
           <LatencyAggregationTypeSelect
@@ -208,7 +240,10 @@ export function ServiceFlyoutOverview() {
       capabilities.schema,
       environment,
       indices,
+      isTransactionTypeResolved,
       latencyAggregationType,
+      preferred,
+      selectedTransactionType,
       service.name,
       transactionType,
       projectRouting,
@@ -231,7 +266,11 @@ export function ServiceFlyoutOverview() {
 
   return (
     <div data-test-subj="serviceFlyoutOverview">
-      <ServiceFlyoutQueryControls />
+      <ServiceFlyoutQueryControls
+        transactionTypes={transactionTypes}
+        transactionTypeStatus={transactionTypeStatus}
+        selectedTransactionType={selectedTransactionType}
+      />
       <EuiSpacer size="m" />
       <EuiFlexGroup direction="column" responsive={false} gutterSize="m">
         <EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/query_controls.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout/overview/query_controls.tsx
@@ -17,22 +17,28 @@ import {
 import { getEbtProps } from '@kbn/ebt-click';
 import { UI_SETTINGS } from '@kbn/data-plugin/common';
 import { i18n } from '@kbn/i18n';
-import React, { useEffect, useMemo } from 'react';
-import { ApmDocumentType } from '../../../../../common/document_type';
+import React, { useMemo } from 'react';
 import type { Environment } from '../../../../../common/environment_rt';
-import { getTransactionType } from '../../../../context/apm_service/apm_service_context';
-import { useServiceTransactionTypesFetcher } from '../../../../context/apm_service/use_service_transaction_types_fetcher';
 import { useServiceFlyoutContext } from '../service_flyout_context';
 import { useUnifiedEnvironmentsFetcher } from '../../../../hooks/use_unified_environments_fetcher';
 import { FETCH_STATUS } from '../../../../hooks/use_fetcher';
-import { usePreferredDataSourceAndBucketSize } from '../../../../hooks/use_preferred_data_source_and_bucket_size';
 import { useTimeRange } from '../../../../hooks/use_time_range';
 import type { TimePickerQuickRange } from '../../date_picker/typings';
 import { EnvironmentSelect } from '../../environment_select';
 import { APM_EBT_ACTIONS } from '../../../app/ebt_constants';
 import { SERVICE_FLYOUT_EBT_ELEMENTS } from '../ebt_constants';
 
-export function ServiceFlyoutQueryControls() {
+// The transaction type is resolved by the overview, which needs it to build the chart queries, so it
+// is passed in rather than fetched twice.
+export function ServiceFlyoutQueryControls({
+  transactionTypes,
+  transactionTypeStatus,
+  selectedTransactionType,
+}: {
+  transactionTypes: string[];
+  transactionTypeStatus: FETCH_STATUS;
+  selectedTransactionType?: string;
+}) {
   const {
     deps: { core },
     service,
@@ -41,7 +47,6 @@ export function ServiceFlyoutQueryControls() {
       environment,
       rangeFrom,
       rangeTo,
-      transactionType = '',
       setEnvironment,
       setRange,
       onRefresh,
@@ -52,22 +57,6 @@ export function ServiceFlyoutQueryControls() {
   const showTransactionTypeFilter = capabilities.overview?.transactionTypeFilter ?? false;
 
   const { start, end } = useTimeRange({ rangeFrom, rangeTo });
-
-  const preferred = usePreferredDataSourceAndBucketSize({
-    start,
-    end,
-    kuery: '',
-    type: ApmDocumentType.TransactionMetric,
-    numBuckets: 100,
-  });
-
-  const { transactionTypes, status: transactionTypeStatus } = useServiceTransactionTypesFetcher({
-    serviceName: service.name,
-    start,
-    end,
-    documentType: preferred?.source.documentType,
-    rollupInterval: preferred?.source.rollupInterval,
-  });
 
   const { environments, status: environmentsStatus } = useUnifiedEnvironmentsFetcher({
     serviceName: service.name,
@@ -85,21 +74,6 @@ export function ServiceFlyoutQueryControls() {
       label: display,
     }));
   }, [core?.uiSettings]);
-
-  const selectedTransactionType = useMemo(
-    () => getTransactionType({ transactionType, transactionTypes, agentName: service.agentName }),
-    [service.agentName, transactionType, transactionTypes]
-  );
-
-  useEffect(() => {
-    if (
-      setTransactionType &&
-      selectedTransactionType !== undefined &&
-      selectedTransactionType !== transactionType
-    ) {
-      setTransactionType(selectedTransactionType);
-    }
-  }, [setTransactionType, selectedTransactionType, transactionType]);
 
   const transactionTypeOptions = transactionTypes.map((type) => ({ value: type, text: type }));
   const isTransactionTypeDisabled =


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/286820

The RED charts in the service flyout did not match the ones on the APM service overview page. The flyout builds ES|QL queries over **raw transaction documents** (`traces-apm*`), while the overview page calls the APM chart APIs, which read the **pre-aggregated rollups** APM Server writes (`metrics-apm.service_transaction.*` / `metrics-apm.transaction.*`). Whenever sampling is in play the two sources hold a different number of transactions, so latency and failed transaction rate drift apart; throughput drifted for a second reason, the flyout plotted a raw per-bucket count where the overview page plots transactions per minute.

This aligns the flyout's ES|QL with the overview page rather than changing the page, so the flyout keeps working in Discover and for unprocessed OTel data.

- **Same data source.** The flyout resolves the source with `usePreferredDataSourceAndBucketSize`, the hook the APM charts already use, and queries the rollups when they are available. Ranges or deployments without usable rollups (for example pre-8.7 documents that lack `transaction.duration.summary`) still fall back to raw transactions, which is also what the APM page does.
- **Rollup query builders** (new `apm_rollups.ts`): `AVG(transaction.duration.summary)` for average latency, `PERCENTILE(transaction.duration.histogram::tdigest, 95|99)` for percentiles (`aggregate_metric_double` carries only sum and value_count, so percentiles have to come from the histogram), `SUM`/`COUNT` over `event.success_count` for the failed transaction rate on `service_transaction` rollups, and outcome-weighted counts on `transaction` rollups.
- **Throughput unit.** Throughput is now transactions per minute (` tpm`), matching the `rate` aggregation behind the overview chart.
- **Bucket span.** `TBUCKET` gets an explicit span derived from `bucketSizeInSeconds` instead of a target bucket count, so a spike is diluted over a bucket of the same width in both charts.
- **Transaction type.** It is resolved once in a new `useServiceFlyoutTransactionType` hook shared by the charts and the picker, and the charts stay in their loading state until it settles, so they no longer render unfiltered numbers first and swap them. The service map on the overview page also hands its own transaction type to the flyout via `flyoutOptions`, so both show the same series from the start.

The OTel-native ES|QL path is deliberately untouched: `getDocumentSources` does not detect OTel rollups yet, so those services keep querying `traces-*.otel-*` directly.

### Screenshots

To be added — comparison of both charts before/after for a sampled service.

### Open questions / follow-ups

- **OTel-native rollups.** OTel-native services cannot use this path until `getDocumentSources` learns about the OTel rollup indices. Should that be a follow-up issue, or is there a reason it was left out?
- **One definition of the metrics.** The rollup ES|QL now restates semantics that also live in the server-side APM chart helpers (outcome weighting, `event.success_count`, histogram percentiles). Worth extracting so latency/throughput/failure rate are defined in one place?
- **Bucket boundaries.** Widths match now, but `TBUCKET` and `date_histogram` may still pick different boundaries; any leftover offset should be visual only.

### How to verify

```
node scripts/jest x-pack/solutions/observability/plugins/apm/public/components/shared/service_flyout
node scripts/jest x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview_service_map_section
node scripts/jest x-pack/solutions/observability/plugins/apm/public/components/app/service_map/contextual_map
```

Manually: open the flyout from the service map on a sampled service and compare average / p95 / p99 latency, throughput and failed transaction rate against the service overview charts for the same time range and transaction type.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)

### Identify risks

- **The numbers in the flyout change.** That is the point of the PR, but anyone comparing the flyout against a saved screenshot or a raw-document ES|QL query will see different values. Mitigation: the values now match the APM service overview page, which is the reference users compare against.
- **Percentiles depend on the `::tdigest` cast** over `transaction.duration.histogram`. Mitigation: average latency uses `transaction.duration.summary`, and the raw-document fallback keeps working when rollups are not resolved.
- **Charts show a loading state slightly longer**, since they now wait for the time range metadata and the transaction type. Mitigation: both requests are already made by the flyout for other purposes, and the alternative is rendering numbers that are then replaced.
