### PR TITLE
[9.5] [Synthetics] Enforce per-space authorization when deleting monitors (#281280)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
@@ -27,7 +27,7 @@ import { normalizeAPIConfig, validateMonitor } from './monitor_validation';
 import { mapSavedObjectToMonitor } from './formatters/saved_object_to_monitor';
 import { getBrowserTimeoutWarningForMonitor } from './monitor_warnings';
 import {
-  assertCanUpdateMonitorInAllSpaces,
+  assertCanPerformMonitorBulkActionInAllSpaces,
   validateMonitorPrivateLocationSpaces,
 } from './monitor_locations_utils';
 
@@ -146,7 +146,10 @@ export const addSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
 
       const monitorSpaces = normalizedMonitor[ConfigKey.KIBANA_SPACES] ?? [];
       if (monitorSpaces.length > 0) {
-        const spaceAuthError = await assertCanUpdateMonitorInAllSpaces(routeContext, monitorSpaces);
+        const spaceAuthError = await assertCanPerformMonitorBulkActionInAllSpaces(
+          routeContext,
+          monitorSpaces
+        );
         if (spaceAuthError) {
           return spaceAuthError;
         }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { deleteSyntheticsMonitorBulkRoute } from './delete_monitor_bulk';
+
+jest.mock('../services/delete_monitor_api', () => ({
+  DeleteMonitorAPI: jest.fn(),
+}));
+
+const installExecuteResult = (executeResult: any) => {
+  const { DeleteMonitorAPI } = jest.requireMock('../services/delete_monitor_api');
+  const execute = jest.fn().mockResolvedValue(executeResult);
+  DeleteMonitorAPI.mockImplementation(() => ({ execute }));
+  return { execute };
+};
+
+const mockRouteContext = () =>
+  ({
+    request: { body: { ids: ['mon-1'] } } as any,
+  } as any);
+
+describe('deleteSyntheticsMonitorBulkRoute', () => {
+  const route = deleteSyntheticsMonitorBulkRoute();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the forbidden response from execute instead of a 200 body', async () => {
+    const forbidden = { status: 403, body: { message: 'no access' } };
+    installExecuteResult({ res: forbidden });
+
+    const result = await route.handler(mockRouteContext());
+
+    expect(result).toBe(forbidden);
+  });
+
+  it('returns result and errors when execute succeeds', async () => {
+    const result = [{ id: 'mon-1', deleted: true }];
+    installExecuteResult({ errors: [], result });
+
+    const response = await route.handler(mockRouteContext());
+
+    expect(response).toEqual({ result, errors: [] });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.ts
@@ -34,9 +34,13 @@ export const deleteSyntheticsMonitorBulkRoute: SyntheticsRestApiRouteFactory<
     const { ids: idsToDelete } = request.body || {};
     const deleteMonitorAPI = new DeleteMonitorAPI(routeContext);
 
-    const { errors, result } = await deleteMonitorAPI.execute({
+    const { errors, result, res } = await deleteMonitorAPI.execute({
       monitorIds: idsToDelete,
     });
+
+    if (res) {
+      return res;
+    }
 
     return { result, errors };
   },

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { deleteSyntheticsMonitorRoute } from './delete_monitor';
+
+jest.mock('./services/delete_monitor_api', () => ({
+  DeleteMonitorAPI: jest.fn(),
+}));
+
+const installExecuteResult = (executeResult: any, result: unknown = []) => {
+  const { DeleteMonitorAPI } = jest.requireMock('./services/delete_monitor_api');
+  const execute = jest.fn().mockResolvedValue(executeResult);
+  DeleteMonitorAPI.mockImplementation(() => ({ execute, result }));
+  return { execute };
+};
+
+const mockRouteContext = () =>
+  ({
+    request: { body: { ids: ['mon-1'] }, params: {} } as any,
+    response: {
+      ok: jest.fn((opts: any) => ({ status: 200, ...opts })),
+      badRequest: jest.fn((opts: any) => ({ status: 400, ...opts })),
+    } as any,
+  } as any);
+
+describe('deleteSyntheticsMonitorRoute', () => {
+  const route = deleteSyntheticsMonitorRoute();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the forbidden response from execute instead of a 200', async () => {
+    const forbidden = { status: 403, body: { message: 'no access' } };
+    installExecuteResult({ res: forbidden });
+
+    const result = await route.handler(mockRouteContext());
+
+    expect(result).toBe(forbidden);
+  });
+
+  it('returns the collected result when execute succeeds', async () => {
+    installExecuteResult({ errors: [] }, [{ id: 'mon-1', deleted: true }]);
+
+    const result = await route.handler(mockRouteContext());
+
+    expect(result).toEqual([{ id: 'mon-1', deleted: true }]);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
@@ -62,9 +62,13 @@ export const deleteSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory<
     }
 
     const deleteMonitorAPI = new DeleteMonitorAPI(routeContext);
-    const { errors } = await deleteMonitorAPI.execute({
+    const { errors, res } = await deleteMonitorAPI.execute({
       monitorIds: idsToDelete,
     });
+
+    if (res) {
+      return res;
+    }
 
     if (errors && errors.length > 0) {
       return response.ok({

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.test.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import { syncEditedMonitor } from './edit_monitor';
+import { editSyntheticsMonitorRoute, syncEditedMonitor } from './edit_monitor';
 import type { SavedObject } from '@kbn/core/server';
 import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
+import { ConfigKey } from '../../../common/runtime_types';
 import type {
   EncryptedSyntheticsMonitorAttributes,
   SyntheticsMonitor,
@@ -22,6 +23,28 @@ jest.mock('@kbn/fleet-plugin/server/services/package_policy', () => ({
 jest.mock('../telemetry/monitor_upgrade_sender', () => ({
   sendTelemetryEvents: jest.fn(),
   formatTelemetryUpdateEvent: jest.fn(),
+}));
+
+// Only used by editSyntheticsMonitorRoute (not syncEditedMonitor, tested below),
+// mocked here to reach the route's space-authorization check without exercising
+// the full monitor/location validation and normalization pipeline.
+jest.mock('./monitor_locations_utils', () => ({
+  assertCanPerformMonitorBulkActionInAllSpaces: jest.fn(),
+  validateMonitorPrivateLocationSpaces: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('./monitor_validation', () => {
+  const actual = jest.requireActual('./monitor_validation');
+  return {
+    ...actual,
+    validateMonitor: jest.fn(),
+    normalizeAPIConfig: jest.fn(),
+  };
+});
+
+jest.mock('./formatters/saved_object_to_monitor', () => ({
+  mergeSourceMonitor: jest.fn(),
+  mapSavedObjectToMonitor: jest.fn(),
 }));
 
 describe('syncEditedMonitor', () => {
@@ -152,5 +175,82 @@ describe('syncEditedMonitor', () => {
       expect.any(Object),
       expect.objectContaining({ references: undefined })
     );
+  });
+});
+
+describe('editSyntheticsMonitorRoute', () => {
+  const monitorId = '7af7e2f0-d5dc-11ec-87ac-bdfdb894c53d';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const { validateMonitor, normalizeAPIConfig } = jest.requireMock('./monitor_validation');
+    normalizeAPIConfig.mockImplementation((m: Record<string, unknown>) => ({ formattedConfig: m }));
+    validateMonitor.mockImplementation((m: Record<string, unknown>) => ({
+      valid: true,
+      reason: '',
+      details: '',
+      payload: m,
+      decodedMonitor: m,
+    }));
+
+    // Drop the previous monitor's `locations` from the merge so the edit is
+    // treated as a private-only, location-unchanged update - keeping this test
+    // focused on space authorization instead of the location-parsing paths.
+    const { mergeSourceMonitor } = jest.requireMock('./formatters/saved_object_to_monitor');
+    mergeSourceMonitor.mockImplementation(
+      (prevAttrs: Record<string, unknown>, patch: Record<string, unknown>) => {
+        const { locations, ...restPrev } = prevAttrs;
+        return { ...restPrev, ...patch };
+      }
+    );
+  });
+
+  it("authorizes the union of the monitor's previous and newly-submitted spaces, not just the new ones", async () => {
+    const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+      './monitor_locations_utils'
+    );
+    const forbidden = { status: 403 };
+    assertCanPerformMonitorBulkActionInAllSpaces.mockResolvedValue(forbidden);
+
+    const { routeContext } = getRouteContextMock();
+    routeContext.request = {
+      params: { monitorId },
+      query: {},
+      body: { [ConfigKey.KIBANA_SPACES]: ['space-a'] },
+    } as any;
+    routeContext.spaceId = 'default';
+    routeContext.monitorConfigRepository.getDecrypted = jest.fn().mockResolvedValue({
+      decryptedMonitor: {
+        id: monitorId,
+        type: 'synthetics-monitor-multi-space',
+        // The monitor currently lives in both spaces; the request below drops
+        // 'space-b' from KIBANA_SPACES without the caller having update rights
+        // there.
+        namespaces: ['space-a', 'space-b'],
+      },
+      normalizedMonitor: {
+        id: monitorId,
+        attributes: {
+          origin: 'ui',
+          [ConfigKey.MONITOR_TYPE]: 'http',
+          [ConfigKey.REVISION]: 3,
+          locations: [
+            { id: 'pl-1', label: 'PL 1', isServiceManaged: false, agentPolicyId: 'ap-1' },
+          ],
+        },
+      },
+    });
+
+    const result = await editSyntheticsMonitorRoute().handler(routeContext);
+
+    expect(result).toBe(forbidden);
+    expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledTimes(1);
+    const [, spacesArg] = assertCanPerformMonitorBulkActionInAllSpaces.mock.calls[0];
+    // 'space-b' was dropped from the submitted payload but must still be
+    // authorized - removing a monitor from a space is itself a change that
+    // requires bulk_update privileges there.
+    expect(spacesArg).toEqual(expect.arrayContaining(['space-a', 'space-b']));
+    expect(spacesArg).toHaveLength(2);
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
@@ -22,7 +22,7 @@ import { ELASTIC_MANAGED_LOCATIONS_DISABLED } from './project_monitor/add_monito
 import { getPrivateLocationsForNamespaces } from '../../synthetics_service/get_private_locations';
 import { mergeSourceMonitor } from './formatters/saved_object_to_monitor';
 import {
-  assertCanUpdateMonitorInAllSpaces,
+  assertCanPerformMonitorBulkActionInAllSpaces,
   validateMonitorPrivateLocationSpaces,
 } from './monitor_locations_utils';
 import type { RouteContext, SyntheticsRestApiRouteFactory } from '../types';
@@ -154,11 +154,14 @@ export const editSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => (
         });
       }
 
-      const editedMonitorSpaces = (editedMonitor as MonitorFields)[ConfigKey.KIBANA_SPACES] ?? [];
-      if (editedMonitorSpaces.length > 0) {
-        const spaceAuthError = await assertCanUpdateMonitorInAllSpaces(
+      const editedMonitorSpaces = new Set([
+        ...(decryptedMonitorPrevMonitor.namespaces ?? []),
+        ...((editedMonitor as MonitorFields)[ConfigKey.KIBANA_SPACES] ?? []),
+      ]);
+      if (editedMonitorSpaces.size > 0) {
+        const spaceAuthError = await assertCanPerformMonitorBulkActionInAllSpaces(
           routeContext,
-          editedMonitorSpaces,
+          [...editedMonitorSpaces],
           decryptedMonitorPrevMonitor.type
         );
         if (spaceAuthError) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_locations_utils.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_locations_utils.test.ts
@@ -6,11 +6,13 @@
  */
 
 import {
+  assertCanPerformMonitorBulkActionInAllSpaces,
   privateLocationCoversAllMonitorSpaces,
   validateMonitorPrivateLocationSpaces,
 } from './monitor_locations_utils';
 import { ConfigKey } from '../../../common/runtime_types';
 import type { MonitorFields, SyntheticsPrivateLocations } from '../../../common/runtime_types';
+import type { RouteContext } from '../types';
 
 describe('privateLocationCoversAllMonitorSpaces', () => {
   it('returns false when locationSpaces is undefined', () => {
@@ -202,5 +204,72 @@ describe('validateMonitorPrivateLocationSpaces', () => {
       { id: 'private-loc-1', label: 'Private Location 1', spaces: ['space-a'] },
     ]);
     expect(validateMonitorPrivateLocationSpaces(monitor, privateLocations)).toBeNull();
+  });
+});
+
+describe('assertCanPerformMonitorBulkActionInAllSpaces', () => {
+  const createRouteContext = (hasAllRequested: boolean) => {
+    const checkSavedObjectsPrivileges = jest.fn().mockResolvedValue({ hasAllRequested });
+    const forbidden = jest.fn(({ body }) => ({ status: 403, body }));
+
+    return {
+      routeContext: {
+        request: {},
+        response: { forbidden },
+        spaceId: 'default',
+        server: {
+          security: {
+            authz: {
+              checkSavedObjectsPrivilegesWithRequest: jest
+                .fn()
+                .mockReturnValue(checkSavedObjectsPrivileges),
+            },
+          },
+        },
+      } as unknown as RouteContext,
+      checkSavedObjectsPrivileges,
+    };
+  };
+
+  it('checks bulk_update privileges by default', async () => {
+    const { routeContext, checkSavedObjectsPrivileges } = createRouteContext(true);
+
+    await assertCanPerformMonitorBulkActionInAllSpaces(routeContext, ['default', 'other-space']);
+
+    expect(checkSavedObjectsPrivileges).toHaveBeenCalledWith(
+      'saved_object:synthetics-monitor-multi-space/bulk_update',
+      ['default', 'other-space']
+    );
+  });
+
+  it('checks bulk_delete privileges and returns delete-specific copy', async () => {
+    const { routeContext, checkSavedObjectsPrivileges } = createRouteContext(false);
+
+    const result = await assertCanPerformMonitorBulkActionInAllSpaces(
+      routeContext,
+      ['default', 'other-space'],
+      'synthetics-monitor',
+      'bulk_delete'
+    );
+
+    expect(checkSavedObjectsPrivileges).toHaveBeenCalledWith(
+      'saved_object:synthetics-monitor/bulk_delete',
+      ['default', 'other-space']
+    );
+    expect(result).toEqual({
+      status: 403,
+      body: {
+        message:
+          'This monitor is shared to spaces where you do not have delete permissions. To delete it, request access to those spaces.',
+      },
+    });
+  });
+
+  it('does not check privileges when no spaces are provided', async () => {
+    const { routeContext, checkSavedObjectsPrivileges } = createRouteContext(true);
+
+    await assertCanPerformMonitorBulkActionInAllSpaces(routeContext, []);
+
+    expect(checkSavedObjectsPrivileges).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_locations_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_locations_utils.ts
@@ -114,14 +114,14 @@ export const validateMonitorPrivateLocationSpaces = (
   };
 };
 
-/**
- * Asserts that the current user has bulk_update privileges on the monitor saved object
- * in all the specified spaces. Returns a 403 response if not authorized, or undefined if OK.
- */
-export const assertCanUpdateMonitorInAllSpaces = async (
+type MonitorSavedObjectBulkAction = 'bulk_update' | 'bulk_delete';
+
+/** Asserts that the current user has the requested privileges in all specified spaces. */
+export const assertCanPerformMonitorBulkActionInAllSpaces = async (
   routeContext: RouteContext,
   spaceIds: string[],
-  savedObjectType: string = syntheticsMonitorSavedObjectType
+  savedObjectType: string = syntheticsMonitorSavedObjectType,
+  action: MonitorSavedObjectBulkAction = 'bulk_update'
 ) => {
   const { request, response, server, spaceId } = routeContext;
 
@@ -139,17 +139,23 @@ export const assertCanUpdateMonitorInAllSpaces = async (
     server.security.authz.checkSavedObjectsPrivilegesWithRequest(request);
 
   const { hasAllRequested } = await checkSavedObjectsPrivileges(
-    `saved_object:${savedObjectType}/bulk_update`,
+    `saved_object:${savedObjectType}/${action}`,
     uniqueSpaces
   );
 
   if (!hasAllRequested) {
+    const isDeleteAction = action === 'bulk_delete';
     return response.forbidden({
       body: {
-        message: i18n.translate('xpack.synthetics.validation.multiSpacePermissions', {
-          defaultMessage:
-            'This monitor is shared to spaces where you do not have update permissions. To save changes, either request access to those spaces or remove them from the monitor.',
-        }),
+        message: isDeleteAction
+          ? i18n.translate('xpack.synthetics.validation.multiSpaceDeletePermissions', {
+              defaultMessage:
+                'This monitor is shared to spaces where you do not have delete permissions. To delete it, request access to those spaces.',
+            })
+          : i18n.translate('xpack.synthetics.validation.multiSpacePermissions', {
+              defaultMessage:
+                'This monitor is shared to spaces where you do not have update permissions. To save changes, either request access to those spaces or remove them from the monitor.',
+            }),
       },
     });
   }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/add_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/add_monitor_project.ts
@@ -20,7 +20,7 @@ import type { ProjectMonitor } from '../../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { ProjectMonitorFormatter } from '../../../synthetics_service/project_monitor/project_monitor_formatter';
 import { getBrowserTimeoutWarningsForProjectMonitors } from '../monitor_warnings';
-import { assertCanUpdateMonitorInAllSpaces } from '../monitor_locations_utils';
+import { assertCanPerformMonitorBulkActionInAllSpaces } from '../monitor_locations_utils';
 
 const MAX_PAYLOAD_SIZE = 1048576 * 100; // 50MiB
 const MAX_BROWSER_MONITORS = 250;
@@ -181,7 +181,10 @@ const validMultiSpacePrivileges = async (
 ) => {
   const spacesList = [...new Set(monitors.flatMap((monitor) => monitor.spaces ?? []))];
   if (spacesList.length > 0) {
-    const spaceAuthError = await assertCanUpdateMonitorInAllSpaces(routeContext, spacesList);
+    const spaceAuthError = await assertCanPerformMonitorBulkActionInAllSpaces(
+      routeContext,
+      spacesList
+    );
     if (spaceAuthError) {
       throw spaceAuthError;
     }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObject } from '@kbn/core-saved-objects-server';
+import type { EncryptedSyntheticsMonitorAttributes } from '../../../../common/runtime_types';
+import type { RouteContext } from '../../types';
+import { deleteSyntheticsMonitorProjectRoute } from './delete_monitor_project';
+
+jest.mock('../services/delete_monitor_api', () => ({
+  DeleteMonitorAPI: jest.fn(),
+}));
+
+jest.mock('../services/validate_space_id', () => ({
+  validateSpaceId: jest.fn().mockResolvedValue(undefined),
+}));
+
+const monitor = {
+  id: 'config-id',
+  type: 'synthetics-monitor',
+  attributes: {},
+  references: [],
+} as unknown as SavedObject<EncryptedSyntheticsMonitorAttributes>;
+
+const createRouteContext = () =>
+  ({
+    request: {
+      params: { projectName: 'project-name' },
+      body: { monitors: ['journey-id'] },
+    },
+    monitorConfigRepository: {
+      find: jest.fn().mockResolvedValue({ saved_objects: [monitor] }),
+    },
+  } as unknown as RouteContext<
+    { projectName: string },
+    Record<string, never>,
+    { monitors: string[] }
+  >);
+
+const installExecuteResult = (executeResult: object) => {
+  const { DeleteMonitorAPI } = jest.requireMock('../services/delete_monitor_api');
+  const execute = jest.fn().mockResolvedValue(executeResult);
+  DeleteMonitorAPI.mockImplementation(() => ({ execute }));
+  return { execute };
+};
+
+describe('deleteSyntheticsMonitorProjectRoute', () => {
+  const route = deleteSyntheticsMonitorProjectRoute();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes the filtered monitors through the authorized execution path', async () => {
+    const { execute } = installExecuteResult({ errors: [], result: [] });
+
+    const result = await route.handler(createRouteContext());
+
+    expect(execute).toHaveBeenCalledWith({ monitorIds: ['config-id'] });
+    expect(result).toEqual({ deleted_monitors: ['journey-id'] });
+  });
+
+  it('returns the forbidden response from the authorized execution path', async () => {
+    const forbidden = { status: 403, body: { message: 'no access' } };
+    installExecuteResult({ res: forbidden });
+
+    const result = await route.handler(createRouteContext());
+
+    expect(result).toBe(forbidden);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.ts
@@ -50,9 +50,13 @@ export const deleteSyntheticsMonitorProjectRoute: SyntheticsRestApiRouteFactory 
 
     const deleteMonitorAPI = new DeleteMonitorAPI(routeContext);
 
-    await deleteMonitorAPI.deleteMonitorBulk({
-      monitors,
+    const { res } = await deleteMonitorAPI.execute({
+      monitorIds: monitors.map(({ id }) => id),
     });
+
+    if (res) {
+      return res;
+    }
 
     return {
       deleted_monitors: monitorsToDelete,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.test.ts
@@ -1,0 +1,267 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObject } from '@kbn/core-saved-objects-server';
+import type { EncryptedSyntheticsMonitorAttributes } from '../../../../common/runtime_types';
+import { DeleteMonitorAPI } from './delete_monitor_api';
+
+jest.mock('../edit_monitor', () => ({
+  validatePermissions: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../monitor_locations_utils', () => ({
+  assertCanPerformMonitorBulkActionInAllSpaces: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../telemetry/monitor_upgrade_sender', () => ({
+  formatTelemetryDeleteEvent: jest.fn().mockReturnValue({}),
+  sendTelemetryEvents: jest.fn(),
+  sendErrorTelemetryEvents: jest.fn(),
+}));
+
+const mockMonitor = (
+  id: string,
+  namespaces?: string[],
+  type = 'synthetics-monitor'
+): SavedObject<EncryptedSyntheticsMonitorAttributes> => ({
+  id,
+  type,
+  references: [],
+  ...(namespaces ? { namespaces } : {}),
+  attributes: {
+    id,
+    locations: [{ id: 'loc-1', isServiceManaged: false }],
+  } as EncryptedSyntheticsMonitorAttributes,
+});
+
+const createMockRouteContext = () => {
+  const deleteMonitors = jest.fn().mockResolvedValue([]);
+  const bulkDelete = jest.fn().mockResolvedValue({ statuses: [] });
+  const getDecrypted = jest.fn();
+
+  return {
+    routeContext: {
+      request: {} as any,
+      response: {
+        forbidden: jest.fn((opts: any) => ({ status: 403, ...opts })),
+        ok: jest.fn((opts: any) => opts),
+      } as any,
+      spaceId: 'default',
+      server: {
+        logger: { error: jest.fn() },
+        telemetry: {},
+        stackVersion: '9.5.0',
+      } as any,
+      savedObjectsClient: {} as any,
+      syntheticsMonitorClient: {
+        deleteMonitors,
+      } as any,
+      monitorConfigRepository: {
+        getDecrypted,
+        bulkDelete,
+      } as any,
+    } as any,
+    mocks: { deleteMonitors, bulkDelete, getDecrypted },
+  };
+};
+
+describe('DeleteMonitorAPI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { validatePermissions } = jest.requireMock('../edit_monitor');
+    const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+      '../monitor_locations_utils'
+    );
+    validatePermissions.mockResolvedValue(null);
+    assertCanPerformMonitorBulkActionInAllSpaces.mockResolvedValue(undefined);
+  });
+
+  describe('per-space authorization', () => {
+    it('asserts delete privileges in all monitor spaces before deleting', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({
+        normalizedMonitor: mockMonitor('mon-1', ['default', 'other-space']),
+      });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        ['default', 'other-space'],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+
+    it('authorizes and deletes provided monitors without loading them again', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      const monitor = mockMonitor('mon-1', ['default', 'other-space']);
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.executeWithMonitors({ monitors: [monitor] });
+
+      expect(mocks.getDecrypted).not.toHaveBeenCalled();
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        ['default', 'other-space'],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+
+    it('checks spaces from the saved object namespaces, not the spaces attribute', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      // Authoritative namespaces include a space the (drifted) attribute would omit.
+      const monitor = mockMonitor('mon-1', ['default', 'shared-via-so-api']);
+      (monitor.attributes as any).spaces = ['default'];
+      mocks.getDecrypted.mockResolvedValue({ normalizedMonitor: monitor });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        ['default', 'shared-via-so-api'],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+    });
+
+    it('handles monitors shared to all spaces', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({ normalizedMonitor: mockMonitor('mon-1', ['*']) });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        ['*'],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the forbidden response and does not delete when a space check fails', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const forbidden = { status: 403, body: { message: 'no access' } };
+      assertCanPerformMonitorBulkActionInAllSpaces.mockResolvedValue(forbidden);
+
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({
+        normalizedMonitor: mockMonitor('mon-1', ['default', 'restricted-space']),
+      });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      const { res } = await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(res).toBe(forbidden);
+      expect(mocks.deleteMonitors).not.toHaveBeenCalled();
+      expect(mocks.bulkDelete).not.toHaveBeenCalled();
+    });
+
+    it('aborts the whole batch when a later monitor fails the space check', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const forbidden = { status: 403, body: { message: 'no access' } };
+      assertCanPerformMonitorBulkActionInAllSpaces
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(forbidden);
+
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-1', ['default', 'space-a']) })
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-2', ['default', 'space-b']) });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      const { res } = await api.execute({ monitorIds: ['mon-1', 'mon-2'] });
+
+      expect(res).toBe(forbidden);
+      expect(mocks.deleteMonitors).not.toHaveBeenCalled();
+      expect(mocks.bulkDelete).not.toHaveBeenCalled();
+    });
+
+    it('delegates the empty-space early return to the authorization helper', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({ normalizedMonitor: mockMonitor('mon-1') });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        [],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+
+    it('dedupes the privilege check across monitors sharing the same type and spaces', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-1', ['default', 'space-a']) })
+        // Same spaces, different order — should still be treated as the same key.
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-2', ['space-a', 'default']) })
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-3', ['default', 'space-b']) });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1', 'mon-2', 'mon-3'] });
+
+      // Two distinct space sets -> two checks, not three.
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledTimes(2);
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('location permissions', () => {
+    it('returns forbidden when validatePermissions fails, without checking spaces', async () => {
+      const { validatePermissions } = jest.requireMock('../edit_monitor');
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      validatePermissions.mockResolvedValue('Insufficient permissions');
+
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({
+        normalizedMonitor: mockMonitor('mon-1', ['default', 'other-space']),
+      });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      const { res } = await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(res).toEqual(expect.objectContaining({ status: 403 }));
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).not.toHaveBeenCalled();
+      expect(mocks.deleteMonitors).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.ts
@@ -10,6 +10,7 @@ import type { SavedObject } from '@kbn/core-saved-objects-server';
 import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { syntheticsMonitorSavedObjectType } from '../../../../common/types/saved_objects';
 import { validatePermissions } from '../edit_monitor';
+import { assertCanPerformMonitorBulkActionInAllSpaces } from '../monitor_locations_utils';
 import type {
   EncryptedSyntheticsMonitorAttributes,
   MonitorFields,
@@ -24,6 +25,8 @@ import {
 } from '../../telemetry/monitor_upgrade_sender';
 import type { RouteContext } from '../../types';
 
+type MonitorSavedObject = SavedObject<SyntheticsMonitor | EncryptedSyntheticsMonitorAttributes>;
+
 export class DeleteMonitorAPI {
   routeContext: RouteContext;
   result: Array<{ id: string; deleted: boolean; error?: string }> = [];
@@ -32,7 +35,7 @@ export class DeleteMonitorAPI {
   }
 
   async getMonitorsToDelete(monitorIds: string[]) {
-    const result: Array<SavedObject<SyntheticsMonitor | EncryptedSyntheticsMonitorAttributes>> = [];
+    const result: MonitorSavedObject[] = [];
     await pMap(
       monitorIds,
       async (monitorId) => {
@@ -82,9 +85,18 @@ export class DeleteMonitorAPI {
   }
 
   async execute({ monitorIds }: { monitorIds: string[] }) {
+    const monitors = await this.getMonitorsToDelete(monitorIds);
+
+    return this.executeWithMonitors({ monitors });
+  }
+
+  async executeWithMonitors({ monitors }: { monitors: MonitorSavedObject[] }) {
     const { response, server } = this.routeContext;
 
-    const monitors = await this.getMonitorsToDelete(monitorIds);
+    // Dedup the per-space privilege check across monitors that share the same
+    // saved-object type and space set, so a bulk delete issues one privilege
+    // round-trip per distinct (type, spaces) combination instead of one per monitor.
+    const checkedSpaceKeys = new Set<string>();
     for (const monitor of monitors) {
       const err = await validatePermissions(this.routeContext, monitor.attributes.locations);
       if (err) {
@@ -95,6 +107,24 @@ export class DeleteMonitorAPI {
             },
           }),
         };
+      }
+
+      // Use the saved object's authoritative `namespaces` rather than the
+      // denormalized `spaces` attribute, which can drift (e.g. when a monitor
+      // is shared via the generic saved-objects share API).
+      const monitorSpaces = monitor.namespaces ?? [];
+      const spaceKey = `${monitor.type}::${[...new Set(monitorSpaces)].sort().join(',')}`;
+      if (!checkedSpaceKeys.has(spaceKey)) {
+        checkedSpaceKeys.add(spaceKey);
+        const spaceAuthError = await assertCanPerformMonitorBulkActionInAllSpaces(
+          this.routeContext,
+          monitorSpaces,
+          monitor.type,
+          'bulk_delete'
+        );
+        if (spaceAuthError) {
+          return { res: spaceAuthError };
+        }
       }
     }
 
@@ -119,11 +149,7 @@ export class DeleteMonitorAPI {
     }
   }
 
-  async deleteMonitorBulk({
-    monitors,
-  }: {
-    monitors: Array<SavedObject<SyntheticsMonitor | EncryptedSyntheticsMonitorAttributes>>;
-  }) {
+  async deleteMonitorBulk({ monitors }: { monitors: MonitorSavedObject[] }) {
     const { server, spaceId, syntheticsMonitorClient } = this.routeContext;
     const { logger, telemetry, stackVersion } = server;
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/update_monitor_api.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/update_monitor_api.test.ts
@@ -29,7 +29,7 @@ jest.mock('../project_monitor/add_monitor_project', () => ({
 }));
 
 jest.mock('../monitor_locations_utils', () => ({
-  assertCanUpdateMonitorInAllSpaces: jest.fn().mockResolvedValue(undefined),
+  assertCanPerformMonitorBulkActionInAllSpaces: jest.fn().mockResolvedValue(undefined),
   validateMonitorPrivateLocationSpaces: jest.fn().mockReturnValue(null),
 }));
 
@@ -156,9 +156,9 @@ describe('UpdateMonitorAPI', () => {
       canManagePrivateLocations: true,
     });
 
-    const { assertCanUpdateMonitorInAllSpaces, validateMonitorPrivateLocationSpaces } =
+    const { assertCanPerformMonitorBulkActionInAllSpaces, validateMonitorPrivateLocationSpaces } =
       jest.requireMock('../monitor_locations_utils');
-    assertCanUpdateMonitorInAllSpaces.mockResolvedValue(undefined);
+    assertCanPerformMonitorBulkActionInAllSpaces.mockResolvedValue(undefined);
     validateMonitorPrivateLocationSpaces.mockReturnValue(null);
 
     const { getPrivateLocationsForNamespaces } = jest.requireMock(
@@ -562,8 +562,10 @@ describe('UpdateMonitorAPI', () => {
     });
 
     it('records multi-space privilege failures (without leaking the response object)', async () => {
-      const { assertCanUpdateMonitorInAllSpaces } = jest.requireMock('../monitor_locations_utils');
-      assertCanUpdateMonitorInAllSpaces.mockResolvedValue({ status: 403 });
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      assertCanPerformMonitorBulkActionInAllSpaces.mockResolvedValue({ status: 403 });
 
       const { routeContext, mocks } = createMockRouteContext();
       mocks.findDecryptedMonitors.mockResolvedValue([
@@ -694,7 +696,9 @@ describe('UpdateMonitorAPI', () => {
     });
 
     it('checks bulk_update space privileges once per unique space set', async () => {
-      const { assertCanUpdateMonitorInAllSpaces } = jest.requireMock('../monitor_locations_utils');
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
 
       const { routeContext, mocks } = createMockRouteContext();
       mocks.findDecryptedMonitors.mockResolvedValue([
@@ -720,7 +724,7 @@ describe('UpdateMonitorAPI', () => {
 
       expect(result.survivors).toHaveLength(3);
       // two distinct space sets -> two privilege checks, not three
-      expect(assertCanUpdateMonitorInAllSpaces).toHaveBeenCalledTimes(2);
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/update_monitor_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/update_monitor_api.ts
@@ -19,7 +19,7 @@ import { getSavedObjectKqlFilter } from '../../common';
 import type { MonitorConfigUpdate } from '../bulk_cruds/edit_monitor_bulk';
 import { mergeSourceMonitor } from '../formatters/saved_object_to_monitor';
 import {
-  assertCanUpdateMonitorInAllSpaces,
+  assertCanPerformMonitorBulkActionInAllSpaces,
   validateMonitorPrivateLocationSpaces,
 } from '../monitor_locations_utils';
 import { normalizeAPIConfig, validateMonitor } from '../monitor_validation';
@@ -77,7 +77,7 @@ export class UpdateMonitorAPI {
   private locationPermissionsPromise?: ReturnType<typeof validateLocationPermissions>;
   private readonly spacePermissionCache = new Map<
     string,
-    ReturnType<typeof assertCanUpdateMonitorInAllSpaces>
+    ReturnType<typeof assertCanPerformMonitorBulkActionInAllSpaces>
   >();
 
   constructor(routeContext: RouteContext) {
@@ -392,7 +392,7 @@ export class UpdateMonitorAPI {
     }
 
     /*
-     * `assertCanUpdateMonitorInAllSpaces` returns a Kibana response object on
+     * `assertCanPerformMonitorBulkActionInAllSpaces` returns a Kibana response object on
      * failure (designed for single-PUT early-return). We can't put that in a
      * per-id slot, so collapse to a generic forbidden message. The privilege
      * was already audit-logged by core.
@@ -414,11 +414,15 @@ export class UpdateMonitorAPI {
   private assertCanUpdateInSpaces(
     spaceIds: string[],
     savedObjectType: string
-  ): ReturnType<typeof assertCanUpdateMonitorInAllSpaces> {
+  ): ReturnType<typeof assertCanPerformMonitorBulkActionInAllSpaces> {
     const key = `${savedObjectType}::${[...new Set(spaceIds)].sort().join(',')}`;
     let cached = this.spacePermissionCache.get(key);
     if (!cached) {
-      cached = assertCanUpdateMonitorInAllSpaces(this.routeContext, spaceIds, savedObjectType);
+      cached = assertCanPerformMonitorBulkActionInAllSpaces(
+        this.routeContext,
+        spaceIds,
+        savedObjectType
+      );
       this.spacePermissionCache.set(key, cached);
     }
     return cached;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Synthetics] Enforce per-space authorization when deleting monitors (#281280)](https://github.com/elastic/kibana/pull/281280)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)


