### PR TITLE
[8.19] API Key API Refinements (#285145)

### DIFF
--- a/x-pack/platform/packages/shared/security/plugin_types_server/src/authentication/api_keys/api_keys.ts
+++ b/x-pack/platform/packages/shared/security/plugin_types_server/src/authentication/api_keys/api_keys.ts
@@ -9,13 +9,28 @@ import { schema } from '@kbn/config-schema';
 
 import { elasticsearchRoleSchema, getKibanaRoleSchema } from '../../authorization';
 
+/** Elasticsearch itself rejects API key names longer than 256 characters. */
+const MAX_API_KEY_NAME_LENGTH = 256;
+/** Elasticsearch mints API key IDs as 20-character base64 UUIDs; 256 leaves ample headroom. */
+const MAX_API_KEY_ID_LENGTH = 256;
+/** An Elasticsearch time value, e.g. `30d` or `1000ms`. */
+const MAX_EXPIRATION_LENGTH = 64;
+/** Matches the Elasticsearch role name ceiling. */
+const MAX_ROLE_DESCRIPTOR_NAME_LENGTH = 1024;
+/** Index names are capped at 255 bytes; leaves room for long `/regex/` patterns over them. */
+const MAX_INDEX_NAME_EXPRESSION_LENGTH = 4096;
+
 export const restApiKeySchema = schema.object({
   type: schema.maybe(schema.literal('rest')),
-  name: schema.string(),
-  expiration: schema.maybe(schema.string()),
-  role_descriptors: schema.recordOf(schema.string(), schema.object({}, { unknowns: 'allow' }), {
-    defaultValue: {},
-  }),
+  name: schema.string({ maxLength: MAX_API_KEY_NAME_LENGTH }),
+  expiration: schema.maybe(schema.string({ maxLength: MAX_EXPIRATION_LENGTH })),
+  role_descriptors: schema.recordOf(
+    schema.string({ maxLength: MAX_ROLE_DESCRIPTOR_NAME_LENGTH }),
+    schema.object({}, { unknowns: 'allow' }),
+    {
+      defaultValue: {},
+    }
+  ),
   metadata: schema.maybe(schema.object({}, { unknowns: 'allow' })),
 });
 
@@ -24,11 +39,11 @@ export const getRestApiKeyWithKibanaPrivilegesSchema = (
 ) =>
   schema.object({
     type: schema.maybe(schema.literal('rest')),
-    name: schema.string(),
-    expiration: schema.maybe(schema.string()),
+    name: schema.string({ maxLength: MAX_API_KEY_NAME_LENGTH }),
+    expiration: schema.maybe(schema.string({ maxLength: MAX_EXPIRATION_LENGTH })),
     metadata: schema.maybe(schema.object({}, { unknowns: 'allow' })),
     kibana_role_descriptors: schema.recordOf(
-      schema.string(),
+      schema.string({ maxLength: MAX_ROLE_DESCRIPTOR_NAME_LENGTH }),
       schema.object({
         elasticsearch: elasticsearchRoleSchema.extends({}, { unknowns: 'allow' }),
         kibana: getKibanaRoleSchema(getBasePrivilegeNames),
@@ -38,15 +53,17 @@ export const getRestApiKeyWithKibanaPrivilegesSchema = (
 
 export const crossClusterApiKeySchema = schema.object({
   type: schema.literal('cross_cluster'),
-  name: schema.string(),
-  expiration: schema.maybe(schema.string()),
+  name: schema.string({ maxLength: MAX_API_KEY_NAME_LENGTH }),
+  expiration: schema.maybe(schema.string({ maxLength: MAX_EXPIRATION_LENGTH })),
   metadata: schema.maybe(schema.object({}, { unknowns: 'allow' })),
   access: schema.object(
     {
       search: schema.maybe(
         schema.arrayOf(
           schema.object({
-            names: schema.arrayOf(schema.string()),
+            names: schema.arrayOf(schema.string({ maxLength: MAX_INDEX_NAME_EXPRESSION_LENGTH }), {
+              maxSize: 100,
+            }),
             query: schema.maybe(schema.any()),
             field_security: schema.maybe(schema.any()),
             allow_restricted_indices: schema.maybe(schema.boolean()),
@@ -56,7 +73,9 @@ export const crossClusterApiKeySchema = schema.object({
       replication: schema.maybe(
         schema.arrayOf(
           schema.object({
-            names: schema.arrayOf(schema.string()),
+            names: schema.arrayOf(schema.string({ maxLength: MAX_INDEX_NAME_EXPRESSION_LENGTH }), {
+              maxSize: 100,
+            }),
             allow_restricted_indices: schema.maybe(schema.boolean()),
           })
         )
@@ -67,26 +86,32 @@ export const crossClusterApiKeySchema = schema.object({
 });
 
 export const updateRestApiKeySchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_API_KEY_ID_LENGTH }),
   type: schema.maybe(schema.literal('rest')),
-  expiration: schema.maybe(schema.string()),
-  role_descriptors: schema.recordOf(schema.string(), schema.object({}, { unknowns: 'allow' }), {
-    defaultValue: {},
-  }),
+  expiration: schema.maybe(schema.string({ maxLength: MAX_EXPIRATION_LENGTH })),
+  role_descriptors: schema.recordOf(
+    schema.string({ maxLength: MAX_ROLE_DESCRIPTOR_NAME_LENGTH }),
+    schema.object({}, { unknowns: 'allow' }),
+    {
+      defaultValue: {},
+    }
+  ),
   metadata: schema.maybe(schema.object({}, { unknowns: 'allow' })),
 });
 
 export const updateCrossClusterApiKeySchema = schema.object({
-  id: schema.string(),
+  id: schema.string({ maxLength: MAX_API_KEY_ID_LENGTH }),
   type: schema.literal('cross_cluster'),
-  expiration: schema.maybe(schema.string()),
+  expiration: schema.maybe(schema.string({ maxLength: MAX_EXPIRATION_LENGTH })),
   metadata: schema.maybe(schema.object({}, { unknowns: 'allow' })),
   access: schema.object(
     {
       search: schema.maybe(
         schema.arrayOf(
           schema.object({
-            names: schema.arrayOf(schema.string()),
+            names: schema.arrayOf(schema.string({ maxLength: MAX_INDEX_NAME_EXPRESSION_LENGTH }), {
+              maxSize: 100,
+            }),
             query: schema.maybe(schema.any()),
             field_security: schema.maybe(schema.any()),
             allow_restricted_indices: schema.maybe(schema.boolean()),
@@ -96,7 +121,9 @@ export const updateCrossClusterApiKeySchema = schema.object({
       replication: schema.maybe(
         schema.arrayOf(
           schema.object({
-            names: schema.arrayOf(schema.string()),
+            names: schema.arrayOf(schema.string({ maxLength: MAX_INDEX_NAME_EXPRESSION_LENGTH }), {
+              maxSize: 100,
+            }),
             allow_restricted_indices: schema.maybe(schema.boolean()),
           })
         )
@@ -111,11 +138,11 @@ export const getUpdateRestApiKeyWithKibanaPrivilegesSchema = (
 ) =>
   schema.object({
     type: schema.maybe(schema.literal('rest')),
-    expiration: schema.maybe(schema.string()),
+    expiration: schema.maybe(schema.string({ maxLength: MAX_EXPIRATION_LENGTH })),
     metadata: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-    id: schema.string(),
+    id: schema.string({ maxLength: MAX_API_KEY_ID_LENGTH }),
     kibana_role_descriptors: schema.recordOf(
-      schema.string(),
+      schema.string({ maxLength: MAX_ROLE_DESCRIPTOR_NAME_LENGTH }),
       schema.object({
         elasticsearch: elasticsearchRoleSchema.extends({}, { unknowns: 'allow' }),
         kibana: getKibanaRoleSchema(getBasePrivilegeNames),

--- a/x-pack/platform/plugins/shared/security/server/routes/api_keys/create.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/api_keys/create.test.ts
@@ -7,7 +7,8 @@
 
 import Boom from '@hapi/boom';
 
-import type { RequestHandler } from '@kbn/core/server';
+import type { Type } from '@kbn/config-schema';
+import type { RequestHandler, RouteValidatorConfig } from '@kbn/core/server';
 import { kibanaResponseFactory } from '@kbn/core/server';
 import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
@@ -27,6 +28,7 @@ describe('Create API Key route', () => {
   }
 
   let routeHandler: RequestHandler<any, any, any, any>;
+  let bodyValidation: Type<unknown>;
   let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
   beforeEach(() => {
     authc = authenticationServiceMock.createStart();
@@ -35,14 +37,77 @@ describe('Create API Key route', () => {
 
     defineCreateApiKeyRoutes(mockRouteDefinitionParams);
 
-    const [, apiKeyRouteHandler] = mockRouteDefinitionParams.router.post.mock.calls.find(
-      ([{ path }]) => path === '/internal/security/api_key'
-    )!;
+    const [apiKeyRouteConfig, apiKeyRouteHandler] =
+      mockRouteDefinitionParams.router.post.mock.calls.find(
+        ([{ path }]) => path === '/internal/security/api_key'
+      )!;
     routeHandler = apiKeyRouteHandler;
+    bodyValidation = (apiKeyRouteConfig.validate as RouteValidatorConfig<{}, {}, {}>)
+      .body as Type<unknown>;
+  });
+
+  describe('payload validation', () => {
+    test('accepts a REST API key payload', () => {
+      expect(() =>
+        bodyValidation.validate({
+          name: 'my api key',
+          expiration: '12d',
+          role_descriptors: { role_1: {} },
+          metadata: { foo: 'bar' },
+        })
+      ).not.toThrow();
+    });
+
+    test('accepts a cross-cluster API key payload', () => {
+      expect(() =>
+        bodyValidation.validate({
+          type: 'cross_cluster',
+          name: 'my cc api key',
+          access: {
+            search: [{ names: ['logs*'] }],
+            replication: [{ names: ['logs*'] }],
+          },
+        })
+      ).not.toThrow();
+    });
+
+    test('rejects a name longer than 256 characters', () => {
+      expect(() =>
+        bodyValidation.validate({ name: 'a'.repeat(257), role_descriptors: {} })
+      ).toThrow(/value has length \[257\] but it must have a maximum length of \[256\]/);
+    });
+
+    test('rejects an expiration longer than 64 characters', () => {
+      expect(() =>
+        bodyValidation.validate({
+          name: 'my api key',
+          expiration: '1'.repeat(65),
+          role_descriptors: {},
+        })
+      ).toThrow(/value has length \[65\] but it must have a maximum length of \[64\]/);
+    });
+
+    test('rejects a role descriptor name longer than 1024 characters', () => {
+      expect(() =>
+        bodyValidation.validate({
+          name: 'my api key',
+          role_descriptors: { ['r'.repeat(1025)]: {} },
+        })
+      ).toThrow(/value has length \[1025\] but it must have a maximum length of \[1024\]/);
+    });
+
+    test('rejects a cross-cluster index name expression longer than 4096 characters', () => {
+      expect(() =>
+        bodyValidation.validate({
+          type: 'cross_cluster',
+          name: 'my cc api key',
+          access: { search: [{ names: ['l'.repeat(4097)] }] },
+        })
+      ).toThrow(/value has length \[4097\] but it must have a maximum length of \[4096\]/);
+    });
   });
 
   describe('failure', () => {
-    test.todo('actually exercise different types of payload validation');
     test('returns result of license checker', async () => {
       const mockContext = getMockContext({ state: 'invalid', message: 'test forbidden message' });
       const response = await routeHandler(

--- a/x-pack/platform/plugins/shared/security/server/routes/api_keys/update.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/api_keys/update.test.ts
@@ -7,7 +7,8 @@
 
 import Boom from '@hapi/boom';
 
-import type { RequestHandler } from '@kbn/core/server';
+import type { Type } from '@kbn/config-schema';
+import type { RequestHandler, RouteValidatorConfig } from '@kbn/core/server';
 import { kibanaResponseFactory } from '@kbn/core/server';
 import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
@@ -28,6 +29,8 @@ describe('Update API Key route', () => {
 
   let routeHandler: RequestHandler<any, any, any, any>;
 
+  let bodyValidation: Type<unknown>;
+
   let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
 
   beforeEach(() => {
@@ -39,10 +42,74 @@ describe('Update API Key route', () => {
 
     defineUpdateApiKeyRoutes(mockRouteDefinitionParams);
 
-    const [, apiKeyRouteHandler] = mockRouteDefinitionParams.router.put.mock.calls.find(
-      ([{ path }]) => path === '/internal/security/api_key'
-    )!;
+    const [apiKeyRouteConfig, apiKeyRouteHandler] =
+      mockRouteDefinitionParams.router.put.mock.calls.find(
+        ([{ path }]) => path === '/internal/security/api_key'
+      )!;
     routeHandler = apiKeyRouteHandler;
+    bodyValidation = (apiKeyRouteConfig.validate as RouteValidatorConfig<{}, {}, {}>)
+      .body as Type<unknown>;
+  });
+
+  describe('payload validation', () => {
+    it('accepts a REST API key payload', () => {
+      expect(() =>
+        bodyValidation.validate({
+          id: 'test_id',
+          expiration: '12d',
+          role_descriptors: { role_1: {} },
+          metadata: { foo: 'bar' },
+        })
+      ).not.toThrow();
+    });
+
+    it('accepts a cross-cluster API key payload', () => {
+      expect(() =>
+        bodyValidation.validate({
+          id: 'test_id',
+          type: 'cross_cluster',
+          access: {
+            search: [{ names: ['logs*'] }],
+            replication: [{ names: ['logs*'] }],
+          },
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects an id longer than 256 characters', () => {
+      expect(() => bodyValidation.validate({ id: 'a'.repeat(257), role_descriptors: {} })).toThrow(
+        /value has length \[257\] but it must have a maximum length of \[256\]/
+      );
+    });
+
+    it('rejects an expiration longer than 64 characters', () => {
+      expect(() =>
+        bodyValidation.validate({
+          id: 'test_id',
+          expiration: '1'.repeat(65),
+          role_descriptors: {},
+        })
+      ).toThrow(/value has length \[65\] but it must have a maximum length of \[64\]/);
+    });
+
+    it('rejects a role descriptor name longer than 1024 characters', () => {
+      expect(() =>
+        bodyValidation.validate({
+          id: 'test_id',
+          role_descriptors: { ['r'.repeat(1025)]: {} },
+        })
+      ).toThrow(/value has length \[1025\] but it must have a maximum length of \[1024\]/);
+    });
+
+    it('rejects a cross-cluster index name expression longer than 4096 characters', () => {
+      expect(() =>
+        bodyValidation.validate({
+          id: 'test_id',
+          type: 'cross_cluster',
+          access: { search: [{ names: ['l'.repeat(4097)] }] },
+        })
+      ).toThrow(/value has length \[4097\] but it must have a maximum length of \[4096\]/);
+    });
   });
 
   describe('failure', () => {

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/slack_api/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/slack_api/index.test.ts
@@ -78,15 +78,21 @@ describe('validate params', () => {
   test('should validate and throw error when params are invalid', () => {
     expect(() => {
       validateParams(connectorType, {}, { configurationUtilities });
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"error validating action params: Cannot destructure property 'Symbol(Symbol.iterator)' of 'undefined' as it is undefined."`
-    );
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "error validating action params: types that failed validation:
+      - [0.subAction]: expected value to equal [validChannelId]
+      - [1.subAction]: expected value to equal [postMessage]
+      - [2.subAction]: expected value to equal [postBlockkit]"
+    `);
 
     expect(() => {
       validateParams(connectorType, { message: 1 }, { configurationUtilities });
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"error validating action params: Cannot destructure property 'Symbol(Symbol.iterator)' of 'undefined' as it is undefined."`
-    );
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "error validating action params: types that failed validation:
+      - [0.subAction]: expected value to equal [validChannelId]
+      - [1.subAction]: expected value to equal [postMessage]
+      - [2.subAction]: expected value to equal [postBlockkit]"
+    `);
   });
 
   test('should validate and pass when channels is used as a valid params for post message', () => {

--- a/x-pack/platform/test/api_integration/apis/security/api_keys.ts
+++ b/x-pack/platform/test/api_integration/apis/security/api_keys.ts
@@ -66,6 +66,17 @@ export default function ({ getService }: FtrProviderContext) {
           });
       });
 
+      it('should reject an API Key with a name exceeding 256 characters', async () => {
+        await supertest
+          .post('/internal/security/api_key')
+          .set('kbn-xsrf', 'xxx')
+          .send({
+            name: 'n'.repeat(257),
+            role_descriptors: {},
+          })
+          .expect(400);
+      });
+
       it(`${basic ? 'basic' : 'trial'} license should ${
         basic ? 'not allow' : 'allow'
       } a cross cluster API Key to be created`, async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [API Key API Refinements (#285145)](https://github.com/elastic/kibana/pull/285145)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2026-08-24T14:40:25Z","message":"API Key API Refinements (#285145)\n\n## Summary\n\nDefines reasonable length limits on string entities within our API Key\napis.","sha":"27a019d4940c4cfb9ead881523e3b42b84430c66","branchLabelMapping":{"^v9.6.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:version","v9.6.0","v8.19.21"],"title":"API Key API Refinements","number":285145,"url":"https://github.com/elastic/kibana/pull/285145","mergeCommit":{"message":"API Key API Refinements (#285145)\n\n## Summary\n\nDefines reasonable length limits on string entities within our API Key\napis.","sha":"27a019d4940c4cfb9ead881523e3b42b84430c66"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.6.0","branchLabelMappingKey":"^v9.6.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/285145","number":285145,"mergeCommit":{"message":"API Key API Refinements (#285145)\n\n## Summary\n\nDefines reasonable length limits on string entities within our API Key\napis.","sha":"27a019d4940c4cfb9ead881523e3b42b84430c66"}},{"branch":"8.19","label":"v8.19.21","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->