### PR TITLE
[EDR Workflows][CPS] Disable cross-project search for Defend and osquery

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/experimental_features.ts
@@ -46,7 +46,7 @@ export const allowedExperimentalValues = Object.freeze({
    * project picker is registered on osquery pages. Has no effect on stateful Kibana or
    * when CPS is disabled.
    */
-  crossProjectSearch: true,
+  crossProjectSearch: false,
 });
 
 type ExperimentalFeatures = { [K in keyof typeof allowedExperimentalValues]: boolean };

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -92,7 +92,7 @@ export const allowedExperimentalValues = Object.freeze({
    * it covers from the internal user to a project-routed current-user client. Off until the request
    * user holds index privileges on the Defend indices: a missing grant drops rows silently.
    */
-  defendCrossProjectSearch: true,
+  defendCrossProjectSearch: false,
 
   /**
    * Enables the Assistant Model Evaluation advanced setting and API endpoint, introduced in `8.11.0`.


### PR DESCRIPTION
## Summary

Reverts the flag enablement from #282394 (Defend) and #282392 (osquery). Both defaults go back to `false`.

The serverless security predefined roles do not grant the request user read access to the indices the CPS read paths query, so enabling the flags broke those paths:

- **Defend** — the endpoint list reads the concrete index `.metrics-endpoint.metadata_united_default`. Elasticsearch returns a `security_exception`, which surfaces as an HTTP 500 and leaves the Endpoints page unusable (incident 3540).
- **osquery** — the reads use wildcard patterns, so a missing grant drops rows silently instead of erroring.

The role grants are still open: #283492 (Defend) and #283497 (osquery). Re-enable both flags only after those merge and the updated roles ship.

Already-deployed environments are mitigated at config level in elastic/serverless-gitops#170228.