### PR TITLE
[Data Preview] Fix dims badge for chunked embeddings

### DIFF
--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_field.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_field.test.tsx
@@ -42,6 +42,24 @@ describe('ResultField', () => {
     expect(icons).toEqual(['tokenSemanticText', 'tokenVectorDense']);
     expect(screen.getByText('body')).toBeInTheDocument();
     expect(screen.getByText('embeddings')).toBeInTheDocument();
+    expect(screen.getByText('2 dims')).toBeInTheDocument();
+  });
+
+  it('shows dims and chunks for a semantic_text field with chunked vectors when expanded', () => {
+    renderField({
+      fieldName: 'content',
+      fieldType: 'semantic_text',
+      fieldValue: '"the original text"',
+      embeddings: JSON.stringify([
+        [0.1, 0.2],
+        [0.3, 0.4],
+        [0.5, 0.6],
+      ]),
+      dimensions: 2,
+      isExpanded: true,
+    });
+    expect(screen.getByText('2 dims')).toBeInTheDocument();
+    expect(screen.getByText('3 chunks')).toBeInTheDocument();
   });
 
   it('renders a compact single row for a semantic_text field with vectors when collapsed', () => {
@@ -77,5 +95,14 @@ describe('ResultField', () => {
       fieldValue: '"hello"',
     });
     expect(iconTypeOf(container)).toBe('tokenString');
+  });
+
+  it('shows dims for a dense_vector field', () => {
+    renderField({
+      fieldName: 'embedding',
+      fieldType: 'dense_vector',
+      fieldValue: JSON.stringify([0.1, 0.2, 0.3]),
+    });
+    expect(screen.getByText('3 dims')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_field.tsx
@@ -116,6 +116,7 @@ export const ResultField: React.FC<ResultFieldProps> = ({
   fieldValue,
   fieldType = 'object',
   embeddings,
+  dimensions,
   isExpanded,
 }) => {
   const { euiTheme } = useEuiTheme();
@@ -155,7 +156,7 @@ export const ResultField: React.FC<ResultFieldProps> = ({
                 }
               )}
             />
-            <VectorFieldValue embeddings={embeddings} />
+            <VectorFieldValue embeddings={embeddings} dimensions={dimensions} />
           </Styles.SemanticVectorGrid>
         </EuiTableRowCell>
       </EuiTableRow>
@@ -172,6 +173,7 @@ export const ResultField: React.FC<ResultFieldProps> = ({
           fieldValue={fieldValue}
           fieldType={fieldType}
           embeddings={isExpanded ? embeddings : undefined}
+          dimensions={dimensions}
           isExpanded={isExpanded}
         />
       </EuiTableRowCell>

--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_field_value.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result_field_value.tsx
@@ -25,6 +25,7 @@ interface ResultFieldValueProps {
   fieldType: string;
   isExpanded?: boolean;
   embeddings: string | undefined;
+  dimensions?: number;
 }
 
 function truncateVectors(embeddings: string[] | string[][]): string {
@@ -36,23 +37,31 @@ function truncateVectors(embeddings: string[] | string[][]): string {
   return `[${embeds}]`;
 }
 
-function getEmbeddings(embeddings: string): { embeddings: string[] | string[][]; chunks: number } {
+function getEmbeddings(embeddings: string): {
+  embeddings: string[] | string[][];
+  chunks: number;
+  dims: number;
+} {
   try {
     const embeds = JSON.parse(embeddings);
-    if (Array.isArray(embeds)) {
+    if (Array.isArray(embeds) && embeds.length > 0) {
       if (Array.isArray(embeds[0])) {
-        return { embeddings: embeds, chunks: embeds.length };
+        return { embeddings: embeds, chunks: embeds.length, dims: embeds[0].length };
       }
-      return { embeddings: embeds, chunks: 1 };
+      return { embeddings: embeds, chunks: 1, dims: embeds.length };
     }
-    return { embeddings: [], chunks: 0 };
+    return { embeddings: [], chunks: 0, dims: 0 };
   } catch {
-    return { embeddings: [], chunks: 0 };
+    return { embeddings: [], chunks: 0, dims: 0 };
   }
 }
 
-export const VectorFieldValue: React.FC<{ embeddings: string }> = ({ embeddings }) => {
-  const { embeddings: jsonEmbeddings, chunks } = getEmbeddings(embeddings);
+export const VectorFieldValue: React.FC<{ embeddings: string; dimensions?: number }> = ({
+  embeddings,
+  dimensions,
+}) => {
+  const { embeddings: jsonEmbeddings, chunks, dims } = getEmbeddings(embeddings);
+  const dimCount = dimensions ?? dims;
   return (
     <EuiFlexGroup justifyContent="center" alignItems="center" gutterSize="s">
       <EuiFlexItem grow={false}>
@@ -60,7 +69,7 @@ export const VectorFieldValue: React.FC<{ embeddings: string }> = ({ embeddings 
           {i18n.translate('xpack.searchIndexDocuments.result.value.denseVector.dimLabel', {
             defaultMessage: '{value} dims',
             values: {
-              value: jsonEmbeddings.length,
+              value: dimCount,
             },
           })}
         </EuiBadge>
@@ -108,6 +117,7 @@ export const ResultFieldValue: React.FC<ResultFieldValueProps> = ({
   fieldType,
   isExpanded = false,
   embeddings,
+  dimensions,
 }) => {
   if (
     isExpanded &&
@@ -123,7 +133,7 @@ export const ResultFieldValue: React.FC<ResultFieldValueProps> = ({
     return (
       <>
         {fieldType === 'dense_vector' ? (
-          <VectorFieldValue embeddings={fieldValue} />
+          <VectorFieldValue embeddings={fieldValue} dimensions={dimensions} />
         ) : (
           <EuiText size="s" color="default">
             {fieldValue}
@@ -145,7 +155,7 @@ export const ResultFieldValue: React.FC<ResultFieldValueProps> = ({
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem>
-          <VectorFieldValue embeddings={embeddings} />
+          <VectorFieldValue embeddings={embeddings} dimensions={dimensions} />
         </EuiFlexItem>
       </EuiFlexGroup>
     );


### PR DESCRIPTION
## Summary
- The data preview `dims` badge used the outer array length of chunked `semantic_text` embeddings, so it showed chunk count instead of vector dimensions.
- The badge now uses the existing `dimensions` value from inference metadata (falling back to the inner vector length), so chunked fields show the real dim count alongside the chunks badge.

#### Before
<img width="600" alt="Screenshot 2026-08-25 at 00 18 45" src="https://github.com/user-attachments/assets/d68a8bc7-314f-4aed-961d-e7b40ac9e607" />

#### After
<img width="600" alt="Screenshot 2026-08-25 at 00 19 14" src="https://github.com/user-attachments/assets/1010bec3-d2e9-41de-b929-299a6c3a650d" />


## Test plan
- [ ] Create an index with a `semantic_text` field and ingest text long enough to chunk
- [ ] Open the index details page, expand a document in data preview, and confirm the dims badge shows the embedding dimensions (e.g. 1024), not the chunk count
- [ ] Confirm the chunks badge still shows the correct chunk count when there is more than one chunk
- [ ] Confirm an unchunked `semantic_text` field and a `dense_vector` field still show the correct dims value with no chunks badge

Made with [Cursor](https://cursor.com)