### PR TITLE
[Fleet] Reduce log noise in AutoInstallContentPackagesTask

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.test.ts
@@ -345,6 +345,62 @@ describe('AutoInstallContentPackagesTask', () => {
 
         expect(result).toEqual(['system.cpu']);
       });
+
+      it('should log at INFO level on the first run', async () => {
+        (dataStreamService.getAllFleetDataStreamNames as jest.Mock).mockResolvedValue([
+          'logs-system.cpu-default',
+        ]);
+
+        await (mockTask as any).getDatasetsWithData(esClient, []);
+
+        expect((mockTask as any).logger.info).toHaveBeenCalledWith(
+          '[AutoInstallContentPackagesTask] Found 1 datasets with data'
+        );
+        expect((mockTask as any).logger.debug).not.toHaveBeenCalledWith(
+          '[AutoInstallContentPackagesTask] Found 1 datasets with data'
+        );
+      });
+
+      it('should log at DEBUG level on subsequent runs when dataset count is unchanged', async () => {
+        (dataStreamService.getAllFleetDataStreamNames as jest.Mock).mockResolvedValue([
+          'logs-system.cpu-default',
+        ]);
+
+        await (mockTask as any).getDatasetsWithData(esClient, []);
+        jest.clearAllMocks();
+
+        await (mockTask as any).getDatasetsWithData(esClient, []);
+
+        expect((mockTask as any).logger.debug).toHaveBeenCalledWith(
+          '[AutoInstallContentPackagesTask] Found 1 datasets with data'
+        );
+        expect((mockTask as any).logger.info).not.toHaveBeenCalledWith(
+          '[AutoInstallContentPackagesTask] Found 1 datasets with data'
+        );
+      });
+
+      it('should log at INFO level on subsequent runs when dataset count changes', async () => {
+        (dataStreamService.getAllFleetDataStreamNames as jest.Mock).mockResolvedValue([
+          'logs-system.cpu-default',
+        ]);
+
+        await (mockTask as any).getDatasetsWithData(esClient, []);
+        jest.clearAllMocks();
+
+        (dataStreamService.getAllFleetDataStreamNames as jest.Mock).mockResolvedValue([
+          'logs-system.cpu-default',
+          'logs-system.memory-default',
+        ]);
+
+        await (mockTask as any).getDatasetsWithData(esClient, []);
+
+        expect((mockTask as any).logger.info).toHaveBeenCalledWith(
+          '[AutoInstallContentPackagesTask] Found 2 datasets with data'
+        );
+        expect((mockTask as any).logger.debug).not.toHaveBeenCalledWith(
+          '[AutoInstallContentPackagesTask] Found 2 datasets with data'
+        );
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/auto_install_content_packages_task.ts
@@ -63,6 +63,7 @@ export class AutoInstallContentPackagesTask {
   private discoveryMap?: DiscoveryMap;
   private discoveryMapLastFetched: number = 0;
   private lastPrerelease: boolean = false;
+  private lastDatasetsWithDataCount?: number;
 
   constructor(setupContract: AutoInstallContentPackagesTaskSetupContract) {
     const { core, taskManager, logFactory, config } = setupContract;
@@ -314,9 +315,14 @@ export class AutoInstallContentPackagesTask {
     const datasetsWithData = [
       ...new Set(allDataStreamNames.map((name) => name.split('-')[1])),
     ].filter((dataset) => !installedSet.has(dataset));
-    this.logger.info(
-      `[AutoInstallContentPackagesTask] Found ${datasetsWithData.length} datasets with data`
-    );
+    const count = datasetsWithData.length;
+    const message = `[AutoInstallContentPackagesTask] Found ${count} datasets with data`;
+    if (this.lastDatasetsWithDataCount !== count) {
+      this.logger.info(message);
+    } else {
+      this.logger.debug(message);
+    }
+    this.lastDatasetsWithDataCount = count;
     return datasetsWithData;
   }
 


### PR DESCRIPTION
## Summary

Fixes #286618.

The `AutoInstallContentPackagesTask` logs an identical INFO message each time it runs (the default is once every 1 minute) because the number of datasets has not changed from the previous run, causing infinite messages in steady state.

## Changes
Keep track of the number of datasets from the previous run in a class-level field, similar to how we do `lastPrerelease`/`discoveryMapLastFetched`. Only log the message at INFO level if the number of datasets has changed from the previous run (or on the first run after startup); otherwise, use DEBUG. The message body is identical.

## Note
In this change, the comparison is made on dataset *count* rather than dataset *set*. The example use case from the issue description refers to a dataset set that hasn't changed. However, swapping datasets that results in the same number of datasets would not trigger the INFO message using this code change. This note is just to keep in mind for future reference.

Additionally: the suggestion to log at INFO "when packages are actually queued for install" from the issue description is taken care of already by the existing log at line 202 (`Content packages to install: ...`) and is independent of this change.

## Testing
Test cases were written for first-run, no change in count, and change in count use cases. All existing test cases pass; type check/lint passes.

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->