### PR TITLE
feat: Allow to use relay as a slackv2 connector

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -12,6 +12,7 @@ export type * from './src/connector_spec';
 export type { ConnectorActionErrorMeta } from './src/connector_utils';
 export * as authTypeSpecs from './src/all_auth_types';
 export { EARS_AUTH_ID, EARS_PROVIDERS } from './src/auth_types/ears';
+export { RELAY_AUTH_ID } from './src/auth_types/relay';
 export { OAUTH_AUTHORIZATION_CODE_AUTH_ID } from './src/auth_types/oauth_authorization_code';
 export {
   CERTIFICATE_BINDING_KINDS,
@@ -53,12 +54,15 @@ export {
 } from './src/connector_utils';
 export { normalizeAuthorizationHeaderValue } from './src/auth_types/oauth_authz_code_and_ears_helpers';
 export { isEarsExperimentalConnector } from './src/lib/ears_experimental_utils';
+export { isInternalAuthType } from './src/lib/is_internal_auth_type';
 
 export { ConnectorAuthorizationError, isConnectorAuthorizationError } from './src/errors';
 export type { ConnectorAuthorizationReason } from './src/errors';
 export {
   AUTH_MODE_BY_AUTH_TYPE_ID,
   getAuthModeForAuthTypeId,
+  USES_RELAY_BY_AUTH_TYPE_ID,
+  authTypeUsesRelay,
 } from './src/auth_mode_by_auth_type_id';
 export { getMeta, setMeta, addMeta } from './src/connector_spec_ui';
 export type { BaseMetadata } from './src/connector_spec_ui';

--- a/src/platform/packages/shared/kbn-connector-specs/src/all_auth_types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/all_auth_types.ts
@@ -20,6 +20,7 @@ export * from './auth_types/oauth';
 export { OAuthAuthorizationCode } from './auth_types/oauth_authorization_code';
 export { OAuthClientCredentialsPrivateKeyJwt } from './auth_types/oauth_client_credentials_private_key_jwt';
 export { Ears } from './auth_types/ears';
+export { RelayAuth } from './auth_types/relay';
 export { KubernetesGkeAuth } from './auth_types/kubernetes_gke';
 export { KubernetesEksAuth } from './auth_types/kubernetes_eks';
 export { KubernetesAksAuth } from './auth_types/kubernetes_aks';

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_mode_by_auth_type_id.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_mode_by_auth_type_id.ts
@@ -11,8 +11,14 @@ import { isString } from 'lodash';
 import type { AuthMode } from './connector_spec';
 import * as allAuthTypes from './all_auth_types';
 
-function isAuthTypeSpecEntry(value: unknown): value is { id: string; authMode?: AuthMode } {
+function isAuthTypeSpecEntry(
+  value: unknown
+): value is { id: string; authMode?: AuthMode; usesRelayTransport?: boolean } {
   return isString((value as { id?: unknown })?.id);
+}
+
+function usesRelayTransportOf(spec: { id: string; usesRelayTransport?: boolean }): boolean {
+  return spec.usesRelayTransport ?? false;
 }
 
 export const AUTH_MODE_BY_AUTH_TYPE_ID: Record<string, AuthMode> = Object.fromEntries(
@@ -23,4 +29,14 @@ export const AUTH_MODE_BY_AUTH_TYPE_ID: Record<string, AuthMode> = Object.fromEn
 
 export function getAuthModeForAuthTypeId(authTypeId: string): AuthMode {
   return AUTH_MODE_BY_AUTH_TYPE_ID[authTypeId] ?? 'shared';
+}
+
+export const USES_RELAY_BY_AUTH_TYPE_ID: Record<string, boolean> = Object.fromEntries(
+  Object.values(allAuthTypes)
+    .filter(isAuthTypeSpecEntry)
+    .map((spec) => [spec.id, usesRelayTransportOf(spec)])
+) as Record<string, boolean>;
+
+export function authTypeUsesRelay(authTypeId: string): boolean {
+  return USES_RELAY_BY_AUTH_TYPE_ID[authTypeId] ?? false;
 }

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/relay.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/relay.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import axios from 'axios';
+import { loggerMock } from '@kbn/logging-mocks';
+import type { AuthContext } from '../connector_spec';
+import { RELAY_AUTH_ID, RelayAuth } from './relay';
+
+const mockAuthContext: AuthContext = {
+  getCustomHostSettings: () => undefined,
+  getToken: async () => null,
+  logger: loggerMock.create(),
+  sslSettings: {},
+};
+
+describe('RelayAuth', () => {
+  it('is registered under the relay id', () => {
+    expect(RelayAuth.id).toBe(RELAY_AUTH_ID);
+    expect(RELAY_AUTH_ID).toBe('relay');
+  });
+
+  it('scopes credentials to the deployment rather than a user', () => {
+    expect(RelayAuth.authMode).toBe('shared');
+  });
+
+  it('reaches the third party through the Relay', () => {
+    expect(RelayAuth.usesRelayTransport).toBe(true);
+  });
+
+  describe('schema', () => {
+    it('accepts a tenant key', () => {
+      expect(RelayAuth.schema.parse({ tenantKey: 'tenant-A' })).toEqual({ tenantKey: 'tenant-A' });
+    });
+
+    it('requires a non-empty tenant key', () => {
+      expect(() => RelayAuth.schema.parse({})).toThrow();
+      expect(() => RelayAuth.schema.parse({ tenantKey: '' })).toThrow();
+    });
+
+    it('hides the tenant key from generated forms', () => {
+      expect(RelayAuth.schema.shape.tenantKey.meta()).toMatchObject({ hidden: true });
+    });
+  });
+
+  describe('configure', () => {
+    it('leaves the axios instance without credentials', async () => {
+      const axiosInstance = axios.create();
+      const headersBefore = { ...axiosInstance.defaults.headers.common };
+
+      const configured = await RelayAuth.configure(mockAuthContext, axiosInstance, {
+        tenantKey: 'tenant-A',
+      });
+
+      expect(configured).toBe(axiosInstance);
+      expect(axiosInstance.defaults.headers.common).toEqual(headersBefore);
+      expect(axiosInstance.defaults.headers.common.Authorization).toBeUndefined();
+      expect(axiosInstance.defaults.auth).toBeUndefined();
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/relay.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/relay.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z, lazySchema } from '@kbn/zod/v4';
+import type { AxiosInstance } from 'axios';
+import type { AuthContext, AuthTypeSpec } from '../connector_spec';
+import * as i18n from './translations';
+
+export const RELAY_AUTH_ID = 'relay';
+
+const authSchema = lazySchema(() =>
+  z
+    .object({
+      tenantKey: z.string().min(1).meta({ hidden: true }),
+    })
+    .meta({ label: i18n.RELAY_LABEL })
+);
+
+type AuthSchemaType = z.infer<typeof authSchema>;
+
+/**
+ * The Elastic-hosted Relay holds the third-party credentials and authenticates the deployment with
+ * mTLS, so a connector using it holds none: `tenantKey` only names the workspace it speaks for.
+ *
+ * `configure` is a deliberate no-op — specs reach the third party through the Relay, so an axios
+ * instance that cannot authenticate is the right outcome if a request ever escapes.
+ */
+export const RelayAuth: AuthTypeSpec<AuthSchemaType> = {
+  id: RELAY_AUTH_ID,
+  schema: authSchema,
+  authMode: 'shared',
+  usesRelayTransport: true,
+  configure: async (_: AuthContext, axiosInstance: AxiosInstance): Promise<AxiosInstance> => {
+    return axiosInstance;
+  },
+};

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/translations.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/translations.ts
@@ -315,6 +315,10 @@ export const EARS_LABEL = i18n.translate('connectorSpecs.ears.label', {
   defaultMessage: 'Quick Connect OAuth 2.0',
 });
 
+export const RELAY_LABEL = i18n.translate('connectorSpecs.relay.label', {
+  defaultMessage: 'Elastic app',
+});
+
 export const GCP_SERVICE_ACCOUNT_LABEL = i18n.translate('connectorSpecs.gcpServiceAccount.label', {
   defaultMessage: 'GCP Service Account',
 });

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -140,6 +140,11 @@ export interface AuthTypeDefinition {
 export interface AuthTypeSpec<T extends Record<string, unknown>> extends AuthTypeDefinition {
   configure: (ctx: AuthContext, axiosInstance: AxiosInstance, secret: T) => Promise<AxiosInstance>;
   getAuthHeaders?(ctx: AuthContext, secret: T): Promise<Record<string, string>>;
+  /**
+   * Specs using this auth type reach the third party through the Elastic-hosted Relay rather than
+   * authenticating the axios client. Defaults to false.
+   */
+  usesRelayTransport?: boolean;
 }
 
 export type NormalizedAuthType = AuthTypeSpec<Record<string, unknown>>;
@@ -249,6 +254,31 @@ export interface ActionDefinition<TInput = unknown, TOutput = unknown, TError = 
   scope?: ActionScope;
 }
 
+/**
+ * The slice of the Actions plugin's Relay client that action handlers use. Declared structurally so
+ * this package does not depend on x-pack; the concrete `RelayClient` satisfies it by shape.
+ */
+export interface RelayActionClient {
+  trigger(input: {
+    tenantKey: string;
+    channel: string;
+    message: string;
+    threadTs?: string;
+  }): Promise<{ ref: string; tenantKey: string }>;
+  /** One page of the channels this deployment has connected; follow `nextCursor` for the rest. */
+  listBindings(
+    tenantKey: string,
+    options?: { cursor?: string; limit?: number }
+  ): Promise<{
+    bindings: Array<{
+      scope_id?: string;
+      display_name?: string;
+      visibility?: 'public' | 'private';
+    }>;
+    nextCursor?: string;
+  }>;
+}
+
 export interface ActionContext {
   client: AxiosInstance;
   /**
@@ -266,6 +296,12 @@ export interface ActionContext {
   connectorUsageCollector?: unknown;
   log: Logger;
   secrets?: Record<string, unknown>;
+  /**
+   * Reaches the third party through the Elastic-hosted Relay, for specs whose auth type routes that
+   * way. Undefined when the auth type does not use Relay transport or the deployment has no Relay
+   * configured.
+   */
+  relay?: RelayActionClient;
 }
 
 // ============================================================================
@@ -321,6 +357,8 @@ export interface AuthTypeDef {
   isRecommended?: boolean;
   /** When true, excluded from the UI picker but kept in the validation schema for backwards compatibility with existing connectors. */
   isLegacy?: boolean;
+  /** When true, hidden from the UI picker and rejected on the connector API: Kibana sets these credentials, not the user. Unlike `isLegacy`, it is not deprecated. */
+  isInternal?: boolean;
   isExperimental?: boolean;
   defaults: Record<string, unknown>;
   overrides?: {

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/get_schema_for_auth_type.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/get_schema_for_auth_type.test.ts
@@ -59,6 +59,22 @@ describe('getSchemaForAuthType()', () => {
     });
   });
 
+  test('carries isInternal into the schema meta so the form can skip the option', () => {
+    const { schema } = getSchemaForAuthType({ type: 'relay', isInternal: true, defaults: {} });
+
+    expect(schema.meta()).toEqual({
+      authMode: 'shared',
+      label: 'Elastic app',
+      isInternal: true,
+    });
+  });
+
+  test('omits isInternal for an auth type that does not set it', () => {
+    const { schema } = getSchemaForAuthType({ type: 'relay', defaults: {} });
+
+    expect(schema.meta()).not.toHaveProperty('isInternal');
+  });
+
   test('ignores defaults for key that is not in auth type schema', () => {
     const { schema } = getSchemaForAuthType({
       type: 'api_key_header',

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/get_schema_for_auth_type.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/get_schema_for_auth_type.ts
@@ -33,6 +33,7 @@ export const getSchemaForAuthType = (authTypeDef: string | AuthTypeDef) => {
   let labelOverride: string | undefined;
   let isRecommendedOverride: boolean | undefined;
   let isLegacyOverride: boolean | undefined;
+  let isInternalOverride: boolean | undefined;
 
   if (isString(authTypeDef)) {
     authTypeId = authTypeDef as string;
@@ -44,6 +45,7 @@ export const getSchemaForAuthType = (authTypeDef: string | AuthTypeDef) => {
     labelOverride = def.overrides?.label;
     isRecommendedOverride = def.isRecommended;
     isLegacyOverride = def.isLegacy;
+    isInternalOverride = def.isInternal;
   }
 
   if (!authTypeId) {
@@ -96,6 +98,7 @@ export const getSchemaForAuthType = (authTypeDef: string | AuthTypeDef) => {
     ...(labelOverride !== undefined ? { label: labelOverride } : {}),
     ...(isRecommendedOverride !== undefined ? { isRecommended: isRecommendedOverride } : {}),
     ...(isLegacyOverride !== undefined ? { isLegacy: isLegacyOverride } : {}),
+    ...(isInternalOverride !== undefined ? { isInternal: isInternalOverride } : {}),
   };
 
   return {

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/index.ts
@@ -10,4 +10,5 @@
 export { getSchemaForAuthType, AUTH_TYPE_DISCRIMINATOR } from './get_schema_for_auth_type';
 export { generateSecretsSchemaFromSpec } from './generate_secrets_schema_from_spec';
 export { configureAxiosInstanceWithSsl } from './configure_axios_instance_with_ssl';
+export { isInternalAuthType } from './is_internal_auth_type';
 export { getMeta } from '../connector_spec_ui';

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/is_internal_auth_type.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/is_internal_auth_type.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isInternalAuthType } from './is_internal_auth_type';
+
+describe('isInternalAuthType()', () => {
+  test('is true for an auth type the spec marks as internal', () => {
+    expect(isInternalAuthType('.slack2', 'relay')).toBe(true);
+  });
+
+  test('is false for the auth types a user is meant to pick', () => {
+    expect(isInternalAuthType('.slack2', 'bearer')).toBe(false);
+    expect(isInternalAuthType('.slack2', 'ears')).toBe(false);
+    expect(isInternalAuthType('.slack2', 'oauth_authorization_code')).toBe(false);
+  });
+
+  test('is false for an auth type the spec does not declare at all', () => {
+    expect(isInternalAuthType('.slack2', 'basic')).toBe(false);
+  });
+
+  test('is false for an unknown connector type', () => {
+    expect(isInternalAuthType('.not_a_connector', 'relay')).toBe(false);
+  });
+
+  test('is false when no auth type is given', () => {
+    expect(isInternalAuthType('.slack2', undefined)).toBe(false);
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/is_internal_auth_type.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/is_internal_auth_type.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isString } from 'lodash';
+import { getConnectorSpec } from '../get_connector_spec';
+
+/**
+ * Whether the spec marks this auth type `isInternal` — Kibana sets those credentials, so a user must
+ * never supply them. Use it to reject create/update, not to gate execution: the connectors Kibana
+ * provisioned this way have to keep working.
+ */
+export const isInternalAuthType = (
+  connectorTypeId: string,
+  authTypeId: string | undefined
+): boolean => {
+  if (!authTypeId) {
+    return false;
+  }
+
+  const authTypes = getConnectorSpec(connectorTypeId)?.auth?.types ?? [];
+
+  return authTypes.some(
+    (authType) =>
+      !isString(authType) && authType.type === authTypeId && authType.isInternal === true
+  );
+};

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/relay.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/relay.test.ts
@@ -1,0 +1,410 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { ActionContext } from '../../connector_spec';
+import {
+  getRelayConnection,
+  relayListChannels,
+  relayResolveChannelId,
+  relaySendMessage,
+  relayTest,
+  withRelayGuards,
+} from './relay';
+
+const createLogger = () =>
+  ({ debug: jest.fn(), error: jest.fn() } as unknown as jest.Mocked<Logger>);
+
+const createContext = (
+  secrets: Record<string, unknown>,
+  relay?: { trigger?: jest.Mock; listBindings?: jest.Mock }
+): ActionContext =>
+  ({
+    log: createLogger(),
+    secrets,
+    ...(relay ? { relay } : {}),
+  } as unknown as ActionContext);
+
+const relaySecrets = { authType: 'relay', tenantKey: 'team-A' };
+
+/** What a `RelayRequestError` looks like to this package, which cannot import it. */
+const relayError = (statusCode: number) =>
+  Object.assign(new Error(`Relay request failed with status ${statusCode}`), { statusCode });
+
+describe('getRelayConnection', () => {
+  it('returns null for a connector holding its own Slack token', () => {
+    expect(getRelayConnection(createContext({ authType: 'bearer' }))).toBeNull();
+    expect(getRelayConnection(createContext({}))).toBeNull();
+  });
+
+  it('returns the client and tenant key under relay auth', () => {
+    const relay = { trigger: jest.fn() };
+
+    expect(getRelayConnection(createContext(relaySecrets, relay))).toEqual({
+      relay,
+      tenantKey: 'team-A',
+    });
+  });
+
+  it('throws when the deployment has no Relay configured', () => {
+    expect(() => getRelayConnection(createContext(relaySecrets))).toThrow(
+      /not available on this deployment/
+    );
+  });
+
+  it('throws when the connector is no longer linked to a workspace', () => {
+    expect(() =>
+      getRelayConnection(createContext({ authType: 'relay' }, { trigger: jest.fn() }))
+    ).toThrow(/not linked to a Slack workspace/);
+  });
+});
+
+describe('relaySendMessage', () => {
+  const send = async (input: Record<string, unknown>, trigger: jest.Mock) => {
+    const ctx = createContext(relaySecrets, { trigger });
+    return relaySendMessage(
+      { relay: { trigger } as never, tenantKey: 'team-A' },
+      ctx,
+      input as Parameters<typeof relaySendMessage>[2]
+    );
+  };
+
+  it('maps the input onto trigger and returns the posted timestamp as ts', async () => {
+    const trigger = jest.fn().mockResolvedValue({ ref: '1700.0001', tenantKey: 'team-A' });
+
+    await expect(send({ channel: 'C123', text: 'hello' }, trigger)).resolves.toEqual({
+      ok: true,
+      channel: 'C123',
+      ts: '1700.0001',
+    });
+    expect(trigger).toHaveBeenCalledWith({
+      tenantKey: 'team-A',
+      channel: 'C123',
+      message: 'hello',
+    });
+  });
+
+  it('forwards threadTs when replying in a thread', async () => {
+    const trigger = jest.fn().mockResolvedValue({ ref: '1700.0002', tenantKey: 'team-A' });
+
+    await send({ channel: 'C123', text: 'reply', threadTs: '1700.0001' }, trigger);
+
+    expect(trigger).toHaveBeenCalledWith(expect.objectContaining({ threadTs: '1700.0001' }));
+  });
+
+  it('restates a 403 as an unconnected channel', async () => {
+    const trigger = jest.fn().mockRejectedValue(relayError(403));
+
+    await expect(send({ channel: 'C123', text: 'hello' }, trigger)).rejects.toThrow(
+      'Channel C123 is not connected to this deployment. Connect it in the Elastic Slack app settings, then try again.'
+    );
+  });
+
+  it('restates a 409 as an uninstalled app', async () => {
+    const trigger = jest.fn().mockRejectedValue(relayError(409));
+
+    await expect(send({ channel: 'C123', text: 'hello' }, trigger)).rejects.toThrow(
+      /no longer installed/
+    );
+  });
+
+  it('passes other failures through untouched', async () => {
+    const cause = relayError(502);
+    const trigger = jest.fn().mockRejectedValue(cause);
+
+    await expect(send({ channel: 'C123', text: 'hello' }, trigger)).rejects.toBe(cause);
+  });
+});
+
+describe('relayListChannels', () => {
+  const list = async (input: Record<string, unknown>, listBindings: jest.Mock) =>
+    relayListChannels(
+      { relay: { listBindings } as never, tenantKey: 'team-A' },
+      createContext(relaySecrets, { listBindings }),
+      { limit: 100, ...input } as Parameters<typeof relayListChannels>[2]
+    );
+
+  it('maps connected bindings onto conversations.list-shaped channels', async () => {
+    const listBindings = jest.fn().mockResolvedValue({
+      bindings: [
+        { scope_id: 'C123', display_name: 'general', visibility: 'public' },
+        { scope_id: 'C456', display_name: 'secrets', visibility: 'private' },
+      ],
+    });
+
+    await expect(list({}, listBindings)).resolves.toEqual({
+      ok: true,
+      source: 'relay-bindings',
+      channels: [
+        { id: 'C123', name: 'general', is_private: false },
+        { id: 'C456', name: 'secrets', is_private: true },
+      ],
+      nextCursor: undefined,
+      hasMore: false,
+    });
+  });
+
+  it('falls back to the channel id when a binding has no display snapshot', async () => {
+    const listBindings = jest.fn().mockResolvedValue({ bindings: [{ scope_id: 'C123' }] });
+
+    await expect(list({}, listBindings)).resolves.toMatchObject({
+      channels: [{ id: 'C123', name: 'C123', is_private: false }],
+    });
+  });
+
+  it('drops a binding carrying no channel id', async () => {
+    const listBindings = jest
+      .fn()
+      .mockResolvedValue({ bindings: [{ display_name: 'orphan' }, { scope_id: 'C123' }] });
+
+    await expect(list({}, listBindings)).resolves.toMatchObject({
+      channels: [{ id: 'C123' }],
+    });
+  });
+
+  it('keeps a private channel even when types asks for public only', async () => {
+    const listBindings = jest
+      .fn()
+      .mockResolvedValue({ bindings: [{ scope_id: 'C456', visibility: 'private' }] });
+
+    await expect(
+      list({ types: ['public_channel'], excludeArchived: true }, listBindings)
+    ).resolves.toMatchObject({ channels: [{ id: 'C456', is_private: true }] });
+  });
+
+  it('reports more pages and forwards the cursor back', async () => {
+    const listBindings = jest
+      .fn()
+      .mockResolvedValue({ bindings: [{ scope_id: 'C123' }], nextCursor: 'page-2' });
+
+    await expect(list({ cursor: 'page-1' }, listBindings)).resolves.toMatchObject({
+      nextCursor: 'page-2',
+      hasMore: true,
+    });
+    expect(listBindings).toHaveBeenCalledWith('team-A', { limit: 100, cursor: 'page-1' });
+  });
+
+  it('clamps a limit above the Relay page maximum', async () => {
+    const listBindings = jest.fn().mockResolvedValue({ bindings: [] });
+
+    await list({ limit: 1000 }, listBindings);
+
+    expect(listBindings).toHaveBeenCalledWith('team-A', { limit: 200 });
+  });
+
+  it('ignores raw and still returns the compact channel shape', async () => {
+    const listBindings = jest.fn().mockResolvedValue({
+      bindings: [{ scope_id: 'C123', display_name: 'general', visibility: 'public' }],
+      nextCursor: 'page-2',
+    });
+
+    await expect(list({ raw: true }, listBindings)).resolves.toEqual({
+      ok: true,
+      source: 'relay-bindings',
+      channels: [{ id: 'C123', name: 'general', is_private: false }],
+      nextCursor: 'page-2',
+      hasMore: true,
+    });
+  });
+
+  it('restates a 403 without naming a channel', async () => {
+    const listBindings = jest.fn().mockRejectedValue(relayError(403));
+
+    await expect(list({}, listBindings)).rejects.toThrow(
+      'This deployment is not allowed to read the connected channels. Reconnect the Elastic Slack app, then try again.'
+    );
+  });
+
+  it('restates a 409 as an uninstalled app', async () => {
+    const listBindings = jest.fn().mockRejectedValue(relayError(409));
+
+    await expect(list({}, listBindings)).rejects.toThrow(/no longer installed/);
+  });
+
+  it('passes other failures through untouched', async () => {
+    const cause = relayError(502);
+    const listBindings = jest.fn().mockRejectedValue(cause);
+
+    await expect(list({}, listBindings)).rejects.toBe(cause);
+  });
+});
+
+describe('relayResolveChannelId', () => {
+  const resolve = async (input: Record<string, unknown>, listBindings: jest.Mock) =>
+    relayResolveChannelId(
+      { relay: { listBindings } as never, tenantKey: 'team-A' },
+      createContext(relaySecrets, { listBindings }),
+      { match: 'exact', limit: 100, maxPages: 3, ...input } as Parameters<
+        typeof relayResolveChannelId
+      >[2]
+    );
+
+  it('resolves an exact name, ignoring a leading hash and case', async () => {
+    const listBindings = jest
+      .fn()
+      .mockResolvedValue({ bindings: [{ scope_id: 'C123', display_name: 'General' }] });
+
+    await expect(resolve({ name: '#general' }, listBindings)).resolves.toEqual({
+      ok: true,
+      found: true,
+      id: 'C123',
+      name: 'General',
+      source: 'relay-bindings',
+      pagesFetched: 1,
+      nextCursor: undefined,
+    });
+  });
+
+  it('does not match a partial name under exact', async () => {
+    const listBindings = jest
+      .fn()
+      .mockResolvedValue({ bindings: [{ scope_id: 'C123', display_name: 'general-alerts' }] });
+
+    await expect(resolve({ name: 'general' }, listBindings)).resolves.toMatchObject({
+      found: false,
+    });
+  });
+
+  it('matches a partial name under contains', async () => {
+    const listBindings = jest
+      .fn()
+      .mockResolvedValue({ bindings: [{ scope_id: 'C123', display_name: 'general-alerts' }] });
+
+    await expect(
+      resolve({ name: 'general', match: 'contains' }, listBindings)
+    ).resolves.toMatchObject({ found: true, id: 'C123' });
+  });
+
+  it('walks to a later page to find the channel', async () => {
+    const listBindings = jest
+      .fn()
+      .mockResolvedValueOnce({
+        bindings: [{ scope_id: 'C111', display_name: 'other' }],
+        nextCursor: 'page-2',
+      })
+      .mockResolvedValueOnce({ bindings: [{ scope_id: 'C123', display_name: 'general' }] });
+
+    await expect(resolve({ name: 'general' }, listBindings)).resolves.toMatchObject({
+      found: true,
+      id: 'C123',
+      pagesFetched: 2,
+    });
+    expect(listBindings).toHaveBeenLastCalledWith('team-A', { limit: 100, cursor: 'page-2' });
+  });
+
+  it('stops at maxPages and reports where it got to', async () => {
+    const listBindings = jest.fn().mockResolvedValue({
+      bindings: [{ scope_id: 'C111', display_name: 'other' }],
+      nextCursor: 'next',
+    });
+
+    await expect(resolve({ name: 'general', maxPages: 2 }, listBindings)).resolves.toMatchObject({
+      found: false,
+      id: undefined,
+      name: 'general',
+      pagesFetched: 2,
+      nextCursor: 'next',
+    });
+    expect(listBindings).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports not found without a cursor once the pages run out', async () => {
+    const listBindings = jest.fn().mockResolvedValue({ bindings: [] });
+
+    await expect(resolve({ name: 'general' }, listBindings)).resolves.toMatchObject({
+      found: false,
+      nextCursor: undefined,
+      pagesFetched: 1,
+    });
+  });
+});
+
+describe('relayTest', () => {
+  it('proves the Relay path by reading a single binding', async () => {
+    const listBindings = jest.fn().mockResolvedValue({ bindings: [{ scope_id: 'C123' }] });
+
+    await expect(
+      relayTest(
+        { relay: { listBindings } as never, tenantKey: 'team-A' },
+        createContext(relaySecrets, { listBindings })
+      )
+    ).resolves.toEqual({});
+    expect(listBindings).toHaveBeenCalledWith('team-A', { limit: 1 });
+  });
+
+  it('fails with the restated reason when the workspace is gone', async () => {
+    const listBindings = jest.fn().mockRejectedValue(relayError(409));
+
+    await expect(
+      relayTest(
+        { relay: { listBindings } as never, tenantKey: 'team-A' },
+        createContext(relaySecrets, { listBindings })
+      )
+    ).rejects.toThrow(/no longer installed/);
+  });
+});
+
+describe('withRelayGuards', () => {
+  const createActions = () => ({
+    sendMessage: { input: {} as never, handler: jest.fn().mockResolvedValue({ ok: true }) },
+    listChannels: { input: {} as never, handler: jest.fn().mockResolvedValue({ channels: [] }) },
+    resolveChannelId: {
+      input: {} as never,
+      handler: jest.fn().mockResolvedValue({ found: false }),
+    },
+    searchMessages: { input: {} as never, handler: jest.fn().mockResolvedValue({ messages: [] }) },
+  });
+
+  it('fails an unsupported action under relay auth', async () => {
+    const actions = createActions();
+    const guarded = withRelayGuards(actions);
+
+    await expect(
+      guarded.searchMessages.handler(createContext(relaySecrets, { trigger: jest.fn() }), {})
+    ).rejects.toThrow('searchMessages is not available through the Elastic Slack app');
+    expect(actions.searchMessages.handler).not.toHaveBeenCalled();
+  });
+
+  it('names the supported actions in the failure', async () => {
+    const guarded = withRelayGuards(createActions());
+
+    await expect(
+      guarded.searchMessages.handler(createContext(relaySecrets, { trigger: jest.fn() }), {})
+    ).rejects.toThrow(/sendMessage, listChannels, resolveChannelId/);
+  });
+
+  it('leaves the same action working on the direct-token path', async () => {
+    const actions = createActions();
+    const guarded = withRelayGuards(actions);
+
+    await guarded.searchMessages.handler(createContext({ authType: 'bearer' }), { query: 'x' });
+
+    expect(actions.searchMessages.handler).toHaveBeenCalledWith(expect.anything(), { query: 'x' });
+  });
+
+  it('passes every relay-supported action through unwrapped', () => {
+    const actions = createActions();
+    const guarded = withRelayGuards(actions);
+
+    expect(guarded.sendMessage).toBe(actions.sendMessage);
+    expect(guarded.listChannels).toBe(actions.listChannels);
+    expect(guarded.resolveChannelId).toBe(actions.resolveChannelId);
+  });
+
+  it('preserves the rest of an action definition', () => {
+    const actions = {
+      searchMessages: { isTool: true, input: {} as never, description: 'x', handler: jest.fn() },
+    };
+
+    expect(withRelayGuards(actions).searchMessages).toMatchObject({
+      isTool: true,
+      description: 'x',
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/relay.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/relay.ts
@@ -1,0 +1,278 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { RELAY_AUTH_ID } from '../../auth_types/relay';
+import type { ActionContext, ConnectorSpec, RelayActionClient } from '../../connector_spec';
+import type {
+  SlackListChannelsInput,
+  SlackResolveChannelIdInput,
+  SlackSendMessageInput,
+} from './types';
+
+const RELAY_SUPPORTED_ACTIONS = new Set(['sendMessage', 'listChannels', 'resolveChannelId']);
+
+/** The Relay's own max page size; the Slack schemas allow far larger limits. */
+const RELAY_MAX_BINDINGS_PAGE = 200;
+
+export interface SlackRelayConnection {
+  relay: RelayActionClient;
+  tenantKey: string;
+}
+
+const isRelayAuth = (ctx: ActionContext): boolean =>
+  (ctx.secrets as { authType?: string } | undefined)?.authType === RELAY_AUTH_ID;
+
+/**
+ * The Relay connection for this execution, or `null` when the connector holds its own Slack token.
+ *
+ * Throws rather than falling back to `ctx.client`: a relay connector has no token, so a direct call
+ * would fail with an opaque `invalid_auth` well after the reason was knowable.
+ */
+export function getRelayConnection(ctx: ActionContext): SlackRelayConnection | null {
+  if (!isRelayAuth(ctx)) {
+    return null;
+  }
+
+  if (!ctx.relay) {
+    throw new Error(
+      'This connector sends through the Elastic Slack app, which is not available on this deployment.'
+    );
+  }
+
+  const tenantKey = (ctx.secrets as { tenantKey?: string } | undefined)?.tenantKey;
+  if (!tenantKey) {
+    throw new Error(
+      'This connector is not linked to a Slack workspace. Reconnect the Elastic Slack app.'
+    );
+  }
+
+  return { relay: ctx.relay, tenantKey };
+}
+
+const getStatusCode = (error: unknown): number | undefined => {
+  const statusCode = (error as { statusCode?: unknown } | null)?.statusCode;
+  return typeof statusCode === 'number' ? statusCode : undefined;
+};
+
+/**
+ * Restates the two Relay failures a rule author can act on. Anything else is a deployment or
+ * upstream problem, so it passes through unchanged.
+ */
+function toUserFacingError(error: unknown, channel?: string): unknown {
+  switch (getStatusCode(error)) {
+    case 403:
+      return new Error(
+        channel
+          ? `Channel ${channel} is not connected to this deployment. Connect it in the Elastic Slack app settings, then try again.`
+          : 'This deployment is not allowed to read the connected channels. Reconnect the Elastic Slack app, then try again.'
+      );
+    case 409:
+      return new Error(
+        'The Elastic Slack app is no longer installed in this workspace. Reconnect it, then try again.'
+      );
+    default:
+      return error;
+  }
+}
+
+/** Posts through the Relay, returning the timestamp as `ts` so callers can thread on it as usual. */
+export async function relaySendMessage(
+  { relay, tenantKey }: SlackRelayConnection,
+  ctx: ActionContext,
+  input: SlackSendMessageInput
+): Promise<{ ok: true; channel: string; ts: string }> {
+  if (input.unfurlLinks !== undefined || input.unfurlMedia !== undefined) {
+    ctx.log.debug(
+      'Slack sendMessage: unfurl options are not supported through the Elastic Slack app and were ignored'
+    );
+  }
+
+  ctx.log.debug(`Slack sendMessage request through relay: channel=${input.channel}`);
+
+  try {
+    const { ref } = await relay.trigger({
+      tenantKey,
+      channel: input.channel,
+      message: input.text,
+      ...(input.threadTs ? { threadTs: input.threadTs } : {}),
+    });
+
+    return { ok: true, channel: input.channel, ts: ref };
+  } catch (error) {
+    ctx.log.error(`Slack sendMessage through relay failed: ${(error as Error).message}`);
+    throw toUserFacingError(error, input.channel);
+  }
+}
+
+/** Shaped like a `conversations.list` entry, so callers need no relay branch. */
+interface RelayChannel {
+  id: string;
+  name: string;
+  is_private: boolean;
+}
+
+type RelayBindings = Awaited<ReturnType<RelayActionClient['listBindings']>>['bindings'];
+
+const toChannels = (bindings: RelayBindings): RelayChannel[] =>
+  bindings.flatMap(({ scope_id: id, display_name: displayName, visibility }) =>
+    id
+      ? [
+          {
+            id,
+            // Bindings predating the Relay's display snapshots carry no name, and an unlabeled
+            // entry in a channel picker is worse than one reading `C0123456789`.
+            name: displayName ?? id,
+            is_private: visibility === 'private',
+          },
+        ]
+      : []
+  );
+
+const fetchBindingsPage = async (
+  { relay, tenantKey }: SlackRelayConnection,
+  ctx: ActionContext,
+  { cursor, limit }: { cursor?: string; limit: number }
+) => {
+  try {
+    return await relay.listBindings(tenantKey, {
+      limit: Math.min(limit, RELAY_MAX_BINDINGS_PAGE),
+      ...(cursor ? { cursor } : {}),
+    });
+  } catch (error) {
+    ctx.log.error(`Slack bindings lookup through relay failed: ${(error as Error).message}`);
+    throw toUserFacingError(error);
+  }
+};
+
+/**
+ * Lists the channels connected to this deployment rather than the whole workspace — the only ones
+ * this connector could post to anyway.
+ *
+ * `types` and `excludeArchived` are ignored: the bindings are already an admin-built allow-list, and
+ * the schema's `public_channel`-only default would drop every connected private channel from callers
+ * that pass no input at all, such as the alerting rule form's channel selector.
+ */
+export async function relayListChannels(
+  connection: SlackRelayConnection,
+  ctx: ActionContext,
+  input: SlackListChannelsInput
+) {
+  ctx.log.debug('Slack listChannels request through relay');
+
+  const page = await fetchBindingsPage(connection, ctx, {
+    cursor: input.cursor,
+    limit: input.limit,
+  });
+
+  // `raw` is ignored: there is no Slack API body to pass through.
+  return {
+    ok: true as const,
+    source: 'relay-bindings' as const,
+    channels: toChannels(page.bindings),
+    nextCursor: page.nextCursor,
+    hasMore: Boolean(page.nextCursor),
+  };
+}
+
+/** Resolves a name against the connected channels only. */
+export async function relayResolveChannelId(
+  connection: SlackRelayConnection,
+  ctx: ActionContext,
+  input: SlackResolveChannelIdInput
+) {
+  const nameNorm = input.name.trim().replace(/^#/, '').toLowerCase();
+
+  let cursor = input.cursor;
+  let pagesFetched = 0;
+
+  while (pagesFetched < input.maxPages) {
+    ctx.log.debug(`Slack resolveChannelId scan through relay (page ${pagesFetched + 1})`);
+    const page = await fetchBindingsPage(connection, ctx, { cursor, limit: input.limit });
+
+    const found = toChannels(page.bindings).find(({ name }) => {
+      const candidate = name.toLowerCase();
+      return input.match === 'exact' ? candidate === nameNorm : candidate.includes(nameNorm);
+    });
+
+    pagesFetched += 1;
+
+    if (found) {
+      return {
+        ok: true,
+        found: true,
+        id: found.id,
+        name: found.name,
+        source: 'relay-bindings',
+        pagesFetched,
+        nextCursor: page.nextCursor,
+      };
+    }
+
+    if (!page.nextCursor) {
+      cursor = undefined;
+      break;
+    }
+    cursor = page.nextCursor;
+  }
+
+  return {
+    ok: true,
+    found: false,
+    id: undefined,
+    name: nameNorm,
+    source: 'relay-bindings',
+    pagesFetched,
+    nextCursor: cursor,
+  };
+}
+
+/**
+ * Replaces `auth.test`, which needs a token this connector does not have. Reading one binding proves
+ * the Relay accepts our identity and the workspace is still installed — the two ways this connector
+ * breaks without any local change.
+ */
+export async function relayTest(
+  connection: SlackRelayConnection,
+  ctx: ActionContext
+): Promise<Record<string, never>> {
+  ctx.log.debug('Slack test through relay');
+  await fetchBindingsPage(connection, ctx, { limit: 1 });
+  return {};
+}
+
+/**
+ * Fails the actions the Relay has no route for, so they report what is supported instead of reaching
+ * Slack unauthenticated. The direct-token path is untouched.
+ */
+export function withRelayGuards(actions: ConnectorSpec['actions']): ConnectorSpec['actions'] {
+  return Object.fromEntries(
+    Object.entries(actions).map(([name, action]) => {
+      if (RELAY_SUPPORTED_ACTIONS.has(name)) {
+        return [name, action];
+      }
+
+      return [
+        name,
+        {
+          ...action,
+          handler: async (ctx: ActionContext, input: unknown) => {
+            if (isRelayAuth(ctx)) {
+              throw new Error(
+                `${name} is not available through the Elastic Slack app. Supported actions: ${[
+                  ...RELAY_SUPPORTED_ACTIONS,
+                ].join(', ')}.`
+              );
+            }
+            return action.handler(ctx, input);
+          },
+        },
+      ];
+    })
+  );
+}

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.test.ts
@@ -64,6 +64,17 @@ describe('Slack', () => {
     expect(types).toContain('oauth_authorization_code');
     expect(types).toContain('ears');
     expect(types).toContain('bearer');
+    expect(types).toContain('relay');
+  });
+
+  it('marks the relay auth type internal so a user can never configure it', () => {
+    const relayType = (Slack.auth?.types as Array<string | { type: string }>).find(
+      (t) => typeof t !== 'string' && t.type === 'relay'
+    ) as { isInternal?: boolean; defaults?: Record<string, unknown> } | undefined;
+
+    expect(relayType).toBeDefined();
+    expect(relayType?.isInternal).toBe(true);
+    expect(relayType?.defaults).toEqual({});
   });
 
   it('supports oauth_authorization_code with correct Slack defaults', () => {
@@ -1500,6 +1511,101 @@ describe('Slack', () => {
           text: 'Hello',
         })
       ).rejects.toThrow('Slack sendMessage error: channel_not_found');
+    });
+  });
+
+  describe('relay auth', () => {
+    const relayTrigger = jest.fn();
+    const relayListBindings = jest.fn();
+    const relayContext = {
+      ...mockContext,
+      secrets: { authType: 'relay', tenantKey: 'team-A' },
+      relay: { trigger: relayTrigger, listBindings: relayListBindings },
+    } as unknown as ActionContext;
+
+    it('sendMessage posts through the relay and never touches the Slack client', async () => {
+      relayTrigger.mockResolvedValue({ ref: '1234567890.123456', tenantKey: 'team-A' });
+
+      const result = await Slack.actions.sendMessage.handler(relayContext, {
+        channel: 'C123',
+        text: 'Hello from Kibana',
+      });
+
+      expect(relayTrigger).toHaveBeenCalledWith({
+        tenantKey: 'team-A',
+        channel: 'C123',
+        message: 'Hello from Kibana',
+      });
+      expect(mockClient.post).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: true, channel: 'C123', ts: '1234567890.123456' });
+    });
+
+    it('listChannels returns the connected channels and never touches the Slack client', async () => {
+      relayListBindings.mockResolvedValue({
+        bindings: [{ scope_id: 'C123', display_name: 'general', visibility: 'public' }],
+      });
+
+      const result = await Slack.actions.listChannels.handler(
+        relayContext,
+        SlackListChannelsInputSchema.parse({})
+      );
+
+      expect(relayListBindings).toHaveBeenCalledWith('team-A', { limit: 200 });
+      expect(mockClient.get).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        ok: true,
+        source: 'relay-bindings',
+        channels: [{ id: 'C123', name: 'general', is_private: false }],
+        nextCursor: undefined,
+        hasMore: false,
+      });
+    });
+
+    it('resolveChannelId resolves against the connected channels', async () => {
+      relayListBindings.mockResolvedValue({
+        bindings: [{ scope_id: 'C123', display_name: 'general' }],
+      });
+
+      const result = await Slack.actions.resolveChannelId.handler(
+        relayContext,
+        SlackResolveChannelIdInputSchema.parse({ name: '#general' })
+      );
+
+      expect(mockClient.get).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ found: true, id: 'C123', source: 'relay-bindings' });
+    });
+
+    it('the test handler checks the relay instead of auth.test', async () => {
+      relayListBindings.mockResolvedValue({ bindings: [] });
+
+      await expect(Slack.test.handler(relayContext)).resolves.toEqual({});
+
+      expect(relayListBindings).toHaveBeenCalledWith('team-A', { limit: 1 });
+      expect(mockClient.get).not.toHaveBeenCalled();
+    });
+
+    it('fails an action the relay has no route for, naming what is supported', async () => {
+      await expect(
+        Slack.actions.searchMessages.handler(relayContext, { query: 'anything' })
+      ).rejects.toThrow(
+        'searchMessages is not available through the Elastic Slack app. Supported actions: sendMessage, listChannels, resolveChannelId.'
+      );
+
+      expect(mockClient.post).not.toHaveBeenCalled();
+    });
+
+    it('leaves the Slack path intact for a connector holding its own token', async () => {
+      mockClient.get.mockResolvedValue({
+        data: { ok: true, channels: [], response_metadata: { next_cursor: '' } },
+      });
+
+      await Slack.actions.listChannels.handler(
+        { ...mockContext, secrets: { authType: 'bearer', token: 'xoxb-fake' } } as ActionContext,
+        SlackListChannelsInputSchema.parse({})
+      );
+
+      expect(mockClient.get).toHaveBeenCalled();
+      expect(relayListBindings).not.toHaveBeenCalled();
     });
   });
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
@@ -12,6 +12,14 @@ import { z, lazySchema } from '@kbn/zod/v4';
 import type { AxiosError, AxiosResponse } from 'axios';
 import type { ConnectorSpec, ActionContext } from '../../connector_spec';
 import {
+  getRelayConnection,
+  relayListChannels,
+  relayResolveChannelId,
+  relaySendMessage,
+  relayTest,
+  withRelayGuards,
+} from './relay';
+import {
   SlackCreateConversationInputSchema,
   SlackGetConversationHistoryInputSchema,
   SlackGetConversationInfoInputSchema,
@@ -258,13 +266,23 @@ export const Slack: ConnectorSpec = {
           },
         },
       },
+      {
+        type: 'relay',
+        isInternal: true, // set when the Elastic Slack app connects, never by a user
+        defaults: {},
+        overrides: {
+          label: i18n.translate('core.kibanaConnectorSpecs.slack.auth.relay.label', {
+            defaultMessage: 'Elastic Slack app',
+          }),
+        },
+      },
     ],
   },
 
   // No additional configuration needed beyond OAuth credentials
   schema: lazySchema(() => z.object({})),
 
-  actions: {
+  actions: withRelayGuards({
     // https://api.slack.com/methods/assistant.search.context
     searchMessages: {
       isTool: true,
@@ -369,6 +387,11 @@ export const Slack: ConnectorSpec = {
         'List Slack channels/conversations the token can see (one page per call). Use this to answer which channels exist or to browse IDs before sendMessage. Pass nextCursor from the previous response to fetch the next page. Prefer this over many resolveChannelId calls for discovery.',
       input: SlackListChannelsInputSchema,
       handler: async (ctx, input: SlackListChannelsInput) => {
+        const relayConnection = getRelayConnection(ctx);
+        if (relayConnection) {
+          return relayListChannels(relayConnection, ctx, input);
+        }
+
         const params: SlackConversationsListParams = {
           types: input.types.join(','),
           exclude_archived: input.excludeArchived,
@@ -426,6 +449,11 @@ export const Slack: ConnectorSpec = {
         'Look up a Slack channel/conversation ID from a human-readable channel name (e.g. "general" or "#general"). Use before sendMessage when you already know the target name but need its ID. To list or explore channels, use listChannels instead of many resolveChannelId calls.',
       input: SlackResolveChannelIdInputSchema,
       handler: async (ctx, input: SlackResolveChannelIdInput) => {
+        const relayConnection = getRelayConnection(ctx);
+        if (relayConnection) {
+          return relayResolveChannelId(relayConnection, ctx, input);
+        }
+
         const nameNorm = input.name.trim().replace(/^#/, '').toLowerCase();
 
         let cursor = input.cursor;
@@ -1050,6 +1078,11 @@ export const Slack: ConnectorSpec = {
       handler: async (ctx, input) => {
         const typedInput: SlackSendMessageInput = SlackSendMessageInputSchema.parse(input);
 
+        const relayConnection = getRelayConnection(ctx);
+        if (relayConnection) {
+          return relaySendMessage(relayConnection, ctx, typedInput);
+        }
+
         const payload: Record<string, unknown> = {
           channel: typedInput.channel,
           text: typedInput.text,
@@ -1101,7 +1134,7 @@ export const Slack: ConnectorSpec = {
         }
       },
     },
-  },
+  }),
 
   test: {
     description: i18n.translate('core.kibanaConnectorSpecs.slack.test.description', {
@@ -1109,6 +1142,14 @@ export const Slack: ConnectorSpec = {
     }),
     handler: async (ctx) => {
       ctx.log.debug('Slack test handler');
+
+      // withRelayGuards cannot reach this: it is registered under the reserved `_test` key, outside
+      // spec.actions.
+      const relayConnection = getRelayConnection(ctx);
+      if (relayConnection) {
+        return relayTest(relayConnection, ctx);
+      }
+
       // Test connection by calling auth.test which validates the token
       const response = await ctx.client.get(`${SLACK_API_BASE}/auth.test`);
       if (!response.data.ok) {
@@ -1137,5 +1178,6 @@ export const Slack: ConnectorSpec = {
     'listUserConversations returns the channels a given user (or the authenticated user, if user is omitted) is a member of. Prefer it over listChannels when you only care about a specific user’s memberships.',
     'When a user identity comes back from one action as an ID (e.g. a message author_user_id) and you need their email or profile, resolve it via listUsers or by feeding a known email to lookupUserByEmail.',
     'For Slack files: use getFileInfo with a file ID (F...) when a message references a file you need metadata for, and listFiles when browsing or scoping by channel/user/time range. Both are paginated; listFiles supports a `types` filter (e.g. "images,pdfs").',
+    'A connector using the Elastic Slack app supports only sendMessage, listChannels and resolveChannelId, and only over the channels connected to this deployment — listChannels returns those channels, not the whole workspace. Reading history or searching messages, users, and files fails, so answer from the channel list and the messages you send rather than trying to read the workspace.',
   ].join('\n'),
 };

--- a/x-pack/platform/packages/shared/response-ops/form-generator/src/widgets/components/discriminated_union_widget/multi_option_union_widget.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/form-generator/src/widgets/components/discriminated_union_widget/multi_option_union_widget.test.tsx
@@ -608,7 +608,7 @@ describe('MultiOptionUnionWidget', () => {
     });
   });
 
-  describe('legacy options', () => {
+  describe('legacy and internal options', () => {
     const renderOptions = (
       options: Array<z.ZodObject<z.ZodRawShape>>,
       fieldConfig: Record<string, unknown> = {}
@@ -666,6 +666,37 @@ describe('MultiOptionUnionWidget', () => {
 
       expect(screen.getByText('Bearer (legacy)')).toBeInTheDocument();
       expect(screen.getByLabelText('Legacy Token', { selector: 'input' })).toBeInTheDocument();
+    });
+
+    const internalRelay = () =>
+      z
+        .object({
+          type: z.literal('relay'),
+          tenantKey: z.string().meta({ label: 'Tenant Key' }),
+        })
+        .meta({ label: 'Elastic app', isInternal: true });
+
+    it('does not render an internal option that is not selected', () => {
+      renderOptions([ears(), internalRelay()]);
+
+      expect(screen.getByText('Quick Connect')).toBeInTheDocument();
+      expect(screen.queryByText('Elastic app')).toBeNull();
+    });
+
+    it('skips internal options when picking the default', () => {
+      // internal option listed FIRST — default selection should still land on the other option
+      renderOptions([internalRelay(), ears()]);
+
+      expect(screen.getByLabelText('Quick Token', { selector: 'input' })).toBeInTheDocument();
+      expect(screen.queryByText('Elastic app')).toBeNull();
+    });
+
+    it('renders an internal option when it is the active selection (e.g. provisioned connector)', () => {
+      renderOptions([ears(), internalRelay()], {
+        defaultValue: { type: 'relay', tenantKey: 'tenant-A' },
+      });
+
+      expect(screen.getByText('Elastic app')).toBeInTheDocument();
     });
   });
 

--- a/x-pack/platform/packages/shared/response-ops/form-generator/src/widgets/components/discriminated_union_widget/multi_option_union_widget.tsx
+++ b/x-pack/platform/packages/shared/response-ops/form-generator/src/widgets/components/discriminated_union_widget/multi_option_union_widget.tsx
@@ -63,11 +63,13 @@ const getDefaultOption = (
       return defaultOption;
     }
   }
-  // Skip legacy options (backwards-compat entries) so they are never
-  // auto-selected as the default when creating a new connector.
+  // Never default to a legacy option (backwards-compat only) or an internal one (set
+  // programmatically, nothing for a user to fill in).
   return (
-    options.find((option) => !Boolean((getMeta(option) as Record<string, unknown>).isLegacy)) ??
-    options[0]
+    options.find((option) => {
+      const optionMeta = getMeta(option) as Record<string, unknown>;
+      return !Boolean(optionMeta.isLegacy) && !Boolean(optionMeta.isInternal);
+    }) ?? options[0]
   );
 };
 
@@ -141,12 +143,12 @@ export const MultiOptionUnionWidget: React.FC<DiscriminatedUnionWidgetProps> = (
         const label = optionMeta.label;
         const isRecommended = Boolean((optionMeta as Record<string, unknown>).isRecommended);
         const isLegacy = Boolean((optionMeta as Record<string, unknown>).isLegacy);
+        const isInternal = Boolean((optionMeta as Record<string, unknown>).isInternal);
         const isChecked = selectedOption === discriminatorValue;
 
-        // Legacy auth types are kept only for existing connectors.
-        // Don't render them as selectable choices, but do render if currently active
-        // so the user can still view/edit credentials on an existing connector.
-        if (isLegacy && !isChecked) return null;
+        // Neither is offered as a choice, but both still render while active so an existing
+        // connector's credentials stay viewable.
+        if ((isLegacy || isInternal) && !isChecked) return null;
 
         // if the entire fieldset is disabled, ensure each option is also marked as disabled
         if (isFieldsetDisabled && optionMeta.disabled !== false) {

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/create/create.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/create/create.test.ts
@@ -336,6 +336,66 @@ describe('create()', () => {
     });
   });
 
+  describe('internal auth types', () => {
+    test('throws an error when creating a connector with an internal auth type', async () => {
+      await expect(
+        create({
+          context: mockContext,
+          action: {
+            name: 'my name',
+            actionTypeId: '.slack2',
+            config: {},
+            secrets: { authType: 'relay', tenantKey: 'tenant-A' },
+          },
+        })
+      ).rejects.toThrow(
+        'Authentication type relay is set by Kibana and cannot be configured on a connector. Action type: .slack2.'
+      );
+    });
+
+    test('throws when the internal auth type is only present in config', async () => {
+      await expect(
+        create({
+          context: mockContext,
+          action: {
+            name: 'my name',
+            actionTypeId: '.slack2',
+            config: { authType: 'relay' },
+            secrets: {},
+          },
+        })
+      ).rejects.toThrow(
+        'Authentication type relay is set by Kibana and cannot be configured on a connector. Action type: .slack2.'
+      );
+    });
+
+    test('allows a user-facing auth type on the same connector type', async () => {
+      unsecuredSavedObjectsClient.create.mockResolvedValueOnce({
+        id: '1',
+        type: 'action',
+        attributes: {
+          name: 'my name',
+          actionTypeId: '.slack2',
+          isMissingSecrets: false,
+          config: {},
+        },
+        references: [],
+      });
+
+      await expect(
+        create({
+          context: mockContext,
+          action: {
+            name: 'my name',
+            actionTypeId: '.slack2',
+            config: {},
+            secrets: { authType: 'bearer', token: 'xoxb-token' },
+          },
+        })
+      ).resolves.toEqual(expect.objectContaining({ actionTypeId: '.slack2' }));
+    });
+  });
+
   describe('basic connector creation', () => {
     test('creates an action with all given properties', async () => {
       const savedObjectCreateResult = {

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/create/create.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/create/create.ts
@@ -18,6 +18,7 @@ import type { HookServices, ActionResult } from '../../../../types';
 import { tryCatch } from '../../../../lib';
 import { invokePostCreateListeners } from '../../../../lib/invoke_lifecycle_listeners';
 import { ensureConfigAuthType } from '../../../../lib/ensure_config_auth_type';
+import { ensureNotInternalAuthType } from '../../../../lib/ensure_not_internal_auth_type';
 import { inferAuthMode } from '../../../../lib/infer_auth_mode';
 import { validateConnectorId } from '../../../../../common/validate_connector_id';
 
@@ -72,6 +73,8 @@ export async function create({
       })
     );
   }
+
+  ensureNotInternalAuthType({ actionTypeId, secrets, config });
 
   const actionType = context.actionTypeRegistry.get(actionTypeId);
   const configurationUtilities = context.actionTypeRegistry.getUtils();

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/update/update.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/update/update.test.ts
@@ -259,6 +259,33 @@ describe('update()', () => {
     });
   });
 
+  describe('internal auth types', () => {
+    test('rejects switching an existing connector to an internal auth type', async () => {
+      const soResult = makeSavedObjectResult({
+        actionTypeId: '.slack2',
+        authMode: 'shared',
+        secrets: { authType: 'bearer' },
+      });
+      unsecuredSavedObjectsClient.get.mockResolvedValueOnce(soResult);
+
+      await expect(
+        update({
+          context: mockContext,
+          id: '1',
+          action: {
+            name: 'Test Connector',
+            config: {},
+            secrets: { authType: 'relay', tenantKey: 'tenant-A' },
+          },
+        })
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: Authentication type relay is set by Kibana and cannot be configured on a connector. Action type: .slack2.]`
+      );
+
+      expect(unsecuredSavedObjectsClient.create).not.toHaveBeenCalled();
+    });
+  });
+
   describe('spec connector config.authType on update', () => {
     test('rejects changing per-user auth type when saved config.authType is present', async () => {
       const soResult = makeSavedObjectResult({

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/update/update.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/update/update.ts
@@ -16,6 +16,7 @@ import { PreconfiguredActionDisabledModificationError } from '../../../../lib/er
 import { ConnectorAuditAction, connectorAuditEvent } from '../../../../lib/audit_events';
 import { validateConfig, validateConnector, validateSecrets } from '../../../../lib';
 import { ensureConfigAuthType } from '../../../../lib/ensure_config_auth_type';
+import { ensureNotInternalAuthType } from '../../../../lib/ensure_not_internal_auth_type';
 import { inferAuthMode } from '../../../../lib/infer_auth_mode';
 import { getAuthMode, isConnectorDeprecated } from '../../lib';
 import type { RawAction, HookServices } from '../../../../types';
@@ -75,6 +76,9 @@ export async function update({ context, id, action }: ConnectorUpdateParams): Pr
   const currentAuthMode = authMode ?? 'shared';
   const currentAuthTypeId = getAuthTypeId(attributes.secrets, attributes.config);
   const requestedAuthTypeId = getAuthTypeId(secrets, config);
+
+  ensureNotInternalAuthType({ actionTypeId, secrets, config });
+
   const requestedAuthMode = inferAuthMode({
     authTypeRegistry: context.authTypeRegistry,
     secrets,

--- a/x-pack/platform/plugins/shared/actions/server/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/index.ts
@@ -50,6 +50,8 @@ export type {
   RelayClientContract,
   RelayInstallRequest,
   RelayInstallResponse,
+  RelayTriggerInput,
+  RelayTriggerResponse,
 } from './lib/relay';
 
 export {

--- a/x-pack/platform/plugins/shared/actions/server/lib/ensure_not_internal_auth_type.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/ensure_not_internal_auth_type.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import { i18n } from '@kbn/i18n';
+import { isInternalAuthType } from '@kbn/connector-specs';
+
+interface EnsureNotInternalAuthTypeParams {
+  actionTypeId: string;
+  secrets?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+}
+
+/**
+ * Rejects a create/update asking for an auth type the spec marks internal. Belongs on the mutation
+ * path only — secrets validation also runs on execute, which would break the in-memory connectors
+ * Kibana provisions itself.
+ */
+export const ensureNotInternalAuthType = ({
+  actionTypeId,
+  secrets,
+  config,
+}: EnsureNotInternalAuthTypeParams): void => {
+  const authTypeId =
+    (secrets as { authType?: string } | undefined)?.authType ??
+    (config as { authType?: string } | undefined)?.authType;
+
+  if (!isInternalAuthType(actionTypeId, authTypeId)) {
+    return;
+  }
+
+  throw Boom.badRequest(
+    i18n.translate('xpack.actions.serverSideErrors.internalAuthTypeForbidden', {
+      defaultMessage:
+        'Authentication type {authTypeId} is set by {kibana} and cannot be configured on a connector. Action type: {actionTypeId}.',
+      values: { authTypeId, actionTypeId, kibana: 'Kibana' },
+    })
+  );
+};

--- a/x-pack/platform/plugins/shared/actions/server/lib/relay/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/relay/index.ts
@@ -14,4 +14,6 @@ export type {
   RelayClientContract,
   RelayInstallRequest,
   RelayInstallResponse,
+  RelayTriggerInput,
+  RelayTriggerResponse,
 } from './types';

--- a/x-pack/platform/plugins/shared/actions/server/lib/relay/relay_client.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/relay/relay_client.test.ts
@@ -219,6 +219,63 @@ describe('RelayClient', () => {
     });
   });
 
+  describe('trigger', () => {
+    it('posts the snake_case outbound body with the Relay SSL overrides', async () => {
+      requestMock.mockResolvedValue({
+        status: 202,
+        data: { ok: true, surface: 'slack', tenant_key: 'team-A', ref: '1700000000.000100' },
+      } as never);
+
+      await expect(
+        createClient().trigger({ tenantKey: 'team-A', channel: 'C123', message: 'hello' })
+      ).resolves.toEqual({ ref: '1700000000.000100', tenantKey: 'team-A' });
+
+      expect(requestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://relay.test/v1/trigger',
+          method: 'post',
+          data: { surface: 'slack', tenant_key: 'team-A', channel: 'C123', message: 'hello' },
+          sslOverrides: relaySSLSettings,
+        })
+      );
+    });
+
+    it('includes thread_ts only when replying in a thread', async () => {
+      requestMock.mockResolvedValue({
+        status: 202,
+        data: { ref: '1700000000.000200', tenant_key: 'team-A' },
+      } as never);
+
+      await createClient().trigger({
+        tenantKey: 'team-A',
+        channel: 'C123',
+        message: 'in thread',
+        threadTs: '1700000000.000100',
+      });
+
+      expect(requestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ thread_ts: '1700000000.000100' }),
+        })
+      );
+    });
+
+    it.each([403, 409, 502])(
+      'turns a %s into a RelayRequestError carrying the status',
+      async (status) => {
+        requestMock.mockResolvedValue({ status, data: { message: 'nope' } } as never);
+
+        const error = await createClient()
+          .trigger({ tenantKey: 'team-A', channel: 'C123', message: 'hello' })
+          .then(() => undefined)
+          .catch((cause) => cause);
+
+        expect(error).toBeInstanceOf(RelayRequestError);
+        expect(error).toMatchObject({ statusCode: status, relayMessage: 'nope' });
+      }
+    );
+  });
+
   it('preserves Relay errors', async () => {
     requestMock.mockResolvedValue({
       status: 400,

--- a/x-pack/platform/plugins/shared/actions/server/lib/relay/relay_client.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/relay/relay_client.ts
@@ -20,6 +20,8 @@ import type {
   RelayInstallRequest,
   RelayInstallResponse,
   RelayListBindingsOptions,
+  RelayTriggerInput,
+  RelayTriggerResponse,
 } from './types';
 
 export interface RelayClientOptions {
@@ -39,6 +41,12 @@ interface RelayErrorResponse {
 interface RelayBindingsListResponse {
   bindings?: RelayBinding[];
   next_cursor?: string;
+}
+
+/** Raw shape of the `POST /v1/trigger` acknowledgement body. */
+interface RelayTriggerResponseBody {
+  ref?: string;
+  tenant_key?: string;
 }
 
 export class RelayClient implements RelayClientContract {
@@ -138,6 +146,25 @@ export class RelayClient implements RelayClientContract {
         channelId
       )}/unbind`
     );
+  }
+
+  /** Post to a bound channel. One this deployment does not own is rejected with a 403, not delivered. */
+  async trigger({
+    tenantKey,
+    channel,
+    message,
+    threadTs,
+  }: RelayTriggerInput): Promise<RelayTriggerResponse> {
+    const response = await this.post('/v1/trigger', {
+      surface: 'slack',
+      tenant_key: tenantKey,
+      channel,
+      message,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+    });
+
+    const body = response.data as RelayTriggerResponseBody | undefined;
+    return { ref: body?.ref ?? '', tenantKey: body?.tenant_key ?? tenantKey };
   }
 
   isRelayOrigin(url: string): boolean {

--- a/x-pack/platform/plugins/shared/actions/server/lib/relay/types.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/relay/types.ts
@@ -62,6 +62,24 @@ export interface RelayBindingsPage {
   nextCursor?: string;
 }
 
+/**
+ * The Relay resolves the target from `tenantKey` + `channel`, so `channel` must be the Slack channel
+ * *id* (a binding's `scope_id`), not a display name.
+ */
+export interface RelayTriggerInput {
+  tenantKey: string;
+  channel: string;
+  message: string;
+  /** Timestamp of the message to reply to, when posting into an existing thread. */
+  threadTs?: string;
+}
+
+export interface RelayTriggerResponse {
+  /** The posted message's Slack `ts`. */
+  ref: string;
+  tenantKey: string;
+}
+
 export interface RelayClientContract {
   startInstall(body: RelayInstallRequest): Promise<RelayInstallResponse>;
   fetchClaim(claimId: string): Promise<RelayClaimResponse>;
@@ -78,6 +96,8 @@ export interface RelayClientContract {
   bind(tenantKey: string, channelId: string): Promise<void>;
   /** Release a channel binding owned by this deployment (404 if none; 403 if owned by another). */
   unbindChannel(tenantKey: string, channelId: string): Promise<void>;
+  /** Post a message to a channel bound here (403 if not bound; 409 if the app was uninstalled). */
+  trigger(input: RelayTriggerInput): Promise<RelayTriggerResponse>;
   isRelayOrigin(url: string): boolean;
   postCallback(url: string, body: unknown, signal: AbortSignal): Promise<RelayCallbackResponse>;
 }

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
@@ -64,6 +64,7 @@ export const createConnectorTypeFromSpec = (
         getAxiosInstanceWithAuth: actions.getAxiosInstanceWithAuth,
         getCredential: actions.getCredential,
         getClientLeasePool: actions.getClientLeasePool,
+        getRelayClient: actions.getRelayClient,
         networkSettings,
       })
     : undefined;

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
@@ -132,6 +132,48 @@ describe('generateExecutorFunction', () => {
       );
     });
 
+    it('passes the Relay client in the handler context for relay-authenticated executions', async () => {
+      const relay = { trigger: jest.fn(), listBindings: jest.fn() };
+      const executor = generateExecutorFunction({
+        actions: makeActions(),
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => fakeLeasePool,
+        getRelayClient: () => relay,
+        networkSettings: mockNetwork,
+      });
+
+      const opts = makeExecOptions({ subAction: 'testAction', subActionParams: {} });
+      await executor({ ...opts, secrets: { authType: 'relay', tenantKey: 'tenant-A' } });
+
+      expect(mockHandler).toHaveBeenCalledWith(expect.objectContaining({ relay }), {});
+    });
+
+    it('leaves the Relay client undefined for non-relay auth types even when one is configured', async () => {
+      const relay = { trigger: jest.fn(), listBindings: jest.fn() };
+      const executor = generateExecutorFunction({
+        actions: makeActions(),
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => fakeLeasePool,
+        getRelayClient: () => relay,
+        networkSettings: mockNetwork,
+      });
+
+      const opts = makeExecOptions({ subAction: 'testAction', subActionParams: {} });
+      await executor({ ...opts, secrets: { authType: 'bearer', token: 'secret' } });
+
+      expect(mockHandler.mock.calls[0][0]).toHaveProperty('relay', undefined);
+    });
+
+    it('leaves the Relay client undefined when no Relay is configured', async () => {
+      const executor = makeExecutor();
+
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+
+      expect(mockHandler.mock.calls[0][0]).toHaveProperty('relay', undefined);
+    });
+
     it('returns empty object as data when handler returns null', async () => {
       mockHandler.mockResolvedValue(null);
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -7,13 +7,19 @@
 
 import type { ConnectorSpec } from '@kbn/connector-specs';
 import {
+  authTypeUsesRelay,
   getAuthModeForAuthTypeId,
   getConnectorActionErrorMeta,
   getFinitePositiveNumber,
   getHeaderValue,
   clientTypes as defaultClientTypes,
 } from '@kbn/connector-specs';
-import type { ActionContext, ClientTypeSpec, ConnectorNetworkSettings } from '@kbn/connector-specs';
+import type {
+  ActionContext,
+  ClientTypeSpec,
+  ConnectorNetworkSettings,
+  RelayActionClient,
+} from '@kbn/connector-specs';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import { getErrorSource, isUserError } from '@kbn/task-manager-plugin/server/task_running';
 import type { ExecutorParams } from '../../sub_action_framework/types';
@@ -83,6 +89,7 @@ export const generateExecutorFunction = ({
   getAxiosInstanceWithAuth,
   getCredential,
   getClientLeasePool,
+  getRelayClient,
   networkSettings,
   clientTypes = defaultClientTypes,
 }: {
@@ -90,6 +97,7 @@ export const generateExecutorFunction = ({
   getAxiosInstanceWithAuth: GetAxiosInstanceWithAuthFn;
   getCredential: GetCredentialFn;
   getClientLeasePool: () => LeasePool<unknown>;
+  getRelayClient?: () => RelayActionClient | undefined;
   networkSettings: ConnectorNetworkSettings;
   clientTypes?: Readonly<Record<string, ClientTypeSpec<unknown>>>;
 }) =>
@@ -133,6 +141,12 @@ export const generateExecutorFunction = ({
     }
 
     const pool = getClientLeasePool();
+    // Shared by getClient (authMode) and the Relay gate. Specs that route through the Relay
+    // (isRelayAuth) read this same secrets.authType, so the two cannot disagree: the discriminated
+    // union makes authType mandatory on saved connectors and buildConnector sets it on the
+    // in-memory one. The reserved _test action lives in the same actions map, so it inherits the
+    // gate.
+    const authTypeId = (secrets as { authType?: string }).authType ?? 'none';
     const getClient = async (id: string): Promise<unknown> => {
       const clientType = clientTypes[id];
       if (!clientType) {
@@ -144,7 +158,6 @@ export const generateExecutorFunction = ({
       // `authMode` is inferred once when the connector is created, so it can be absent (no
       // `authType` field, an auth type unknown at creation time, or an in-memory connector) and
       // would then fall back to `shared`.
-      const authTypeId = (secrets as { authType?: string }).authType ?? 'none';
       const derivedAuthMode = getAuthModeForAuthTypeId(authTypeId);
 
       if (derivedAuthMode === 'per-user' && authMode !== 'per-user') {
@@ -204,6 +217,7 @@ export const generateExecutorFunction = ({
       secrets,
       config,
       getClient: getClient as ActionContext['getClient'],
+      relay: authTypeUsesRelay(authTypeId) ? getRelayClient?.() : undefined,
     };
 
     try {

--- a/x-pack/platform/plugins/shared/significant_events/moon.yml
+++ b/x-pack/platform/plugins/shared/significant_events/moon.yml
@@ -69,6 +69,7 @@ dependsOn:
   - '@kbn/licensing-plugin'
   - '@kbn/fields-metadata-plugin'
   - '@kbn/actions-plugin'
+  - '@kbn/connector-specs'
   - '@kbn/encrypted-saved-objects-plugin'
   - '@kbn/inference-plugin'
   - '@kbn/security-plugin'

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import {
+  ELASTIC_APPS_SLACK_CONNECTOR_ID,
+  ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID,
+  getRegisteredTenantKey,
+  registerElasticAppsSlackConnector,
+  unregisterElasticAppsSlackConnector,
+} from './connector';
+
+const createLogger = () => ({ debug: jest.fn() } as unknown as jest.Mocked<Logger>);
+
+const createActions = () => {
+  const calls: string[] = [];
+  return {
+    calls,
+    registerDynamicConnector: jest.fn(() => {
+      calls.push('register');
+      return true;
+    }),
+    unregisterDynamicConnector: jest.fn(() => {
+      calls.push('unregister');
+      return true;
+    }),
+  };
+};
+
+describe('registerElasticAppsSlackConnector', () => {
+  it('registers a Slack (v2) connector authenticated through the Relay', () => {
+    const actions = createActions();
+
+    registerElasticAppsSlackConnector({
+      actions,
+      logger: createLogger(),
+      tenantKey: 'tenant-A',
+    });
+
+    expect(actions.registerDynamicConnector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+        actionTypeId: '.slack2',
+        config: { authType: 'relay' },
+        secrets: { authType: 'relay', tenantKey: 'tenant-A' },
+        isPreconfigured: true,
+        isSystemAction: false,
+        isMissingSecrets: false,
+      })
+    );
+  });
+
+  it('unregisters before registering so a new tenant key takes effect', () => {
+    const actions = createActions();
+
+    registerElasticAppsSlackConnector({
+      actions,
+      logger: createLogger(),
+      tenantKey: 'tenant-A',
+    });
+
+    expect(actions.calls).toEqual(['unregister', 'register']);
+  });
+});
+
+describe('unregisterElasticAppsSlackConnector', () => {
+  it('unregisters by the well-known id', () => {
+    const actions = createActions();
+
+    unregisterElasticAppsSlackConnector({ actions, logger: createLogger() });
+
+    expect(actions.unregisterDynamicConnector).toHaveBeenCalledWith(
+      ELASTIC_APPS_SLACK_CONNECTOR_ID
+    );
+  });
+
+  it('logs only when a connector was actually removed', () => {
+    const logger = createLogger();
+    const actions = { unregisterDynamicConnector: jest.fn().mockReturnValue(false) };
+
+    unregisterElasticAppsSlackConnector({ actions, logger });
+
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+});
+
+describe('getRegisteredTenantKey', () => {
+  it('returns the tenant key this process is serving', () => {
+    expect(
+      getRegisteredTenantKey({
+        inMemoryConnectors: [
+          { id: 'other', secrets: { tenantKey: 'tenant-Z' } },
+          { id: ELASTIC_APPS_SLACK_CONNECTOR_ID, secrets: { tenantKey: 'tenant-A' } },
+        ] as never,
+      })
+    ).toBe('tenant-A');
+  });
+
+  it('returns undefined when the connector is not registered', () => {
+    expect(getRegisteredTenantKey({ inMemoryConnectors: [] })).toBeUndefined();
+  });
+
+  it('returns undefined when the registered connector carries no tenant key', () => {
+    expect(
+      getRegisteredTenantKey({
+        inMemoryConnectors: [{ id: ELASTIC_APPS_SLACK_CONNECTOR_ID, secrets: {} }] as never,
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe('connector type', () => {
+  it('is the Slack (v2) spec, not a connector type of its own', () => {
+    expect(ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID).toBe('.slack2');
+  });
+});

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { InMemoryConnector, PluginStartContract } from '@kbn/actions-plugin/server';
+import { RELAY_AUTH_ID } from '@kbn/connector-specs';
+
+/** The Elastic Slack app is not its own connector type — it is the `relay` auth method on this one. */
+export const ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID = '.slack2';
+
+/**
+ * One instance per deployment, under a stable id: rules and workflows reference it directly, so it
+ * must survive restarts and reconnects unchanged.
+ */
+export const ELASTIC_APPS_SLACK_CONNECTOR_ID = 'elastic-apps-slack';
+
+const ELASTIC_APPS_SLACK_CONNECTOR_NAME = 'Slack (Elastic app)';
+
+type DynamicConnectorActions = Pick<
+  PluginStartContract,
+  'registerDynamicConnector' | 'unregisterDynamicConnector' | 'inMemoryConnectors'
+>;
+
+const buildConnector = (tenantKey: string): InMemoryConnector => ({
+  id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+  actionTypeId: ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID,
+  name: ELASTIC_APPS_SLACK_CONNECTOR_NAME,
+  // The Relay holds the Slack credentials, so naming the workspace is all this needs. `config`
+  // mirrors the auth type in plaintext, as `ensureConfigAuthType` does for saved connectors.
+  config: { authType: RELAY_AUTH_ID },
+  secrets: { authType: RELAY_AUTH_ID, tenantKey },
+  isMissingSecrets: false,
+  isPreconfigured: true,
+  isDeprecated: false,
+  isSystemAction: false,
+  isConnectorTypeDeprecated: false,
+});
+
+/**
+ * Unregisters first because `registerDynamicConnector` is a no-op when the id is taken, so a
+ * reconnect to a different workspace would otherwise keep serving the previous tenant key.
+ */
+export const registerElasticAppsSlackConnector = ({
+  actions,
+  logger,
+  tenantKey,
+}: {
+  actions: Pick<DynamicConnectorActions, 'registerDynamicConnector' | 'unregisterDynamicConnector'>;
+  logger: Logger;
+  tenantKey: string;
+}): void => {
+  actions.unregisterDynamicConnector(ELASTIC_APPS_SLACK_CONNECTOR_ID);
+  actions.registerDynamicConnector(buildConnector(tenantKey));
+  logger.debug(`Registered the ${ELASTIC_APPS_SLACK_CONNECTOR_ID} connector`);
+};
+
+export const unregisterElasticAppsSlackConnector = ({
+  actions,
+  logger,
+}: {
+  actions: Pick<DynamicConnectorActions, 'unregisterDynamicConnector'>;
+  logger: Logger;
+}): void => {
+  if (actions.unregisterDynamicConnector(ELASTIC_APPS_SLACK_CONNECTOR_ID)) {
+    logger.debug(`Unregistered the ${ELASTIC_APPS_SLACK_CONNECTOR_ID} connector`);
+  }
+};
+
+/** Lets a reconcile tell "already correct" from "registered for the wrong workspace". */
+export const getRegisteredTenantKey = (
+  actions: Pick<DynamicConnectorActions, 'inMemoryConnectors'>
+): string | undefined => {
+  const connector = actions.inMemoryConnectors.find(
+    ({ id }) => id === ELASTIC_APPS_SLACK_CONNECTOR_ID
+  );
+  const tenantKey = (connector?.secrets as { tenantKey?: unknown } | undefined)?.tenantKey;
+  return typeof tenantKey === 'string' ? tenantKey : undefined;
+};

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector_poller.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector_poller.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import type { StreamsServer } from '@kbn/streams-plugin/server/types';
+import { SlackAppService } from './service';
+import { createElasticAppsSlackConnectorPoller } from './connector_poller';
+
+const reconcileConnector = jest.spyOn(SlackAppService.prototype, 'reconcileConnector');
+
+const INTERVAL_MS = 60_000;
+
+const createPoller = () => {
+  const logger = { warn: jest.fn(), get: jest.fn() } as unknown as jest.Mocked<Logger>;
+  (logger.get as jest.Mock).mockReturnValue(logger);
+  const soClient = {} as SavedObjectsClientContract;
+
+  return {
+    logger,
+    soClient,
+    poller: createElasticAppsSlackConnectorPoller({
+      server: { logger } as unknown as StreamsServer,
+      logger,
+      soClient,
+      intervalMs: INTERVAL_MS,
+    }),
+  };
+};
+
+describe('createElasticAppsSlackConnectorPoller', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    reconcileConnector.mockReset();
+    reconcileConnector.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does nothing until subscribed', async () => {
+    createPoller();
+    await jest.advanceTimersByTimeAsync(INTERVAL_MS * 3);
+
+    expect(reconcileConnector).not.toHaveBeenCalled();
+  });
+
+  it('reconciles on the first tick, so a restart restores the connector', async () => {
+    const { poller, soClient } = createPoller();
+
+    const subscription = poller.subscribe();
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(reconcileConnector).toHaveBeenCalledWith(soClient);
+    subscription.unsubscribe();
+  });
+
+  it('keeps reconciling on the interval', async () => {
+    const { poller } = createPoller();
+    const subscription = poller.subscribe();
+
+    await jest.advanceTimersByTimeAsync(INTERVAL_MS * 2);
+
+    expect(reconcileConnector).toHaveBeenCalledTimes(3);
+    subscription.unsubscribe();
+  });
+
+  it('skips a tick that lands while the previous pass is still running', async () => {
+    const { poller } = createPoller();
+    let releasePass = () => {};
+    reconcileConnector.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releasePass = resolve;
+      })
+    );
+
+    const subscription = poller.subscribe();
+    await jest.advanceTimersByTimeAsync(INTERVAL_MS * 2);
+
+    expect(reconcileConnector).toHaveBeenCalledTimes(1);
+
+    releasePass();
+    await jest.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(reconcileConnector).toHaveBeenCalledTimes(2);
+    subscription.unsubscribe();
+  });
+
+  it('logs a failed pass and carries on', async () => {
+    const { poller, logger } = createPoller();
+    reconcileConnector.mockRejectedValueOnce(new Error('saved object unavailable'));
+
+    const subscription = poller.subscribe();
+    await jest.advanceTimersByTimeAsync(INTERVAL_MS);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to reconcile the Elastic Slack connector')
+    );
+    expect(reconcileConnector).toHaveBeenCalledTimes(2);
+    subscription.unsubscribe();
+  });
+
+  it('stops on unsubscribe', async () => {
+    const { poller } = createPoller();
+    const subscription = poller.subscribe();
+    await jest.advanceTimersByTimeAsync(0);
+
+    subscription.unsubscribe();
+    await jest.advanceTimersByTimeAsync(INTERVAL_MS * 3);
+
+    expect(reconcileConnector).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector_poller.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/connector_poller.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { catchError, exhaustMap, from, of, timer } from 'rxjs';
+import type { Observable } from 'rxjs';
+import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import type { StreamsServer } from '@kbn/streams-plugin/server/types';
+import { SlackAppService } from './service';
+
+const RECONCILE_INTERVAL_MS = 60_000;
+
+/**
+ * Keeps this process's Elastic Slack connector in line with the stored connection: in-memory
+ * connectors are per-process, so a connect handled by another node never reaches here otherwise.
+ */
+export const createElasticAppsSlackConnectorPoller = ({
+  server,
+  logger,
+  soClient,
+  intervalMs = RECONCILE_INTERVAL_MS,
+}: {
+  server: StreamsServer;
+  logger: Logger;
+  soClient: SavedObjectsClientContract;
+  intervalMs?: number;
+}): Observable<unknown> => {
+  const service = new SlackAppService(server);
+
+  // `timer(0, …)` makes the first tick the startup restore. `catchError` must stay inside the inner
+  // observable — outside, one failed tick would end the poller for the process's lifetime.
+  return timer(0, intervalMs).pipe(
+    exhaustMap(() =>
+      from(service.reconcileConnector(soClient)).pipe(
+        catchError((error: unknown) => {
+          logger.warn(
+            `Failed to reconcile the Elastic Slack connector: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+          return of(undefined);
+        })
+      )
+    )
+  );
+};

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.test.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.test.ts
@@ -13,6 +13,7 @@ import { RELAY_APP_CONNECTION_STATUS } from '../../../common/slack_app/types';
 import { SlackAppService } from './service';
 import { SlackAppUnavailableError } from './errors';
 import { RELAY_APP_CONNECTION_SO_ID, RELAY_APP_CONNECTION_SO_TYPE } from './saved_object';
+import { ELASTIC_APPS_SLACK_CONNECTOR_ID, ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID } from './connector';
 
 const request = {} as unknown as KibanaRequest;
 
@@ -52,11 +53,31 @@ function createHarness({ featureFlagEnabled = true, hasRelayClient = true }: Har
 
   const getLicense = jest.fn().mockResolvedValue({ type: 'platinum' });
 
+  // Mutated in place like the actions plugin's own array, so `getRegisteredTenantKey` sees what the
+  // service just did.
+  const inMemoryConnectors: Array<{ id: string; secrets?: unknown }> = [];
+  const registerDynamicConnector = jest.fn((connector: { id: string; secrets?: unknown }) => {
+    if (inMemoryConnectors.some(({ id }) => id === connector.id)) {
+      return false;
+    }
+    inMemoryConnectors.push(connector);
+    return true;
+  });
+  const unregisterDynamicConnector = jest.fn((connectorId: string) => {
+    const index = inMemoryConnectors.findIndex(({ id }) => id === connectorId);
+    if (index === -1) {
+      return false;
+    }
+    inMemoryConnectors.splice(index, 1);
+    return true;
+  });
+
   const server = {
     logger,
     config: {},
     agentBuilder: {},
     kibanaVersion: '9.2.0',
+    actions: { registerDynamicConnector, unregisterDynamicConnector, inMemoryConnectors },
     relayClient: hasRelayClient ? { startInstall, fetchClaim, unbind } : undefined,
     core: {
       savedObjects: { getScopedClient: jest.fn().mockReturnValue(soClient) },
@@ -72,7 +93,16 @@ function createHarness({ featureFlagEnabled = true, hasRelayClient = true }: Har
     },
   } as unknown as StreamsServer;
 
-  return { server, soClient, grantAsInternalUser, invalidateAsInternalUser, getBooleanValue };
+  return {
+    server,
+    soClient,
+    grantAsInternalUser,
+    invalidateAsInternalUser,
+    getBooleanValue,
+    inMemoryConnectors,
+    registerDynamicConnector,
+    unregisterDynamicConnector,
+  };
 }
 
 describe('SlackAppService', () => {
@@ -749,6 +779,231 @@ describe('SlackAppService', () => {
       await new SlackAppService(server).unbindChannel(request, 'C123');
 
       expect(unbindChannel).toHaveBeenCalledWith('tenant-A', 'C123');
+    });
+  });
+
+  describe('elastic slack connector registration', () => {
+    const connectorFor = (tenantKey: string) =>
+      expect.objectContaining({
+        id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+        actionTypeId: ELASTIC_APPS_SLACK_CONNECTOR_TYPE_ID,
+        config: { authType: 'relay' },
+        secrets: { authType: 'relay', tenantKey },
+      });
+
+    it('registers the connector when the Relay claim completes', async () => {
+      const { server, soClient, registerDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.oauthInProgress,
+          apiKeyId: 'key-1',
+          claimId: 'claim-1',
+        },
+      });
+      fetchClaim.mockResolvedValue({ status: 'complete', tenant_key: 'tenant-A' });
+
+      await new SlackAppService(server).getStatus(request);
+
+      expect(registerDynamicConnector).toHaveBeenCalledWith(connectorFor('tenant-A'));
+    });
+
+    it('does not register while the claim is still pending', async () => {
+      const { server, soClient, registerDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.oauthInProgress,
+          apiKeyId: 'key-1',
+          claimId: 'claim-1',
+        },
+      });
+      fetchClaim.mockResolvedValue({ status: 'pending' });
+
+      await new SlackAppService(server).getStatus(request);
+
+      expect(registerDynamicConnector).not.toHaveBeenCalled();
+    });
+
+    it('unregisters when an in-progress install fails terminally', async () => {
+      const { server, soClient, unregisterDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: { status: RELAY_APP_CONNECTION_STATUS.oauthInProgress, apiKeyId: 'key-1' },
+      });
+
+      await new SlackAppService(server).getStatus(request);
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
+    });
+
+    it('withdraws the stale connector when a reconnect starts', async () => {
+      const { server, grantAsInternalUser, unregisterDynamicConnector } = createHarness();
+      grantAsInternalUser.mockResolvedValue({ id: 'key-2', name: 'k', api_key: 'secret' });
+      startInstall.mockResolvedValue({
+        authorize_url: 'https://slack/oauth',
+        claim_id: 'claim-2',
+      });
+
+      await new SlackAppService(server).connect(request);
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
+    });
+
+    it('replaces the connector on reconnect so a new tenant key takes effect', async () => {
+      const { server, soClient, inMemoryConnectors, registerDynamicConnector } = createHarness();
+      inMemoryConnectors.push({
+        id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+        secrets: { tenantKey: 'tenant-A' },
+      });
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.oauthInProgress,
+          apiKeyId: 'key-1',
+          claimId: 'claim-1',
+        },
+      });
+      fetchClaim.mockResolvedValue({ status: 'complete', tenant_key: 'tenant-B' });
+
+      await new SlackAppService(server).getStatus(request);
+
+      expect(registerDynamicConnector).toHaveBeenCalledWith(connectorFor('tenant-B'));
+      expect(inMemoryConnectors).toEqual([connectorFor('tenant-B')]);
+    });
+
+    it('unregisters on disconnect', async () => {
+      const { server, soClient, unregisterDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.connected,
+          apiKeyId: 'key-1',
+          tenantKey: 'tenant-A',
+        },
+      });
+      unbind.mockResolvedValue(undefined);
+
+      await new SlackAppService(server).disconnect(request);
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
+    });
+
+    it('still unregisters when the Relay unbind fails and the connection is left in error', async () => {
+      const { server, soClient, unregisterDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: {
+          status: RELAY_APP_CONNECTION_STATUS.connected,
+          apiKeyId: 'key-1',
+          tenantKey: 'tenant-A',
+        },
+      });
+      unbind.mockRejectedValue(new RelayRequestError('/v1/slack/uninstall', 502));
+
+      await expect(new SlackAppService(server).disconnect(request)).rejects.toThrow();
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
+    });
+  });
+
+  describe('reconcileConnector', () => {
+    it('restores the connector for a deployment that is already connected', async () => {
+      const { server, soClient, registerDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({
+        attributes: { status: RELAY_APP_CONNECTION_STATUS.connected, tenantKey: 'tenant-A' },
+      });
+
+      await new SlackAppService(server).reconcileConnector(soClient as never);
+
+      expect(registerDynamicConnector).toHaveBeenCalledWith(
+        expect.objectContaining({ secrets: { authType: 'relay', tenantKey: 'tenant-A' } })
+      );
+    });
+
+    it('registers nothing when there is no connection document', async () => {
+      const { server, soClient, registerDynamicConnector } = createHarness();
+
+      await new SlackAppService(server).reconcileConnector(soClient as never);
+
+      expect(registerDynamicConnector).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [RELAY_APP_CONNECTION_STATUS.oauthInProgress, null],
+      [RELAY_APP_CONNECTION_STATUS.error, null],
+      [RELAY_APP_CONNECTION_STATUS.connected, null],
+    ])('registers nothing for a %s connection without a tenant key', async (status, tenantKey) => {
+      const { server, soClient, registerDynamicConnector } = createHarness();
+      soClient.get.mockResolvedValue({ attributes: { status, tenantKey } });
+
+      await new SlackAppService(server).reconcileConnector(soClient as never);
+
+      expect(registerDynamicConnector).not.toHaveBeenCalled();
+    });
+
+    it('leaves an already correct registration untouched', async () => {
+      const {
+        server,
+        soClient,
+        inMemoryConnectors,
+        registerDynamicConnector,
+        unregisterDynamicConnector,
+      } = createHarness();
+      inMemoryConnectors.push({
+        id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+        secrets: { tenantKey: 'tenant-A' },
+      });
+      soClient.get.mockResolvedValue({
+        attributes: { status: RELAY_APP_CONNECTION_STATUS.connected, tenantKey: 'tenant-A' },
+      });
+
+      await new SlackAppService(server).reconcileConnector(soClient as never);
+
+      expect(registerDynamicConnector).not.toHaveBeenCalled();
+      expect(unregisterDynamicConnector).not.toHaveBeenCalled();
+    });
+
+    it('replaces a registration made for another workspace', async () => {
+      const { server, soClient, inMemoryConnectors } = createHarness();
+      inMemoryConnectors.push({
+        id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+        secrets: { tenantKey: 'tenant-A' },
+      });
+      soClient.get.mockResolvedValue({
+        attributes: { status: RELAY_APP_CONNECTION_STATUS.connected, tenantKey: 'tenant-B' },
+      });
+
+      await new SlackAppService(server).reconcileConnector(soClient as never);
+
+      expect(inMemoryConnectors).toEqual([
+        expect.objectContaining({ secrets: { authType: 'relay', tenantKey: 'tenant-B' } }),
+      ]);
+    });
+
+    it('withdraws a connector left behind by a disconnect on another node', async () => {
+      const { server, soClient, inMemoryConnectors, unregisterDynamicConnector } = createHarness();
+      inMemoryConnectors.push({
+        id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+        secrets: { tenantKey: 'tenant-A' },
+      });
+
+      await new SlackAppService(server).reconcileConnector(soClient as never);
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
+      expect(inMemoryConnectors).toEqual([]);
+    });
+
+    it('withdraws the connector when the app is no longer available', async () => {
+      const { server, soClient, inMemoryConnectors, unregisterDynamicConnector } = createHarness({
+        featureFlagEnabled: false,
+      });
+      inMemoryConnectors.push({
+        id: ELASTIC_APPS_SLACK_CONNECTOR_ID,
+        secrets: { tenantKey: 'tenant-A' },
+      });
+      soClient.get.mockResolvedValue({
+        attributes: { status: RELAY_APP_CONNECTION_STATUS.connected, tenantKey: 'tenant-A' },
+      });
+
+      await new SlackAppService(server).reconcileConnector(soClient as never);
+
+      expect(unregisterDynamicConnector).toHaveBeenCalledWith(ELASTIC_APPS_SLACK_CONNECTOR_ID);
+      expect(soClient.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/lib/slack_app/service.ts
@@ -24,6 +24,11 @@ import {
 } from './saved_object';
 import { SlackAppUnavailableError } from './errors';
 import { getKibanaUrl } from './get_kibana_url';
+import {
+  getRegisteredTenantKey,
+  registerElasticAppsSlackConnector,
+  unregisterElasticAppsSlackConnector,
+} from './connector';
 
 /** Pagination options for a single page of connected channels. */
 export interface ListBindingsOptions {
@@ -60,6 +65,42 @@ export class SlackAppService {
     return this.server.core.savedObjects.getScopedClient(request, {
       includedHiddenTypes: [RELAY_APP_CONNECTION_SO_TYPE],
     });
+  }
+
+  private publishConnector(tenantKey: string): void {
+    registerElasticAppsSlackConnector({
+      actions: this.server.actions,
+      logger: this.logger,
+      tenantKey,
+    });
+  }
+
+  private withdrawConnector(): void {
+    unregisterElasticAppsSlackConnector({ actions: this.server.actions, logger: this.logger });
+  }
+
+  /**
+   * Brings this process's connector in line with the stored connection. In-memory connectors are
+   * per-process, so a connect handled by another node only reaches here. Safe to call repeatedly.
+   */
+  async reconcileConnector(soClient: SavedObjectsClientContract): Promise<void> {
+    // Gated like every request, so disabling the app also withdraws the connector rather than
+    // leaving one that can only fail.
+    const available = await this.getRelayClient();
+    const connection = available ? await this.readConnection(soClient) : undefined;
+    const desiredTenantKey =
+      connection?.status === RELAY_APP_CONNECTION_STATUS.connected
+        ? connection.tenantKey ?? undefined
+        : undefined;
+
+    if (desiredTenantKey === getRegisteredTenantKey(this.server.actions)) {
+      return;
+    }
+    if (!desiredTenantKey) {
+      this.withdrawConnector();
+      return;
+    }
+    this.publishConnector(desiredTenantKey);
   }
 
   private async readConnection(
@@ -218,6 +259,10 @@ export class SlackAppService {
       createdAt: now,
     });
 
+    // The install may land on a different workspace, so any leftover connector now carries a stale
+    // tenant key. Republished once the claim completes.
+    this.withdrawConnector();
+
     return { authorizeUrl: installResponse.authorize_url };
   }
 
@@ -243,6 +288,7 @@ export class SlackAppService {
       apiKeyId: null,
       error: message,
     });
+    this.withdrawConnector();
 
     return { available: true, status: RELAY_APP_CONNECTION_STATUS.error, error: message };
   }
@@ -298,6 +344,7 @@ export class SlackAppService {
             tenantKey: claim.tenant_key,
             status: RELAY_APP_CONNECTION_STATUS.connected,
           });
+          this.publishConnector(claim.tenant_key);
           return { available: true, status: RELAY_APP_CONNECTION_STATUS.connected };
         }
       } catch (error) {
@@ -406,6 +453,10 @@ export class SlackAppService {
     if (!connection) {
       return { status: 'disconnected' };
     }
+
+    // Up front, not on the success path: a failed unbind below leaves the connection in `error` for
+    // the user to retry, and rules must not keep posting through a connection being torn down.
+    this.withdrawConnector();
 
     if (connection.apiKeyId) {
       await this.invalidateApiKey(connection.apiKeyId, 'on disconnect');

--- a/x-pack/platform/plugins/shared/significant_events/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/significant_events/server/plugin.ts
@@ -13,6 +13,7 @@ import type {
   Plugin,
   PluginInitializerContext,
 } from '@kbn/core/server';
+import { SavedObjectsClient } from '@kbn/core/server';
 import { registerRoutes } from '@kbn/server-route-repository';
 import { DEFAULT_SPACE_ID } from '@kbn/core-spaces-common';
 import type { RulesClientCreateOptions } from '@kbn/alerting-plugin/server';
@@ -20,7 +21,11 @@ import { combineLatest, distinctUntilChanged, filter, skip, switchMap } from 'rx
 import type { Subscription } from 'rxjs';
 import type { StreamsServer } from '@kbn/streams-plugin/server/types';
 import { PROJECT_ROUTING_ALL } from '@kbn/cps-server-utils';
-import { getRelayAppConnectionSavedObjectType } from './lib/slack_app/saved_object';
+import {
+  getRelayAppConnectionSavedObjectType,
+  RELAY_APP_CONNECTION_SO_TYPE,
+} from './lib/slack_app/saved_object';
+import { createElasticAppsSlackConnectorPoller } from './lib/slack_app/connector_poller';
 import { getSignificantEventsMaintenanceStateSavedObjectType } from './lib/maintenance/saved_object';
 import {
   createSignificantEventsMaintenanceService,
@@ -384,6 +389,22 @@ export class SignificantEventsPlugin
       this.server.agentBuilder = plugins.agentBuilder;
 
       this.server.relayClient = plugins.actions.getRelayClient();
+
+      // The Elastic Slack connector is in-memory, so it survives neither a restart nor a connect
+      // handled by another node. The connection document is namespace-agnostic, so one internal
+      // client covers the deployment. Relay config is static at start, so skip the poller when the
+      // client is absent rather than ticking a reconcile loop that can never do anything.
+      if (this.server.relayClient) {
+        this.subscriptions.push(
+          createElasticAppsSlackConnectorPoller({
+            server: this.server,
+            logger: this.logger,
+            soClient: new SavedObjectsClient(
+              core.savedObjects.createInternalRepository([RELAY_APP_CONNECTION_SO_TYPE])
+            ),
+          }).subscribe()
+        );
+      }
     }
 
     // Availability is the same requirement registry that gates requests, so a deployment never gets

--- a/x-pack/platform/plugins/shared/significant_events/tsconfig.json
+++ b/x-pack/platform/plugins/shared/significant_events/tsconfig.json
@@ -66,6 +66,7 @@
     "@kbn/licensing-plugin",
     "@kbn/fields-metadata-plugin",
     "@kbn/actions-plugin",
+    "@kbn/connector-specs",
     "@kbn/encrypted-saved-objects-plugin",
     "@kbn/inference-plugin",
     "@kbn/security-plugin",


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/nightshift-program/issues/672

## Summary

Allow a configured Relay connection to be used as a Slack connector.

Context: [Relay](https://github.com/elastic/relay-service) is an Elastic-hosted service that act as a relay between Kibana and third party surfaces and allow bi-directionnal communications (ingesting external surface events and sending them to Kibana) not like EARs service. 

Once the Elastic Slack app is connected, Kibana registers a **Slack (Elastic app)** connector that sends through the Relay. No bot token, or credentials to configure, workflows and agents use it like any other Slack connector. Slack credentials live in Relay and Kibana auth itself to relay using the relay client.


## What it does (AI generated)

- Connecting the Elastic Slack app registers the connector; disconnecting removes it. There is one per deployment, under a stable id, so rules keep working across restarts and reconnects.
- It supports `sendMessage`, `listChannels` and `resolveChannelId` — enough for the alerting rule form's channel picker and for agents. Every other Slack action (search, history, file upload, …) fails immediately with a message naming what *is* supported, instead of reaching Slack unauthenticated and returning an opaque `invalid_auth`.
- `listChannels` returns the channels connected to this deployment rather than the whole workspace, the only ones this connector could post to anyway.
- **Test** proves the Relay still accepts the deployment and the app is still installed in the workspace, since there is no token to validate.
- Users cannot create this connector by hand: the auth method is hidden in the picker and rejected by the create and update APIs.

## Implementation notes (AI generated)

- **New `relay` auth type** in `@kbn/connector-specs`. It holds only a `tenantKey` naming the Slack workspace; the Relay holds the Slack credentials and authenticates the deployment with mTLS. Its `configure` is a deliberate no-op, so if a request ever escapes the relay path it fails rather than going out unauthenticated.
- **Two new declarative flags on auth types**, both resolved through the same lookup as the existing `authMode`. `isInternal` marks a method as provisioned by Kibana rather than picked by a user, and drives the UI and API guards; execution is untouched, so provisioned connectors still run. `usesRelayTransport` decides whether a handler is handed a Relay client at all, so only relay-authenticated executions get one.
- **The connector is in-memory** (`registerDynamicConnector`), which is per-process. A connect handled by one node, or a restart, would otherwise leave other nodes without it — so each node reconciles itself against the stored connection saved object every minute, with the first tick doubling as the startup restore.
- **The Slack spec branches per action**: each handler asks `getRelayConnection(ctx)` and falls straight through when the connector holds its own token, so the existing direct-token path is unchanged.

## How to test

1. Start a local Relay and configure Kibana yo have relay working doc [here](https://codex.elastic.dev/r/relay-service/development/local-development)
2. Connect slack http://localhost:5601/app/streams/_discovery/settings and confirm the connector appears
<img width="500" alt="Screenshot 2026-08-24 at 2 41 52 PM" src="https://github.com/user-attachments/assets/b8c9ad80-8597-404d-a7c0-e11ae57b1776" />


4.. Create a rule with a Slack action and check the channel picker lists your connected channels, then fire it and confirm the message lands, you can do the same with workflow
<img width="500" alt="Screenshot 2026-08-24 at 1 32 44 PM" src="https://github.com/user-attachments/assets/186cf393-3805-4ff6-9fa8-47c8ced408bf" />
<img width="500" alt="Screenshot 2026-08-24 at 1 32 09 PM" src="https://github.com/user-attachments/assets/c1a9f0b0-e01d-4d1c-9ba7-845d13d9054b" />

5. Disconnect http://localhost:5601/app/streams/_discovery/settings and confirm the connector disappears.
6. Restart Kibana while connected — the connector should come back on its own within a minute.
7. Confirm you cannot create one yourself: the Elastic Slack app option is absent from the auth picker, and a create call using it is rejected.



## Not done in that PR/follow up

- In my POCs I added autocomplete for channels in workflow UI, we could do that in other PRs but it should not add to that already big PR.
- We are waiting on that PR https://github.com/elastic/kibana/pull/283299 to block other slack method for relay