### PR TITLE
[Cases] Block cross-project/cross-cluster alert and event attachments in cases

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/common/models/case_with_comments.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/models/case_with_comments.test.ts
@@ -1141,4 +1141,102 @@ describe('CaseCommentModel', () => {
       expect(args.updatedAttributes.total_comments).toEqual(1);
     });
   });
+
+  describe('alert/event indexed-reference validation', () => {
+    it('checks alert authorization before persisting the attachment (createComment)', async () => {
+      clientArgs.services.alertsService.ensureAlertsAuthorized.mockRejectedValueOnce(
+        new Error('not authorized')
+      );
+
+      await expect(
+        model.createComment({
+          id: 'comment-1',
+          commentReq: alertComment,
+          createdDate,
+        })
+      ).rejects.toThrow('not authorized');
+
+      expect(clientArgs.services.attachmentService.create).not.toHaveBeenCalled();
+    });
+
+    it('checks alert authorization before persisting the attachment batch (bulkCreate)', async () => {
+      clientArgs.services.alertsService.ensureAlertsAuthorized.mockRejectedValueOnce(
+        new Error('not authorized')
+      );
+
+      await expect(
+        model.bulkCreate({
+          attachments: [
+            { id: 'comment-1', ...comment },
+            { id: 'comment-2', ...alertComment },
+          ],
+        })
+      ).rejects.toThrow('not authorized');
+
+      expect(clientArgs.services.attachmentService.bulkCreate).not.toHaveBeenCalled();
+    });
+
+    it('checks event existence before persisting the attachment (createComment)', async () => {
+      clientArgs.services.alertsService.ensureDocumentsExist.mockRejectedValueOnce(
+        new Error('document not found')
+      );
+
+      await expect(
+        model.createComment({
+          id: 'comment-1',
+          commentReq: eventComment,
+          createdDate,
+        })
+      ).rejects.toThrow('document not found');
+
+      expect(clientArgs.services.alertsService.ensureDocumentsExist).toHaveBeenCalledWith({
+        alerts: [{ id: 'event-id-1', index: 'mock-index' }],
+      });
+      expect(clientArgs.services.attachmentService.create).not.toHaveBeenCalled();
+    });
+
+    it('checks event existence before persisting the attachment batch (bulkCreate)', async () => {
+      clientArgs.services.alertsService.ensureDocumentsExist.mockRejectedValueOnce(
+        new Error('document not found')
+      );
+
+      await expect(
+        model.bulkCreate({
+          attachments: [{ id: 'comment-1', ...eventComment }],
+        })
+      ).rejects.toThrow('document not found');
+
+      expect(clientArgs.services.attachmentService.bulkCreate).not.toHaveBeenCalled();
+    });
+
+    it('does not call ensureDocumentsExist for a batch with no event attachments', async () => {
+      await model.bulkCreate({
+        attachments: [{ id: 'comment-1', ...alertComment }],
+      });
+
+      expect(clientArgs.services.alertsService.ensureDocumentsExist).not.toHaveBeenCalled();
+    });
+
+    it('does not call ensureAlertsAuthorized for a batch with no alert attachments', async () => {
+      await model.bulkCreate({
+        attachments: [{ id: 'comment-1', ...eventComment }],
+      });
+
+      expect(clientArgs.services.alertsService.ensureAlertsAuthorized).not.toHaveBeenCalled();
+    });
+
+    it('validates alert authorization before the saved object is created', async () => {
+      await model.createComment({
+        id: 'comment-1',
+        commentReq: alertComment,
+        createdDate,
+      });
+
+      const authorizeOrder =
+        clientArgs.services.alertsService.ensureAlertsAuthorized.mock.invocationCallOrder[0];
+      const createOrder = clientArgs.services.attachmentService.create.mock.invocationCallOrder[0];
+
+      expect(authorizeOrder).toBeLessThan(createOrder);
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/cases/server/common/models/case_with_comments.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/models/case_with_comments.ts
@@ -50,6 +50,7 @@ import {
   getOrUpdateLensReferences,
   isCommentRequestTypeAlert,
   getAlertInfoFromComments,
+  getEventInfoFromComments,
   getIDsAndIndicesAsArrays,
   isCommentRequestTypeEvent,
   countEventsForID,
@@ -288,6 +289,8 @@ export class CaseCommentModel {
       }
 
       const { id: commentId, ...attachment } = attachmentsWithoutDuplicates[0];
+
+      await this.ensureIndexedAttachmentsValid([attachment]);
 
       const references = [...this.buildRefsToCase(), ...this.getCommentReferences(attachment)];
 
@@ -561,13 +564,32 @@ export class CaseCommentModel {
     return references;
   }
 
+  /**
+   * Validates alert/event attachments before the saved object is persisted, so a failure here
+   * never leaves an already-created attachment on the case.
+   */
+  private async ensureIndexedAttachmentsValid(attachments: AttachmentRequestV2[]) {
+    const alertAttachments = attachments.filter((a) => isAlertAttachmentType(a.type));
+    const alerts = getAlertInfoFromComments(alertAttachments, true);
+
+    if (alerts.length > 0) {
+      await this.params.services.alertsService.ensureAlertsAuthorized({ alerts });
+    }
+
+    const eventAttachments = attachments.filter((a) => isEventAttachmentType(a.type));
+    const events = getEventInfoFromComments(eventAttachments, true);
+
+    if (events.length > 0) {
+      await this.params.services.alertsService.ensureDocumentsExist({ alerts: events });
+    }
+  }
+
   private async handleAlertComments(attachments: AttachmentRequestV2[]) {
     const alertAttachments = attachments.filter((a) => isAlertAttachmentType(a.type));
 
     const alerts = getAlertInfoFromComments(alertAttachments);
 
     if (alerts.length > 0) {
-      await this.params.services.alertsService.ensureAlertsAuthorized({ alerts });
       await this.updateAlertsSchemaWithCaseInfo(alerts);
 
       if (this.caseInfo.attributes.settings.syncAlerts) {
@@ -689,6 +711,8 @@ export class CaseCommentModel {
       if (attachmentWithoutDuplicateAlerts.length === 0) {
         return this;
       }
+
+      await this.ensureIndexedAttachmentsValid(attachmentWithoutDuplicateAlerts);
 
       const caseReference = this.buildRefsToCase();
 

--- a/x-pack/platform/plugins/shared/cases/server/common/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/utils.test.ts
@@ -26,6 +26,8 @@ import {
   getCaseViewPath,
   countUserAttachments,
   isPersistableStateOrExternalReference,
+  getAlertInfoFromComments,
+  getEventInfoFromComments,
 } from './utils';
 import { newCase } from '../routes/api/__mocks__/request_responses';
 import { CASE_VIEW_PAGE_TABS } from '../../common/types';
@@ -35,6 +37,7 @@ import type {
   AttachmentAttributes,
   Case,
   CaseConnector,
+  EventAttachmentPayload,
   UserCommentAttachmentPayload,
 } from '../../common/types/domain';
 import {
@@ -44,11 +47,13 @@ import {
   CustomFieldTypes,
 } from '../../common/types/domain';
 import type { AttachmentRequest } from '../../common/types/api';
+import { SECURITY_EVENT_ATTACHMENT_TYPE } from '../../common/constants/attachments';
 import {
   createAlertRequests,
   createExternalReferenceRequests,
   createPersistableStateRequests,
   createUserRequests,
+  createUnifiedAlertRequests,
 } from './limiter_checker/test_utils';
 
 interface CommentReference {
@@ -1666,6 +1671,213 @@ describe('common utils', () => {
       expect(isPersistableStateOrExternalReference(createAlertRequests(1, 'alert-id')[0])).toBe(
         false
       );
+    });
+  });
+
+  describe('getAlertInfoFromComments', () => {
+    it('extracts id/index pairs for legacy alert attachments', () => {
+      const requests = createAlertRequests(1, ['alert-1', 'alert-2']);
+
+      expect(getAlertInfoFromComments(requests)).toEqual([
+        { id: 'alert-1', index: 'alert-1' },
+        { id: 'alert-2', index: 'alert-2' },
+      ]);
+    });
+
+    it('extracts id/index pairs for unified alert attachments when metadata.index is present', () => {
+      const requests = createUnifiedAlertRequests(1, ['alert-1', 'alert-2']).map((request) => ({
+        ...request,
+        metadata: { index: ['index-1', 'index-2'] },
+      }));
+
+      expect(getAlertInfoFromComments(requests)).toEqual([
+        { id: 'alert-1', index: 'index-1' },
+        { id: 'alert-2', index: 'index-2' },
+      ]);
+    });
+
+    it('silently drops a unified alert attachment that omits metadata.index', () => {
+      // Lenient by default so reads of already-persisted (possibly malformed) data don't fail;
+      // write-time validation passes `strict: true` instead (see below).
+      const requests = createUnifiedAlertRequests(1, 'alert-1');
+
+      expect(getAlertInfoFromComments(requests)).toEqual([]);
+    });
+
+    it('silently drops when attachmentId and a metadata.index array have mismatched lengths', () => {
+      const requests = createUnifiedAlertRequests(1, ['alert-1', 'alert-2']).map((request) => ({
+        ...request,
+        metadata: { index: ['index-1'] },
+      }));
+
+      expect(getAlertInfoFromComments(requests)).toEqual([]);
+    });
+
+    it('broadcasts a scalar metadata.index across every id (no length mismatch)', () => {
+      const requests = createUnifiedAlertRequests(1, ['alert-1', 'alert-2']).map((request) => ({
+        ...request,
+        metadata: { index: 'shared-index' },
+      }));
+
+      expect(getAlertInfoFromComments(requests)).toEqual([
+        { id: 'alert-1', index: 'shared-index' },
+        { id: 'alert-2', index: 'shared-index' },
+      ]);
+    });
+
+    it('ignores non-alert attachments', () => {
+      expect(getAlertInfoFromComments(createUserRequests(1))).toEqual([]);
+    });
+  });
+
+  describe('getAlertInfoFromComments (strict: true)', () => {
+    it('extracts id/index pairs for unified alert attachments when metadata.index is present', () => {
+      const requests = createUnifiedAlertRequests(1, ['alert-1', 'alert-2']).map((request) => ({
+        ...request,
+        metadata: { index: ['index-1', 'index-2'] },
+      }));
+
+      expect(getAlertInfoFromComments(requests, true)).toEqual([
+        { id: 'alert-1', index: 'index-1' },
+        { id: 'alert-2', index: 'index-2' },
+      ]);
+    });
+
+    it('throws instead of silently skipping when a unified alert attachment omits metadata.index', () => {
+      // the exact shape that let ensureAlertsAuthorized be bypassed before this fix.
+      const requests = createUnifiedAlertRequests(1, 'alert-1');
+
+      expect(() => getAlertInfoFromComments(requests, true)).toThrow(
+        /missing a valid index reference/
+      );
+    });
+
+    it('broadcasts a scalar metadata.index across every id instead of throwing', () => {
+      const requests = createUnifiedAlertRequests(1, ['alert-1', 'alert-2']).map((request) => ({
+        ...request,
+        metadata: { index: 'shared-index' },
+      }));
+
+      expect(getAlertInfoFromComments(requests, true)).toEqual([
+        { id: 'alert-1', index: 'shared-index' },
+        { id: 'alert-2', index: 'shared-index' },
+      ]);
+    });
+
+    it('throws when attachmentId and a metadata.index array have mismatched lengths', () => {
+      const requests = createUnifiedAlertRequests(1, ['alert-1', 'alert-2']).map((request) => ({
+        ...request,
+        metadata: { index: ['index-1'] },
+      }));
+
+      expect(() => getAlertInfoFromComments(requests, true)).toThrow(
+        /missing a valid index reference/
+      );
+    });
+
+    it('ignores non-alert attachments', () => {
+      expect(getAlertInfoFromComments(createUserRequests(1), true)).toEqual([]);
+    });
+  });
+
+  describe('getEventInfoFromComments', () => {
+    it('extracts id/index pairs for legacy event attachments', () => {
+      const requests: EventAttachmentPayload[] = [
+        {
+          type: AttachmentType.event as const,
+          eventId: 'event-1',
+          index: 'event-index-1',
+          owner: 'test',
+        },
+      ];
+
+      expect(getEventInfoFromComments(requests)).toEqual([
+        { id: 'event-1', index: 'event-index-1' },
+      ]);
+    });
+
+    it('extracts id/index pairs for unified security.event attachments when metadata.index is present', () => {
+      const requests = [
+        {
+          type: SECURITY_EVENT_ATTACHMENT_TYPE,
+          attachmentId: 'event-1',
+          metadata: { index: 'event-index-1' },
+          owner: 'test',
+        },
+      ];
+
+      expect(getEventInfoFromComments(requests)).toEqual([
+        { id: 'event-1', index: 'event-index-1' },
+      ]);
+    });
+
+    it('silently drops a unified event attachment that omits metadata.index', () => {
+      // getEventInfoFromComments stays lenient by default — see the getAlertInfoFromComments
+      // comment above for why. Write-time validation passes `strict: true` instead.
+      const requests = [
+        {
+          type: SECURITY_EVENT_ATTACHMENT_TYPE,
+          attachmentId: 'event-1',
+          owner: 'test',
+        },
+      ];
+
+      expect(getEventInfoFromComments(requests)).toEqual([]);
+    });
+
+    it('broadcasts a scalar metadata.index across every id (no length mismatch)', () => {
+      const requests = [
+        {
+          type: SECURITY_EVENT_ATTACHMENT_TYPE,
+          attachmentId: ['event-1', 'event-2'],
+          metadata: { index: 'shared-index' },
+          owner: 'test',
+        },
+      ];
+
+      expect(getEventInfoFromComments(requests)).toEqual([
+        { id: 'event-1', index: 'shared-index' },
+        { id: 'event-2', index: 'shared-index' },
+      ]);
+    });
+
+    it('ignores non-event attachments', () => {
+      expect(getEventInfoFromComments(createAlertRequests(1, 'alert-1'))).toEqual([]);
+    });
+  });
+
+  describe('getEventInfoFromComments (strict: true)', () => {
+    it('extracts id/index pairs for unified security.event attachments when metadata.index is present', () => {
+      const requests = [
+        {
+          type: SECURITY_EVENT_ATTACHMENT_TYPE,
+          attachmentId: 'event-1',
+          metadata: { index: 'event-index-1' },
+          owner: 'test',
+        },
+      ];
+
+      expect(getEventInfoFromComments(requests, true)).toEqual([
+        { id: 'event-1', index: 'event-index-1' },
+      ]);
+    });
+
+    it('throws instead of silently skipping when a unified event attachment omits metadata.index', () => {
+      const requests = [
+        {
+          type: SECURITY_EVENT_ATTACHMENT_TYPE,
+          attachmentId: 'event-1',
+          owner: 'test',
+        },
+      ];
+
+      expect(() => getEventInfoFromComments(requests, true)).toThrow(
+        /missing a valid index reference/
+      );
+    });
+
+    it('ignores non-event attachments', () => {
+      expect(getEventInfoFromComments(createAlertRequests(1, 'alert-1'), true)).toEqual([]);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/server/common/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/utils.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
 import type {
   SavedObjectsFindResult,
   SavedObjectsFindResponse,
@@ -249,34 +250,60 @@ export const getIDsAndIndicesAsArrays = (
 };
 
 /**
- * This functions extracts the ids and indices from an alert comment. It enforces that the alertId and index are either
- * both strings or string arrays that are the same length. If they are arrays they represent a 1-to-1 mapping of
- * id existing in an index at each position in the array. This is not ideal. Ideally an alert comment request would
- * accept an array of objects like this: Array<{id: string; index: string; ruleName: string ruleID: string}> instead.
- *
- * To reformat the alert comment request requires a migration and a breaking API change.
+ * Extracts id/index pairs for an alert/event comment: 1-to-1 arrays, or a scalar `metadata.index`
+ * broadcasting across every id. Pass `strict: true` to throw on an invalid pairing instead of dropping it.
  */
-const getAndValidateAlertInfoFromComment = (comment: AttachmentRequestV2): AlertInfo[] => {
-  if (!isAlertAttachmentType(comment.type)) {
+const getAndValidateIndexedAttachmentInfo = (
+  comment: AttachmentRequestV2,
+  isTargetType: (type: string) => boolean,
+  strict: boolean
+): AlertInfo[] => {
+  if (!isTargetType(comment.type)) {
     return [];
   }
 
   const { ids, indices } = getIDsAndIndicesAsArrays(comment);
 
-  if (ids.length !== indices.length) {
+  // Only a scalar metadata.index broadcasts; an array (even length 1) must match 1-to-1.
+  const rawMetadataIndex =
+    'attachmentId' in comment ? getIndexFromMetadata(comment.metadata) : undefined;
+  const isBroadcastIndex = typeof rawMetadataIndex === 'string';
+
+  if (!isBroadcastIndex && ids.length !== indices.length) {
+    if (strict) {
+      throw Boom.badRequest(
+        `Attachment of type "${comment.type}" is missing a valid index reference (id count=${ids.length}, index count=${indices.length}).`
+      );
+    }
+
     return [];
   }
 
-  return ids.map((id, index) => ({ id, index: indices[index] }));
+  return ids.map((id, index) => ({ id, index: isBroadcastIndex ? indices[0] : indices[index] }));
 };
 
 /**
- * Builds an AlertInfo object accumulating the alert IDs and indices for the passed in alerts.
+ * Builds AlertInfo for the alerts in `comments`. Pass `strict: true` only when validating a new
+ * write before it's persisted; reads of already-persisted attachments must stay lenient.
  */
-export const getAlertInfoFromComments = (comments: AttachmentRequestV2[] = []): AlertInfo[] =>
+export const getAlertInfoFromComments = (
+  comments: AttachmentRequestV2[] = [],
+  strict = false
+): AlertInfo[] =>
   comments.reduce((acc: AlertInfo[], comment) => {
-    const alertInfo = getAndValidateAlertInfoFromComment(comment);
-    acc.push(...alertInfo);
+    acc.push(...getAndValidateIndexedAttachmentInfo(comment, isAlertAttachmentType, strict));
+    return acc;
+  }, []);
+
+/**
+ * Same as {@link getAlertInfoFromComments}, but for events (legacy `event` + unified `security.event`).
+ */
+export const getEventInfoFromComments = (
+  comments: AttachmentRequestV2[] = [],
+  strict = false
+): AlertInfo[] =>
+  comments.reduce((acc: AlertInfo[], comment) => {
+    acc.push(...getAndValidateIndexedAttachmentInfo(comment, isEventAttachmentType, strict));
     return acc;
   }, []);
 

--- a/x-pack/platform/plugins/shared/cases/server/services/alerts/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/alerts/index.test.ts
@@ -700,4 +700,137 @@ describe('updateAlertsStatus', () => {
       );
     });
   });
+
+  describe('ensureAlertsAuthorized', () => {
+    const alerts = [
+      {
+        id: 'alert-1',
+        index: '.alerts-security.alerts-default',
+      },
+    ];
+
+    it('authorizes local alerts', async () => {
+      alertsClient.ensureAllAlertsAuthorizedRead.mockResolvedValueOnce(undefined);
+
+      await expect(alertService.ensureAlertsAuthorized({ alerts })).resolves.not.toThrow();
+
+      expect(alertsClient.ensureAllAlertsAuthorizedRead).toHaveBeenCalledWith({ alerts });
+    });
+
+    it('throws without calling ensureAllAlertsAuthorizedRead when the index belongs to a linked project (CPS)', async () => {
+      await expect(
+        alertService.ensureAlertsAuthorized({
+          alerts: [{ id: 'alert-1', index: 'my-linked-project:.alerts-security.alerts-default' }],
+        })
+      ).rejects.toThrow(/linked project or remote cluster/);
+
+      expect(alertsClient.ensureAllAlertsAuthorizedRead).not.toHaveBeenCalled();
+    });
+
+    it('throws without calling ensureAllAlertsAuthorizedRead when the index is a remote-cluster (CCS) reference', async () => {
+      await expect(
+        alertService.ensureAlertsAuthorized({
+          alerts: [{ id: 'alert-1', index: 'my-remote-cluster:.alerts-security.alerts-default' }],
+        })
+      ).rejects.toThrow(/linked project or remote cluster/);
+
+      expect(alertsClient.ensureAllAlertsAuthorizedRead).not.toHaveBeenCalled();
+    });
+
+    it('does not call ensureAllAlertsAuthorizedRead when there are no non-empty alerts', async () => {
+      await expect(
+        alertService.ensureAlertsAuthorized({ alerts: [{ id: '', index: '' }] })
+      ).resolves.not.toThrow();
+
+      expect(alertsClient.ensureAllAlertsAuthorizedRead).not.toHaveBeenCalled();
+    });
+
+    it('wraps and rethrows authorization errors', async () => {
+      alertsClient.ensureAllAlertsAuthorizedRead.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(alertService.ensureAlertsAuthorized({ alerts })).rejects.toThrow(
+        /Failed to authorize alerts/
+      );
+    });
+  });
+
+  describe('ensureDocumentsExist', () => {
+    const alerts = [
+      {
+        id: 'event-1',
+        index: '.ds-logs-endpoint.events.process-default',
+      },
+    ];
+
+    it('does not throw when the document exists', async () => {
+      esClient.mget.mockResolvedValueOnce({
+        docs: [
+          {
+            _index: '.ds-logs-endpoint.events.process-default',
+            _id: 'event-1',
+            found: true,
+            _source: {},
+          },
+        ],
+      });
+
+      await expect(alertService.ensureDocumentsExist({ alerts })).resolves.not.toThrow();
+    });
+
+    it('throws when the document is not found', async () => {
+      esClient.mget.mockResolvedValueOnce({
+        docs: [
+          {
+            _index: '.ds-logs-endpoint.events.process-default',
+            _id: 'event-1',
+            found: false,
+          },
+        ],
+      });
+
+      await expect(alertService.ensureDocumentsExist({ alerts })).rejects.toThrow(
+        /Referenced document\(s\) not found: event-1/
+      );
+    });
+
+    it('throws without calling mget when the index belongs to a linked project (CPS)', async () => {
+      await expect(
+        alertService.ensureDocumentsExist({
+          alerts: [
+            { id: 'event-1', index: 'my-linked-project:.ds-logs-endpoint.events.process-default' },
+          ],
+        })
+      ).rejects.toThrow(/linked project or remote cluster/);
+
+      expect(esClient.mget).not.toHaveBeenCalled();
+    });
+
+    it('throws without calling mget when the index is a remote-cluster (CCS) reference', async () => {
+      await expect(
+        alertService.ensureDocumentsExist({
+          alerts: [
+            { id: 'event-1', index: 'my-remote-cluster:.ds-logs-endpoint.events.process-default' },
+          ],
+        })
+      ).rejects.toThrow(/linked project or remote cluster/);
+
+      expect(esClient.mget).not.toHaveBeenCalled();
+    });
+
+    it('does not call mget when there are no non-empty alerts', async () => {
+      await expect(
+        alertService.ensureDocumentsExist({ alerts: [{ id: '', index: '' }] })
+      ).resolves.not.toThrow();
+
+      expect(esClient.mget).not.toHaveBeenCalled();
+    });
+
+    it('wraps and rethrows mget errors', async () => {
+      esClient.mget.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(alertService.ensureDocumentsExist({ alerts })).rejects.toThrow(
+        /Failed to verify referenced documents exist/
+      );
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/cases/server/services/alerts/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/alerts/index.test.ts
@@ -789,7 +789,7 @@ describe('updateAlertsStatus', () => {
       });
 
       await expect(alertService.ensureDocumentsExist({ alerts })).rejects.toThrow(
-        /Referenced document\(s\) not found: event-1/
+        /Referenced event\(s\) not found: event-1/
       );
     });
 
@@ -829,7 +829,7 @@ describe('updateAlertsStatus', () => {
       esClient.mget.mockRejectedValueOnce(new Error('boom'));
 
       await expect(alertService.ensureDocumentsExist({ alerts })).rejects.toThrow(
-        /Failed to verify referenced documents exist/
+        /Failed to verify referenced events exist/
       );
     });
   });

--- a/x-pack/platform/plugins/shared/cases/server/services/alerts/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/alerts/index.ts
@@ -315,19 +315,19 @@ export class AlertService {
         return;
       }
 
-      this.rejectNonLocalIndices(nonEmptyAlerts, 'a document');
+      this.rejectNonLocalIndices(nonEmptyAlerts, 'an event');
 
       const results = await this.getAlerts(nonEmptyAlerts);
-      const missingDocIds = (results?.docs ?? [])
+      const missingEventIds = (results?.docs ?? [])
         .filter((doc) => !('found' in doc && doc.found))
         .map((doc) => doc._id);
 
-      if (missingDocIds.length > 0) {
-        throw Boom.badRequest(`Referenced document(s) not found: ${missingDocIds.join(', ')}`);
+      if (missingEventIds.length > 0) {
+        throw Boom.badRequest(`Referenced event(s) not found: ${missingEventIds.join(', ')}`);
       }
     } catch (error) {
       throw createCaseError({
-        message: `Failed to verify referenced documents exist: ${error}`,
+        message: `Failed to verify referenced events exist: ${error}`,
         error,
         logger: this.logger,
       });

--- a/x-pack/platform/plugins/shared/cases/server/services/alerts/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/alerts/index.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
 import pMap from 'p-map';
 import { isEmpty } from 'lodash';
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { isNonLocalIndexName } from '@kbn/es-query';
 import type { STATUS_VALUES } from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
 import {
   ALERT_WORKFLOW_REASON,
@@ -273,12 +275,59 @@ export class AlertService {
         return;
       }
 
+      this.rejectNonLocalIndices(nonEmptyAlerts, 'an alert');
+
       await this.alertsClient.ensureAllAlertsAuthorizedRead({
         alerts: nonEmptyAlerts,
       });
     } catch (error) {
       throw createCaseError({
         message: `Failed to authorize alerts: ${error}`,
+        error,
+        logger: this.logger,
+      });
+    }
+  }
+
+  /**
+   * Rejects CPS/CCS index references before any `mget` — rule_registry's own authorization check
+   * silently skips (doesn't throw) a hit missing `_source`, which is what a cross-project `mget` returns.
+   */
+  private rejectNonLocalIndices(alerts: AlertInfo[], label: string): void {
+    const nonLocalAlert = alerts.find((alert) => isNonLocalIndexName(alert.index));
+
+    if (nonLocalAlert != null) {
+      throw Boom.badRequest(
+        `Cannot attach ${label} from a linked project or remote cluster index: ${nonLocalAlert.index}`
+      );
+    }
+  }
+
+  /**
+   * Existence check for non-alert indexed attachments (events) — no alerting RBAC, and CPS/CCS
+   * refs are rejected before `mget`.
+   */
+  public async ensureDocumentsExist({ alerts }: { alerts: AlertInfo[] }): Promise<void> {
+    try {
+      const nonEmptyAlerts = this.getNonEmptyAlerts(alerts);
+
+      if (nonEmptyAlerts.length <= 0) {
+        return;
+      }
+
+      this.rejectNonLocalIndices(nonEmptyAlerts, 'a document');
+
+      const results = await this.getAlerts(nonEmptyAlerts);
+      const missingDocIds = (results?.docs ?? [])
+        .filter((doc) => !('found' in doc && doc.found))
+        .map((doc) => doc._id);
+
+      if (missingDocIds.length > 0) {
+        throw Boom.badRequest(`Referenced document(s) not found: ${missingDocIds.join(', ')}`);
+      }
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to verify referenced documents exist: ${error}`,
         error,
         logger: this.logger,
       });

--- a/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
@@ -156,6 +156,7 @@ export const createAlertServiceMock = (): AlertServiceMock => {
     executeAggregations: jest.fn(),
     bulkUpdateCases: jest.fn(),
     ensureAlertsAuthorized: jest.fn(),
+    ensureDocumentsExist: jest.fn(),
     removeCaseIdFromAlerts: jest.fn(),
     removeCaseIdsFromAllAlerts: jest.fn(),
   });

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/attachments_framework/events.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/attachments_framework/events.ts
@@ -25,6 +25,9 @@ import {
   getCase,
 } from '../../../../common/lib/api';
 
+const EVENTS_INDEX = 'test-events-index';
+const LEGACY_EVENTS_INDEX = 'legacy-events-index';
+
 /**
  * Legacy v1 `event` payload. With the flag ON the owner prefix resolves it to a
  * unified `security.event`, but it is written through the legacy path so it lands
@@ -34,7 +37,7 @@ const legacyEventPayload = (overrides: Record<string, unknown> = {}): Attachment
   ({
     type: AttachmentType.event,
     eventId: 'legacy-event-1',
-    index: 'legacy-events-index',
+    index: LEGACY_EVENTS_INDEX,
     owner: 'securitySolutionFixture',
     ...overrides,
   } as AttachmentRequest);
@@ -43,13 +46,27 @@ export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
   const es = getService('es');
 
+  // Attaching an event requires the referenced document to actually exist (mget-backed
+  // existence check), so tests must seed it first.
+  const seedEvents = (ids: string[], index = EVENTS_INDEX) =>
+    Promise.all(
+      ids.map((id) =>
+        es.index({ index, id, document: { '@timestamp': new Date().toISOString() }, refresh: true })
+      )
+    );
+
   describe('Unified Events — CRUD, aggregation, stats', () => {
     afterEach(async () => {
       await deleteAllCaseItems(es);
+      await es.indices.delete({
+        index: [EVENTS_INDEX, LEGACY_EVENTS_INDEX],
+        ignore_unavailable: true,
+      });
     });
 
     describe('create', () => {
       it('creates a unified event attachment via v2 payload', async () => {
+        await seedEvents(['event-doc-1']);
         const postedCase = await createCase(supertest, postCaseReq);
         const updatedCase = await bulkCreateAttachments({
           supertest,
@@ -71,6 +88,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('writes event to cases-attachments SO when flag is ON', async () => {
+        await seedEvents(['event-so-check']);
         const postedCase = await createCase(supertest, postCaseReq);
         const updatedCase = await bulkCreateAttachments({
           supertest,
@@ -117,6 +135,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('creates event with array attachmentId', async () => {
+        await seedEvents(['event-1', 'event-2', 'event-3']);
         const postedCase = await createCase(supertest, postCaseReq);
         const updatedCase = await bulkCreateAttachments({
           supertest,
@@ -138,6 +157,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
     describe('read', () => {
       it('retrieves a unified event by id', async () => {
+        await seedEvents(['event-read-1']);
         const postedCase = await createCase(supertest, postCaseReq);
         const updatedCase = await bulkCreateAttachments({
           supertest,
@@ -164,6 +184,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('reflects unified events in case totalEvents count', async () => {
+        await seedEvents(['event-find-1', 'event-find-2']);
         const postedCase = await createCase(supertest, postCaseReq);
         await bulkCreateAttachments({
           supertest,
@@ -195,6 +216,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
     describe('stats and aggregation', () => {
       it('totalEvents reflects unified event count on the case', async () => {
+        await seedEvents(['stats-event-1', 'stats-event-2']);
         const postedCase = await createCase(supertest, postCaseReq);
         const updatedCase = await bulkCreateAttachments({
           supertest,
@@ -226,6 +248,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('counts comments and events in case totals', async () => {
+        await seedEvents(['mixed-event-1']);
         const postedCase = await createCase(supertest, postCaseReq);
         const updatedCase = await bulkCreateAttachments({
           supertest,
@@ -253,6 +276,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
     describe('mixed legacy + unified events on the same case', () => {
       it('reads a legacy `event` through the v2 read path (legacy type preserved in legacy mode)', async () => {
+        await seedEvents(['legacy-event-1'], LEGACY_EVENTS_INDEX);
         const postedCase = await createCase(supertest, postCaseReq);
         const legacyCase = await createComment({
           supertest,
@@ -273,6 +297,8 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('lifts a legacy `event` onto cases-attachments alongside a unified event', async () => {
+        await seedEvents(['legacy-event-1'], LEGACY_EVENTS_INDEX);
+        await seedEvents(['unified-event-mix']);
         const postedCase = await createCase(supertest, postCaseReq);
 
         const legacyCase = await createComment({
@@ -339,6 +365,8 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('totalEvents equals the union of legacy and unified events', async () => {
+        await seedEvents(['legacy-event-1'], LEGACY_EVENTS_INDEX);
+        await seedEvents(['union-event-1', 'union-event-2', 'union-event-3']);
         const postedCase = await createCase(supertest, postCaseReq);
 
         // One legacy event (lifted onto cases-attachments when the flag is ON).
@@ -376,6 +404,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
     describe('delete', () => {
       it('deletes a unified event', async () => {
+        await seedEvents(['event-delete-1']);
         const postedCase = await createCase(supertest, postCaseReq);
         const updatedCase = await bulkCreateAttachments({
           supertest,

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/attachments_framework/mixed_reads.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/common/attachments_framework/mixed_reads.ts
@@ -32,13 +32,30 @@ import {
   getCase,
 } from '../../../../common/lib/api';
 
+const EVENTS_INDEX = 'test-events-index';
+
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
   const es = getService('es');
 
+  // Attaching an event requires the referenced document to actually exist (mget-backed
+  // existence check), so tests must seed it first.
+  const seedEvents = (ids: string[]) =>
+    Promise.all(
+      ids.map((id) =>
+        es.index({
+          index: EVENTS_INDEX,
+          id,
+          document: { '@timestamp': new Date().toISOString() },
+          refresh: true,
+        })
+      )
+    );
+
   describe('Mixed Legacy + Unified Reads', () => {
     afterEach(async () => {
       await deleteAllCaseItems(es);
+      await es.indices.delete({ index: EVENTS_INDEX, ignore_unavailable: true });
     });
 
     describe('coexistence of legacy and unified attachments', () => {
@@ -80,6 +97,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('counts events and comments in case totals', async () => {
+        await seedEvents(['mixed-event-1']);
         const postedCase = await createCase(supertest, postCaseReq);
 
         // Create unified comment
@@ -289,6 +307,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
     describe('cross-type stats and documents over a mixed case', () => {
       it('reports correct totals and retrieves every attachment across both SOs', async () => {
+        await seedEvents(['stats-event-1']);
         const postedCase = await createCase(supertest, postCaseReq);
 
         // Track ids as they appear — each response returns the full comment list.


### PR DESCRIPTION
## Summary

This PR fixes a few gaps to block CPS attachments (alerts, events) to be added to a case: 

- Added `rejectNonLocalIndices` to reject CPS/CCS index references upfront, supports both alerts and events
<img width="1312" height="460" alt="image" src="https://github.com/user-attachments/assets/ad6496a5-b606-4af2-b005-3006f6ddf86c" />


- Reordered validation check and SO creation so that a failed validation does not create the attachment saved object in a race condition
- Throws when an array of ids are provided but index array has mismatching count. This check previously bypassed the validation check for unified attachments

<img width="1338" height="461" alt="image" src="https://github.com/user-attachments/assets/ce15beb9-54d1-48b2-9be8-753dc9a94f80" />



### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/docs/extend/kibana/contributing/workflow/how-we-use-github#release-notes)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->