### PR TITLE
[8.19] [Synthetics] Enforce per-space authorization when deleting monitors (#281280)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { deleteSyntheticsMonitorBulkRoute } from './delete_monitor_bulk';
+
+jest.mock('../services/delete_monitor_api', () => ({
+  DeleteMonitorAPI: jest.fn(),
+}));
+
+const installExecuteResult = (executeResult: any) => {
+  const { DeleteMonitorAPI } = jest.requireMock('../services/delete_monitor_api');
+  const execute = jest.fn().mockResolvedValue(executeResult);
+  DeleteMonitorAPI.mockImplementation(() => ({ execute }));
+  return { execute };
+};
+
+const mockRouteContext = () =>
+  ({
+    request: { body: { ids: ['mon-1'] } } as any,
+  } as any);
+
+describe('deleteSyntheticsMonitorBulkRoute', () => {
+  const route = deleteSyntheticsMonitorBulkRoute();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the forbidden response from execute instead of a 200 body', async () => {
+    const forbidden = { status: 403, body: { message: 'no access' } };
+    installExecuteResult({ res: forbidden });
+
+    const result = await route.handler(mockRouteContext());
+
+    expect(result).toBe(forbidden);
+  });
+
+  it('returns result and errors when execute succeeds', async () => {
+    const result = [{ id: 'mon-1', deleted: true }];
+    installExecuteResult({ errors: [], result });
+
+    const response = await route.handler(mockRouteContext());
+
+    expect(response).toEqual({ result, errors: [] });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/bulk_cruds/delete_monitor_bulk.ts
@@ -34,9 +34,13 @@ export const deleteSyntheticsMonitorBulkRoute: SyntheticsRestApiRouteFactory<
     const { ids: idsToDelete } = request.body || {};
     const deleteMonitorAPI = new DeleteMonitorAPI(routeContext);
 
-    const { errors, result } = await deleteMonitorAPI.execute({
+    const { errors, result, res } = await deleteMonitorAPI.execute({
       monitorIds: idsToDelete,
     });
+
+    if (res) {
+      return res;
+    }
 
     return { result, errors };
   },

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { deleteSyntheticsMonitorRoute } from './delete_monitor';
+
+jest.mock('./services/delete_monitor_api', () => ({
+  DeleteMonitorAPI: jest.fn(),
+}));
+
+const installExecuteResult = (executeResult: any, result: unknown = []) => {
+  const { DeleteMonitorAPI } = jest.requireMock('./services/delete_monitor_api');
+  const execute = jest.fn().mockResolvedValue(executeResult);
+  DeleteMonitorAPI.mockImplementation(() => ({ execute, result }));
+  return { execute };
+};
+
+const mockRouteContext = () =>
+  ({
+    request: { body: { ids: ['mon-1'] }, params: {} } as any,
+    response: {
+      ok: jest.fn((opts: any) => ({ status: 200, ...opts })),
+      badRequest: jest.fn((opts: any) => ({ status: 400, ...opts })),
+    } as any,
+  } as any);
+
+describe('deleteSyntheticsMonitorRoute', () => {
+  const route = deleteSyntheticsMonitorRoute();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the forbidden response from execute instead of a 200', async () => {
+    const forbidden = { status: 403, body: { message: 'no access' } };
+    installExecuteResult({ res: forbidden });
+
+    const result = await route.handler(mockRouteContext());
+
+    expect(result).toBe(forbidden);
+  });
+
+  it('returns the collected result when execute succeeds', async () => {
+    installExecuteResult({ errors: [] }, [{ id: 'mon-1', deleted: true }]);
+
+    const result = await route.handler(mockRouteContext());
+
+    expect(result).toEqual([{ id: 'mon-1', deleted: true }]);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
@@ -62,9 +62,13 @@ export const deleteSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory<
     }
 
     const deleteMonitorAPI = new DeleteMonitorAPI(routeContext);
-    const { errors } = await deleteMonitorAPI.execute({
+    const { errors, res } = await deleteMonitorAPI.execute({
       monitorIds: idsToDelete,
     });
+
+    if (res) {
+      return res;
+    }
 
     if (errors && errors.length > 0) {
       return response.ok({

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_locations_utils.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_locations_utils.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { assertCanPerformMonitorBulkActionInAllSpaces } from './monitor_locations_utils';
+import { RouteContext } from '../types';
+
+describe('assertCanPerformMonitorBulkActionInAllSpaces', () => {
+  const createRouteContext = (hasAllRequested: boolean) => {
+    const checkSavedObjectsPrivileges = jest.fn().mockResolvedValue({ hasAllRequested });
+    const forbidden = jest.fn(({ body }) => ({ status: 403, body }));
+
+    return {
+      routeContext: {
+        request: {},
+        response: { forbidden },
+        spaceId: 'default',
+        server: {
+          security: {
+            authz: {
+              checkSavedObjectsPrivilegesWithRequest: jest
+                .fn()
+                .mockReturnValue(checkSavedObjectsPrivileges),
+            },
+          },
+        },
+      } as unknown as RouteContext,
+      checkSavedObjectsPrivileges,
+    };
+  };
+
+  it('checks bulk_update privileges by default', async () => {
+    const { routeContext, checkSavedObjectsPrivileges } = createRouteContext(true);
+
+    await assertCanPerformMonitorBulkActionInAllSpaces(routeContext, ['default', 'other-space']);
+
+    expect(checkSavedObjectsPrivileges).toHaveBeenCalledWith(
+      'saved_object:synthetics-monitor-multi-space/bulk_update',
+      ['default', 'other-space']
+    );
+  });
+
+  it('checks bulk_delete privileges and returns delete-specific copy', async () => {
+    const { routeContext, checkSavedObjectsPrivileges } = createRouteContext(false);
+
+    const result = await assertCanPerformMonitorBulkActionInAllSpaces(
+      routeContext,
+      ['default', 'other-space'],
+      'synthetics-monitor',
+      'bulk_delete'
+    );
+
+    expect(checkSavedObjectsPrivileges).toHaveBeenCalledWith(
+      'saved_object:synthetics-monitor/bulk_delete',
+      ['default', 'other-space']
+    );
+    expect(result).toEqual({
+      status: 403,
+      body: {
+        message:
+          'This monitor is shared to spaces where you do not have delete permissions. To delete it, request access to those spaces.',
+      },
+    });
+  });
+
+  it('does not check privileges when no spaces are provided', async () => {
+    const { routeContext, checkSavedObjectsPrivileges } = createRouteContext(true);
+
+    await assertCanPerformMonitorBulkActionInAllSpaces(routeContext, []);
+
+    expect(checkSavedObjectsPrivileges).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_locations_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/monitor_locations_utils.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
+import { syntheticsMonitorSavedObjectType } from '../../../common/types/saved_objects';
+import { RouteContext } from '../types';
+
+type MonitorSavedObjectBulkAction = 'bulk_update' | 'bulk_delete';
+
+/** Asserts that the current user has the requested privileges in all specified spaces. */
+export const assertCanPerformMonitorBulkActionInAllSpaces = async (
+  routeContext: RouteContext,
+  spaceIds: string[],
+  savedObjectType: string = syntheticsMonitorSavedObjectType,
+  action: MonitorSavedObjectBulkAction = 'bulk_update'
+) => {
+  const { request, response, server, spaceId } = routeContext;
+
+  const uniqueSpaces = [...new Set(spaceIds)];
+  const hasAllSpaces = uniqueSpaces.includes(ALL_SPACES_ID);
+
+  if (!hasAllSpaces && uniqueSpaces.length <= 1 && uniqueSpaces[0] === spaceId) {
+    return;
+  }
+  if (uniqueSpaces.length === 0) {
+    return;
+  }
+
+  const checkSavedObjectsPrivileges =
+    server.security.authz.checkSavedObjectsPrivilegesWithRequest(request);
+
+  const { hasAllRequested } = await checkSavedObjectsPrivileges(
+    `saved_object:${savedObjectType}/${action}`,
+    uniqueSpaces
+  );
+
+  if (!hasAllRequested) {
+    const isDeleteAction = action === 'bulk_delete';
+    return response.forbidden({
+      body: {
+        message: isDeleteAction
+          ? i18n.translate('xpack.synthetics.validation.multiSpaceDeletePermissions', {
+              defaultMessage:
+                'This monitor is shared to spaces where you do not have delete permissions. To delete it, request access to those spaces.',
+            })
+          : i18n.translate('xpack.synthetics.validation.multiSpacePermissions', {
+              defaultMessage:
+                'This monitor is shared to spaces where you do not have update permissions. To save changes, either request access to those spaces or remove them from the monitor.',
+            }),
+      },
+    });
+  }
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObject } from '@kbn/core-saved-objects-server';
+import type { EncryptedSyntheticsMonitorAttributes } from '../../../../common/runtime_types';
+import type { RouteContext } from '../../types';
+import { deleteSyntheticsMonitorProjectRoute } from './delete_monitor_project';
+
+jest.mock('../services/delete_monitor_api', () => ({
+  DeleteMonitorAPI: jest.fn(),
+}));
+
+jest.mock('../services/validate_space_id', () => ({
+  validateSpaceId: jest.fn().mockResolvedValue(undefined),
+}));
+
+const monitor = {
+  id: 'config-id',
+  type: 'synthetics-monitor',
+  attributes: {},
+  references: [],
+} as unknown as SavedObject<EncryptedSyntheticsMonitorAttributes>;
+
+const createRouteContext = () =>
+  ({
+    request: {
+      params: { projectName: 'project-name' },
+      body: { monitors: ['journey-id'] },
+    },
+    monitorConfigRepository: {
+      find: jest.fn().mockResolvedValue({ saved_objects: [monitor] }),
+    },
+  } as unknown as RouteContext<
+    { projectName: string },
+    Record<string, never>,
+    { monitors: string[] }
+  >);
+
+const installExecuteResult = (executeResult: object) => {
+  const { DeleteMonitorAPI } = jest.requireMock('../services/delete_monitor_api');
+  const execute = jest.fn().mockResolvedValue(executeResult);
+  DeleteMonitorAPI.mockImplementation(() => ({ execute }));
+  return { execute };
+};
+
+describe('deleteSyntheticsMonitorProjectRoute', () => {
+  const route = deleteSyntheticsMonitorProjectRoute();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes the filtered monitors through the authorized execution path', async () => {
+    const { execute } = installExecuteResult({ errors: [], result: [] });
+
+    const result = await route.handler(createRouteContext());
+
+    expect(execute).toHaveBeenCalledWith({ monitorIds: ['config-id'] });
+    expect(result).toEqual({ deleted_monitors: ['journey-id'] });
+  });
+
+  it('returns the forbidden response from the authorized execution path', async () => {
+    const forbidden = { status: 403, body: { message: 'no access' } };
+    installExecuteResult({ res: forbidden });
+
+    const result = await route.handler(createRouteContext());
+
+    expect(result).toBe(forbidden);
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.ts
@@ -56,9 +56,13 @@ export const deleteSyntheticsMonitorProjectRoute: SyntheticsRestApiRouteFactory 
 
     const deleteMonitorAPI = new DeleteMonitorAPI(routeContext);
 
-    await deleteMonitorAPI.deleteMonitorBulk({
-      monitors,
+    const { res } = await deleteMonitorAPI.execute({
+      monitorIds: monitors.map(({ id }) => id),
     });
+
+    if (res) {
+      return res;
+    }
 
     return {
       deleted_monitors: monitorsToDelete,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.test.ts
@@ -1,0 +1,267 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObject } from '@kbn/core-saved-objects-server';
+import type { EncryptedSyntheticsMonitorAttributes } from '../../../../common/runtime_types';
+import { DeleteMonitorAPI } from './delete_monitor_api';
+
+jest.mock('../edit_monitor', () => ({
+  validatePermissions: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../monitor_locations_utils', () => ({
+  assertCanPerformMonitorBulkActionInAllSpaces: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../telemetry/monitor_upgrade_sender', () => ({
+  formatTelemetryDeleteEvent: jest.fn().mockReturnValue({}),
+  sendTelemetryEvents: jest.fn(),
+  sendErrorTelemetryEvents: jest.fn(),
+}));
+
+const mockMonitor = (
+  id: string,
+  namespaces?: string[],
+  type = 'synthetics-monitor'
+): SavedObject<EncryptedSyntheticsMonitorAttributes> => ({
+  id,
+  type,
+  references: [],
+  ...(namespaces ? { namespaces } : {}),
+  attributes: {
+    id,
+    locations: [{ id: 'loc-1', isServiceManaged: false }],
+  } as EncryptedSyntheticsMonitorAttributes,
+});
+
+const createMockRouteContext = () => {
+  const deleteMonitors = jest.fn().mockResolvedValue([]);
+  const bulkDelete = jest.fn().mockResolvedValue({ statuses: [] });
+  const getDecrypted = jest.fn();
+
+  return {
+    routeContext: {
+      request: {} as any,
+      response: {
+        forbidden: jest.fn((opts: any) => ({ status: 403, ...opts })),
+        ok: jest.fn((opts: any) => opts),
+      } as any,
+      spaceId: 'default',
+      server: {
+        logger: { error: jest.fn() },
+        telemetry: {},
+        stackVersion: '9.5.0',
+      } as any,
+      savedObjectsClient: {} as any,
+      syntheticsMonitorClient: {
+        deleteMonitors,
+      } as any,
+      monitorConfigRepository: {
+        getDecrypted,
+        bulkDelete,
+      } as any,
+    } as any,
+    mocks: { deleteMonitors, bulkDelete, getDecrypted },
+  };
+};
+
+describe('DeleteMonitorAPI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { validatePermissions } = jest.requireMock('../edit_monitor');
+    const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+      '../monitor_locations_utils'
+    );
+    validatePermissions.mockResolvedValue(null);
+    assertCanPerformMonitorBulkActionInAllSpaces.mockResolvedValue(undefined);
+  });
+
+  describe('per-space authorization', () => {
+    it('asserts delete privileges in all monitor spaces before deleting', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({
+        normalizedMonitor: mockMonitor('mon-1', ['default', 'other-space']),
+      });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        ['default', 'other-space'],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+
+    it('authorizes and deletes provided monitors without loading them again', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      const monitor = mockMonitor('mon-1', ['default', 'other-space']);
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.executeWithMonitors({ monitors: [monitor] });
+
+      expect(mocks.getDecrypted).not.toHaveBeenCalled();
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        ['default', 'other-space'],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+
+    it('checks spaces from the saved object namespaces, not the spaces attribute', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      // Authoritative namespaces include a space the (drifted) attribute would omit.
+      const monitor = mockMonitor('mon-1', ['default', 'shared-via-so-api']);
+      (monitor.attributes as any).spaces = ['default'];
+      mocks.getDecrypted.mockResolvedValue({ normalizedMonitor: monitor });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        ['default', 'shared-via-so-api'],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+    });
+
+    it('handles monitors shared to all spaces', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({ normalizedMonitor: mockMonitor('mon-1', ['*']) });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        ['*'],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the forbidden response and does not delete when a space check fails', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const forbidden = { status: 403, body: { message: 'no access' } };
+      assertCanPerformMonitorBulkActionInAllSpaces.mockResolvedValue(forbidden);
+
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({
+        normalizedMonitor: mockMonitor('mon-1', ['default', 'restricted-space']),
+      });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      const { res } = await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(res).toBe(forbidden);
+      expect(mocks.deleteMonitors).not.toHaveBeenCalled();
+      expect(mocks.bulkDelete).not.toHaveBeenCalled();
+    });
+
+    it('aborts the whole batch when a later monitor fails the space check', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const forbidden = { status: 403, body: { message: 'no access' } };
+      assertCanPerformMonitorBulkActionInAllSpaces
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(forbidden);
+
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-1', ['default', 'space-a']) })
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-2', ['default', 'space-b']) });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      const { res } = await api.execute({ monitorIds: ['mon-1', 'mon-2'] });
+
+      expect(res).toBe(forbidden);
+      expect(mocks.deleteMonitors).not.toHaveBeenCalled();
+      expect(mocks.bulkDelete).not.toHaveBeenCalled();
+    });
+
+    it('delegates the empty-space early return to the authorization helper', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({ normalizedMonitor: mockMonitor('mon-1') });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledWith(
+        routeContext,
+        [],
+        'synthetics-monitor',
+        'bulk_delete'
+      );
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+
+    it('dedupes the privilege check across monitors sharing the same type and spaces', async () => {
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-1', ['default', 'space-a']) })
+        // Same spaces, different order — should still be treated as the same key.
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-2', ['space-a', 'default']) })
+        .mockResolvedValueOnce({ normalizedMonitor: mockMonitor('mon-3', ['default', 'space-b']) });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      await api.execute({ monitorIds: ['mon-1', 'mon-2', 'mon-3'] });
+
+      // Two distinct space sets -> two checks, not three.
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).toHaveBeenCalledTimes(2);
+      expect(mocks.deleteMonitors).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('location permissions', () => {
+    it('returns forbidden when validatePermissions fails, without checking spaces', async () => {
+      const { validatePermissions } = jest.requireMock('../edit_monitor');
+      const { assertCanPerformMonitorBulkActionInAllSpaces } = jest.requireMock(
+        '../monitor_locations_utils'
+      );
+      validatePermissions.mockResolvedValue('Insufficient permissions');
+
+      const { routeContext, mocks } = createMockRouteContext();
+      mocks.getDecrypted.mockResolvedValue({
+        normalizedMonitor: mockMonitor('mon-1', ['default', 'other-space']),
+      });
+
+      const api = new DeleteMonitorAPI(routeContext);
+      const { res } = await api.execute({ monitorIds: ['mon-1'] });
+
+      expect(res).toEqual(expect.objectContaining({ status: 403 }));
+      expect(assertCanPerformMonitorBulkActionInAllSpaces).not.toHaveBeenCalled();
+      expect(mocks.deleteMonitors).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/services/delete_monitor_api.ts
@@ -9,6 +9,7 @@ import pMap from 'p-map';
 import { SavedObject, SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { syntheticsMonitorSavedObjectType } from '../../../../common/types/saved_objects';
 import { validatePermissions } from '../edit_monitor';
+import { assertCanPerformMonitorBulkActionInAllSpaces } from '../monitor_locations_utils';
 import {
   ConfigKey,
   EncryptedSyntheticsMonitorAttributes,
@@ -23,6 +24,8 @@ import {
 } from '../../telemetry/monitor_upgrade_sender';
 import { RouteContext } from '../../types';
 
+type MonitorSavedObject = SavedObject<SyntheticsMonitor | EncryptedSyntheticsMonitorAttributes>;
+
 export class DeleteMonitorAPI {
   routeContext: RouteContext;
   result: Array<{ id: string; deleted: boolean; error?: string }> = [];
@@ -31,7 +34,7 @@ export class DeleteMonitorAPI {
   }
 
   async getMonitorsToDelete(monitorIds: string[]) {
-    const result: Array<SavedObject<SyntheticsMonitor | EncryptedSyntheticsMonitorAttributes>> = [];
+    const result: MonitorSavedObject[] = [];
     await pMap(
       monitorIds,
       async (monitorId) => {
@@ -81,9 +84,18 @@ export class DeleteMonitorAPI {
   }
 
   async execute({ monitorIds }: { monitorIds: string[] }) {
+    const monitors = await this.getMonitorsToDelete(monitorIds);
+
+    return this.executeWithMonitors({ monitors });
+  }
+
+  async executeWithMonitors({ monitors }: { monitors: MonitorSavedObject[] }) {
     const { response, server } = this.routeContext;
 
-    const monitors = await this.getMonitorsToDelete(monitorIds);
+    // Dedup the per-space privilege check across monitors that share the same
+    // saved-object type and space set, so a bulk delete issues one privilege
+    // round-trip per distinct (type, spaces) combination instead of one per monitor.
+    const checkedSpaceKeys = new Set<string>();
     for (const monitor of monitors) {
       const err = await validatePermissions(this.routeContext, monitor.attributes.locations);
       if (err) {
@@ -94,6 +106,24 @@ export class DeleteMonitorAPI {
             },
           }),
         };
+      }
+
+      // Use the saved object's authoritative `namespaces` rather than the
+      // denormalized `spaces` attribute, which can drift (e.g. when a monitor
+      // is shared via the generic saved-objects share API).
+      const monitorSpaces = monitor.namespaces ?? [];
+      const spaceKey = `${monitor.type}::${[...new Set(monitorSpaces)].sort().join(',')}`;
+      if (!checkedSpaceKeys.has(spaceKey)) {
+        checkedSpaceKeys.add(spaceKey);
+        const spaceAuthError = await assertCanPerformMonitorBulkActionInAllSpaces(
+          this.routeContext,
+          monitorSpaces,
+          monitor.type,
+          'bulk_delete'
+        );
+        if (spaceAuthError) {
+          return { res: spaceAuthError };
+        }
       }
     }
 
@@ -118,11 +148,7 @@ export class DeleteMonitorAPI {
     }
   }
 
-  async deleteMonitorBulk({
-    monitors,
-  }: {
-    monitors: Array<SavedObject<SyntheticsMonitor | EncryptedSyntheticsMonitorAttributes>>;
-  }) {
+  async deleteMonitorBulk({ monitors }: { monitors: MonitorSavedObject[] }) {
     const { server, spaceId, syntheticsMonitorClient } = this.routeContext;
     const { logger, telemetry, stackVersion } = server;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Enforce per-space authorization when deleting monitors (#281280)](https://github.com/elastic/kibana/pull/281280)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

## Manual backport notes

\`monitor_locations_utils.ts\` / \`update_monitor_api.ts\` / per-space add+edit checks (#260642 / #268141) are not on 8.19. This backport:

- Adds a slim \`assertCanPerformMonitorBulkActionInAllSpaces\` helper used only by delete
- Wires per-space \`bulk_delete\` into \`DeleteMonitorAPI\` and surfaces the \`403\` from single, bulk, and project delete handlers
- Leaves add/edit/project-add on 8.19 unchanged (they still only use location \`validatePermissions\`)
- Drops \`update_monitor_api\` changes (file does not exist on 8.19)
