### PR TITLE
[Cloud Security] Use cardinality agg for benchmarks evaluation count

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/benchmarks/v2.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/benchmarks/v2.test.ts
@@ -57,7 +57,7 @@ describe('getBenchmarksData PIT refresh', () => {
         })
         .mockResolvedValueOnce({
           pit_id: 'pit-2',
-          aggregations: { aggs_by_asset_identifier: { buckets: [] } },
+          aggregations: { asset_count: { value: 5 } },
         })
         .mockResolvedValueOnce({
           pit_id: 'pit-3',
@@ -69,19 +69,27 @@ describe('getBenchmarksData PIT refresh', () => {
         })
         .mockResolvedValueOnce({
           pit_id: 'pit-4',
-          aggregations: { aggs_by_asset_identifier: { buckets: [] } },
+          aggregations: { asset_count: { value: 7 } },
         }),
       closePointInTime: jest.fn().mockResolvedValue({ succeeded: true, num_freed: 1 }),
     };
 
     const logger = { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() };
 
-    await getBenchmarksData(soClient, encryptedSoClient, esClient as any, logger as any);
+    const result = await getBenchmarksData(
+      soClient,
+      encryptedSoClient,
+      esClient as any,
+      logger as any
+    );
 
     expect(esClient.search.mock.calls[0][0].pit.id).toBe('pit-0');
     expect(esClient.search.mock.calls[1][0].pit.id).toBe('pit-1');
     expect(esClient.search.mock.calls[2][0].pit.id).toBe('pit-2');
     expect(esClient.search.mock.calls[3][0].pit.id).toBe('pit-3');
     expect(esClient.closePointInTime).toHaveBeenCalledWith({ id: 'pit-4' });
+
+    // evaluation is the distinct-asset cardinality count per benchmark version
+    expect(result.map((benchmark) => benchmark.evaluation)).toEqual([5, 7]);
   });
 });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/benchmarks/v2.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/benchmarks/v2.ts
@@ -17,10 +17,47 @@ import { CDR_LATEST_NATIVE_MISCONFIGURATIONS_INDEX_ALIAS } from '@kbn/cloud-secu
 import { CSP_BENCHMARK_RULE_SAVED_OBJECT_TYPE } from '../../../common/constants';
 
 import type { Benchmark } from '../../../common/types/latest';
-import { getClusters } from '../compliance_dashboard/get_clusters';
 import { getStats } from '../compliance_dashboard/get_stats';
 import { getSafePostureTypeRuntimeMapping } from '../../../common/runtime_mappings/get_safe_posture_type_runtime_mapping';
+import { getIdentifierRuntimeMapping } from '../../../common/runtime_mappings/get_identifier_runtime_mapping';
 import { getMutedRulesFilterQuery } from '../benchmark_rules/get_states/v1';
+
+/**
+ * Counts the distinct assets evaluated for a benchmark using a cardinality aggregation.
+ * The benchmarks page only needs the count, so this avoids the expensive per-asset
+ * terms + top_hits aggregation used by the compliance dashboard (getClusters), whose
+ * response size grows with the number and size of findings and can exceed the ES
+ * client's 100MB response limit. It is also not capped at 500 assets like getClusters.
+ */
+const getBenchmarkEvaluationCount = async (
+  esClient: ElasticsearchClient,
+  query: QueryDslQueryContainer,
+  pit: OpenPointInTimeResponse,
+  runtimeMappings: MappingRuntimeFields
+): Promise<number> => {
+  const result = await esClient.search<unknown, { asset_count: { value: number } }>({
+    size: 0,
+    // `asset_identifier` is a runtime field; `safe_posture_type` is used by the query filter
+    runtime_mappings: { ...runtimeMappings, ...getIdentifierRuntimeMapping() },
+    query,
+    aggs: {
+      asset_count: {
+        cardinality: {
+          field: 'asset_identifier',
+        },
+      },
+    },
+    pit: {
+      id: pit.id,
+    },
+  });
+
+  if (result.pit_id) {
+    pit.id = result.pit_id;
+  }
+
+  return result.aggregations?.asset_count?.value ?? 0;
+};
 
 export const getBenchmarksData = async (
   soClient: SavedObjectsClientContract,
@@ -87,14 +124,19 @@ export const getBenchmarksData = async (
         },
       };
       const benchmarkScore = await getStats(esClient, query, pit, runtimeMappings, logger);
-      const benchmarkEvaluation = await getClusters(esClient, query, pit, runtimeMappings, logger);
+      const benchmarkEvaluation = await getBenchmarkEvaluationCount(
+        esClient,
+        query,
+        pit,
+        runtimeMappings
+      );
 
       result.push({
         id: benchmarkId,
         name: benchmarkName,
         version: benchmarkVersion.replace('v', ''),
         score: benchmarkScore,
-        evaluation: benchmarkEvaluation.length,
+        evaluation: benchmarkEvaluation,
       });
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #286417 (which fixed the benchmarks endpoint 500 by restricting the `top_hits` `_source` in `getClusters`). Relates to #286895 (SDH: https://github.com/elastic/sdh-beats/issues/7508).

The benchmarks endpoint (`GET /internal/cloud_security_posture/benchmarks`, v2) only uses `getClusters` for `benchmarkEvaluation.length`, i.e. the number of distinct evaluated assets. This PR replaces that call with a `cardinality` aggregation on `asset_identifier`:

- Avoids the per-asset terms + `top_hits` + sub-aggregations work entirely for this endpoint. Even with #286417's `_source` filtering, the endpoint was doing (and transferring) far more work than needed just to count assets.
- Removes the silent 500-asset cap (the terms agg `size`) on the "Evaluated" counter. For customers with more than 500 evaluated assets the counter was underreporting; it is now exact.

## Changes

- **`benchmarks/v2.ts`**: new `getBenchmarkEvaluationCount` helper (cardinality agg, PIT-aware) replaces the `getClusters` call.
- **`benchmarks/v2.test.ts`**: mocks updated to the cardinality response shape; added an assertion that evaluation counts flow through per benchmark version.

## Test plan

- `node scripts/jest .../server/routes/benchmarks/v2.test.ts` and `get_clusters.test.ts` pass.
- Type check of the plugin passes.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)