### PR TITLE
[Security Solution][Alert flyout] fix slight vertical alignment in the entities section

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insight_distribution_bar.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/main/components/insight_distribution_bar.tsx
@@ -8,13 +8,13 @@
 import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import {
+  EuiBadge,
   EuiFlexGroup,
+  type EuiFlexGroupProps,
   EuiFlexItem,
   EuiText,
-  EuiBadge,
-  useEuiTheme,
   useEuiFontSize,
-  type EuiFlexGroupProps,
+  useEuiTheme,
 } from '@elastic/eui';
 import { DistributionBar } from '@kbn/security-solution-distribution-bar';
 
@@ -54,7 +54,7 @@ export const InsightDistributionBar: React.FC<InsightDistributionBarProps> = ({
 
   const barComponent = useMemo(
     () => (
-      <EuiFlexGroup gutterSize="xs" responsive={false}>
+      <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
         <EuiFlexItem>
           <DistributionBar
             stats={stats}


### PR DESCRIPTION
## Summary

Fix a small vertical alignment issue in the document details flyout, Insights section, under the Entities subsection.

| Before | After |
| ------------- | ------------- |
| <img width="364" height="300" alt="Screenshot 2026-08-24 at 10 02 04 PM" src="https://github.com/user-attachments/assets/e5fe5fee-0515-412c-b279-900b14a14c5a" /> | <img width="399" height="300" alt="Screenshot 2026-08-24 at 10 01 22 PM" src="https://github.com/user-attachments/assets/e22f871f-4ab0-4132-96e9-3e4d3162874c" /> |

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/286950

<!--ONMERGE {"backportTargets":["9.4","9.5"]} ONMERGE-->